### PR TITLE
Delete trailing whitespace in example configuration files

### DIFF
--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -1,45 +1,45 @@
 # Coturn TURN SERVER configuration file
 #
 # Boolean values note: where a boolean value is supposed to be used,
-# you can use '0', 'off', 'no', 'false', or 'f' as 'false, 
-# and you can use '1', 'on', 'yes', 'true', or 't' as 'true' 
+# you can use '0', 'off', 'no', 'false', or 'f' as 'false,
+# and you can use '1', 'on', 'yes', 'true', or 't' as 'true'
 # If the value is missing, then it means 'true' by default.
 #
 
 # Listener interface device (optional, Linux only).
-# NOT RECOMMENDED. 
+# NOT RECOMMENDED.
 #
 #listening-device=eth0
 
 # TURN listener port for UDP and TCP (Default: 3478).
-# Note: actually, TLS & DTLS sessions can connect to the 
+# Note: actually, TLS & DTLS sessions can connect to the
 # "plain" TCP & UDP port(s), too - if allowed by configuration.
 #
 listening-port=3478
 
 # TURN listener port for TLS (Default: 5349).
 # Note: actually, "plain" TCP & UDP sessions can connect to the TLS & DTLS
-# port(s), too - if allowed by configuration. The TURN server 
+# port(s), too - if allowed by configuration. The TURN server
 # "automatically" recognizes the type of traffic. Actually, two listening
 # endpoints (the "plain" one and the "tls" one) are equivalent in terms of
 # functionality; but Coturn keeps both endpoints to satisfy the RFC 5766 specs.
-# For secure TCP connections, Coturn currently supports SSL version 3 and 
+# For secure TCP connections, Coturn currently supports SSL version 3 and
 # TLS version 1.0, 1.1 and 1.2.
 # For secure UDP connections, Coturn supports DTLS version 1.
 #
 tls-listening-port=5349
 
 # Alternative listening port for UDP and TCP listeners;
-# default (or zero) value means "listening port plus one". 
+# default (or zero) value means "listening port plus one".
 # This is needed for RFC 5780 support
-# (STUN extension specs, NAT behavior discovery). The TURN Server 
-# supports RFC 5780 only if it is started with more than one 
+# (STUN extension specs, NAT behavior discovery). The TURN Server
+# supports RFC 5780 only if it is started with more than one
 # listening IP address of the same family (IPv4 or IPv6).
 # RFC 5780 is supported only by UDP protocol, other protocols
 # are listening to that endpoint only for "symmetry".
 #
 #alt-listening-port=0
-							 
+
 # Alternative listening port for TLS and DTLS protocols.
 # Default (or zero) value means "TLS listening port plus one".
 #
@@ -52,9 +52,9 @@ tls-listening-port=5349
 # (https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
 #
 #tcp-proxy-port=5555
-	
+
 # Listener IP address of relay server. Multiple listeners can be specified.
-# If no IP(s) specified in the config file or in the command line options, 
+# If no IP(s) specified in the config file or in the command line options,
 # then all IPv4 and IPv6 system IPs will be used for listening.
 #
 #listening-ip=172.17.19.101
@@ -69,7 +69,7 @@ tls-listening-port=5349
 # they do not support STUN RFC 5780 functionality (CHANGE REQUEST).
 #
 # 2) Auxiliary servers also are never returning ALTERNATIVE-SERVER reply.
-# 
+#
 # Valid formats are 1.2.3.4:5555 for IPv4 and [1:2::3:4]:5555 for IPv6.
 #
 # There may be multiple aux-server options, each will be used for listening
@@ -81,7 +81,7 @@ tls-listening-port=5349
 # (recommended for older Linuxes only)
 # Automatically balance UDP traffic over auxiliary servers (if configured).
 # The load balancing is using the ALTERNATE-SERVER mechanism.
-# The TURN client must support 300 ALTERNATE-SERVER response for this 
+# The TURN client must support 300 ALTERNATE-SERVER response for this
 # functionality.
 #
 #udp-self-balance
@@ -91,13 +91,13 @@ tls-listening-port=5349
 #
 #relay-device=eth1
 
-# Relay address (the local IP address that will be used to relay the 
+# Relay address (the local IP address that will be used to relay the
 # packets to the peer).
 # Multiple relay addresses may be used.
 # The same IP(s) can be used as both listening IP(s) and relay IP(s).
 #
 # If no relay IP(s) specified, then the turnserver will apply the default
-# policy: it will decide itself which relay addresses to be used, and it 
+# policy: it will decide itself which relay addresses to be used, and it
 # will always be using the client socket IP address as the relay IP address
 # of the TURN session (if the requested relay address family is the same
 # as the family of the client socket).
@@ -120,7 +120,7 @@ tls-listening-port=5349
 # that option must be used several times, each entry must
 # have form "-X <public-ip/private-ip>", to map all involved addresses.
 # RFC5780 NAT discovery STUN functionality will work correctly,
-# if the addresses are mapped properly, even when the TURN server itself 
+# if the addresses are mapped properly, even when the TURN server itself
 # is behind A NAT.
 #
 # By default, this value is empty, and no address mapping is used.
@@ -135,18 +135,18 @@ external-ip=193.224.22.37
 
 # Number of the relay threads to handle the established connections
 # (in addition to authentication thread and the listener thread).
-# If explicitly set to 0 then application runs relay process in a 
-# single thread, in the same thread with the listener process 
+# If explicitly set to 0 then application runs relay process in a
+# single thread, in the same thread with the listener process
 # (the authentication thread will still be a separate thread).
 #
-# If this parameter is not set, then the default OS-dependent 
+# If this parameter is not set, then the default OS-dependent
 # thread pattern algorithm will be employed. Usually the default
 # algorithm is optimal, so you have to change this option
