### PR TITLE
Make SIGUSR2 reload TLS certificates

### DIFF
--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -198,6 +198,9 @@ typedef struct _turn_params_ {
   int no_tls;
   int no_dtls;
 
+  struct event *tls_ctx_update_ev;
+  pthread_mutex_t tls_mutex;
+
 //////////////// Common params ////////////////////
 
   int verbose;

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -298,6 +298,63 @@ void del_tls_alternate_server(const char *saddr)
 
 //////////////////////////////////////////////////
 
+typedef struct update_ssl_ctx_cb_args {
+	ioa_engine_handle engine;
+	turn_params_t *params;
+	struct event *next;
+} update_ssl_ctx_cb_args_t;
+
+static void update_ssl_ctx(evutil_socket_t sock, short events, update_ssl_ctx_cb_args_t *args)
+{
+	ioa_engine_handle e = args->engine;
+	turn_params_t *params = args->params;
+
+	pthread_mutex_lock(&turn_params.tls_mutex);
+	e->tls_ctx_ssl23 = params->tls_ctx_ssl23;
+	e->tls_ctx_v1_0 = params->tls_ctx_v1_0;
+#if TLSv1_1_SUPPORTED
+	e->tls_ctx_v1_1 = params->tls_ctx_v1_1;
+#if TLSv1_2_SUPPORTED
+	e->tls_ctx_v1_2 = params->tls_ctx_v1_2;
+#endif
+#endif
+#if DTLS_SUPPORTED
+	e->dtls_ctx = params->dtls_ctx;
+#endif
+#if DTLSv1_2_SUPPORTED
+	e->dtls_ctx_v1_2 = params->dtls_ctx_v1_2;
+#endif
+	struct event *next = args->next;
+	pthread_mutex_unlock(&turn_params.tls_mutex);
+
+	if (next != NULL)
+		event_active(next, EV_READ, 0);
+
+	UNUSED_ARG(sock);
+	UNUSED_ARG(events);
+}
+
+static void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params)
+{
+	update_ssl_ctx_cb_args_t *args = (update_ssl_ctx_cb_args_t *)turn_malloc(sizeof(update_ssl_ctx_cb_args_t));
+	args->engine = e;
+	args->params = params;
+	args->next = NULL;
+
+	update_ssl_ctx(-1, 0, args);
+
+	struct event_base *base = e->event_base;
+	if (base != NULL) {
+		struct event *ev = event_new(base, -1, EV_PERSIST, (event_callback_fn)update_ssl_ctx, (void *)args);
+		pthread_mutex_lock(&turn_params.tls_mutex);
+		args->next = params->tls_ctx_update_ev;
+		params->tls_ctx_update_ev = ev;
+		pthread_mutex_unlock(&turn_params.tls_mutex);
+	}
+}
+
+//////////////////////////////////////////////////
+
 void add_listener_addr(const char* addr) {
 	ioa_addr baddr;
 	if(make_ioa_addr((const u08bits*)addr,0,&baddr)<0) {
@@ -962,20 +1019,7 @@ static ioa_engine_handle create_new_listener_engine(void)
 			,turn_params.redis_statsdb
 #endif
 	);
-	set_ssl_ctx(e, turn_params.tls_ctx_ssl23, turn_params.tls_ctx_v1_0
-#if TLSv1_1_SUPPORTED
-		    ,turn_params.tls_ctx_v1_1
-#if TLSv1_2_SUPPORTED
-		    ,turn_params.tls_ctx_v1_2
-#endif
-#endif
-#if DTLS_SUPPORTED
-		    ,turn_params.dtls_ctx
-#endif
-#if DTLSv1_2_SUPPORTED
-		    ,turn_params.dtls_ctx_v1_2
-#endif
-	);
+	set_ssl_ctx(e, &turn_params);
 	ioa_engine_set_rtcp_map(e, turn_params.listener.rtcpmap);
 	return e;
 }
@@ -1018,23 +1062,8 @@ static void setup_listener(void)
 	if(!turn_params.listener.ioa_eng)
 		exit(-1);
 
-	set_ssl_ctx(turn_params.listener.ioa_eng, turn_params.tls_ctx_ssl23, turn_params.tls_ctx_v1_0
-#if TLSv1_1_SUPPORTED
-		    ,turn_params.tls_ctx_v1_1
-#if TLSv1_2_SUPPORTED
-		    ,turn_params.tls_ctx_v1_2
-#endif
-#endif
-#if DTLS_SUPPORTED
-		    ,turn_params.dtls_ctx
-#endif
-#if DTLSv1_2_SUPPORTED
-		    ,turn_params.dtls_ctx_v1_2
-#endif
-	);
-
+	set_ssl_ctx(turn_params.listener.ioa_eng, &turn_params);
 	turn_params.listener.rtcpmap = rtcp_map_create(turn_params.listener.ioa_eng);
