### PR TITLE
Update turnserver.conf

### DIFF
--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -192,7 +192,7 @@
 #
 # You can simply run the turnserver and access the port 9641 and path /metrics
 #
-# For mor info on the prometheus exporter and metrics
+# For more info on the prometheus exporter and metrics
 # https://prometheus.io/docs/introduction/overview/
 # https://prometheus.io/docs/concepts/data_model/
 #


### PR DESCRIPTION
fixed typo _mor_ to _more_ in description of prometheus exporter