### PR TITLE
stats via HTTP/HTTPS POST

### DIFF
--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -620,3 +620,22 @@
 #no-tlsv1
 #no-tlsv1_1
 #no-tlsv1_2
+#
+# Send stats via HTTP/HTTPS POST. By default, no stats are sent.
+# To send user stats to a stats server via HTTP/HTTPS POST, at the end of the session.
+# The url may contain fqdn or IP address (IPv4 or IPv6). In addition it may	contain
+# the path which starts with the "/" following the fqdn or IP address. When a
+# session ends, the stats are sent to the stats server via HTTP POST. By default,
+# stats are sent via "HTTP" POST on port 80.
+# An example would be 
+# "www.example.com/turnstats" or "<IPv4 address>/turnstats" or "<IPv6 address>/turnstats"
+#
+#stats-server=<domain or ip/path or resource>
+#
+# Send user stats on a specific port to the stats server.
+# The port MUST be 443, if the stats are to be sent via "HTTPS" POST. The url set as
+# the "stats-server" MUST contain the fqdn of the stats server, if the port is set to 443.
+# The stats server MUST also have proper SSL certificate for the fqdn. For all other ports,
+# transport will be via "HTTP" POST.
+#
+#stats-server-port=80

--- a/src/apps/relay/mainrelay.c.bak
+++ b/src/apps/relay/mainrelay.c.bak
@@ -75,9 +75,9 @@ NULL, NULL,
 #endif
 #if DTLS_SUPPORTED
 NULL,
-#endif
 #if DTLSv1_2_SUPPORTED
 NULL,
+#endif
 #endif
 NULL,
 DH_1066, "", "", "",

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -188,6 +188,8 @@ typedef struct _turn_params_ {
 #endif
 #endif
   
+  SSL_CTX *stats_server_ctx;
+  
   DH_KEY_SIZE dh_key_size;
   
   char cipher_list[1025];
@@ -300,6 +302,8 @@ typedef struct _turn_params_ {
   band_limit_t bps_capacity_allocated;
   vint total_quota;
   vint user_quota;
+  char stats_server[1024];
+  int stats_server_port;
 
 /////// Users DB ///////////
 

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1647,7 +1647,9 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
 			 send_turn_session_info,
 			 send_https_socket,
 			 allocate_bps,
-			 turn_params.oauth, turn_params.oauth_server_name);
+			 turn_params.oauth, turn_params.oauth_server_name,
+			 turn_params.stats_server_ctx,
+			 turn_params.stats_server, turn_params.stats_server_port);
 	
 	if(to_set_rfc5780) {
 		set_rfc5780(&(rs->server), get_alt_addr, send_message_from_listener_to_client);

--- a/src/client/ns_turn_ioaddr.c
+++ b/src/client/ns_turn_ioaddr.c
@@ -317,6 +317,28 @@ static char* get_addr_string_and_port(char* s0, int *port)
 	return NULL;
 }
 
+// Extracts the fqdn or ip and the resource or path from the URL
+// This method assumes the scheme to be either http or https
+void split_url_into_domain_or_ip_and_path(s08bits* s0, s08bits* domain_or_ip, s08bits* path)
+{
+	int offset=0;
+	s08bits* p = NULL;
+	s08bits* s = s0;
+	offset = (strstr(s0, "http://") == NULL) ? ((strstr(s0, "https://") == NULL) ? 0 : 8) : 7;
+	s += offset;
+	p = strstr(s, "/");
+	if (p) {
+		// copy domain or ip
+		strncpy(domain_or_ip, (s08bits*)s, p - s);
+		domain_or_ip[p-s] = '\0';
+		// copy path
+		STRCPY(path, p);
+	} else {
+		STRCPY(domain_or_ip, s);
+		path[0] = '\0';	// no path in url
+	}
+}
+
 int make_ioa_addr_from_full_string(const u08bits* saddr, int default_port, ioa_addr *addr)
 {
 	if(!addr)

--- a/src/client/ns_turn_ioaddr.h
+++ b/src/client/ns_turn_ioaddr.h
@@ -74,6 +74,7 @@ void addr_set_port(ioa_addr* addr, int port);
 int addr_get_port(const ioa_addr* addr);
 int addr_to_string(const ioa_addr* addr, u08bits* saddr);
 int addr_to_string_no_port(const ioa_addr* addr, u08bits* saddr);
+void split_url_into_domain_or_ip_and_path(s08bits* s0, s08bits* domain_or_ip, s08bits* path);
 
 u32bits hash_int32(u32bits a);
 u64bits hash_int64(u64bits a);

--- a/src/server/ns_turn_allocation.c
+++ b/src/server/ns_turn_allocation.c
@@ -233,6 +233,40 @@ static void free_turn_permission_hashtable(turn_permission_hashtable *map)
 	}
 }
 
