### PR TITLE
Allow MD5 in FIPS mode

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -238,14 +238,25 @@ int stun_produce_integrity_key_str(uint8_t *uname, uint8_t *realm, uint8_t *upwd
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 		unsigned int keylen = 0;
 		EVP_MD_CTX ctx;
-		EVP_DigestInit(&ctx,EVP_md5());
+		EVP_MD_CTX_init(&ctx);
+#ifdef OPENSSL_FIPS
+		if (FIPS_mode()) {
+			EVP_MD_CTX_set_flags(&ctx,EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+		}
+#endif
+		EVP_DigestInit_ex(&ctx,EVP_md5(), NULL);
 		EVP_DigestUpdate(&ctx,str,strl);
 		EVP_DigestFinal(&ctx,key,&keylen);
 		EVP_MD_CTX_cleanup(&ctx);
 #else
 		unsigned int keylen = 0;
 		EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-		EVP_DigestInit(ctx,EVP_md5());
+#ifdef OPENSSL_FIPS
+		if (FIPS_mode()) {
+			EVP_MD_CTX_set_flags(ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+		}
+#endif
+		EVP_DigestInit_ex(ctx,EVP_md5(), NULL);
 		EVP_DigestUpdate(ctx,str,strl);
 		EVP_DigestFinal(ctx,key,&keylen);
 		EVP_MD_CTX_free(ctx);

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -235,10 +235,21 @@ int stun_produce_integrity_key_str(uint8_t *uname, uint8_t *realm, uint8_t *upwd
 		return -1;
 #endif
 	} else {
-		MD5_CTX ctx;
-		MD5_Init(&ctx);
-		MD5_Update(&ctx,str,strl);
-		MD5_Final(key,&ctx);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+		unsigned int keylen = 0;
+		EVP_MD_CTX ctx;
+		EVP_DigestInit(&ctx,EVP_md5());
+		EVP_DigestUpdate(&ctx,str,strl);
+		EVP_DigestFinal(&ctx,key,&keylen);
+		EVP_MD_CTX_cleanup(&ctx);
+#else
+		unsigned int keylen = 0;
+		EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+		EVP_DigestInit(ctx,EVP_md5());
+		EVP_DigestUpdate(ctx,str,strl);
+		EVP_DigestFinal(ctx,key,&keylen);
+		EVP_MD_CTX_free(ctx);
+#endif
 	}
 
 	free(str);

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -239,11 +239,9 @@ int stun_produce_integrity_key_str(uint8_t *uname, uint8_t *realm, uint8_t *upwd
 		unsigned int keylen = 0;
 		EVP_MD_CTX ctx;
 		EVP_MD_CTX_init(&ctx);
-#ifdef OPENSSL_FIPS
 		if (FIPS_mode()) {
 			EVP_MD_CTX_set_flags(&ctx,EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
 		}
-#endif
 		EVP_DigestInit_ex(&ctx,EVP_md5(), NULL);
 		EVP_DigestUpdate(&ctx,str,strl);
 		EVP_DigestFinal(&ctx,key,&keylen);
@@ -251,11 +249,9 @@ int stun_produce_integrity_key_str(uint8_t *uname, uint8_t *realm, uint8_t *upwd
 #else
 		unsigned int keylen = 0;
 		EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-#ifdef OPENSSL_FIPS
 		if (FIPS_mode()) {
 			EVP_MD_CTX_set_flags(ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
 		}
-#endif
 		EVP_DigestInit_ex(ctx,EVP_md5(), NULL);
 		EVP_DigestUpdate(ctx,str,strl);
 		EVP_DigestFinal(ctx,key,&keylen);


### PR DESCRIPTION
This is one of those special cases where a non approved cryptographic
algorithm is allowed when operating in FIPS mode. Inform OpenSSL that
this is the case.

In the STUN RFC the long-term credential mechanism requires that the key
used in the HMAC-SHA1 generation be the MD5 of specific values:
https://tools.ietf.org/html/rfc5389#section-15.4

Since this is obfuscating parameters to be used in an approved
cryptographic algorithm, this is allowed usage per the [FIPS 140-2 Implementation Guidance](https://csrc.nist.gov/csrc/media/projects/cryptographic-module-validation-program/documents/fips140-2/fips1402ig.pdf).
See page 81.

Without this change, coturn crashes when trying to set up any long-term
credential mechanism.