### PR TITLE
added bandwidth usage reporting for bandwidth used by peers

### DIFF
--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -503,11 +503,34 @@ int turn_session_info_copy_from(struct turn_session_info* tsi, ts_ur_super_sessi
 				tsi->sent_bytes = ss->t_sent_bytes;
 			else
 				tsi->sent_bytes = ss->sent_bytes;
+			
+			if (ss->t_peer_received_packets > ss->peer_received_packets)
+				tsi->peer_received_packets = ss->t_peer_received_packets;
+			else
+				tsi->peer_received_packets = ss->peer_received_packets;
+
+			if (ss->t_peer_sent_packets > ss->peer_sent_packets)
+				tsi->peer_sent_packets = ss->t_peer_sent_packets;
+			else
+				tsi->peer_sent_packets = ss->peer_sent_packets;
+
+			if (ss->t_peer_received_bytes > ss->peer_received_bytes)
+				tsi->peer_received_bytes = ss->t_peer_received_bytes;
+			else
+				tsi->peer_received_bytes = ss->peer_received_bytes;
+
+			if (ss->t_peer_sent_bytes > ss->peer_sent_bytes)
+				tsi->peer_sent_bytes = ss->t_peer_sent_bytes;
+			else
+				tsi->peer_sent_bytes = ss->peer_sent_bytes;
 
 			{
 				tsi->received_rate = ss->received_rate;
 				tsi->sent_rate = ss->sent_rate;
 				tsi->total_rate = tsi->received_rate + tsi->sent_rate;
+				tsi->peer_received_rate = ss->peer_received_rate;
+				tsi->peer_sent_rate = ss->peer_sent_rate;
+				tsi->peer_total_rate = tsi->peer_received_rate + tsi->peer_sent_rate;
 			}
 
 			tsi->is_mobile = ss->is_mobile;
@@ -1903,6 +1926,11 @@ static void tcp_peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_
 	in_buffer->nbh = NULL;
 
 	u32bits bytes = (u32bits)ioa_network_buffer_get_size(nbh);
+	
+	if (ss) {
+		++(ss->peer_received_packets);
+		ss->peer_received_bytes += bytes;
+	}
 
 	int ret = send_data_from_ioa_socket_nbh(tc->client_s, NULL, nbh, TTL_IGNORE, TOS_IGNORE, NULL);
 	if (ret < 0) {
@@ -1910,6 +1938,9 @@ static void tcp_peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_
 	} else if(ss) {
 		++(ss->sent_packets);
 		ss->sent_bytes += bytes;
+	}
+	
+	if (ss) {
 		turn_report_session_usage(ss, 0);
 	}
 }
@@ -1938,15 +1969,21 @@ static void tcp_client_input_handler_rfc6062data(ioa_socket_handle s, int event_
 	ioa_network_buffer_handle nbh = in_buffer->nbh;
 	in_buffer->nbh = NULL;
 
+	u32bits bytes = (u32bits)ioa_network_buffer_get_size(nbh);
 	if(ss) {
-		u32bits bytes = (u32bits)ioa_network_buffer_get_size(nbh);
 		++(ss->received_packets);
 		ss->received_bytes += bytes;
 	}
 
-	int ret = send_data_from_ioa_socket_nbh(tc->peer_s, NULL, nbh, TTL_IGNORE, TOS_IGNORE, NULL);
+	int skip = 0;
+	int ret = send_data_from_ioa_socket_nbh(tc->peer_s, NULL, nbh, TTL_IGNORE, TOS_IGNORE, &skip);
 	if (ret < 0) {
 		set_ioa_socket_tobeclosed(s);
+	}
+
+	if (!skip) {
+		++(ss->peer_sent_packets);
+		ss->peer_sent_bytes += bytes;
 	}
 
 	turn_report_session_usage(ss, 0);
@@ -2998,7 +3035,13 @@ static int handle_turn_send(turn_turnserver *server, ts_ur_super_session *ss,
 					ioa_network_buffer_set_size(nbh,len);
 				}
 				ioa_network_buffer_header_init(nbh);
-				send_data_from_ioa_socket_nbh(get_relay_socket_ss(ss,peer_addr.ss.sa_family), &peer_addr, nbh, in_buffer->recv_ttl-1, in_buffer->recv_tos, NULL);
+				int skip = 0;
+				send_data_from_ioa_socket_nbh(get_relay_socket_ss(ss,peer_addr.ss.sa_family), &peer_addr, nbh, in_buffer->recv_ttl-1, in_buffer->recv_tos, &skip);
+				if (!skip) {
+					++(ss->peer_sent_packets);
+					ss->peer_sent_bytes += len;
+					turn_report_session_usage(ss, 0);
+				}
 				in_buffer->nbh = NULL;
 			}
 
