### PR TITLE
Fix misleading option in doc

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -265,8 +265,8 @@ Flags:
 			check: across the session, all requests must have the same
 			main ORIGIN attribute value (if the ORIGIN was
 			initially used by the session).
- --no-prometheus	Disable prometheus metrics. By default it is
-			enabled and listening on port 9641 unther the path /metrics
+ --prometheus		Enable prometheus metrics. By default it is
+			disabled. Would listen on port 9641 unther the path /metrics
 			also the path / on this port can be used as a health check
 
 -h			Help.


### PR DESCRIPTION
While that prometheus exporter was initially enabled by default, it looks like there's been a change of plan, resulting in some inconsistencies in the doc.

The `--no-prometheus` option was replaced by a `--prometheus` one -- according to https://github.com/wolmi/coturn/blob/master/src/apps/relay/mainrelay.c#L540