+turn_permission_info* get_permission_info(turn_permission_hashtable *map)
+{
+	if(map) {
+		size_t i;
+		for(i=0;i<TURN_PERMISSION_HASHTABLE_SIZE;++i) {
+
+			turn_permission_array *parray = &(map->table[i]);
+
+			{
+				size_t j;
+				for(j=0;j<TURN_PERMISSION_ARRAY_SIZE;++j) {
+					turn_permission_slot *slot = &(parray->main_slots[j]);
+					if(slot->info.allocated) {
+						return &(slot->info);
+					}
+				}
+			}
+
+			if(parray->extra_slots) {
+				size_t j;
+				for(j=0;j<parray->extra_sz;++j) {
+					turn_permission_slot *slot = parray->extra_slots[j];
+					if(slot) {
+						if(slot->info.allocated) {
+							return &(slot->info);
+						}
+					}
+				}
+			}
+		}
+	}
+	return NULL;
+}
+
 static turn_permission_info* get_from_turn_permission_hashtable(turn_permission_hashtable *map, const ioa_addr *addr)
 {
 	if (!addr || !map)

--- a/src/server/ns_turn_allocation.h
+++ b/src/server/ns_turn_allocation.h
@@ -205,6 +205,7 @@ void set_allocation_valid(allocation* a, int value);
 turn_permission_info* allocation_get_permission(allocation* a, const ioa_addr *addr);
 turn_permission_hashtable* allocation_get_turn_permission_hashtable(allocation *a);
 turn_permission_info* allocation_add_permission(allocation *a, const ioa_addr* addr);
+turn_permission_info* get_permission_info(turn_permission_hashtable *map);
 
 ch_info* allocation_get_new_ch_info(allocation* a, u16bits chnum, ioa_addr* peer_addr);
 ch_info* allocation_get_ch_info(allocation* a, u16bits chnum);

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4809,7 +4809,11 @@ void init_turn_server(turn_turnserver* server,
 		send_turn_session_info_cb send_turn_session_info,
 		send_https_socket_cb send_https_socket,
 		allocate_bps_cb allocate_bps_func,
-		int oauth, const char* oauth_server_name) {
+		int oauth, const char* oauth_server_name,
+		SSL_CTX* stats_server_ctx,
+		char* stats_server,
+		int stats_server_port
+		) {
 
 	if (!server)
 		return;
@@ -4873,6 +4877,10 @@ void init_turn_server(turn_turnserver* server,
 	server->allocate_bps_func = allocate_bps_func;
 
 	set_ioa_timer(server->e, 1, 0, timer_timeout_handler, server, 1, "timer_timeout_handler");
+	//stats server
+	server->stats_server_ctx = stats_server_ctx;
+	split_url_into_domain_or_ip_and_path(stats_server, server->stats_server_domain_or_ip, server->stats_server_uri_path);
+	server->stats_server_port = stats_server_port;
 }
 
 ioa_engine_handle turn_server_get_engine(turn_turnserver *s) {

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -31,6 +31,7 @@
 #ifndef __TURN_SERVER__
 #define __TURN_SERVER__
 
+#include <openssl/ssl.h>
 #include "ns_turn_utils.h"
 #include "ns_turn_session.h"
 
@@ -165,6 +166,12 @@ struct _turn_turnserver {
 	/* oAuth: */
 	int oauth;
 	const char* oauth_server_name;
+	
+	/* stats server */
+	SSL_CTX* stats_server_ctx;
+	char stats_server_domain_or_ip[1024];
+	char stats_server_uri_path[1024];
+	int stats_server_port;
 };
 
 ///////////////////////////////////////////
@@ -202,7 +209,10 @@ void init_turn_server(turn_turnserver* server,
 				    send_https_socket_cb send_https_socket,
 				    allocate_bps_cb allocate_bps_func,
 				    int oauth,
-				    const char* oauth_server_name);
+				    const char* oauth_server_name,
+				    SSL_CTX* stats_server_ctx,
+				    char* stats_server,
+				    int stats_server_port);
 
 ioa_engine_handle turn_server_get_engine(turn_turnserver *s);
 


### PR DESCRIPTION
Based on configuration the changes will allow user stats to be sent to a
server, after a session has ended.

The following information is posted

username
received packets
received bytes
sent packets
sent bytes

The changes have been tested against OpenSSL 1.0.2a