### PR TITLE
Fix memory leak in read_config_file

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1604,7 +1604,7 @@ static void read_config_file(int argc, char **argv, int pass)
 		if (full_path_to_config_file)
 			f = fopen(full_path_to_config_file, "r");
 
-		if (f && full_path_to_config_file) {
+		if (f) {
 
 			char sbuf[1025];
 			char sarg[1035];
@@ -1653,6 +1653,11 @@ static void read_config_file(int argc, char **argv, int pass)
 		} else
 			TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "WARNING: Cannot find config file: %s. Default and command-line settings will be used.\n",
 				config_file);
+
+		if (full_path_to_config_file) {
+			free(full_path_to_config_file);
+			full_path_to_config_file = NULL;
+		}
 	}
 }
 

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1655,7 +1655,7 @@ static void read_config_file(int argc, char **argv, int pass)
 				config_file);
 
 		if (full_path_to_config_file) {
-			free(full_path_to_config_file);
+			turn_free(full_path_to_config_file, strlen(full_path_to_config_file)+1);
 			full_path_to_config_file = NULL;
 		}
 	}


### PR DESCRIPTION
There is a small memory leak in the read_config_file (mainrelay.c:1603) function.
The function find_config_file() returns a malloc'ed string which is not freed.


https://github.com/coturn/coturn/blob/5d88f8275df4fa27236cc219d526c9e09d89815c/src/apps/relay/mainrelay.c#L1603


Valgrind result:

> ==36711== 31 bytes in 1 blocks are definitely lost in loss record 603 of 885
==36711==    at 0x4C2BBAF: malloc (vg_replace_malloc.c:299)
==36711==    by 0x14C560: find_config_file (apputils.c:827)
==36711==    by 0x11E944: read_config_file (mainrelay.c:1603)
==36711==    by 0x11FCE2: main (mainrelay.c:2128)
==36711== 
==36711== 31 bytes in 1 blocks are definitely lost in loss record 604 of 885
==36711==    at 0x4C2BBAF: malloc (vg_replace_malloc.c:299)
==36711==    by 0x14C560: find_config_file (apputils.c:827)
==36711==    by 0x11E944: read_config_file (mainrelay.c:1603)
==36711==    by 0x11FD56: main (mainrelay.c:2138)