-# if you want to make some fine tweaks. 
+# if you want to make some fine tweaks.
 #
 # In the older systems (Linux kernel before 3.9),
 # the number of UDP threads is always one thread per network listening
-# endpoint - including the auxiliary endpoints - unless 0 (zero) or 
+# endpoint - including the auxiliary endpoints - unless 0 (zero) or
 # 1 (one) value is set.
 #
 #relay-threads=0
@@ -156,15 +156,15 @@ external-ip=193.224.22.37
 #
 min-port=49152
 max-port=65535
-	
+
 # Uncomment to run TURN server in 'normal' 'moderate' verbose mode.
 # By default the verbose mode is off.
 verbose
-	
+
 # Uncomment to run TURN server in 'extra' verbose mode.
 # This mode is very annoying and produces lots of output.
 # Not recommended under normal circumstances.
-#	
+#
 #Verbose
 
 # Uncomment to use fingerprints in the TURN messages.
@@ -177,10 +177,10 @@ fingerprint
 #
 lt-cred-mech
 
-# This option is the opposite of lt-cred-mech. 
+# This option is the opposite of lt-cred-mech.
 # (TURN Server with no-auth option allows anonymous access).
 # If neither option is defined, and no users are defined,
-# then no-auth is default. If at least one user is defined, 
+# then no-auth is default. If at least one user is defined,
 # in this file, in command line or in usersdb file, then
 # lt-cred-mech is default.
 #
@@ -191,11 +191,11 @@ lt-cred-mech
 # Flag that sets a special authorization option that is based upon authentication secret.
 #
 # This feature's purpose is to support "TURN Server REST API", see
-# "TURN REST API" link in the project's page 
+# "TURN REST API" link in the project's page
 # https://github.com/coturn/coturn/
 #
 # This option is used with timestamp:
-# 
+#
 # usercombo -> "timestamp:userid"
 # turn user -> usercombo
 # turn password -> base64(hmac(secret key, usercombo))
@@ -205,7 +205,7 @@ lt-cred-mech
 # This option is enabled by turning on secret-based authentication.
 # The actual value of the secret is defined either by the option static-auth-secret,
 # or can be found in the turn_secret table in the database (see below).
-# 
+#
 # Read more about it:
 #  - https://tools.ietf.org/html/draft-uberti-behave-turn-rest-00
 #  - https://www.ietf.org/proceedings/87/slides/slides-87-behave-10.pdf
@@ -217,13 +217,13 @@ lt-cred-mech
 #
 # Note that you can use only one auth mechanism at the same time! This is because,
 # both mechanisms conduct username and password validation in different ways.
-# 
+#
 # Use either lt-cred-mech or use-auth-secret in the conf
 # to avoid any confusion.
 #
 #use-auth-secret
 
-# 'Static' authentication secret value (a string) for TURN REST API only. 
+# 'Static' authentication secret value (a string) for TURN REST API only.
 # If not set, then the turn server
 # will try to use the 'dynamic' value in the turn_secret table
 # in the user database (if present). The database-stored  value can be changed on-the-fly
@@ -243,7 +243,7 @@ lt-cred-mech
 
 # 'Static' user accounts for the long term credentials mechanism, only.
 # This option cannot be used with TURN REST API.
-# 'Static' user accounts are NOT dynamically checked by the turnserver process, 
+# 'Static' user accounts are NOT dynamically checked by the turnserver process,
 # so they can NOT be changed while the turnserver is running.
 #
 #user=username1:key1
@@ -262,7 +262,7 @@ lt-cred-mech
 # password. If it has 0x then it is a key, otherwise it is a password).
 #
 # The corresponding user account entry in the config file will be:
-# 
+#
 #user=ninefingers:0xbc807ee29df3c9ffa736523fb2c4e8ee
 # Or, equivalently, with open clear password (less secure):
 #user=ninefingers:youhavetoberealistic
@@ -272,15 +272,15 @@ lt-cred-mech
 #
 # The default file name is /var/db/turndb or /usr/local/var/db/turndb or
 # /var/lib/turn/turndb.
-# 
+#
 #userdb=/var/db/turndb
 
 # PostgreSQL database connection string in the case that you are using PostgreSQL
 # as the user database.
 # This database can be used for the long-term credential mechanism
-# and it can store the secret value for secret-based timed authentication in TURN REST API. 
+# and it can store the secret value for secret-based timed authentication in TURN REST API.
 # See http://www.postgresql.org/docs/8.4/static/libpq-connect.html for 8.x PostgreSQL
-# versions connection string format, see 
+# versions connection string format, see
 # http://www.postgresql.org/docs/9.2/static/libpq-connect.html#LIBPQ-CONNSTRING
 # for 9.x and newer connection string formats.
 #
@@ -291,9 +291,9 @@ lt-cred-mech
 # This database can be used for the long-term credential mechanism
 # and it can store the secret value for secret-based timed authentication in TURN REST API.
 #
-# Optional connection string parameters for the secure communications (SSL): 
-# ca, capath, cert, key, cipher 
-# (see http://dev.mysql.com/doc/refman/5.1/en/ssl-options.html for the 
+# Optional connection string parameters for the secure communications (SSL):
+# ca, capath, cert, key, cipher
+# (see http://dev.mysql.com/doc/refman/5.1/en/ssl-options.html for the
 # command options description).
 #
 # Use the string format below (space separated parameters, all optional):
@@ -303,7 +303,7 @@ mysql-userdb="host=mysql dbname=coturn user=coturn password=CHANGE_ME port=3306 
 # If you want to use an encrypted password in the MySQL connection string,
 # then set the MySQL password encryption secret key file with this option.
 #
-# Warning: If this option is set, then the mysql password must be set in "mysql-userdb" in an encrypted format! 
+# Warning: If this option is set, then the mysql password must be set in "mysql-userdb" in an encrypted format!
 # If you want to use a cleartext password then do not set this option!
 #
 # This is the file path for the aes encrypted secret key used for password encryption.
