### PR TITLE
case call to check_tentative_tls with TLS_SUPPORTED

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -3313,19 +3313,20 @@ int register_callback_on_ioa_socket(ioa_engine_handle e, ioa_socket_handle s, in
 							return -1;
 						}
 					} else {
+#if TLS_SUPPORTED
 						if(check_tentative_tls(s->fd)) {
 							s->tobeclosed = 1;
 							return -1;
-						} else {
-							s->bev = bufferevent_socket_new(s->e->event_base,
-										s->fd,
-										TURN_BUFFEREVENTS_OPTIONS);
-							debug_ptr_add(s->bev);
-							bufferevent_setcb(s->bev, socket_input_handler_bev, socket_output_handler_bev,
-											eventcb_bev, s);
-							bufferevent_setwatermark(s->bev, EV_READ|EV_WRITE, 0, BUFFEREVENT_HIGH_WATERMARK);
-							bufferevent_enable(s->bev, EV_READ|EV_WRITE); /* Start reading. */
 						}
+#endif
+						s->bev = bufferevent_socket_new(s->e->event_base,
+									s->fd,
+									TURN_BUFFEREVENTS_OPTIONS);
+						debug_ptr_add(s->bev);
+						bufferevent_setcb(s->bev, socket_input_handler_bev, socket_output_handler_bev,
+										eventcb_bev, s);
+						bufferevent_setwatermark(s->bev, EV_READ|EV_WRITE, 0, BUFFEREVENT_HIGH_WATERMARK);
+						bufferevent_enable(s->bev, EV_READ|EV_WRITE); /* Start reading. */
 					}
 					break;
 				case TLS_SCTP_SOCKET:


### PR DESCRIPTION
If you configure coturn without openssl, there is a single usage of check_tentative_tls here https://github.com/coturn/coturn/blob/master/src/apps/relay/ns_ioalib_engine_impl.c on line 3316 which is not covered by a `#if TLS_SUPPORTED` macro, causing a check_tentative_tls undefined error.