### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,42 @@ matrix:
     osx_image: xcode11.6
   - os: osx
     osx_image: xcode12
-
+  - os: linux
+    arch: ppc64le
+    dist: xenial
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - mysql-client
+        - debhelper
+        - dpkg-dev
+        - libssl-dev
+        - libevent-dev
+        - sqlite3
+        - libsqlite3-dev
+        - postgresql-client
+        - libpq-dev
+        - libmysqlclient-dev
+        - libhiredis-dev
+  - os: linux
+    arch: ppc64le
+    dist: bionic
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - mysql-client
+        - debhelper
+        - dpkg-dev
+        - libssl-dev
+        - libevent-dev
+        - sqlite3
+        - libsqlite3-dev
+        - postgresql-client
+        - libpq-dev
+        - libmysqlclient-dev
+        - libhiredis-dev
 
 notifications:
   slack:


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3