### PR TITLE
Report total traffic used per allocation via Redis

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -3596,6 +3596,14 @@ void turn_report_allocation_delete(void *a)
 					}
 					send_message_to_redis(e->rch, "del", key, "");
 					send_message_to_redis(e->rch, "publish", key, "deleted");
+
+					// report total traffic usage for this allocation
+					if(ss->realm_options.name[0]) {
+						snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/total_traffic", ss->realm_options.name, (char*)ss->username, (unsigned long long)ss->id);
+					} else {
+						snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/total_traffic", (char*)ss->username, (unsigned long long)ss->id);
+					}
+					send_message_to_redis(e->rch, "publish", key, "rcvp=%lu, rcvb=%lu, sentp=%lu, sentb=%lu", (unsigned long)(ss->t_received_packets), (unsigned long)(ss->t_received_bytes), (unsigned long)(ss->t_sent_packets), (unsigned long)(ss->t_sent_bytes));
 				}
 #endif
 			}

--- a/turndb/schema.stats.redis
+++ b/turndb/schema.stats.redis
@@ -16,6 +16,12 @@ The keys are "turn/user/<username>/allocation/<id>/traffic". The application tha
 in the traffic information must subscribe to the events as:
 
 	psubscribe turn/realm/*/user/*/allocation/*/traffic
+
+Total traffic information is also reported when the allocation is deleted. The keys are
+"turn/user/<username>/allocation/<id>/total_traffic". Applications interested in the total amount
+of traffic per allocation can subscribe to these events as:
+
+	psubscribe turn/realm/*/user/*/allocation/*/total_traffic
 	
 Or, to receive all allocation events:
 


### PR DESCRIPTION
Publish total traffic information when an allocation is deleted. This
makes it easier for applications to monitor total usage per session.