### PR TITLE
strip white-spaces from config file lines end

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1620,8 +1620,8 @@ static void read_config_file(int argc, char **argv, int pass)
 					continue;
 				size_t slen = strlen(s);
 
-				// strip white-spaces from config file lines end, use arg="value " syntax if you need space at the end
-				while (slen && ((s[slen - 1] == 10) || (s[slen - 1] == 13) || (s[slen - 1] == ' ')))
+				// strip white-spaces from config file lines end
+				while (slen && isspace(s[slen - 1]))
 					s[--slen] = 0;
 				if (slen) {
 					int c = 0;

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1619,7 +1619,9 @@ static void read_config_file(int argc, char **argv, int pass)
 				if (!s[0])
 					continue;
 				size_t slen = strlen(s);
-				while (slen && ((s[slen - 1] == 10) || (s[slen - 1] == 13)))
+
+				// strip white-spaces from config file lines end, use arg="value " syntax if you need space at the end
+				while (slen && ((s[slen - 1] == 10) || (s[slen - 1] == 13) || (s[slen - 1] == ' ')))
 					s[--slen] = 0;
 				if (slen) {
 					int c = 0;


### PR DESCRIPTION

Configfile lines with filenames for example could have a trailing white space,
which most editors don't show. The user gets "file not found" which is not 
trivial to debug, because this white space is almost invisible in the logfile also.

I suggest to strip white spaces at config file line ends for convenience of the sysadmins.

If you really need a white space in an config file value you might use the arg="value " syntax.