### PR TITLE
Updated incorrect string length check for 'ssh'

### DIFF
--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -556,7 +556,7 @@ int get_default_protocol_port(const char* scheme, size_t slen)
 				return 21;
 			if(!memcmp("svn",scheme,3))
 				return 3690;
-			if(!memcmp("ssh",scheme,4))
+			if(!memcmp("ssh",scheme,3))
 				return 22;
 			if(!memcmp("sip",scheme,3))
 				return 5060;


### PR DESCRIPTION
ssh length should be 3, but checking for 4. So updated memcmp method to 3 instead of 4.