### PR TITLE
Allow RFC6062 TCP relay data to look like TLS; fixes #605

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -3374,7 +3374,7 @@ int register_callback_on_ioa_socket(ioa_engine_handle e, ioa_socket_handle s, in
 						}
 					} else {
 #if TLS_SUPPORTED
-						if(check_tentative_tls(s->fd)) {
+						if((s->sat != TCP_CLIENT_DATA_SOCKET) && (s->sat != TCP_RELAY_DATA_SOCKET) && check_tentative_tls(s->fd)) {
 							s->tobeclosed = 1;
 							return -1;
 						}


### PR DESCRIPTION
This point in the code was making a best-effort attempt to reject TLS connections on non-TLS listeners.

After this is merged, it will skip this check when the socket is being used for RFC6062 TCP relay data.  That data should be opaque for the TURN server and it is fine if it happens to be (or look like) TLS.

Fixes #605 .