### PR TITLE
build RPM from local folder instead of git repo

### DIFF
--- a/rpm/build.settings.sh
+++ b/rpm/build.settings.sh
@@ -5,7 +5,6 @@
 TURNVERSION=4.5.1.2
 BUILDDIR=~/rpmbuild
 ARCH=`uname -p`
-TURNSERVER_GIT_URL=https://github.com/coturn/coturn.git
 
 WGETOPTIONS="--no-check-certificate"
 RPMOPTIONS="-ivh --force"

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -18,18 +18,11 @@ fi
 
 # TURN
 
+#create archive from local folder
 cd ${BUILDDIR}/tmp
 rm -rf turnserver-${TURNVERSION}
-git clone ${TURNSERVER_GIT_URL} --branch ${TURNVERSION} turnserver-${TURNVERSION}
-ER=$?
-if ! [ ${ER} -eq 0 ] ; then
-	git clone ${TURNSERVER_GIT_URL} turnserver-${TURNVERSION}
-	ER=$?
-	if ! [ ${ER} -eq 0 ] ; then
-    	cd ${CPWD}
-    	exit -1
-    fi
-fi
+mkdir -p ${BUILDDIR}/tmp/turnserver-${TURNVERSION}
+cp -R ${CPWD}/.. ${BUILDDIR}/tmp/turnserver-${TURNVERSION}
 
 tar zcf ${BUILDDIR}/SOURCES/turnserver-${TURNVERSION}.tar.gz turnserver-${TURNVERSION}
 ER=$?
@@ -38,6 +31,7 @@ if ! [ ${ER} -eq 0 ] ; then
     exit -1
 fi
 
+#build package from archive
 rpmbuild -ta ${BUILDDIR}/SOURCES/turnserver-${TURNVERSION}.tar.gz
 ER=$?
 if ! [ ${ER} -eq 0 ] ; then


### PR DESCRIPTION
Hello! 

RPM package build script always uses the master git repo, so it makes it hard to add local patches.
I had faced up with issue #556 and was surprised that my attempts to fix it ignored. So, I had to make this patch to have an ability to resolve the RPM-issue.