@@ -313,7 +313,7 @@ mysql-userdb="host=mysql dbname=coturn user=coturn password=CHANGE_ME port=3306 
 # MongoDB database connection string in the case that you are using MongoDB
 # as the user database.
 # This database can be used for long-term credential mechanism
-# and it can store the secret value for secret-based timed authentication in TURN REST API. 
+# and it can store the secret value for secret-based timed authentication in TURN REST API.
 # Use the string format described at http://hergert.me/docs/mongo-c-driver/mongoc_uri.html
 #
 #mongo-userdb="mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]"
@@ -321,7 +321,7 @@ mysql-userdb="host=mysql dbname=coturn user=coturn password=CHANGE_ME port=3306 
 # Redis database connection string in the case that you are using Redis
 # as the user database.
 # This database can be used for long-term credential mechanism
-# and it can store the secret value for secret-based timed authentication in TURN REST API. 
+# and it can store the secret value for secret-based timed authentication in TURN REST API.
 # Use the string format below (space separated parameters, all optional):
 #
 #redis-userdb="ip=<ip-address> dbname=<database-number> password=<database-user-password> port=<port> connect_timeout=<seconds>"
@@ -329,15 +329,15 @@ mysql-userdb="host=mysql dbname=coturn user=coturn password=CHANGE_ME port=3306 
 # Redis status and statistics database connection string, if used (default - empty, no Redis stats DB used).
 # This database keeps allocations status information, and it can be also used for publishing
 # and delivering traffic and allocation event notifications.
-# The connection string has the same parameters as redis-userdb connection string. 
+# The connection string has the same parameters as redis-userdb connection string.
 # Use the string format below (space separated parameters, all optional):
 #
 #redis-statsdb="ip=<ip-address> dbname=<database-number> password=<database-user-password> port=<port> connect_timeout=<seconds>"
 
-# The default realm to be used for the users when no explicit 
+# The default realm to be used for the users when no explicit
 # origin/realm relationship is found in the database, or if the TURN
 # server is not using any database (just the commands-line settings
-# and the userdb file). Must be used with long-term credentials 
+# and the userdb file). Must be used with long-term credentials
 # mechanism or with TURN REST API.
 #
 # Note: If the default realm is not specified, then realm falls back to the host domain name.
@@ -345,7 +345,7 @@ mysql-userdb="host=mysql dbname=coturn user=coturn password=CHANGE_ME port=3306 
 #
 realm=example.org
 
-# This flag sets the origin consistency 
+# This flag sets the origin consistency
 # check. Across the session, all requests must have the same
 # main ORIGIN attribute value (if the ORIGIN was
 # initially used by the session).
@@ -412,9 +412,9 @@ realm=example.org
 # Uncomment if extra security is desired,
 # with nonce value having a limited lifetime.
 # By default, the nonce value is unique for a session,
-# and has an unlimited lifetime. 
-# Set this option to limit the nonce lifetime. 
-# It defaults to 600 secs (10 min) if no value is provided. After that delay, 
+# and has an unlimited lifetime.
+# Set this option to limit the nonce lifetime.
+# It defaults to 600 secs (10 min) if no value is provided. After that delay,
 # the client will get 438 error and will have to re-authenticate itself.
 #
 #stale-nonce=600
@@ -440,14 +440,14 @@ realm=example.org
 #permission-lifetime=300
 
 # Certificate file.
-# Use an absolute path or path relative to the 
+# Use an absolute path or path relative to the
 # configuration file.
 # Use PEM file format.
 #
 cert=/etc/ssl/certs/cert.pem
 
 # Private key file.
-# Use an absolute path or path relative to the 
+# Use an absolute path or path relative to the
 # configuration file.
 # Use PEM file format.
 #
@@ -463,7 +463,7 @@ pkey=/etc/ssl/private/privkey.pem
 #
 #cipher-list="DEFAULT"
 
-# CA file in OpenSSL format. 
+# CA file in OpenSSL format.
 # Forces TURN server to verify the client SSL certificates.
 # By default this is not set: there is no default value and the client
 # certificate is not checked.
@@ -471,8 +471,8 @@ pkey=/etc/ssl/private/privkey.pem
 # Example:
 #CA-file=/etc/ssh/id_rsa.cert
 
-# Curve name for EC ciphers, if supported by OpenSSL 
-# library (TLS and DTLS). The default value is prime256v1, 
+# Curve name for EC ciphers, if supported by OpenSSL
+# library (TLS and DTLS). The default value is prime256v1,
 # if pre-OpenSSL 1.0.2 is used. With OpenSSL 1.0.2+,
 # an optimal curve will be automatically calculated, if not defined
 # by this option.
@@ -493,21 +493,21 @@ pkey=/etc/ssl/private/privkey.pem
 #dh-file=<DH-PEM-file-name>
 
 # Flag to prevent stdout log messages.
-# By default, all log messages go to both stdout and to 
-# the configured log file. With this option everything will 
+# By default, all log messages go to both stdout and to
+# the configured log file. With this option everything will
 # go to the configured log only (unless the log file itself is stdout).
 #
 #no-stdout-log
 
 # Option to set the log file name.
-# By default, the turnserver tries to open a log file in 
+# By default, the turnserver tries to open a log file in
 # /var/log, /var/tmp, /tmp and the current directory
 # (Whichever file open operation succeeds first will be used).
 # With this option you can set the definite log file name.
-# The special names are "stdout" and "-" - they will force everything 
+# The special names are "stdout" and "-" - they will force everything
 # to the stdout. Also, the "syslog" name will force everything to
