### PR TITLE
debian/coturn.postrm: fix check for dpkg-statoverride on package removal

### DIFF
--- a/debian/coturn.postrm
+++ b/debian/coturn.postrm
@@ -6,6 +6,11 @@ TURNSERVER_USER=turnserver
 TURNSERVER_GROUP=turnserver
 
 if [ "$1" = "purge" ] ; then
+        TURNSERVER_CONFIG=/etc/turnserver.conf
+        if dpkg-statoverride --list "$TURNSERVER_CONFIG" >/dev/null 2>&1; then
+                dpkg-statoverride --remove "$TURNSERVER_CONFIG"
+        fi
+
         if getent passwd $TURNSERVER_USER >/dev/null; then
                 userdel $TURNSERVER_USER
         fi
@@ -15,11 +20,6 @@ if [ "$1" = "purge" ] ; then
 
         rm -f /var/lib/turn/turndb
         rmdir /var/lib/turn
-
-        TURNSERVER_CONFIG=/etc/turnserver.conf
-        if ! dpkg-statoverride --list "$TURNSERVER_CONFIG" >/dev/null 2>&1; then
-	    dpkg-statoverride --remove "$TURNSERVER_CONFIG"
-        fi
 fi
 
 


### PR DESCRIPTION
This fixes a regression introduced in commit b9a4a8.
When trying to remove a dpkg-statoverride, we need to check,
whether it exists. Otherwise it's failing, as can be observed
via piuparts runs:

| dpkg: unrecoverable fatal error, aborting:
|  unknown system group 'turnserver' in statoverride file; the system group got removed
| before the override, which is most probably a packaging bug, to recover you
| can remove the override manually with dpkg-statoverride
| E: Sub-process /usr/bin/dpkg returned an error code (2)

Closes: #981330