### PR TITLE
turnserver.conf: add --prod section to enhance security

### DIFF
--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -575,6 +575,15 @@ syslog
 #
 #stun-only
 
+# Option to hide software version. Enhance security when used in production.
+# Revealing the specific software version of the agent through the
+# SOFTWARE attribute might allow them to become more vulnerable to
+# attacks against software that is known to contain security holes.
+# Implementers SHOULD make usage of the SOFTWARE attribute a
+# configurable option (https://tools.ietf.org/html/rfc5389#section-16.1.2)
+#
+#prod
+
 # Option to suppress STUN functionality, only TURN requests will be processed.
 # Run as TURN server only, all STUN requests will be ignored.
 # By default, this option is NOT set.

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -559,6 +559,15 @@
 #
 #stun-only
 
+# Option to hide software version. Enhance security when used in production.
+# Revealing the specific software version of the agent through the
+# SOFTWARE attribute might allow them to become more vulnerable to
+# attacks against software that is known to contain security holes.
+# Implementers SHOULD make usage of the SOFTWARE attribute a
+# configurable option (https://tools.ietf.org/html/rfc5389#section-16.1.2)
+#
+#prod
+
 # Option to suppress STUN functionality, only TURN requests will be processed.
 # Run as TURN server only, all STUN requests will be ignored.
 # By default, this option is NOT set.


### PR DESCRIPTION
As reported by [RFC:](https://tools.ietf.org/html/rfc5389#section-16.1.2)
```
Revealing the specific software version of the agent through the
SOFTWARE attribute might allow them to become more vulnerable to
attacks against software that is known to contain security holes.
Implementers SHOULD make usage of the SOFTWARE attribute a
configurable option.
```
Just add `prod` to the configuration file to hide software version in Binding Success Response

![image](https://user-images.githubusercontent.com/1625334/71191778-5fb75080-2287-11ea-8f6a-0232de5ec8bb.png)
