### PR TITLE
Docker turnserver.conf edit (--allow-loopback-peers option)

### DIFF
--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -594,10 +594,17 @@ syslog
 # The default value is ':'.
 # rest-api-separator=:
 
-# Flag that can be used to disallow peers on the loopback addresses (127.x.x.x and ::1).
+# Flag that can be used to allow peers on the loopback addresses (127.x.x.x and ::1).
 # This is an extra security measure.
 #
-no-loopback-peers
+# (To avoid any security issue that allowing loopback access may raise,
+# the no-loopback-peers option is replaced by allow-loopback-peers.)
+#
+# Allow it only for testing in a development environment! 
+# In production it adds a possible security vulnerability, so for security reasons 
+# it is not allowed using it together with empty cli-password. 
+#
+#allow-loopback-peers
 
 # Flag that can be used to disallow peers on well-known broadcast addresses (224.0.0.0 and above, and FFXX:*).
 # This is an extra security measure.


### PR DESCRIPTION
In new turnserver.conf file, no more --no-loopback-peers option.

Docker turnserver.conf file should be edited.