### PR TITLE
tell tar to not include the metadata into release

### DIFF
--- a/examples/scripts/pack.sh
+++ b/examples/scripts/pack.sh
@@ -16,7 +16,8 @@ mkdir tmp
 cd tmp
 mkdir ${DDIR}
 cp -R ${SRCDIR}/* ${DDIR}/
-tar cvfz ../${DDIR}.tar.gz ${DDIR}
+#tell tar to not include the metadata
+COPYFILE_DISABLE=1 tar cvfz ../${DDIR}.tar.gz ${DDIR}
 cd ..
 rm -rf tmp
 


### PR DESCRIPTION
Hello! 
The latest release [https://coturn.net/turnserver/v4.5.1.2/turnserver-4.5.1.2.tar.gz] has a lot of Mac metadata files (._*).
This fix tells tar to not include the metadata into the release archive.