### PR TITLE
Set and expire rather than publishing statdb

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -3596,7 +3596,10 @@ void turn_report_session_usage(void *session, int force_invalid)
 					} else {
 						snprintf(key,sizeof(key),"turn/user/%s/allocation/%018llu/traffic",(char*)ss->username, (unsigned long long)(ss->id));
 					}
-					send_message_to_redis(e->rch, "publish", key, "rcvp=%lu, rcvb=%lu, sentp=%lu, sentb=%lu",(unsigned long)(ss->received_packets), (unsigned long)(ss->received_bytes),(unsigned long)(ss->sent_packets),(unsigned long)(ss->sent_bytes));
+					// Remove publishing and set and expire the key
+					//send_message_to_redis(e->rch, "publish", key, "rcvp=%lu, rcvb=%lu, sentp=%lu, sentb=%lu",(unsigned long)(ss->received_packets), (unsigned long)(ss->received_bytes),(unsigned long)(ss->sent_packets),(unsigned long)(ss->sent_bytes));
+					send_message_to_redis(e->rch, "set", key, "rcvp=%lu, rcvb=%lu, sentp=%lu, sentb=%lu",(unsigned long)(ss->received_packets), (unsigned long)(ss->received_bytes),(unsigned long)(ss->sent_packets),(unsigned long)(ss->sent_bytes));
+					send_message_to_redis(e->rch, "expire", key, "5");
 				}
 #endif
 				ss->t_received_packets += ss->received_packets;


### PR DESCRIPTION
**Why**
Coturn's statdb publish to Redis when the packets are turned. However, we want to set and expire that information in order to check if the user is still connected or not.

**Changes**
This PR set and expire for 5 seconds when the packets are turned.