### PR TITLE
Remove reference to SSLv3

### DIFF
--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -23,7 +23,7 @@
 # "automatically" recognizes the type of traffic. Actually, two listening
 # endpoints (the "plain" one and the "tls" one) are equivalent in terms of
 # functionality; but Coturn keeps both endpoints to satisfy the RFC 5766 specs.
-# For secure TCP connections, Coturn currently supports SSL version 3 and 
+# For secure TCP connections, Coturn currently supports
 # TLS version 1.0, 1.1 and 1.2.
 # For secure UDP connections, Coturn supports DTLS version 1.
 #


### PR DESCRIPTION
Judging from the information provided here https://github.com/coturn/coturn/issues/220#issuecomment-371916988,
SSL isn't supported anymore so the reference should be removed from the config file.