### PR TITLE
Set "READ_TIMEOUT" just after coturn sets "CONNECT_TIMEOUT".

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_mysql.c
+++ b/src/apps/relay/dbdrivers/dbd_mysql.c
@@ -226,6 +226,7 @@ static MYSQL *get_mydb_connection(void) {
 			} else {
 				if(co->connect_timeout)
 					mysql_options(mydbconnection,MYSQL_OPT_CONNECT_TIMEOUT,&(co->connect_timeout));
+					mysql_options(mydbconnection,MYSQL_OPT_READ_TIMEOUT,&(co->connect_timeout));
 				if(co->ca || co->capath || co->cert || co->cipher || co->key) {
 					mysql_ssl_set(mydbconnection, co->key, co->cert, co->ca, co->capath, co->cipher);
 				}


### PR DESCRIPTION
For MYSQL_OPT_READ_TIMEOUT of variable does not exist, it has been substituting the "connect_timeout".

[Assumed cause]
Because "MYSQL_OPT_READ_TIMEOUT" is not set, coturn cannot detect mysql_ping timeout.
I think coturn shoud have "READ_TIMEOUT" setting(like tomcat) to detect mysql_ping timeout.

[Possible modification]
Set "READ_TIMEOUT" just after coturn sets "CONNECT_TIMEOUT".
