### PR TITLE
Timestamp parameter seems ignored in webadmin oauth key creation.

### DIFF
--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -3664,8 +3664,8 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh)
 					}
 
 					const char* add_kid = "";
-					const char* add_ts = "0";
-					const char* add_lt = "0";
+					const char* add_ts = "";
+					const char* add_lt = "";
 					const char* add_ikm = "";
 					const char* add_tea = "";
 					const char* add_realm = "";
@@ -3712,8 +3712,8 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh)
 									msg = "Cannot insert oAuth key into the database";
 								} else {
 									add_kid = "";
-									add_ts = "0";
-									add_lt = "0";
+									add_ts = "";
+									add_lt = "";
 									add_ikm = "";
 									add_tea = "";
 									add_realm = "";


### PR DESCRIPTION
Hello,

When opening the webadmin oAuth key page and trying to create a new key, if you fill the "Timestamp" field with a value (and the other required fields) but leave the "Lifetime" parameter to its default value "0" then the key will be created with values:
- Lifetime: 0
- Timestamp: 0
which is not expected.

Because in the code, the value "0" for lifetime is **not** considered as empty, but when it is 0  t ignores the timestamp. cf:

https://github.com/coturn/coturn/blob/c4477bfddd2cd51de1ad37032ca88330f3c44ed6/src/apps/relay/turn_admin_server.c#L3690-L3692

I made the default values 'empty values' which then works as expected, if I open the form, fill the Timestamp and click create, the value Timestamp is used.

If you prefer I can keep the "0" value as default and change the behaviour to make it consider "0" as empty value.

Thanks,
Thibaut.