### PR TITLE
Update the example config file: use-auth-secret overrides lt-cred-mech.

### DIFF
--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -180,8 +180,8 @@
 
 # TURN REST API flag.
 # Flag that sets a special authorization option that is based upon authentication secret.
-# This feature can be used with the long-term authentication mechanism, only.
-# This feature purpose is to support "TURN Server REST API", see
+# This feature cannot be used with the long-term credential mechanism.
+# This feature's purpose is to support "TURN Server REST API", see
 # "TURN REST API" link in the project's page 
 # https://github.com/coturn/coturn/
 #


### PR DESCRIPTION
The comment before the TURN REST API flag was confusing: it seemed to imply that `use-auth-secret` _required_ the use of `lt-cred-mech`, but I've since learnt from PR #160 that in fact you're not supposed to use both of them together.

(I suspect that this was why lots of sample coturn config files you can find on the internet have both of those flags set.)