-# the system log (syslog). 
-# In the runtime, the logfile can be reset with the SIGHUP signal 
+# the system log (syslog).
+# In the runtime, the logfile can be reset with the SIGHUP signal
 # to the turnserver process.
 #
 #log-file=/var/tmp/turn.log
@@ -523,40 +523,40 @@ syslog
 #simple-log
 
 # Option to set the "redirection" mode. The value of this option
-# will be the address of the alternate server for UDP & TCP service in the form of 
+# will be the address of the alternate server for UDP & TCP service in the form of
 # <ip>[:<port>]. The server will send this value in the attribute
 # ALTERNATE-SERVER, with error 300, on ALLOCATE request, to the client.
 # Client will receive only values with the same address family
-# as the client network endpoint address family. 
-# See RFC 5389 and RFC 5766 for the description of ALTERNATE-SERVER functionality. 
+# as the client network endpoint address family.
+# See RFC 5389 and RFC 5766 for the description of ALTERNATE-SERVER functionality.
 # The client must use the obtained value for subsequent TURN communications.
 # If more than one --alternate-server option is provided, then the functionality
-# can be more accurately described as "load-balancing" than a mere "redirection". 
-# If the port number is omitted, then the default port 
+# can be more accurately described as "load-balancing" than a mere "redirection".
+# If the port number is omitted, then the default port
 # number 3478 for the UDP/TCP protocols will be used.
-# Colon (:) characters in IPv6 addresses may conflict with the syntax of 
-# the option. To alleviate this conflict, literal IPv6 addresses are enclosed 
-# in square brackets in such resource identifiers, for example: 
-# [2001:db8:85a3:8d3:1319:8a2e:370:7348]:3478 . 
+# Colon (:) characters in IPv6 addresses may conflict with the syntax of
+# the option. To alleviate this conflict, literal IPv6 addresses are enclosed
+# in square brackets in such resource identifiers, for example:
+# [2001:db8:85a3:8d3:1319:8a2e:370:7348]:3478 .
 # Multiple alternate servers can be set. They will be used in the
-# round-robin manner. All servers in the pool are considered of equal weight and 
-# the load will be distributed equally. For example, if you have 4 alternate servers, 
-# then each server will receive 25% of ALLOCATE requests. A alternate TURN server 
-# address can be used more than one time with the alternate-server option, so this 
+# round-robin manner. All servers in the pool are considered of equal weight and
+# the load will be distributed equally. For example, if you have 4 alternate servers,
+# then each server will receive 25% of ALLOCATE requests. A alternate TURN server
+# address can be used more than one time with the alternate-server option, so this
 # can emulate "weighting" of the servers.
 #
-# Examples: 
+# Examples:
 #alternate-server=1.2.3.4:5678
 #alternate-server=11.22.33.44:56789
 #alternate-server=5.6.7.8
 #alternate-server=[2001:db8:85a3:8d3:1319:8a2e:370:7348]:3478
-			
-# Option to set alternative server for TLS & DTLS services in form of 
-# <ip>:<port>. If the port number is omitted, then the default port 
-# number 5349 for the TLS/DTLS protocols will be used. See the previous 
+
+# Option to set alternative server for TLS & DTLS services in form of
+# <ip>:<port>. If the port number is omitted, then the default port
+# number 5349 for the TLS/DTLS protocols will be used. See the previous
 # option for the functionality description.
 #
-# Examples: 
+# Examples:
 #tls-alternate-server=1.2.3.4:5678
 #tls-alternate-server=11.22.33.44:56789
 #tls-alternate-server=[2001:db8:85a3:8d3:1319:8a2e:370:7348]:3478
@@ -584,7 +584,7 @@ syslog
 
 # This is the timestamp/username separator symbol (character) in TURN REST API.
 # The default value is ':'.
-# rest-api-separator=:	
+# rest-api-separator=:
 
 # Flag that can be used to allow peers on the loopback addresses (127.x.x.x and ::1).
 # This is an extra security measure.
@@ -592,9 +592,9 @@ syslog
 # (To avoid any security issue that allowing loopback access may raise,
 # the no-loopback-peers option is replaced by allow-loopback-peers.)
 #
-# Allow it only for testing in a development environment! 
-# In production it adds a possible security vulnerability, so for security reasons 
-# it is not allowed using it together with empty cli-password. 
+# Allow it only for testing in a development environment!
+# In production it adds a possible security vulnerability, so for security reasons
+# it is not allowed using it together with empty cli-password.
 #
 #allow-loopback-peers
 
@@ -603,18 +603,18 @@ syslog
 #
 #no-multicast-peers
 
-# Option to set the max time, in seconds, allowed for full allocation establishment. 
+# Option to set the max time, in seconds, allowed for full allocation establishment.
 # Default is 60 seconds.
 #
 #max-allocate-timeout=60
 
-# Option to allow or ban specific ip addresses or ranges of ip addresses. 
-# If an ip address is specified as both allowed and denied, then the ip address is 
-# considered to be allowed. This is useful when you wish to ban a range of ip 
+# Option to allow or ban specific ip addresses or ranges of ip addresses.
+# If an ip address is specified as both allowed and denied, then the ip address is
+# considered to be allowed. This is useful when you wish to ban a range of ip
 # addresses, except for a few specific ips within that range.
 #
 # This can be used when you do not want users of the turn server to be able to access
-# machines reachable by the turn server, but would otherwise be unreachable from the 
+# machines reachable by the turn server, but would otherwise be unreachable from the
 # internet (e.g. when the turn server is sitting behind a NAT)
 #
 # Examples:
@@ -636,8 +636,8 @@ syslog
 #
 #mobility
 
-# Allocate Address Family according 
-# If enabled then TURN server allocates address family according  the TURN 
+# Allocate Address Family according
+# If enabled then TURN server allocates address family according  the TURN
 # Client <=> Server communication address family.
 # (By default Coturn works according RFC 6156.)
 # !!Warning: Enabling this option breaks RFC6156 section-4.2 (violates use default IPv4)!!
