### PR TITLE
Update total usage on client shutdown

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -3611,14 +3611,14 @@ void turn_report_allocation_delete(void *a)
 	}
 }
 
-void turn_report_session_usage(void *session)
+void turn_report_session_usage(void *session, int force_invalid)
 {
 	if(session) {
 		ts_ur_super_session *ss = (ts_ur_super_session *)session;
 		turn_turnserver *server = (turn_turnserver*)ss->server;
-		if(server && (ss->received_packets || ss->sent_packets)) {
+		if(server && (ss->received_packets || ss->sent_packets || force_invalid)) {
 			ioa_engine_handle e = turn_server_get_engine(server);
-			if(((ss->received_packets+ss->sent_packets)&2047)==0) {
+			if(((ss->received_packets+ss->sent_packets)&2047)==0 || force_invalid) {
 				if(e && e->verbose) {
 					TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"session %018llu: usage: realm=<%s>, username=<%s>, rp=%lu, rb=%lu, sp=%lu, sb=%lu\n", (unsigned long long)(ss->id), (char*)ss->realm_options.name, (char*)ss->username, (unsigned long)(ss->received_packets), (unsigned long)(ss->received_bytes),(unsigned long)(ss->sent_packets),(unsigned long)(ss->sent_bytes));
 				}
@@ -3648,7 +3648,7 @@ void turn_report_session_usage(void *session)
 					}
 				}
 
-				report_turn_session_info(server,ss,0);
+				report_turn_session_info(server,ss,force_invalid);
 
 				ss->received_packets=0;
 				ss->received_bytes=0;

--- a/src/server/ns_turn_ioalib.h
+++ b/src/server/ns_turn_ioalib.h
@@ -187,7 +187,7 @@ void ioa_network_buffer_delete(ioa_engine_handle e, ioa_network_buffer_handle nb
  */
 void turn_report_allocation_set(void *a, turn_time_t lifetime, int refresh);
 void turn_report_allocation_delete(void *a);
-void turn_report_session_usage(void *session);
+void turn_report_session_usage(void *session, int force_invalid);
 
 /*
  * Network event handler callback

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -1851,7 +1851,7 @@ static void tcp_deliver_delayed_buffer(unsent_buffer *ub, ioa_socket_handle s, t
 			} else {
 				++(ss->sent_packets);
 				ss->sent_bytes += bytes;
-				turn_report_session_usage(ss);
+				turn_report_session_usage(ss, 0);
 			}
 			pop_unsent_buffer(ub);
 		} while(!ioa_socket_tobeclosed(s) && ((i++)<MAX_UNSENT_BUFFER_SIZE));
@@ -1890,7 +1890,7 @@ static void tcp_peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_
 	} else if(ss) {
 		++(ss->sent_packets);
 		ss->sent_bytes += bytes;
-		turn_report_session_usage(ss);
+		turn_report_session_usage(ss, 0);
 	}
 }
 
@@ -1929,7 +1929,7 @@ static void tcp_client_input_handler_rfc6062data(ioa_socket_handle s, int event_
 		set_ioa_socket_tobeclosed(s);
 	}
 
-	turn_report_session_usage(ss);
+	turn_report_session_usage(ss, 0);
 }
 
 static void tcp_conn_bind_timeout_handler(ioa_engine_handle e, void *arg)
@@ -4082,7 +4082,7 @@ int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss,
 	if (!ss)
 		return -1;
 
-	report_turn_session_info(server,ss,1);
+	turn_report_session_usage(ss, 1);
 	dec_quota(ss);
 	dec_bps(ss);
 
@@ -4217,7 +4217,7 @@ static int write_client_connection(turn_turnserver *server, ts_ur_super_session*
 		if(!skip) {
 			++(ss->sent_packets);
 			ss->sent_bytes += (u32bits)ioa_network_buffer_get_size(nbh);
-			turn_report_session_usage(ss);
+			turn_report_session_usage(ss, 0);
 		}
 
 		FUNCEND;
@@ -4427,7 +4427,7 @@ static int read_client_connection(turn_turnserver *server,
 	if(count_usage) {
 		++(ss->received_packets);
 		ss->received_bytes += (u32bits)ioa_network_buffer_get_size(in_buffer->nbh);
-		turn_report_session_usage(ss);
+		turn_report_session_usage(ss, 0);
 	}
 
 	if (eve(server->verbose)) {


### PR DESCRIPTION
Call turn_report_session_usage() from shutdown_client_connection(), so
that any accumulated packets and data sent/received gets added to the
totals before passing it to report_turn_session_info(). This also
ensures that the total_traffic message sent to redis contains correct
values.

Add a force_invalid argument to turn_report_session_usage() to ensure
that report_turn_session_info() is still called when the former is
called from shutdown_client_connection(). This should avoid any
unexpected change in behavior.