### PR TITLE
fix memory initialization in src/client/ns_turn_msg.c in function stun_attr_get_addr_str

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1439,7 +1439,8 @@ int stun_attr_get_addr_str(const u08bits *buf, size_t len, stun_attr_ref attr, i
   stun_tid_from_message_str(buf, len, &tid);
   ioa_addr public_addr;
 
-  ns_bzero(ca,sizeof(ioa_addr));
+  ns_bzero(ca, sizeof(ioa_addr));
+  ns_bzero(&public_addr, sizeof(ioa_addr));
 
   int attr_type = stun_attr_get_type(attr);
   if(attr_type<0) return -1;


### PR DESCRIPTION
The initialization was on the memory we received in parameter, but this memory will get copied later in map_addr_from_public_to_private.
However the source of the copy, public_addr is never initialized.