@@ -701,10 +701,10 @@ cli-password=CHANGE_ME
 #
 #web-admin-listen-on-workers
 
-# Server relay. NON-STANDARD AND DANGEROUS OPTION. 
-# Only for those applications when you want to run 
+# Server relay. NON-STANDARD AND DANGEROUS OPTION.
+# Only for those applications when you want to run
 # server applications on the relay endpoints.
-# This option eliminates the IP permissions check on 
+# This option eliminates the IP permissions check on
 # the packets incoming to the relay endpoints.
 #
 #server-relay

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -1,25 +1,25 @@
 # Coturn TURN SERVER configuration file
 #
 # Boolean values note: where a boolean value is supposed to be used,
-# you can use '0', 'off', 'no', 'false', or 'f' as 'false, 
-# and you can use '1', 'on', 'yes', 'true', or 't' as 'true' 
+# you can use '0', 'off', 'no', 'false', or 'f' as 'false,
+# and you can use '1', 'on', 'yes', 'true', or 't' as 'true'
 # If the value is missing, then it means 'true' by default.
 #
 
 # Listener interface device (optional, Linux only).
-# NOT RECOMMENDED. 
+# NOT RECOMMENDED.
 #
 #listening-device=eth0
 
 # TURN listener port for UDP and TCP (Default: 3478).
-# Note: actually, TLS & DTLS sessions can connect to the 
+# Note: actually, TLS & DTLS sessions can connect to the
 # "plain" TCP & UDP port(s), too - if allowed by configuration.
 #
 #listening-port=3478
 
 # TURN listener port for TLS (Default: 5349).
 # Note: actually, "plain" TCP & UDP sessions can connect to the TLS & DTLS
-# port(s), too - if allowed by configuration. The TURN server 
+# port(s), too - if allowed by configuration. The TURN server
 # "automatically" recognizes the type of traffic. Actually, two listening
 # endpoints (the "plain" one and the "tls" one) are equivalent in terms of
 # functionality; but Coturn keeps both endpoints to satisfy the RFC 5766 specs.
@@ -30,16 +30,16 @@
 #tls-listening-port=5349
 
 # Alternative listening port for UDP and TCP listeners;
-# default (or zero) value means "listening port plus one". 
+# default (or zero) value means "listening port plus one".
 # This is needed for RFC 5780 support
-# (STUN extension specs, NAT behavior discovery). The TURN Server 
-# supports RFC 5780 only if it is started with more than one 
+# (STUN extension specs, NAT behavior discovery). The TURN Server
+# supports RFC 5780 only if it is started with more than one
 # listening IP address of the same family (IPv4 or IPv6).
 # RFC 5780 is supported only by UDP protocol, other protocols
 # are listening to that endpoint only for "symmetry".
 #
 #alt-listening-port=0
-							 
+
 # Alternative listening port for TLS and DTLS protocols.
 # Default (or zero) value means "TLS listening port plus one".
 #
@@ -52,9 +52,9 @@
 # (https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
 #
 #tcp-proxy-port=5555
-	
+
 # Listener IP address of relay server. Multiple listeners can be specified.
-# If no IP(s) specified in the config file or in the command line options, 
+# If no IP(s) specified in the config file or in the command line options,
 # then all IPv4 and IPv6 system IPs will be used for listening.
 #
 #listening-ip=172.17.19.101
@@ -69,7 +69,7 @@
 # they do not support STUN RFC 5780 functionality (CHANGE REQUEST).
 #
 # 2) Auxiliary servers also are never returning ALTERNATIVE-SERVER reply.
-# 
+#
 # Valid formats are 1.2.3.4:5555 for IPv4 and [1:2::3:4]:5555 for IPv6.
 #
 # There may be multiple aux-server options, each will be used for listening
@@ -81,7 +81,7 @@
 # (recommended for older Linuxes only)
 # Automatically balance UDP traffic over auxiliary servers (if configured).
 # The load balancing is using the ALTERNATE-SERVER mechanism.
-# The TURN client must support 300 ALTERNATE-SERVER response for this 
+# The TURN client must support 300 ALTERNATE-SERVER response for this
 # functionality.
 #
 #udp-self-balance
@@ -91,13 +91,13 @@
 #
 #relay-device=eth1
 
-# Relay address (the local IP address that will be used to relay the 
+# Relay address (the local IP address that will be used to relay the
 # packets to the peer).
 # Multiple relay addresses may be used.
 # The same IP(s) can be used as both listening IP(s) and relay IP(s).
 #
 # If no relay IP(s) specified, then the turnserver will apply the default
-# policy: it will decide itself which relay addresses to be used, and it 
+# policy: it will decide itself which relay addresses to be used, and it
 # will always be using the client socket IP address as the relay IP address
 # of the TURN session (if the requested relay address family is the same
 # as the family of the client socket).
@@ -120,7 +120,7 @@
 # that option must be used several times, each entry must
 # have form "-X <public-ip/private-ip>", to map all involved addresses.
 # RFC5780 NAT discovery STUN functionality will work correctly,
-# if the addresses are mapped properly, even when the TURN server itself 
+# if the addresses are mapped properly, even when the TURN server itself
 # is behind A NAT.
 #
 # By default, this value is empty, and no address mapping is used.
@@ -135,18 +135,18 @@
 
 # Number of the relay threads to handle the established connections
 # (in addition to authentication thread and the listener thread).
-# If explicitly set to 0 then application runs relay process in a 
-# single thread, in the same thread with the listener process 
+# If explicitly set to 0 then application runs relay process in a
+# single thread, in the same thread with the listener process
 # (the authentication thread will still be a separate thread).
 #