@@ -4080,7 +4123,15 @@ static int write_to_peerchannel(ts_ur_super_session* ss, u16bits chnum, ioa_net_
 
 			ioa_network_buffer_header_init(nbh);
 
-			rc = send_data_from_ioa_socket_nbh(get_relay_socket_ss(ss, chn->peer_addr.ss.sa_family), &(chn->peer_addr), nbh, in_buffer->recv_ttl-1, in_buffer->recv_tos, NULL);
+			int skip = 0;
+			rc = send_data_from_ioa_socket_nbh(get_relay_socket_ss(ss, chn->peer_addr.ss.sa_family), &(chn->peer_addr), nbh, in_buffer->recv_ttl-1, in_buffer->recv_tos, &skip);
+
+			if (!skip) {
+				++(ss->peer_sent_packets);
+				ss->peer_sent_bytes += (u32bits)ioa_network_buffer_get_size(in_buffer->nbh);
+				turn_report_session_usage(ss, 0);
+			}
+
 			in_buffer->nbh = NULL;
 		}
 	}
@@ -4709,6 +4760,9 @@ static void peer_input_handler(ioa_socket_handle s, int event_type,
 			(int)(ioa_network_buffer_get_capacity_udp() - offset));
 
 	if (ilen >= 0) {
+		++(ss->peer_received_packets);
+		ss->peer_received_bytes += ilen;
+		turn_report_session_usage(ss, 0);
 
 		allocation* a = get_allocation_ss(ss);
 		if (is_allocation_valid(a)) {

--- a/src/server/ns_turn_session.h
+++ b/src/server/ns_turn_session.h
@@ -101,6 +101,17 @@ struct _ts_ur_super_session {
   u64bits received_rate;
   size_t sent_rate;
   size_t total_rate;
+  u32bits peer_received_packets;
+  u32bits peer_sent_packets;
+  u32bits peer_received_bytes;
+  u32bits peer_sent_bytes;
+  u32bits t_peer_received_packets;
+  u32bits t_peer_sent_packets;
+  u32bits t_peer_received_bytes;
+  u32bits t_peer_sent_bytes;
+  u64bits peer_received_rate;
+  size_t peer_sent_rate;
+  size_t peer_total_rate;
   /* Mobile */
   int is_mobile;
   mobile_id_t mobile_id;
@@ -143,6 +154,13 @@ struct turn_session_info {
 	u32bits received_rate;
 	u32bits sent_rate;
 	u32bits total_rate;
+	u64bits peer_received_packets;
+	u64bits peer_sent_packets;
+	u64bits peer_received_bytes;
+	u64bits peer_sent_bytes;
+	u32bits peer_received_rate;
+	u32bits peer_sent_rate;
+	u32bits peer_total_rate;
 /* Mobile */
 	int is_mobile;
 /* Peers */

--- a/turndb/schema.stats.redis
+++ b/turndb/schema.stats.redis
@@ -17,11 +17,17 @@ in the traffic information must subscribe to the events as:
 
 	psubscribe turn/realm/*/user/*/allocation/*/traffic
 
+Additionally peer traffic is available with the key "turn/user/<username>/allocation/<id>/traffic/peer". 
+The application that is interested in the peer traffic information must subscribe to the events as:
+
+	psubscribe turn/realm/*/user/*/allocation/*/traffic/peer
+
 Total traffic information is also reported when the allocation is deleted. The keys are
-"turn/user/<username>/allocation/<id>/total_traffic". Applications interested in the total amount
-of traffic per allocation can subscribe to these events as:
+"turn/user/<username>/allocation/<id>/total_traffic" or "turn/user/<username>/allocation/<id>/total_traffic/peer". 
+Applications interested in the total amount of traffic per allocation can subscribe to these events as:
 
 	psubscribe turn/realm/*/user/*/allocation/*/total_traffic
+	psubscribe turn/realm/*/user/*/allocation/*/total_traffic/peer
 	
 Or, to receive all allocation events:
 


### PR DESCRIPTION
I needed to track all outgoing bandwidth so I expanded the bandwidth reporting to also report bandwidth used by peers. The traffic is reported separately from the client traffic so no existing functionality is changed. 

The redis keys for the peer data are: 
/turn/realm/[realm]/user/[user]/allocation/[allocation]/traffic/peer
/turn/realm/[realm]/user/[user]/allocation/[allocation]/total_traffic/peer
/turn/user/[user]/allocation/[allocation]/traffic/peer
/turn/user/[user]/allocation/[allocation]/total_traffic/peer

I tested with the turnutils_uclient and turnutils_peer for both tcp and udp connections and everything seems correct. I was not able to test passive tcp because I don't really know what it is and when I try and start the turnutils_uclient with -P I get errors.