### PR TITLE
Updated turnserver.conf to fix typos and grammar to clarify documentation. 

### DIFF
--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -1,9 +1,9 @@
 # Coturn TURN SERVER configuration file
 #
-# Boolean values note: where boolean value is supposed to be used,
-# you can use '0', 'off', 'no', 'false', 'f' as 'false, 
-# and you can use '1', 'on', 'yes', 'true', 't' as 'true' 
-# If the value is missed, then it means 'true'.
+# Boolean values note: where a boolean value is supposed to be used,
+# you can use '0', 'off', 'no', 'false', or 'f' as 'false, 
+# and you can use '1', 'on', 'yes', 'true', or 't' as 'true' 
+# If the value is missing, then it means 'true' by default.
 #
 
 # Listener interface device (optional, Linux only).
@@ -22,10 +22,10 @@
 # port(s), too - if allowed by configuration. The TURN server 
 # "automatically" recognizes the type of traffic. Actually, two listening
 # endpoints (the "plain" one and the "tls" one) are equivalent in terms of
-# functionality; but we keep both endpoints to satisfy the RFC 5766 specs.
-# For secure TCP connections, we currently support SSL version 3 and 
+# functionality; but Coturn keeps both endpoints to satisfy the RFC 5766 specs.
+# For secure TCP connections, Coturn currently supports SSL version 3 and 
 # TLS version 1.0, 1.1 and 1.2.
-# For secure UDP connections, we support DTLS version 1.
+# For secure UDP connections, Coturn supports DTLS version 1.
 #
 #tls-listening-port=5349
 
@@ -133,8 +133,8 @@
 #
 # If this parameter is not set, then the default OS-dependent 
 # thread pattern algorithm will be employed. Usually the default
-# algorithm is the most optimal, so you have to change this option
-# only if you want to make some fine tweaks. 
+# algorithm is optimal, so you have to change this option
+# if you want to make some fine tweaks. 
 #
 # In the older systems (Linux kernel before 3.9),
 # the number of UDP threads is always one thread per network listening
@@ -155,7 +155,7 @@
 	
 # Uncomment to run TURN server in 'extra' verbose mode.
 # This mode is very annoying and produces lots of output.
-# Not recommended under any normal circumstances.
+# Not recommended under normal circumstances.
 #	
 #Verbose
 
@@ -169,11 +169,11 @@
 #
 #lt-cred-mech
 
-# This option is opposite to lt-cred-mech. 
+# This option is the opposite of lt-cred-mech. 
 # (TURN Server with no-auth option allows anonymous access).
 # If neither option is defined, and no users are defined,
 # then no-auth is default. If at least one user is defined, 
-# in this file or in command line or in usersdb file, then
+# in this file, in command line or in usersdb file, then
 # lt-cred-mech is default.
 #
 #no-auth
@@ -193,34 +193,33 @@
 # turn password -> base64(hmac(secret key, usercombo))
 #
 # This allows TURN credentials to be accounted for a specific user id.
-# If you don't have a suitable id, the timestamp alone can be used.
-# This option is just turning on secret-based authentication.
-# The actual value of the secret is defined either by option static-auth-secret,
+# If you don't have a suitable id, then the timestamp alone can be used.
+# This option is enabled by turning on secret-based authentication.
+# The actual value of the secret is defined either by the option static-auth-secret,
 # or can be found in the turn_secret table in the database (see below).
 # 
 # Read more about it:
 #  - https://tools.ietf.org/html/draft-uberti-behave-turn-rest-00
 #  - https://www.ietf.org/proceedings/87/slides/slides-87-behave-10.pdf
 #
-# Be aware that use-auth-secret overrides some part of lt-cred-mech.
-# Notice that this feature depends internally on lt-cred-mech, so if you set
-# use-auth-secret then it enables internally automatically lt-cred-mech option
-# like if you enable both.
+# Be aware that use-auth-secret overrides some parts of lt-cred-mech.
+# The use-auth-secret feature depends internally on lt-cred-mech, so if you set
+# this option then it automatically enables lt-cred-mech internally
+# as if you had enabled both.
 #
