### PR TITLE
Drop of supplementary group IDs

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -2061,6 +2061,7 @@ static void set_network_engine(void)
 
 static void drop_privileges(void)
 {
+	setgroups(0, NULL);
 	if(procgroupid_set) {
 		if(getgid() != procgroupid) {
 			if (setgid(procgroupid) != 0) {


### PR DESCRIPTION
Fix related to POS36-C and rpmlint error "missing-call-to-setgroups-before-setuid".