### PR TITLE
fix compilation on macOS Big Sur

### DIFF
--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -39,6 +39,10 @@
 #include <sys/param.h>
 #endif
 
+#if defined(__APPLE__) || defined(__DARWIN__) || defined(__MACH__)
+#define __APPLE_USE_RFC_3542
+#endif
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>


### PR DESCRIPTION
You must define `__APPLE_USE_RFC_3542` in order to use the `IPV6_DONTFRAG` sockopt: https://opensource.apple.com/source/xnu/xnu-6153.141.1/bsd/netinet6/in6.h.auto.html
```
 * To use the new IPv6 Sockets options introduced by RFC 3542
 * the constant __APPLE_USE_RFC_3542 must be defined before
 * including <netinet/in.h>
```