### PR TITLE
config warning about both using use-auth-secret and lt-cred-mech

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -39,6 +39,8 @@
 
 static int use_lt_credentials = 0;
 static int anon_credentials = 0;
+static int use_lt_credentials_only = 0;
+static int timestamp_credentials = 0;
 
 ////// ALPN //////////
 
@@ -1156,6 +1158,7 @@ static void set_option(int c, char *value)
 		if (get_bool_value(value)) {
 			turn_params.ct = TURN_CREDENTIALS_LONG_TERM;
 			use_lt_credentials=1;
+            use_lt_credentials_only=1;
 		} else {
 			turn_params.ct = TURN_CREDENTIALS_UNDEFINED;
 			use_lt_credentials=0;
@@ -1217,12 +1220,14 @@ static void set_option(int c, char *value)
 #endif
 	case AUTH_SECRET_OPT:
 		turn_params.use_auth_secret_with_timestamp = 1;
+        timestamp_credentials = 1;
 		turn_params.ct = TURN_CREDENTIALS_LONG_TERM;
 		use_lt_credentials = 1;
 		break;
 	case STATIC_AUTH_SECRET_VAL_OPT:
 		add_to_secrets_list(&turn_params.default_users_db.ram_db.static_auth_secrets,value);
 		turn_params.use_auth_secret_with_timestamp = 1;
+        timestamp_credentials = 1;
 		turn_params.ct = TURN_CREDENTIALS_LONG_TERM;
 		use_lt_credentials = 1;
 		break;
@@ -1982,6 +1987,10 @@ int main(int argc, char **argv)
 		TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "\nCONFIG ERROR: -a and -z options cannot be used together.\n");
 		exit(-1);
 	}
+
+    if(use_lt_credentials_only && timestamp_credentials) {
+		TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "\nCONFIGURATION ALERT: you specified --lt-cred-mech and --use-auth-secret both. Check your configuration.\n");
+    }
 
 	if(!use_lt_credentials && !anon_credentials) {
 		if(turn_params.default_users_db.ram_db.users_number) {


### PR DESCRIPTION
I found that if I use `lt-cred-mech` and `use-auth-secret` option both, only `use-auth-secret`'s behavior is appeared and credentials in `turnusers_lt` table are disabled.

I think this should be alarmed with warning.

Thanks.