-# If this parameter is not set, then the default OS-dependent 
+# If this parameter is not set, then the default OS-dependent
 # thread pattern algorithm will be employed. Usually the default
 # algorithm is optimal, so you have to change this option
-# if you want to make some fine tweaks. 
+# if you want to make some fine tweaks.
 #
 # In the older systems (Linux kernel before 3.9),
 # the number of UDP threads is always one thread per network listening
-# endpoint - including the auxiliary endpoints - unless 0 (zero) or 
+# endpoint - including the auxiliary endpoints - unless 0 (zero) or
 # 1 (one) value is set.
 #
 #relay-threads=0
@@ -156,15 +156,15 @@
 #
 #min-port=49152
 #max-port=65535
-	
+
 # Uncomment to run TURN server in 'normal' 'moderate' verbose mode.
 # By default the verbose mode is off.
 #verbose
-	
+
 # Uncomment to run TURN server in 'extra' verbose mode.
 # This mode is very annoying and produces lots of output.
 # Not recommended under normal circumstances.
-#	
+#
 #Verbose
 
 # Uncomment to use fingerprints in the TURN messages.
@@ -177,10 +177,10 @@
 #
 #lt-cred-mech
 
-# This option is the opposite of lt-cred-mech. 
+# This option is the opposite of lt-cred-mech.
 # (TURN Server with no-auth option allows anonymous access).
 # If neither option is defined, and no users are defined,
-# then no-auth is default. If at least one user is defined, 
+# then no-auth is default. If at least one user is defined,
 # in this file, in command line or in usersdb file, then
 # lt-cred-mech is default.
 #
@@ -203,11 +203,11 @@
 # Flag that sets a special authorization option that is based upon authentication secret.
 #
 # This feature's purpose is to support "TURN Server REST API", see
-# "TURN REST API" link in the project's page 
+# "TURN REST API" link in the project's page
 # https://github.com/coturn/coturn/
 #
 # This option is used with timestamp:
-# 
+#
 # usercombo -> "timestamp:userid"
 # turn user -> usercombo
 # turn password -> base64(hmac(secret key, usercombo))
@@ -217,7 +217,7 @@
 # This option is enabled by turning on secret-based authentication.
 # The actual value of the secret is defined either by the option static-auth-secret,
 # or can be found in the turn_secret table in the database (see below).
-# 
+#
 # Read more about it:
 #  - https://tools.ietf.org/html/draft-uberti-behave-turn-rest-00
 #  - https://www.ietf.org/proceedings/87/slides/slides-87-behave-10.pdf
@@ -229,13 +229,13 @@
 #
 # Note that you can use only one auth mechanism at the same time! This is because,
 # both mechanisms conduct username and password validation in different ways.
-# 
+#
 # Use either lt-cred-mech or use-auth-secret in the conf
 # to avoid any confusion.
 #
 #use-auth-secret
 
-# 'Static' authentication secret value (a string) for TURN REST API only. 
+# 'Static' authentication secret value (a string) for TURN REST API only.
 # If not set, then the turn server
 # will try to use the 'dynamic' value in the turn_secret table
 # in the user database (if present). The database-stored  value can be changed on-the-fly
@@ -255,7 +255,7 @@
 
 # 'Static' user accounts for the long term credentials mechanism, only.
 # This option cannot be used with TURN REST API.
-# 'Static' user accounts are NOT dynamically checked by the turnserver process, 
+# 'Static' user accounts are NOT dynamically checked by the turnserver process,
 # so they can NOT be changed while the turnserver is running.
 #
 #user=username1:key1
@@ -274,7 +274,7 @@
 # password. If it has 0x then it is a key, otherwise it is a password).
 #
 # The corresponding user account entry in the config file will be:
-# 
+#
 #user=ninefingers:0xbc807ee29df3c9ffa736523fb2c4e8ee
 # Or, equivalently, with open clear password (less secure):
 #user=ninefingers:youhavetoberealistic
@@ -284,15 +284,15 @@
 #
 # The default file name is /var/db/turndb or /usr/local/var/db/turndb or
 # /var/lib/turn/turndb.
-# 
+#
 #userdb=/var/db/turndb
 
 # PostgreSQL database connection string in the case that you are using PostgreSQL
 # as the user database.
 # This database can be used for the long-term credential mechanism
-# and it can store the secret value for secret-based timed authentication in TURN REST API. 
+# and it can store the secret value for secret-based timed authentication in TURN REST API.
 # See http://www.postgresql.org/docs/8.4/static/libpq-connect.html for 8.x PostgreSQL
-# versions connection string format, see 
+# versions connection string format, see
 # http://www.postgresql.org/docs/9.2/static/libpq-connect.html#LIBPQ-CONNSTRING
 # for 9.x and newer connection string formats.
 #
@@ -303,9 +303,9 @@
 # This database can be used for the long-term credential mechanism
 # and it can store the secret value for secret-based timed authentication in TURN REST API.
 #
-# Optional connection string parameters for the secure communications (SSL): 
-# ca, capath, cert, key, cipher 
-# (see http://dev.mysql.com/doc/refman/5.1/en/ssl-options.html for the 
+# Optional connection string parameters for the secure communications (SSL):
+# ca, capath, cert, key, cipher
+# (see http://dev.mysql.com/doc/refman/5.1/en/ssl-options.html for the
 # command options description).
 #
 # Use the string format below (space separated parameters, all optional):
@@ -315,7 +315,7 @@
 # If you want to use an encrypted password in the MySQL connection string,
 # then set the MySQL password encryption secret key file with this option.
 #
-# Warning: If this option is set, then the mysql password must be set in "mysql-userdb" in an encrypted format! 
+# Warning: If this option is set, then the mysql password must be set in "mysql-userdb" in an encrypted format!
 # If you want to use a cleartext password then do not set this option!
 #
 # This is the file path for the aes encrypted secret key used for password encryption.
