### PR TITLE
Packaging scripts can miss out on these errors

### DIFF
--- a/configure
+++ b/configure
@@ -596,7 +596,7 @@ if [ -z "${CC}" ] ; then
     if [ -z "$CC" ] ; then
         ${ECHO_CMD} "ERROR: failed to a find working C compiler"
         cleanup
-        exit
+        exit 1
     fi
 else
     ${CC} ${TMPCPROGC} ${OSCFLAGS} -o ${TMPCPROGB} 2>>/dev/null
@@ -604,7 +604,7 @@ else
     if ! [ ${ER} -eq 0 ] ; then
         ${ECHO_CMD} "ERROR: cannot use compiler ${CC} properly"
         cleanup
-        exit
+        exit 1
     fi
 fi
 
@@ -633,13 +633,13 @@ if [ -z "$PKGCONFIG" ] ; then
     if [ -z "$PKGCONFIG" ] ; then
         ${ECHO_CMD} "ERROR: pkg-config not found"
         cleanup
-        exit
+        exit 1
     fi
 else
     if ! type "$PKGCONFIG" 2>/dev/null ; then
         ${ECHO_CMD} "ERROR: cannot use $PKGCONFIG"
         cleanup
-        exit
+        exit 1
     fi
 fi
 
@@ -717,7 +717,7 @@ pthread_testlib
 ER=$?
 if [ ${ER} -ne 0 ] ; then
     ${ECHO_CMD} "ERROR: Cannot find pthread library functions."
-    exit
+    exit 1
 fi
 
 if [ -z ${TURN_NO_THREAD_BARRIERS} ] ; then 
@@ -749,7 +749,7 @@ if [ -n "${SSL_CFLAGS}" ] && [ -n "${SSL_LIBS}" ]; then
     ER=$?
     if ! [ ${ER} -eq 0 ] ; then
         ${ECHO_CMD} "Private SSL Library option cannot be used"
-        exit
+        exit 1
     else
         OSCFLAGS="${OSCFLAGS} ${SSL_CFLAGS}"
         OSLIBS="${OSLIBS} ${SSL_LIBS}"
@@ -766,7 +766,7 @@ else
             ${ECHO_CMD} "ERROR: OpenSSL Crypto development libraries are not installed properly in required location."
             ${ECHO_CMD} "Abort."
             cleanup
-            exit
+            exit 1
         fi
     fi
 
@@ -781,7 +781,7 @@ else
             ${ECHO_CMD} "ERROR: OpenSSL development libraries are not installed properly in required location."
             ${ECHO_CMD} "Abort."
             cleanup
-            exit
+            exit 1
         fi
     fi
 fi
@@ -811,7 +811,7 @@ if [ -n "${EVENT_CFLAGS}" ] && [ -n "${EVENT_LIBS}" ]; then
     ER=$?
     if ! [ ${ER} -eq 0 ] ; then
         ${ECHO_CMD} "Private Event Library option cannot be used"
-        exit
+        exit 1
     else
         OSCFLAGS="${OSCFLAGS} ${EVENT_CFLAGS}"
         OSLIBS="${OSLIBS} ${EVENT_LIBS}"
@@ -825,7 +825,7 @@ else
         ${ECHO_CMD} "See the INSTALL file."
         ${ECHO_CMD} "Abort."
         cleanup
-        exit
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
This script looks like it's designed to use a portable subset of
sh; I'm not aware of any portability problems of this patch.