### PR TITLE
Updates make-man.sh

### DIFF
--- a/make-man.sh
+++ b/make-man.sh
@@ -1,17 +1,29 @@
 #!/bin/sh
 
-rm -rf man/man1/*
+pushd man/man1 >/dev/null 2>&1
+  rm -rf ~0/*.1
 
-txt2man -s 1 -t TURN -I turnserver -I turnadmin -I turnutils -I turnutils_uclient -I turnutils_stunclient -I turnutils_rfc5769check -I turnutils_peer -I turnutils_natdiscovery -I turnutils_oauth -B "TURN Server" README.turnserver | sed -e 's/-/\\-/g' > man/man1/turnserver.1
+  for _tMB in {admin,server,utils} ;
+    do
+      txt2man -s 1 -t TURN \
+        -I turn${_tMB} \
+        -I turnadmin \
+        -I turnutils \
+        -I turnutils_uclient \
+        -I turnutils_stunclient \
+        -I turnutils_rfc5769check \
+        -I turnutils_peer \
+        -I turnutils_natdiscovery \
+        -I turnutils_oauth \
+        -B "TURN Server" ~1/README.turn${_tMB} | \
+        sed -e 's/-/\\-/g' > turn${_tMB}.1 ;
+    done
 
-txt2man -s 1 -t TURN -I turnserver -I turnadmin -I turnutils -I turnutils_uclient -I turnutils_stunclient -I turnutils_rfc5769check -I turnutils_peer -I turnutils_natdiscovery -I turnutils_oauth -B "TURN Server" README.turnadmin | sed -e 's/-/\\-/g'> man/man1/turnadmin.1
+  for _tLNK in {uclient,peer,stunclient,natdiscovery,oauth} ;
+    do
+      ln -s turnutils.1 turnutils_${_tLNK}.1 ; 
+    done
 
-txt2man -s 1 -t TURN -I turnserver -I turnadmin -I turnutils -I turnutils_uclient -I turnutils_stunclient -I turnutils_rfc5769check -I turnutils_peer -I turnutils_natdiscovery -I turnutils_oauth -B "TURN Server" README.turnutils | sed -e 's/-/\\-/g' > man/man1/turnutils.1
+  ln -s turnserver.1 coturn.1 ;
 
-cd man/man1; ln -s turnutils.1 turnutils_uclient.1;cd ../..
-cd man/man1; ln -s turnutils.1 turnutils_peer.1;cd ../..
-cd man/man1; ln -s turnutils.1 turnutils_stunclient.1;cd ../..
-cd man/man1; ln -s turnutils.1 turnutils_natdiscovery.1;cd ../..
-cd man/man1; ln -s turnutils.1 turnutils_oauth.1;cd ../..
-cd man/man1; ln -s turnserver.1 coturn.1;cd ../..
-
+popd >/dev/null 2>&1


### PR DESCRIPTION
Changes from cd's to pushd/popd
Switches from hardcoding to script looping
Changed the rm call to act on manpages (.1) files only which adds a bit of safety while still doing the job

*Note
Removing the file redirection from the last `popd >/dev/null 2>&1` echoes the current working directory so if needed for compatibility with the env, a little comment and extra line would then properly define the var.
```shell
#popd >/dev/null 2>&1
CPWD=$(popd)
```