@@ -325,7 +325,7 @@
 # MongoDB database connection string in the case that you are using MongoDB
 # as the user database.
 # This database can be used for long-term credential mechanism
-# and it can store the secret value for secret-based timed authentication in TURN REST API. 
+# and it can store the secret value for secret-based timed authentication in TURN REST API.
 # Use the string format described at http://hergert.me/docs/mongo-c-driver/mongoc_uri.html
 #
 #mongo-userdb="mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]"
@@ -333,7 +333,7 @@
 # Redis database connection string in the case that you are using Redis
 # as the user database.
 # This database can be used for long-term credential mechanism
-# and it can store the secret value for secret-based timed authentication in TURN REST API. 
+# and it can store the secret value for secret-based timed authentication in TURN REST API.
 # Use the string format below (space separated parameters, all optional):
 #
 #redis-userdb="ip=<ip-address> dbname=<database-number> password=<database-user-password> port=<port> connect_timeout=<seconds>"
@@ -341,15 +341,15 @@
 # Redis status and statistics database connection string, if used (default - empty, no Redis stats DB used).
 # This database keeps allocations status information, and it can be also used for publishing
 # and delivering traffic and allocation event notifications.
-# The connection string has the same parameters as redis-userdb connection string. 
+# The connection string has the same parameters as redis-userdb connection string.
 # Use the string format below (space separated parameters, all optional):
 #
 #redis-statsdb="ip=<ip-address> dbname=<database-number> password=<database-user-password> port=<port> connect_timeout=<seconds>"
 
-# The default realm to be used for the users when no explicit 
+# The default realm to be used for the users when no explicit
 # origin/realm relationship is found in the database, or if the TURN
 # server is not using any database (just the commands-line settings
-# and the userdb file). Must be used with long-term credentials 
+# and the userdb file). Must be used with long-term credentials
 # mechanism or with TURN REST API.
 #
 # Note: If the default realm is not specified, then realm falls back to the host domain name.
@@ -357,7 +357,7 @@
 #
 #realm=mycompany.org
 
-# This flag sets the origin consistency 
+# This flag sets the origin consistency
 # check. Across the session, all requests must have the same
 # main ORIGIN attribute value (if the ORIGIN was
 # initially used by the session).
@@ -424,9 +424,9 @@
 # Uncomment if extra security is desired,
 # with nonce value having a limited lifetime.
 # By default, the nonce value is unique for a session,
-# and has an unlimited lifetime. 
-# Set this option to limit the nonce lifetime. 
-# It defaults to 600 secs (10 min) if no value is provided. After that delay, 
+# and has an unlimited lifetime.
+# Set this option to limit the nonce lifetime.
+# It defaults to 600 secs (10 min) if no value is provided. After that delay,
 # the client will get 438 error and will have to re-authenticate itself.
 #
 #stale-nonce=600
@@ -452,14 +452,14 @@
 #permission-lifetime=300
 
 # Certificate file.
-# Use an absolute path or path relative to the 
+# Use an absolute path or path relative to the
 # configuration file.
 # Use PEM file format.
 #
 #cert=/usr/local/etc/turn_server_cert.pem
 
 # Private key file.
-# Use an absolute path or path relative to the 
+# Use an absolute path or path relative to the
 # configuration file.
 # Use PEM file format.
 #
@@ -475,7 +475,7 @@
 #
 #cipher-list="DEFAULT"
 
-# CA file in OpenSSL format. 
+# CA file in OpenSSL format.
 # Forces TURN server to verify the client SSL certificates.
 # By default this is not set: there is no default value and the client
 # certificate is not checked.
@@ -483,8 +483,8 @@
 # Example:
 #CA-file=/etc/ssh/id_rsa.cert
 
-# Curve name for EC ciphers, if supported by OpenSSL 
-# library (TLS and DTLS). The default value is prime256v1, 
+# Curve name for EC ciphers, if supported by OpenSSL
+# library (TLS and DTLS). The default value is prime256v1,
 # if pre-OpenSSL 1.0.2 is used. With OpenSSL 1.0.2+,
 # an optimal curve will be automatically calculated, if not defined
 # by this option.
@@ -505,21 +505,21 @@
 #dh-file=<DH-PEM-file-name>
 
 # Flag to prevent stdout log messages.
-# By default, all log messages go to both stdout and to 
-# the configured log file. With this option everything will 
+# By default, all log messages go to both stdout and to
+# the configured log file. With this option everything will
 # go to the configured log only (unless the log file itself is stdout).
 #
 #no-stdout-log
 
 # Option to set the log file name.
-# By default, the turnserver tries to open a log file in 
+# By default, the turnserver tries to open a log file in
 # /var/log, /var/tmp, /tmp and the current directory
 # (Whichever file open operation succeeds first will be used).
 # With this option you can set the definite log file name.
-# The special names are "stdout" and "-" - they will force everything 
+# The special names are "stdout" and "-" - they will force everything
 # to the stdout. Also, the "syslog" name will force everything to
-# the system log (syslog). 
-# In the runtime, the logfile can be reset with the SIGHUP signal 
+# the system log (syslog).
+# In the runtime, the logfile can be reset with the SIGHUP signal
 # to the turnserver process.
 #
 #log-file=/var/tmp/turn.log
@@ -535,40 +535,40 @@
 #simple-log
 
 # Option to set the "redirection" mode. The value of this option
-# will be the address of the alternate server for UDP & TCP service in the form of 
+# will be the address of the alternate server for UDP & TCP service in the form of
 # <ip>[:<port>]. The server will send this value in the attribute
 # ALTERNATE-SERVER, with error 300, on ALLOCATE request, to the client.
 # Client will receive only values with the same address family
