### PR TITLE
Rename "prod" config option to "no-software-attribute"

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -158,7 +158,7 @@ Flags:
 
 -o, --daemon		Run server as daemon.
 
---prod       	 	Production mode: hide the software version.
+--no-software-attribute	Production mode: hide the software version.
 
 -f, --fingerprint	Use fingerprints in the TURN messages. If an incoming request
 			contains a fingerprint, then TURN server will always add 

--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -582,7 +582,7 @@ syslog
 # Implementers SHOULD make usage of the SOFTWARE attribute a
 # configurable option (https://tools.ietf.org/html/rfc5389#section-16.1.2)
 #
-#prod
+#no-software-attribute
 
 # Option to suppress STUN functionality, only TURN requests will be processed.
 # Run as TURN server only, all STUN requests will be ignored.

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -566,7 +566,7 @@
 # Implementers SHOULD make usage of the SOFTWARE attribute a
 # configurable option (https://tools.ietf.org/html/rfc5389#section-16.1.2)
 #
-#prod
+#no-software-attribute
 
 # Option to suppress STUN functionality, only TURN requests will be processed.
 # Run as TURN server only, all STUN requests will be ignored.

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -236,8 +236,8 @@ Extra verbose mode, very annoying and not recommended.
 Run server as daemon.
 .TP
 .B
-\fB\-\-prod\fP
-Production mode: hide the software version.
+\fB\-\-no-software-attribute\fP
+Do not send the software version. Should be used in production.
 .TP
 .B
 \fB\-f\fP, \fB\-\-fingerprint\fP

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -448,7 +448,7 @@ static char Usage[] = "Usage: turnserver [options]\n"
 " -v, --verbose					'Moderate' verbose mode.\n"
 " -V, --Verbose					Extra verbose mode, very annoying (for debug purposes only).\n"
 " -o, --daemon					Start process as daemon (detach from current shell).\n"
-" --prod       	 				Production mode: hide the software version.\n"
+" --no-software-attribute	 		Production mode: hide the software version (formerly --prod).\n"
 " -f, --fingerprint				Use fingerprints in the TURN messages.\n"
 " -a, --lt-cred-mech				Use the long-term credential mechanism.\n"
 " -z, --no-auth					Do not use any credential mechanism, allow anonymous access.\n"
@@ -779,7 +779,7 @@ enum EXTRA_OPTS {
 	ADMIN_USER_QUOTA_OPT,
 	SERVER_NAME_OPT,
 	OAUTH_OPT,
-	PROD_OPT,
+	NO_SOFTWARE_ATTRIBUTE_OPT,
 	NO_HTTP_OPT,
 	SECRET_KEY_OPT
 };
@@ -844,7 +844,8 @@ static const struct myoption long_options[] = {
 				{ "verbose", optional_argument, NULL, 'v' },
 				{ "Verbose", optional_argument, NULL, 'V' },
 				{ "daemon", optional_argument, NULL, 'o' },
-				{ "prod", optional_argument, NULL, PROD_OPT },
+/* deprecated: */		{ "prod", optional_argument, NULL, NO_SOFTWARE_ATTRIBUTE_OPT },
+				{ "no-software-attribute", optional_argument, NULL, NO_SOFTWARE_ATTRIBUTE_OPT },
 				{ "fingerprint", optional_argument, NULL, 'f' },
 				{ "check-origin-consistency", optional_argument, NULL, CHECK_ORIGIN_CONSISTENCY_OPT },
 				{ "no-udp", optional_argument, NULL, NO_UDP_OPT },
@@ -1378,8 +1379,8 @@ static void set_option(int c, char *value)
 			anon_credentials = 1;
 		}
 		break;
-	case PROD_OPT:
-		turn_params.prod = get_bool_value(value);
+	case NO_SOFTWARE_ATTRIBUTE_OPT:
+		turn_params.no_software_attribute = get_bool_value(value);
 		break;
 	case 'f':
 		turn_params.fingerprint = get_bool_value(value);

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -213,7 +213,7 @@ typedef struct _turn_params_ {
 
   int verbose;
   int turn_daemon;
-  int prod;
+  int no_software_attribute;
   int web_admin_listen_on_workers;
 
   int do_not_use_config_file;

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1651,7 +1651,7 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
 			 &turn_params.permission_lifetime,
 			 &turn_params.stun_only,
 			 &turn_params.no_stun,
-			 &turn_params.prod,
+			 &turn_params.no_software_attribute,
 			 &turn_params.web_admin_listen_on_workers,
 			 &turn_params.alternate_servers_list,
 			 &turn_params.tls_alternate_servers_list,

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -1659,7 +1659,7 @@ static void https_finish_page(struct str_buffer *sb, ioa_socket_handle s, int cc
 	str_buffer_append(sb,"</body>\r\n</html>\r\n");
 
 	send_str_from_ioa_socket_tcp(s,"HTTP/1.1 200 OK\r\nServer: ");
-	if(!turn_params.prod) {
+	if(!turn_params.no_software_attribute) {
 		send_str_from_ioa_socket_tcp(s,TURN_SOFTWARE);
 	}
 	send_str_from_ioa_socket_tcp(s,"\r\n");

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -64,7 +64,7 @@ static inline int get_family(int stun_family, ioa_engine_handle e, ioa_socket_ha
 ////////////////////////////////////////////////
 
 const char * get_version(turn_turnserver *server) {
-	if(server && !*server->prod) {
+	if(server && !*server->no_software_attribute) {
 		return (const char *) TURN_SOFTWARE;
 	} else {
 		return (const char *) "None";
@@ -4900,7 +4900,7 @@ void init_turn_server(turn_turnserver* server,
 		vintp permission_lifetime,
 		vintp stun_only,
 		vintp no_stun,
-		vintp prod,
+		vintp no_software_attribute,
     vintp web_admin_listen_on_workers,
 		turn_server_addrs_list_t *alternate_servers_list,
 		turn_server_addrs_list_t *tls_alternate_servers_list,
@@ -4962,7 +4962,7 @@ void init_turn_server(turn_turnserver* server,
 	server->permission_lifetime = permission_lifetime;
 	server->stun_only = stun_only;
 	server->no_stun = no_stun;
-	server->prod = prod;
+	server->no_software_attribute = no_software_attribute;
 	server-> web_admin_listen_on_workers = web_admin_listen_on_workers;
 
 	server->dont_fragment = dont_fragment;

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -120,7 +120,7 @@ struct _turn_turnserver {
         vintp permission_lifetime;
 	vintp stun_only;
 	vintp no_stun;
-	vintp prod;
+	vintp no_software_attribute;
 	vintp web_admin_listen_on_workers;
 	vintp secure_stun;
 	turn_credential_type ct;
@@ -199,7 +199,7 @@ void init_turn_server(turn_turnserver* server,
                                     vintp permission_lifetime,
 				    vintp stun_only,
 				    vintp no_stun,
-				    vintp prod,
+				    vintp no_software_attribute,
 				    vintp web_admin_listen_on_workers,
 				    turn_server_addrs_list_t *alternate_servers_list,
 				    turn_server_addrs_list_t *tls_alternate_servers_list,


### PR DESCRIPTION
As discussed in #478, if the parameter only controls whether or not to send the software attribute and not other production-relevant configurations, it should be named accordingly.

The old --prod configuration option still works, but is now deprecated and undocumented.