### PR TITLE
fix the webadmin ip permission add/delete sql injection

### DIFF
--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -3230,6 +3230,8 @@ static void handle_update_request(ioa_socket_handle s, struct http_request* hr)
 
 					if(current_realm()[0] && strcmp(current_realm(),r)) {
 						//forbidden
+					} else if (strcmp(kind, "allowed") != 0 && strcmp(kind, "denied") != 0) {
+						//forbidden
 					} else {
 
 						uint8_t realm[STUN_MAX_REALM_SIZE+1]="\0";
@@ -3262,6 +3264,8 @@ static void handle_update_request(ioa_socket_handle s, struct http_request* hr)
 						}
 
 						if(current_realm()[0] && strcmp(current_realm(),r)) {
+							//forbidden
+						} else if (strcmp(kind, "allowed") != 0 && strcmp(kind, "denied") != 0) {
 							//forbidden
 						} else {
 


### PR DESCRIPTION
Hello,

The web-admin handler "/update", used to add/delete ip permissions per realm, contains a sql-injection.

The URL parameters "dipk" and "aipk" (ip permission kind to delete/add) are taken from the URL and directly passed to the DB drivers (which most of them use this value as a table/collection prefix directly)

For example I was able to delete any of my sqlite tables with a simple forged GET request.

Of course, you need to be logged first, so the criticity is very limited, but if I send the forged link to an admin connected to the web-admin interface, if the admin open the link, he will delete the entries for me (because this request is a simple GET and not a POST).

To prevent this, I added simple checks because this "ip kind" value MUST be either "allowed" or "denied". Anything else should be considered as an error.

Thanks,
Thibaut.
