### PR TITLE
added null check for second char

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -786,7 +786,7 @@ void print_abs_file_name(const char *msg1, const char *msg2, const char *fn)
       if(fn[0]=='/') {
 	STRCPY(absfn,fn);
       } else {
-	if(fn[0]=='.' && fn[1]=='/')
+	if(fn[0]=='.' && fn[1] && fn[1]=='/')
 	  fn+=2;
 	if(!getcwd(absfn,sizeof(absfn)-1))
 	  absfn[0]=0;


### PR DESCRIPTION
There is a null check for the first char fn[0], but missing for second char fn[1], so added null check for the second character before access.