-# You can use only one auth mechanisms in the same time because,
-# both mechanism use the username and password validation in different way.
-#
-# This way be aware that you can't use both auth mechnaism in the same time!
-# Use in config either the lt-cred-mech or the use-auth-secret
+# Note that you can use only one auth mechanism at the same time! This is because,
+# both mechanisms conduct username and password validation in different ways.
+# 
+# Use either lt-cred-mech or use-auth-secret in the conf
 # to avoid any confusion.
 #
 #use-auth-secret
 
 # 'Static' authentication secret value (a string) for TURN REST API only. 
 # If not set, then the turn server
-# will try to use the 'dynamic' value in turn_secret table
-# in user database (if present). The database-stored  value can be changed on-the-fly
-# by a separate program, so this is why that other mode is 'dynamic'.
+# will try to use the 'dynamic' value in the turn_secret table
+# in the user database (if present). The database-stored  value can be changed on-the-fly
+# by a separate program, so this is why that mode is considered 'dynamic'.
 #
 #static-auth-secret=north
 
@@ -234,10 +233,10 @@
 #
 #oauth
 
-# 'Static' user accounts for long term credentials mechanism, only.
+# 'Static' user accounts for the long term credentials mechanism, only.
 # This option cannot be used with TURN REST API.
 # 'Static' user accounts are NOT dynamically checked by the turnserver process, 
-# so that they can NOT be changed while the turnserver is running.
+# so they can NOT be changed while the turnserver is running.
 #
 #user=username1:key1
 #user=username2:key2
@@ -263,14 +262,14 @@
 
 # SQLite database file name.
 #
-# Default file name is /var/db/turndb or /usr/local/var/db/turndb or
+# The default file name is /var/db/turndb or /usr/local/var/db/turndb or
 # /var/lib/turn/turndb.
 # 
 #userdb=/var/db/turndb
 
-# PostgreSQL database connection string in the case that we are using PostgreSQL
+# PostgreSQL database connection string in the case that you are using PostgreSQL
 # as the user database.
-# This database can be used for long-term credential mechanism
+# This database can be used for the long-term credential mechanism
 # and it can store the secret value for secret-based timed authentication in TURN REST API. 
 # See http://www.postgresql.org/docs/8.4/static/libpq-connect.html for 8.x PostgreSQL
 # versions connection string format, see 
@@ -279,9 +278,9 @@
 #
 #psql-userdb="host=<host> dbname=<database-name> user=<database-user> password=<database-user-password> connect_timeout=30"
 
-# MySQL database connection string in the case that we are using MySQL
+# MySQL database connection string in the case that you are using MySQL
 # as the user database.
-# This database can be used for long-term credential mechanism
+# This database can be used for the long-term credential mechanism
 # and it can store the secret value for secret-based timed authentication in TURN REST API.
 #
 # Optional connection string parameters for the secure communications (SSL): 
@@ -289,33 +288,33 @@
 # (see http://dev.mysql.com/doc/refman/5.1/en/ssl-options.html for the 
 # command options description).
 #
-# Use string format as below (space separated parameters, all optional):
+# Use the string format below (space separated parameters, all optional):
 #
 #mysql-userdb="host=<host> dbname=<database-name> user=<database-user> password=<database-user-password> port=<port> connect_timeout=<seconds> read_timeout=<seconds>"
 
-# If you want to use in the MySQL connection string the password in encrypted format,
-# then set in this option the MySQL password encryption secret key file.
+# If you want to use an encrypted password in the MySQL connection string,
+# then set the MySQL password encryption secret key file with this option.
 #
-# Warning: If this option is set, then mysql password must be set in "mysql-userdb" in encrypted format! 
-# If you want to use cleartext password then do not set this option!
+# Warning: If this option is set, then the mysql password must be set in "mysql-userdb" in an encrypted format! 
+# If you want to use a cleartext password then do not set this option!
 #
