### PR TITLE
fix mongo driver crash when invalid connection string is used

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_mongo.c
+++ b/src/apps/relay/dbdrivers/dbd_mongo.c
@@ -89,6 +89,8 @@ static MONGO * get_mongodb_connection(void) {
 		mongoc_log_set_handler(&mongo_logger, NULL);
 
 		mydbconnection = (MONGO *) malloc(sizeof(MONGO));
+		bzero(mydbconnection, sizeof(MONGO));
+
 		mydbconnection->uri = mongoc_uri_new(pud->userdb);
 
 		if (!mydbconnection->uri) {


### PR DESCRIPTION
Hello, 

When configuring the --mongo-userdb (or -J) parameter to something invalid, like `127.0.0.1/coturn` instead of `mongodb://127.0.0.1/coturn` for example,

both the turnserver and the turnadmin command crash (see trace below).

Inside the mongo driver, the struct MONGO is allocated but not zero-ed so when trying to free some of its fields in MongoFree() method (in case of failure for example), it result in freeing undefined data. The fix is to zeromem the newly allocated structure.

> 0: ERROR: Cannot open parse MongoDB URI <127.0.0.1/coturn>, connection string format error
> *** Error in `./bin/turnserver': free(): invalid pointer: 0x00007fbb900001d8 ***
> ======= Backtrace: =========
> /lib/x86_64-linux-gnu/libc.so.6(+0x70bfb)[0x7fbbaf1c5bfb]
> /lib/x86_64-linux-gnu/libc.so.6(+0x76fc6)[0x7fbbaf1cbfc6]
> /lib/x86_64-linux-gnu/libc.so.6(+0x7780e)[0x7fbbaf1cc80e]
> /usr/lib/x86_64-linux-gnu/libbson-1.0.so.0(bson_destroy+0x34)[0x7fbbaf92ec04]
> /usr/lib/x86_64-linux-gnu/libmongoc-1.0.so.0(mongoc_write_concern_destroy+0x34)[0x7fbbafb96524]
> /usr/lib/x86_64-linux-gnu/libmongoc-1.0.so.0(mongoc_client_destroy+0x2d)[0x7fbbafb66fed]
> ./bin/turnserver(+0x411c3)[0x564f3640f1c3]
> ./bin/turnserver(+0x4126e)[0x564f3640f26e]
> ./bin/turnserver(+0x41353)[0x564f3640f353]
> ./bin/turnserver(+0x44d10)[0x564f36412d10]
> ./bin/turnserver(+0x45094)[0x564f36413094]
> ./bin/turnserver(+0x32126)[0x564f36400126]
> ./bin/turnserver(+0x3217d)[0x564f3640017d]
> ./bin/turnserver(+0x1fec1)[0x564f363edec1]
> /lib/x86_64-linux-gnu/libpthread.so.0(+0x74a4)[0x7fbbaf4fb4a4]
> /lib/x86_64-linux-gnu/libc.so.6(clone+0x3f)[0x7fbbaf23dd0f]
> ======= Memory map: ========
> [...]
> Aborted

Thanks,
Thibaut