-
 	ioa_engine_set_rtcp_map(turn_params.listener.ioa_eng, turn_params.listener.rtcpmap);
 
 	{
@@ -1592,20 +1621,7 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
 			,turn_params.redis_statsdb
 #endif
 		);
-		set_ssl_ctx(rs->ioa_eng, turn_params.tls_ctx_ssl23, turn_params.tls_ctx_v1_0
-#if TLSv1_1_SUPPORTED
-			    ,turn_params.tls_ctx_v1_1
-#if TLSv1_2_SUPPORTED
-			    ,turn_params.tls_ctx_v1_2
-#endif
-#endif
-#if DTLS_SUPPORTED
-			    ,turn_params.dtls_ctx
-#endif
-#if DTLSv1_2_SUPPORTED
-			    ,turn_params.dtls_ctx_v1_2
-#endif
-		);
+		set_ssl_ctx(rs->ioa_eng, &turn_params);
 		ioa_engine_set_rtcp_map(rs->ioa_eng, turn_params.listener.rtcpmap);
 	}
 

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -436,39 +436,6 @@ ioa_engine_handle create_ioa_engine(super_memory_t *sm,
 	}
 }
 
-void set_ssl_ctx(ioa_engine_handle e,
-		SSL_CTX *tls_ctx_ssl23,
-		SSL_CTX *tls_ctx_v1_0
-#if TLSv1_1_SUPPORTED
-		 ,SSL_CTX *tls_ctx_v1_1
-#if TLSv1_2_SUPPORTED
-		 ,SSL_CTX *tls_ctx_v1_2
-#endif
-#endif
-#if DTLS_SUPPORTED
-		 ,SSL_CTX *dtls_ctx
-#endif
-#if DTLSv1_2_SUPPORTED
-		,SSL_CTX *dtls_ctx_v1_2
-#endif
-)
-{
-	e->tls_ctx_ssl23 = tls_ctx_ssl23;
-	e->tls_ctx_v1_0 = tls_ctx_v1_0;
-#if TLSv1_1_SUPPORTED
-	e->tls_ctx_v1_1 = tls_ctx_v1_1;
-#if TLSv1_2_SUPPORTED
-	e->tls_ctx_v1_2 = tls_ctx_v1_2;
-#endif
-#endif
-#if DTLS_SUPPORTED
-	e->dtls_ctx = dtls_ctx;
-#endif
-#if DTLSv1_2_SUPPORTED
-	e->dtls_ctx_v1_2 = dtls_ctx_v1_2;
-#endif
-}
-
 void ioa_engine_set_rtcp_map(ioa_engine_handle e, rtcp_map *rtcpmap)
 {
 	if(e)

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -258,23 +258,6 @@ ioa_engine_handle create_ioa_engine(super_memory_t *sm,
 #endif
 				);
 
-void set_ssl_ctx(ioa_engine_handle e,
-		SSL_CTX *tls_ctx_ssl23,
-		SSL_CTX *tls_ctx_v1_0
-#if TLSv1_1_SUPPORTED
-		 ,SSL_CTX *tls_ctx_v1_1
-#if TLSv1_2_SUPPORTED
-		 ,SSL_CTX *tls_ctx_v1_2
-#endif
-#endif
-#if DTLS_SUPPORTED
-		 ,SSL_CTX *dtls_ctx
-#endif
-#if DTLSv1_2_SUPPORTED
-		,SSL_CTX *dtls_ctx_v1_2
-#endif
-);
-
 void ioa_engine_set_rtcp_map(ioa_engine_handle e, rtcp_map *rtcpmap);
 
 ioa_socket_handle create_ioa_socket_from_fd(ioa_engine_handle e, ioa_socket_raw fd, ioa_socket_handle parent_s, SOCKET_TYPE st, SOCKET_APP_TYPE sat, const ioa_addr *remote_addr, const ioa_addr *local_addr);


### PR DESCRIPTION
This commit does the following:

* Factor out loading of TLS keys and certificates into turn_params SSL
  context so that it can be repeated. (Contexts are not overwritten
  when loading encounters errors, but initial contexts will be set
  regardless of errors. This keeps existing semantics.)
* Isolate copying of turn_params SSL context to ioa_engine structs
  into callback functions appropriate for libevent invocation.
* Chain both of the above to a signal event handler responding to
  SIGUSR2.

This allows replacement of keys and certificates during run-time
without interrupting relaying operations.