### PR TITLE
Add "--prod" to turnserver command-line options.

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -100,7 +100,7 @@ DH_1066, "", "", "",
 0,
 #endif
 
-TURN_VERBOSE_NONE,0,0,
+TURN_VERBOSE_NONE,0,0,0,
 "/var/run/turnserver.pid",
 DEFAULT_STUN_PORT,DEFAULT_STUN_TLS_PORT,0,0,1,
 0,0,0,0,
@@ -435,6 +435,7 @@ static char Usage[] = "Usage: turnserver [options]\n"
 " -v, --verbose					'Moderate' verbose mode.\n"
 " -V, --Verbose					Extra verbose mode, very annoying (for debug purposes only).\n"
 " -o, --daemon					Start process as daemon (detach from current shell).\n"
+" --prod       	 				Hide version.\n"
 " -f, --fingerprint				Use fingerprints in the TURN messages.\n"
 " -a, --lt-cred-mech				Use the long-term credential mechanism.\n"
 " -z, --no-auth					Do not use any credential mechanism, allow anonymous access.\n"
@@ -677,6 +678,7 @@ static char AdminUsage[] = "Usage: turnadmin [command] [options]\n"
 #define ADMIN_OPTIONS "PgGORIHKYlLkaADSdb:e:M:J:N:u:r:p:s:X:o:h"
 
 enum EXTRA_OPTS {
+	PROD_OPT,
 	NO_UDP_OPT=256,
 	NO_TCP_OPT,
 	NO_TLS_OPT,
@@ -803,6 +805,7 @@ static const struct myoption long_options[] = {
 				{ "verbose", optional_argument, NULL, 'v' },
 				{ "Verbose", optional_argument, NULL, 'V' },
 				{ "daemon", optional_argument, NULL, 'o' },
+				{ "prod", optional_argument, NULL, PROD_OPT },
 				{ "fingerprint", optional_argument, NULL, 'f' },
 				{ "check-origin-consistency", optional_argument, NULL, CHECK_ORIGIN_CONSISTENCY_OPT },
 				{ "no-udp", optional_argument, NULL, NO_UDP_OPT },
@@ -1166,6 +1169,9 @@ static void set_option(int c, char *value)
 			turn_params.ct = TURN_CREDENTIALS_NONE;
 			anon_credentials = 1;
 		}
+		break;
+	case PROD_OPT:
+		turn_params.prod = get_bool_value(value);
 		break;
 	case 'f':
 		turn_params.fingerprint = get_bool_value(value);

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -202,6 +202,7 @@ typedef struct _turn_params_ {
 
   int verbose;
   int turn_daemon;
+  int prod;
 
   int do_not_use_config_file;
 

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1638,6 +1638,7 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
 			 &turn_params.permission_lifetime,
 			 &turn_params.stun_only,
 			 &turn_params.no_stun,
+			 &turn_params.prod,
 			 &turn_params.alternate_servers_list,
 			 &turn_params.tls_alternate_servers_list,
 			 &turn_params.aux_servers_list,

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -1512,7 +1512,9 @@ static void https_finish_page(struct str_buffer *sb, ioa_socket_handle s, int cc
 	str_buffer_append(sb,"</body>\r\n</html>\r\n");
 
 	send_str_from_ioa_socket_tcp(s,"HTTP/1.1 200 OK\r\nServer: ");
-	send_str_from_ioa_socket_tcp(s,TURN_SOFTWARE);
+	if(!turn_params.prod) {
+		send_str_from_ioa_socket_tcp(s,TURN_SOFTWARE);
+	}
 	send_str_from_ioa_socket_tcp(s,"\r\n");
 	send_str_from_ioa_socket_tcp(s,get_http_date_header());
 	if(cclose) {

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -57,6 +57,14 @@ static inline int get_family(int stun_family) {
 
 ////////////////////////////////////////////////
 
+const char * get_version(turn_turnserver *server) {
+	if(!server->prod) {
+		return (const char *) TURN_SOFTWARE;
+	} else {
+		return (const char *) "None";
+	}
+}
+
 #define MAX_NUMBER_OF_UNKNOWN_ATTRS (128)
 
 int TURN_MAX_ALLOCATE_TIMEOUT = 60;
@@ -1715,8 +1723,8 @@ static int handle_turn_refresh(turn_turnserver *server,
 										ioa_network_buffer_set_size(nbh,len);
 
 										{
-											static const u08bits *field = (const u08bits *) TURN_SOFTWARE;
-											static const size_t fsz = sizeof(TURN_SOFTWARE)-1;
+											const u08bits *field = (const u08bits *) get_version(server);
+											static const size_t fsz = sizeof(get_version(server))-1;
 											size_t len = ioa_network_buffer_get_size(nbh);
 											stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_SOFTWARE, field, fsz);
 											ioa_network_buffer_set_size(nbh, len);
@@ -2182,8 +2190,8 @@ static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg)
 		ioa_network_buffer_set_size(nbh,len);
 
 		{
-			static const u08bits *field = (const u08bits *) TURN_SOFTWARE;
-			static const size_t fsz = sizeof(TURN_SOFTWARE)-1;
+			const u08bits *field = (const u08bits *) get_version(server);
+			static const size_t fsz = sizeof(get_version(server))-1;
 			size_t len = ioa_network_buffer_get_size(nbh);
 			stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_SOFTWARE, field, fsz);
 			ioa_network_buffer_set_size(nbh, len);
@@ -2459,8 +2467,8 @@ int turnserver_accept_tcp_client_data_connection(turn_turnserver *server, tcp_co
 		}
 
 		{
-			static const u08bits *field = (const u08bits *) TURN_SOFTWARE;
-			static const size_t fsz = sizeof(TURN_SOFTWARE)-1;
+			const u08bits *field = (const u08bits *) get_version(server);
+			static const size_t fsz = sizeof(get_version(server))-1;
 			size_t len = ioa_network_buffer_get_size(nbh);
 			stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_SOFTWARE, field, fsz);
 			ioa_network_buffer_set_size(nbh, len);
@@ -3765,8 +3773,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 					}
 
 					{
-						static const u08bits *field = (const u08bits *) TURN_SOFTWARE;
-						static const size_t fsz = sizeof(TURN_SOFTWARE)-1;
+						const u08bits *field = (const u08bits *) get_version(server);
+						static const size_t fsz = sizeof(get_version(server))-1;
 						size_t len = ioa_network_buffer_get_size(nbh);
 						stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_SOFTWARE, field, fsz);
 						ioa_network_buffer_set_size(nbh, len);
@@ -3866,8 +3874,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 		}
 
 		{
-			static const u08bits *field = (const u08bits *) TURN_SOFTWARE;
-			static const size_t fsz = sizeof(TURN_SOFTWARE)-1;
+			const u08bits *field = (const u08bits *) get_version(server);
+			static const size_t fsz = sizeof(get_version(server))-1;
 			size_t len = ioa_network_buffer_get_size(nbh);
 			stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_SOFTWARE, field, fsz);
 			ioa_network_buffer_set_size(nbh, len);
@@ -3947,11 +3955,11 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
 				}
 
 				{
-					size_t newsz = (((sizeof(TURN_SOFTWARE))>>2) + 1)<<2;
+					size_t newsz = (((sizeof(get_version(server)))>>2) + 1)<<2;
 					u08bits software[120];
 					if(newsz>sizeof(software))
 						newsz = sizeof(software);
-					ns_bcopy(TURN_SOFTWARE,software,newsz);
+					ns_bcopy(get_version(server),software,newsz);
 					size_t len = ioa_network_buffer_get_size(nbh);
 					stun_attr_add_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_SERVER, software, newsz);
 					ioa_network_buffer_set_size(nbh, len);
@@ -3999,11 +4007,11 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
 		}
 
 		{
-			size_t newsz = (((sizeof(TURN_SOFTWARE))>>2) + 1)<<2;
+			size_t newsz = (((sizeof(get_version(server)))>>2) + 1)<<2;
 			u08bits software[120];
 			if(newsz>sizeof(software))
 				newsz = sizeof(software);
-			ns_bcopy(TURN_SOFTWARE,software,newsz);
+			ns_bcopy(get_version(server),software,newsz);
 			size_t len = ioa_network_buffer_get_size(nbh);
 			stun_attr_add_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_SERVER, software, newsz);
 			ioa_network_buffer_set_size(nbh, len);
@@ -4727,8 +4735,8 @@ static void peer_input_handler(ioa_socket_handle s, int event_type,
 				ioa_network_buffer_set_size(nbh,len);
 
 				{
-					static const u08bits *field = (const u08bits *) TURN_SOFTWARE;
-					static const size_t fsz = sizeof(TURN_SOFTWARE)-1;
+					const u08bits *field = (const u08bits *) get_version(server);
+					static const size_t fsz = sizeof(get_version(server))-1;
 					size_t len = ioa_network_buffer_get_size(nbh);
 					stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_SOFTWARE, field, fsz);
 					ioa_network_buffer_set_size(nbh, len);
@@ -4801,6 +4809,7 @@ void init_turn_server(turn_turnserver* server,
 		vintp permission_lifetime,
 		vintp stun_only,
 		vintp no_stun,
+		vintp prod,
 		turn_server_addrs_list_t *alternate_servers_list,
 		turn_server_addrs_list_t *tls_alternate_servers_list,
 		turn_server_addrs_list_t *aux_servers_list,
@@ -4859,6 +4868,7 @@ void init_turn_server(turn_turnserver* server,
 	server->permission_lifetime = permission_lifetime;
 	server->stun_only = stun_only;
 	server->no_stun = no_stun;
+	server->prod = prod;
 
 	server->dont_fragment = dont_fragment;
 	server->fingerprint = fingerprint;

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -120,6 +120,7 @@ struct _turn_turnserver {
         vintp permission_lifetime;
 	vintp stun_only;
 	vintp no_stun;
+	vintp prod;
 	vintp secure_stun;
 	turn_credential_type ct;
 	get_alt_addr_cb alt_addr_cb;
@@ -170,6 +171,8 @@ struct _turn_turnserver {
 	const char* oauth_server_name;
 };
 
+const char * get_version(turn_turnserver *server);
+
 ///////////////////////////////////////////
 
 void init_turn_server(turn_turnserver* server,
@@ -192,6 +195,7 @@ void init_turn_server(turn_turnserver* server,
                                     vintp permission_lifetime,
 				    vintp stun_only,
 				    vintp no_stun,
+				    vintp prod,
 				    turn_server_addrs_list_t *alternate_servers_list,
 				    turn_server_addrs_list_t *tls_alternate_servers_list,
 				    turn_server_addrs_list_t *aux_servers_list,


### PR DESCRIPTION
It will hide turnserver version (like apache does).
This is a common corporate security requirement.
