### PR TITLE
Disconnect database gracefully

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_mongo.c
+++ b/src/apps/relay/dbdrivers/dbd_mongo.c
@@ -1349,6 +1349,15 @@ static int mongo_list_admin_users(int no_print)
 	return ret;
 }
 
+static void mongo_disconnect(void) {
+	MONGO * mongoconnection = (MONGO *) pthread_getspecific(connection_key);
+	if (mongoconnection) {
+		MongoFree(mongoconnection);
+		mongoconnection = NULL;
+	}
+	TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "MongoDB connection was closed.\n");
+}
+
 //////////////////////////////////////////////////////////
 
 static const turn_dbdriver_t driver = {
@@ -1376,7 +1385,8 @@ static const turn_dbdriver_t driver = {
   &mongo_get_admin_user,
   &mongo_set_admin_user,
   &mongo_del_admin_user,
-  &mongo_list_admin_users
+  &mongo_list_admin_users,
+  &mongo_disconnect
 };
 
 const turn_dbdriver_t * get_mongo_dbdriver(void) {

--- a/src/apps/relay/dbdrivers/dbd_mysql.c
+++ b/src/apps/relay/dbdrivers/dbd_mysql.c
@@ -1261,6 +1261,15 @@ static int mysql_list_admin_users(int no_print)
 	return ret;
 }
 
+static void mysql_disconnect(void) {
+	MYSQL *mydbconnection = (MYSQL*)pthread_getspecific(connection_key);
+	if (mydbconnection) {
+		mysql_close(mydbconnection);
+		mydbconnection=NULL;
+	}
+	TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "MySQL connection was closed.\n");
+}
+
 //////////////////////////////////////////////////////
 
 static const turn_dbdriver_t driver = {
@@ -1288,7 +1297,8 @@ static const turn_dbdriver_t driver = {
   &mysql_get_admin_user,
   &mysql_set_admin_user,
   &mysql_del_admin_user,
-  &mysql_list_admin_users
+  &mysql_list_admin_users,
+  &mysql_disconnect
 };
 
 const turn_dbdriver_t * get_mysql_dbdriver(void) {

--- a/src/apps/relay/dbdrivers/dbd_pgsql.c
+++ b/src/apps/relay/dbdrivers/dbd_pgsql.c
@@ -949,6 +949,15 @@ static int pgsql_list_admin_users(int no_print)
 	return ret;
 }
 
+static void pgsql_disconnect(void) {
+	PGconn *pqdbconnection = (PGconn*)pthread_getspecific(connection_key);
+	if (pqdbconnection) {
+		PQfinish(pqdbconnection);
+		pqdbconnection=NULL;
+	}
+	TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "PostgreSQL connection was closed.\n");
+}
+
 /////////////////////////////////////////////////////////////
 
 static const turn_dbdriver_t driver = {
@@ -976,7 +985,8 @@ static const turn_dbdriver_t driver = {
   &pgsql_get_admin_user,
   &pgsql_set_admin_user,
   &pgsql_del_admin_user,
-  &pgsql_list_admin_users
+  &pgsql_list_admin_users,
+  &pgsql_disconnect
 };
 
 const turn_dbdriver_t * get_pgsql_dbdriver(void) {

--- a/src/apps/relay/dbdrivers/dbd_redis.c
+++ b/src/apps/relay/dbdrivers/dbd_redis.c
@@ -1347,6 +1347,15 @@ static int redis_list_admin_users(int no_print)
   return ret;
 }
 
+static void redis_disconnect(void) {
+	redisContext *redisconnection = (redisContext*)pthread_getspecific(connection_key);
+	if (redisconnection) {
+		redisFree(redisconnection);
+		redisconnection = NULL;
+	}
+	TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Redis connection was closed.\n");
+}
+
 //////////////////////////////////////////////////////
 
 static const turn_dbdriver_t driver = {
@@ -1374,7 +1383,8 @@ static const turn_dbdriver_t driver = {
   &redis_get_admin_user,
   &redis_set_admin_user,
   &redis_del_admin_user,
-  &redis_list_admin_users
+  &redis_list_admin_users,
+  &redis_disconnect
 };
 
 const turn_dbdriver_t * get_redis_dbdriver(void) {

--- a/src/apps/relay/dbdrivers/dbd_sqlite.c
+++ b/src/apps/relay/dbdrivers/dbd_sqlite.c
@@ -1294,6 +1294,15 @@ static int sqlite_list_admin_users(int no_print)
 	return ret;
 }
 
+static void *sqlite_disconnect(void) {
+	sqlite3 *sqliteconnection = (sqlite3 *)pthread_getspecific(connection_key);
+	if (sqliteconnection) {
+		sqlite3_close(sqliteconnection);
+		sqliteconnection=NULL;
+	}
+	TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "SQLite connection was closed.\n");
+}
+
 ///////////////////////////////////////////////////////
 
 static const turn_dbdriver_t driver = {
@@ -1321,7 +1330,8 @@ static const turn_dbdriver_t driver = {
   &sqlite_get_admin_user,
   &sqlite_set_admin_user,
   &sqlite_del_admin_user,
-  &sqlite_list_admin_users
+  &sqlite_list_admin_users,
+  &sqlite_disconnect
 };
 
 //////////////////////////////////////////////////

--- a/src/apps/relay/dbdrivers/dbdriver.h
+++ b/src/apps/relay/dbdrivers/dbdriver.h
@@ -73,6 +73,7 @@ typedef struct _turn_dbdriver_t {
   int (*set_admin_user)(const uint8_t *usname, const uint8_t *realm, const password_t pwd);
   int (*del_admin_user)(const uint8_t *usname);
   int (*list_admin_users)(int no_print);
+  void (*disconnect)(void);
 } turn_dbdriver_t;
 
 /////////// USER DB CHECK //////////////////

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -29,6 +29,7 @@
  */
 
 #include "mainrelay.h"
+#include "dbdrivers/dbdriver.h"
 
 #if (defined LIBRESSL_VERSION_NUMBER && OPENSSL_VERSION_NUMBER == 0x20000000L)
 #undef OPENSSL_VERSION_NUMBER
@@ -1690,6 +1691,15 @@ static void read_config_file(int argc, char **argv, int pass)
 	}
 }
 
+static int disconnect_database(void)
+{
+	const turn_dbdriver_t * dbd = get_dbdriver();
+	if (dbd && dbd->disconnect) {
+			dbd->disconnect();
+	}
+	return 0;
+}
+
 static int adminmain(int argc, char **argv)
 {
 	int c = 0;
@@ -1907,7 +1917,11 @@ static int adminmain(int argc, char **argv)
 		exit(-1);
 	}
 
-	return adminuser(user, realm, pwd, secret, origin, ct, &po, is_admin);
+	int result = adminuser(user, realm, pwd, secret, origin, ct, &po, is_admin);
+
+	disconnect_database();
+
+	return result;
 }
 
 static void print_features(unsigned long mfn)
@@ -2413,6 +2427,8 @@ int main(int argc, char **argv)
 	drop_privileges();
 
 	run_listener_server(&(turn_params.listener));
+
+	disconnect_database();
 
 	return 0;
 }


### PR DESCRIPTION
Coturn does not disconnect database properly when shutdown.
This behavior causes accumulation of sockets for database with TIME_WAIT.
Especially, `turnadmin` is recommended to manage userdb,
but use of `turnadmin` from other application or scripts
can run out of socket resource due to above problem.

This patch adds database disconnection when shutdown
for both of `turnserver` and `turnadmin`.

Fixes #366