-# as the client network endpoint address family. 
-# See RFC 5389 and RFC 5766 for the description of ALTERNATE-SERVER functionality. 
+# as the client network endpoint address family.
+# See RFC 5389 and RFC 5766 for the description of ALTERNATE-SERVER functionality.
 # The client must use the obtained value for subsequent TURN communications.
 # If more than one --alternate-server option is provided, then the functionality
-# can be more accurately described as "load-balancing" than a mere "redirection". 
-# If the port number is omitted, then the default port 
+# can be more accurately described as "load-balancing" than a mere "redirection".
+# If the port number is omitted, then the default port
 # number 3478 for the UDP/TCP protocols will be used.
-# Colon (:) characters in IPv6 addresses may conflict with the syntax of 
-# the option. To alleviate this conflict, literal IPv6 addresses are enclosed 
-# in square brackets in such resource identifiers, for example: 
-# [2001:db8:85a3:8d3:1319:8a2e:370:7348]:3478 . 
+# Colon (:) characters in IPv6 addresses may conflict with the syntax of
+# the option. To alleviate this conflict, literal IPv6 addresses are enclosed
+# in square brackets in such resource identifiers, for example:
+# [2001:db8:85a3:8d3:1319:8a2e:370:7348]:3478 .
 # Multiple alternate servers can be set. They will be used in the
-# round-robin manner. All servers in the pool are considered of equal weight and 
-# the load will be distributed equally. For example, if you have 4 alternate servers, 
-# then each server will receive 25% of ALLOCATE requests. A alternate TURN server 
-# address can be used more than one time with the alternate-server option, so this 
+# round-robin manner. All servers in the pool are considered of equal weight and
+# the load will be distributed equally. For example, if you have 4 alternate servers,
+# then each server will receive 25% of ALLOCATE requests. A alternate TURN server
+# address can be used more than one time with the alternate-server option, so this
 # can emulate "weighting" of the servers.
 #
-# Examples: 
+# Examples:
 #alternate-server=1.2.3.4:5678
 #alternate-server=11.22.33.44:56789
 #alternate-server=5.6.7.8
 #alternate-server=[2001:db8:85a3:8d3:1319:8a2e:370:7348]:3478
-			
-# Option to set alternative server for TLS & DTLS services in form of 
-# <ip>:<port>. If the port number is omitted, then the default port 
-# number 5349 for the TLS/DTLS protocols will be used. See the previous 
+
+# Option to set alternative server for TLS & DTLS services in form of
+# <ip>:<port>. If the port number is omitted, then the default port
+# number 5349 for the TLS/DTLS protocols will be used. See the previous
 # option for the functionality description.
 #
-# Examples: 
+# Examples:
 #tls-alternate-server=1.2.3.4:5678
 #tls-alternate-server=11.22.33.44:56789
 #tls-alternate-server=[2001:db8:85a3:8d3:1319:8a2e:370:7348]:3478
@@ -596,7 +596,7 @@
 
 # This is the timestamp/username separator symbol (character) in TURN REST API.
 # The default value is ':'.
-# rest-api-separator=:	
+# rest-api-separator=:
 
 # Flag that can be used to allow peers on the loopback addresses (127.x.x.x and ::1).
 # This is an extra security measure.
@@ -604,9 +604,9 @@
 # (To avoid any security issue that allowing loopback access may raise,
 # the no-loopback-peers option is replaced by allow-loopback-peers.)
 #
-# Allow it only for testing in a development environment! 
-# In production it adds a possible security vulnerability, so for security reasons 
-# it is not allowed using it together with empty cli-password. 
+# Allow it only for testing in a development environment!
+# In production it adds a possible security vulnerability, so for security reasons
+# it is not allowed using it together with empty cli-password.
 #
 #allow-loopback-peers
 
@@ -615,18 +615,18 @@
 #
 #no-multicast-peers
 
-# Option to set the max time, in seconds, allowed for full allocation establishment. 
+# Option to set the max time, in seconds, allowed for full allocation establishment.
 # Default is 60 seconds.
 #
 #max-allocate-timeout=60
 
-# Option to allow or ban specific ip addresses or ranges of ip addresses. 
-# If an ip address is specified as both allowed and denied, then the ip address is 
-# considered to be allowed. This is useful when you wish to ban a range of ip 
+# Option to allow or ban specific ip addresses or ranges of ip addresses.
+# If an ip address is specified as both allowed and denied, then the ip address is
+# considered to be allowed. This is useful when you wish to ban a range of ip
 # addresses, except for a few specific ips within that range.
 #
 # This can be used when you do not want users of the turn server to be able to access
-# machines reachable by the turn server, but would otherwise be unreachable from the 
+# machines reachable by the turn server, but would otherwise be unreachable from the
 # internet (e.g. when the turn server is sitting behind a NAT)
 #
 # Examples:
@@ -648,8 +648,8 @@
 #
 #mobility
 
-# Allocate Address Family according 
-# If enabled then TURN server allocates address family according  the TURN 
+# Allocate Address Family according
+# If enabled then TURN server allocates address family according  the TURN
 # Client <=> Server communication address family.
 # (By default Coturn works according RFC 6156.)
 # !!Warning: Enabling this option breaks RFC6156 section-4.2 (violates use default IPv4)!!
@@ -713,10 +713,10 @@
 #
 #web-admin-listen-on-workers
 
-# Server relay. NON-STANDARD AND DANGEROUS OPTION. 
-# Only for those applications when you want to run 
+# Server relay. NON-STANDARD AND DANGEROUS OPTION.
+# Only for those applications when you want to run
 # server applications on the relay endpoints.
-# This option eliminates the IP permissions check on 
+# This option eliminates the IP permissions check on
 # the packets incoming to the relay endpoints.
 #
 #server-relay


### PR DESCRIPTION
FYI, this patch was created by doing `M-x delete-trailing-whitespace` in GNU Emacs.