### PR TITLE
Add additional input validation for STUN messages

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -360,7 +360,14 @@ int stun_get_command_message_len_str(const uint8_t* buf, size_t len)
 {
 	if (len < STUN_HEADER_LENGTH)
 		return -1;
-	return (int) (nswap16(((const uint16_t*)(buf))[1]) + STUN_HEADER_LENGTH);
+
+	/* Validate the size the buffer claims to be */
+	int bufLen = (int) (nswap16(((const uint16_t*)(buf))[1]) + STUN_HEADER_LENGTH);
+	if (bufLen > len) {
+		return -1;
+	}
+
+	return bufLen;
 }
 
 static int stun_set_command_message_len_str(uint8_t* buf, int len) {


### PR DESCRIPTION
The STUN attribute API wasn't checking that the size the buffer reported itself to be was not greater than the size of the buffer available, and `stun_attr_ref`s were not size-checked before being returned to the caller.