-# This is the file path which contain secret key of aes encryption while using password encryption.
+# This is the file path for the aes encrypted secret key used for password encryption.
 #
 #secret-key-file=/path/
 
-# MongoDB database connection string in the case that we are using MongoDB
+# MongoDB database connection string in the case that you are using MongoDB
 # as the user database.
 # This database can be used for long-term credential mechanism
 # and it can store the secret value for secret-based timed authentication in TURN REST API. 
-# Use string format is described at http://hergert.me/docs/mongo-c-driver/mongoc_uri.html
+# Use the string format described at http://hergert.me/docs/mongo-c-driver/mongoc_uri.html
 #
 #mongo-userdb="mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]"
 
-# Redis database connection string in the case that we are using Redis
+# Redis database connection string in the case that you are using Redis
 # as the user database.
 # This database can be used for long-term credential mechanism
 # and it can store the secret value for secret-based timed authentication in TURN REST API. 
-# Use string format as below (space separated parameters, all optional):
+# Use the string format below (space separated parameters, all optional):
 #
 #redis-userdb="ip=<ip-address> dbname=<database-number> password=<database-user-password> port=<port> connect_timeout=<seconds>"
 
@@ -323,23 +322,23 @@
 # This database keeps allocations status information, and it can be also used for publishing
 # and delivering traffic and allocation event notifications.
 # The connection string has the same parameters as redis-userdb connection string. 
-# Use string format as below (space separated parameters, all optional):
+# Use the string format below (space separated parameters, all optional):
 #
 #redis-statsdb="ip=<ip-address> dbname=<database-number> password=<database-user-password> port=<port> connect_timeout=<seconds>"
 
 # The default realm to be used for the users when no explicit 
-# origin/realm relationship was found in the database, or if the TURN
+# origin/realm relationship is found in the database, or if the TURN
 # server is not using any database (just the commands-line settings
 # and the userdb file). Must be used with long-term credentials 
 # mechanism or with TURN REST API.
 #
-# Note: If default realm is not specified at all, then realm falls back to the host domain name.
-#       If domain name is empty string, or '(None)', then it is initialized to am empty string.
+# Note: If the default realm is not specified, then realm falls back to the host domain name.
+#       If the domain name string is empty, or set to '(None)', then it is initialized as an empty string.
 #
 #realm=mycompany.org
 
-# The flag that sets the origin consistency 
-# check: across the session, all requests must have the same
+# This flag sets the origin consistency 
+# check. Across the session, all requests must have the same
 # main ORIGIN attribute value (if the ORIGIN was
 # initially used by the session).
 #
@@ -359,7 +358,7 @@
 
 # Max bytes-per-second bandwidth a TURN session is allowed to handle
 # (input and output network streams are treated separately). Anything above
-# that limit will be dropped or temporary suppressed (within
+# that limit will be dropped or temporarily suppressed (within
 # the available buffer limits).
 # This option can also be set through the database, for a particular realm.
 #
@@ -403,9 +402,9 @@
 #no-tcp-relay
 
 # Uncomment if extra security is desired,
-# with nonce value having limited lifetime.
+# with nonce value having a limited lifetime.
 # By default, the nonce value is unique for a session,
-# and has unlimited lifetime. 
+# and has an unlimited lifetime. 
 # Set this option to limit the nonce lifetime. 
 # It defaults to 600 secs (10 min) if no value is provided. After that delay, 
 # the client will get 438 error and will have to re-authenticate itself.
@@ -435,6 +434,7 @@
 # Certificate file.
 # Use an absolute path or path relative to the 
 # configuration file.
+# Use PEM file format.
 #
 #cert=/usr/local/etc/turn_server_cert.pem
 
@@ -457,7 +457,7 @@
 
 # CA file in OpenSSL format. 
 # Forces TURN server to verify the client SSL certificates.
