### PR TITLE
Fix permissions on manpages and libturnclient

### DIFF
--- a/configure
+++ b/configure
@@ -559,7 +559,7 @@ if [ ${ER} -eq 0 ] ; then
 	INSTALL_MAN="ginstall -m 0644"
 	INSTALL_SCRIPT="ginstall"
 	INSTALL_SHARED_LIB="ginstall"
-	INSTALL_STATIC_LIB="ginstall"
+	INSTALL_STATIC_LIB="ginstall -m 0644"
 	INSTALL_DATA="ginstall"
 	MKDIR="ginstall -d"
 else
@@ -570,7 +570,7 @@ else
 		INSTALL_MAN="install -m 0644"
 		INSTALL_SCRIPT="install"
 		INSTALL_SHARED_LIB="install"
-		INSTALL_STATIC_LIB="install"
+		INSTALL_STATIC_LIB="install -m 0644"
 		INSTALL_DATA="install"
 		MKDIR="install -d"
 	else

--- a/configure
+++ b/configure
@@ -556,7 +556,7 @@ type ginstall 2>>/dev/null
 ER=$?
 if [ ${ER} -eq 0 ] ; then
 	INSTALL_PROGRAM="ginstall"
-	INSTALL_MAN="ginstall"
+	INSTALL_MAN="ginstall -m 0644"
 	INSTALL_SCRIPT="ginstall"
 	INSTALL_SHARED_LIB="ginstall"
 	INSTALL_STATIC_LIB="ginstall"
@@ -567,7 +567,7 @@ else
 	ER=$?
 	if [ ${ER} -eq 0 ] ; then
 		INSTALL_PROGRAM="install"
-		INSTALL_MAN="install"
+		INSTALL_MAN="install -m 0644"
 		INSTALL_SCRIPT="install"
 		INSTALL_SHARED_LIB="install"
 		INSTALL_STATIC_LIB="install"


### PR DESCRIPTION
Fixes `spurious-executable-perm` warnings on manpages files and libturnclient during RPM linting.

This came up here: https://bugzilla.redhat.com/show_bug.cgi?id=1491492#c5