-# By default it is not set: there is no default value and the client
+# By default this is not set: there is no default value and the client
 # certificate is not checked.
 #
 # Example:
@@ -485,16 +485,16 @@
 #dh-file=<DH-PEM-file-name>
 
 # Flag to prevent stdout log messages.
-# By default, all log messages are going to both stdout and to 
-# the configured log file. With this option everything will be 
-# going to the configured log only (unless the log file itself is stdout).
+# By default, all log messages go to both stdout and to 
+# the configured log file. With this option everything will 
+# go to the configured log only (unless the log file itself is stdout).
 #
 #no-stdout-log
 
 # Option to set the log file name.
 # By default, the turnserver tries to open a log file in 
-# /var/log, /var/tmp, /tmp and current directories directories
-# (which open operation succeeds first that file will be used).
+# /var/log, /var/tmp, /tmp and the current directory
+# (Whichever file open operation succeeds first will be used).
 # With this option you can set the definite log file name.
 # The special names are "stdout" and "-" - they will force everything 
 # to the stdout. Also, the "syslog" name will force everything to
@@ -515,14 +515,14 @@
 #simple-log
 
 # Option to set the "redirection" mode. The value of this option
-# will be the address of the alternate server for UDP & TCP service in form of 
+# will be the address of the alternate server for UDP & TCP service in the form of 
 # <ip>[:<port>]. The server will send this value in the attribute
 # ALTERNATE-SERVER, with error 300, on ALLOCATE request, to the client.
 # Client will receive only values with the same address family
 # as the client network endpoint address family. 
-# See RFC 5389 and RFC 5766 for ALTERNATE-SERVER functionality description. 
+# See RFC 5389 and RFC 5766 for the description of ALTERNATE-SERVER functionality. 
 # The client must use the obtained value for subsequent TURN communications.
-# If more than one --alternate-server options are provided, then the functionality
+# If more than one --alternate-server option is provided, then the functionality
 # can be more accurately described as "load-balancing" than a mere "redirection". 
 # If the port number is omitted, then the default port 
 # number 3478 for the UDP/TCP protocols will be used.
@@ -532,7 +532,7 @@
 # [2001:db8:85a3:8d3:1319:8a2e:370:7348]:3478 . 
 # Multiple alternate servers can be set. They will be used in the
 # round-robin manner. All servers in the pool are considered of equal weight and 
-# the load will be distributed equally. For example, if we have 4 alternate servers, 
+# the load will be distributed equally. For example, if you have 4 alternate servers, 
 # then each server will receive 25% of ALLOCATE requests. A alternate TURN server 
 # address can be used more than one time with the alternate-server option, so this 
 # can emulate "weighting" of the servers.
@@ -629,12 +629,12 @@
 
 
 # User name to run the process. After the initialization, the turnserver process
-# will make an attempt to change the current user ID to that user.
+# will attempt to change the current user ID to that user.
 #
 #proc-user=<user-name>
 
 # Group name to run the process. After the initialization, the turnserver process
-# will make an attempt to change the current group ID to that group.
+# will attempt to change the current group ID to that group.
 #
 #proc-group=<group-name>
 
@@ -654,8 +654,8 @@
 #cli-port=5766
 
 # CLI access password. Default is empty (no password).
-# For the security reasons, it is recommended to use the encrypted
-# for of the password (see the -P command in the turnadmin utility).
+# For the security reasons, it is recommended that you use the encrypted
+# form of the password (see the -P command in the turnadmin utility).
 #
 # Secure form for password 'qwerty':
 #
@@ -685,7 +685,7 @@
 #web-admin-listen-on-workers
 
 # Server relay. NON-STANDARD AND DANGEROUS OPTION. 
-# Only for those applications when we want to run 
+# Only for those applications when you want to run 
 # server applications on the relay endpoints.
 # This option eliminates the IP permissions check on 
 # the packets incoming to the relay endpoints.


### PR DESCRIPTION
Edited turnserver.conf to fix typos and grammar and clarify explanations of various options for documentation. 