### PR TITLE
Support Prometheus in Docker image

### DIFF
--- a/configure
+++ b/configure
@@ -506,6 +506,15 @@ else
 fi
 
 #############################
+# Adjustments for Debian
+#############################
+
+if [ -f "/etc/debian_version" ] ; then
+    # https://github.com/coturn/coturn/pull/754#issuecomment-824693226
+    OSLIBS="${OSLIBS} -latomic"
+fi
+
+#############################
 # Adjustments for Solaris
 #############################
 

--- a/docker/coturn/CHANGELOG.md
+++ b/docker/coturn/CHANGELOG.md
@@ -7,9 +7,15 @@ Coturn TURN server Docker image changelog
 ## [4.5.2-r1] · 2021-04-?? · To-be-done
 [4.5.2-r1]: /../../tree/docker/4.5.2-r1
 
+### Added
+
+- [Prometheus] support with [prometheus-client-c] 0.1.3: <https://github.com/digitalocean/prometheus-client-c/releases/tag/v0.1.3> ([#754])
+
 ### Fixed
 
 - Incorrect linking with [mongo-c-driver] on [Debian Linux] image.
+
+[#754]: /../../pull/754
 
 
 
@@ -39,3 +45,5 @@ Coturn TURN server Docker image changelog
 [Coturn]: https://haraka.github.io
 [Debian Linux]: https://www.debian.org
 [mongo-c-driver]: https://github.com/mongodb/mongo-c-driver
+[Prometheus]: https://prometheus.io
+[prometheus-client-c]: https://github.com/digitalocean/prometheus-client-c

--- a/docker/coturn/Makefile
+++ b/docker/coturn/Makefile
@@ -90,7 +90,7 @@ define docker.buildx
 	docker buildx build --force-rm $(args) \
 		--platform $(platform) \
 		$(if $(call eq,$(no-cache),yes),--no-cache --pull,) \
-		$(if $(call eq,$(git-ref),),,--build-arg git_ref=$(git-ref)) \
+		$(if $(call eq,$(git-ref),),,--build-arg coturn_git_ref=$(git-ref)) \
 		-f docker/coturn/$(dockerfile)/Dockerfile \
 		-t $(namespace)/$(NAME):$(tag) ./
 endef

--- a/docker/coturn/alpine/Dockerfile
+++ b/docker/coturn/alpine/Dockerfile
@@ -8,6 +8,74 @@ ARG alpine_ver=3.13
 
 
 #
+# Stage 'dist-libprom' creates prometheus-client-c distribution.
+#
+
+# We compile prometheus-client-c from sources, because Alpine doesn't provide
+# it as its package yet.
+#
+# TODO: Re-check this to be present in packages on next Alpine major version update.
+
+# https://hub.docker.com/_/alpine
+FROM alpine:${alpine_ver} AS dist-libprom
+
+# Install tools for building.
+RUN apk update \
+ && apk add --no-cache \
+        ca-certificates cmake g++ git make \
+ && update-ca-certificates
+
+# Install prometheus-client-c build dependencies.
+RUN apk add --no-cache \
+        libmicrohttpd-dev
+
+# Prepare prometheus-client-c sources for building.
+ARG prom_ver=0.1.3
+RUN mkdir -p /build/ && cd /build/ \
+ && git init \
+ && git remote add origin https://github.com/digitalocean/prometheus-client-c \
+ && git fetch --depth=1 origin "v${prom_ver}" \
+ && git checkout FETCH_HEAD
+
+# Build libprom.so from sources.
+RUN mkdir -p /build/prom/build/ && cd /build/prom/build/ \
+ && TEST=0 cmake -v -G "Unix Makefiles" \
+                 -DCMAKE_INSTALL_PREFIX=/usr \
+                 -DCMAKE_SKIP_BUILD_RPATH=TRUE \
+                 -DCMAKE_C_FLAGS="-DPROM_LOG_ENABLE -g -O3" \
+                 .. \
+ && make
+
+# Build libpromhttp.so from sources.
+RUN mkdir -p /build/promhttp/build/ && cd /build/promhttp/build/ \
+ # Fix compiler warning: -Werror=incompatible-pointer-types
+ && sed -i 's/\&promhttp_handler/(MHD_AccessHandlerCallback)\&promhttp_handler/' \
+           /build/promhttp/src/promhttp.c \
+ && TEST=0 cmake -v -G "Unix Makefiles" \
+                 -DCMAKE_INSTALL_PREFIX=/usr \
+                 -DCMAKE_SKIP_BUILD_RPATH=TRUE \
+                 -DCMAKE_C_FLAGS="-g -O3" \
+                 .. \
+ && make VERBOSE=1
+
+# Install prometheus-client-c.
+RUN LIBS_DIR=/out/$(dirname $(find /usr/ -name libc.so)) \
+ && mkdir -p $LIBS_DIR/ \
+ && cp -rf /build/prom/build/libprom.so \
+           /build/promhttp/build/libpromhttp.so \
+       $LIBS_DIR/ \
+ && mkdir -p /out/usr/include/ \
+ && cp -rf /build/prom/include/* \
+           /build/promhttp/include/* \
+       /out/usr/include/ \
+ # Preserve license file.
+ && mkdir -p /out/usr/share/licenses/prometheus-client-c/ \
+ && cp /build/LICENSE /out/usr/share/licenses/prometheus-client-c/
+
+
+
+
+#
 # Stage 'dist-coturn' creates Coturn distribution.
 #
 
@@ -27,7 +95,11 @@ RUN apk add --no-cache \
         openssl-dev \
         postgresql-dev mariadb-connector-c-dev sqlite-dev \
         hiredis-dev \
-        mongo-c-driver-dev
+        mongo-c-driver-dev \
+        libmicrohttpd-dev
+
+# Install prometheus-client-c distribution.
+COPY --from=dist-libprom /out/ /
 
 # Prepare local Coturn sources for building.
 COPY CMakeLists.txt \
@@ -85,6 +157,9 @@ RUN ln -s /usr/local/bin/detect-external-ip.sh \
           /out/usr/local/bin/detect-external-ip
 RUN chown -R nobody:nogroup /out/var/lib/coturn/
 
+# Re-export prometheus-client-c distribution.
+COPY --from=dist-libprom /out/ /out/
+
 
 
 
@@ -109,6 +184,7 @@ RUN apk update \
         libpq mariadb-connector-c sqlite-libs \
         hiredis \
         mongo-c-driver \
+        libmicrohttpd \
  # Cleanup unnecessary stuff.
  && rm -rf /var/cache/apk/*
 

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -8,6 +8,75 @@ ARG debian_ver=buster
 
 
 #
+# Stage 'dist-libprom' creates prometheus-client-c distribution.
+#
+
+# We compile prometheus-client-c from sources, because Alpine doesn't provide
+# it as its package yet.
+#
+# TODO: Re-check this to be present in packages on next Debian major version update.
+
+# https://hub.docker.com/_/debian
+# We use 'bullseye' here due to too old cmake on 'buster'.
+FROM debian:bullseye-slim AS dist-libprom
+
+# Install tools for building.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends --no-install-suggests \
+            ca-certificates cmake g++ git make \
+ && update-ca-certificates
+
+# Install prometheus-client-c build dependencies.
+RUN apt-get install -y --no-install-recommends --no-install-suggests \
+            libmicrohttpd-dev
+
+# Prepare prometheus-client-c sources for building.
+ARG prom_ver=0.1.3
+RUN mkdir -p /build/ && cd /build/ \
+ && git init \
+ && git remote add origin https://github.com/digitalocean/prometheus-client-c \
+ && git fetch --depth=1 origin "v${prom_ver}" \
+ && git checkout FETCH_HEAD
+
+# Build libprom.so from sources.
+RUN mkdir -p /build/prom/build/ && cd /build/prom/build/ \
+ && TEST=0 cmake -v -G "Unix Makefiles" \
+                 -DCMAKE_INSTALL_PREFIX=/usr \
+                 -DCMAKE_SKIP_BUILD_RPATH=TRUE \
+                 -DCMAKE_C_FLAGS="-DPROM_LOG_ENABLE -g -O3" \
+                 .. \
+ && make
+
+# Build libpromhttp.so from sources.
+RUN mkdir -p /build/promhttp/build/ && cd /build/promhttp/build/ \
+ # Fix compiler warning: -Werror=incompatible-pointer-types
+ && sed -i 's/\&promhttp_handler/(MHD_AccessHandlerCallback)\&promhttp_handler/' \
+           /build/promhttp/src/promhttp.c \
+ && TEST=0 cmake -v -G "Unix Makefiles" \
+                 -DCMAKE_INSTALL_PREFIX=/usr \
+                 -DCMAKE_SKIP_BUILD_RPATH=TRUE \
+                 -DCMAKE_C_FLAGS="-g -O3" \
+                 .. \
+ && make VERBOSE=1
+
+# Install prometheus-client-c.
+RUN LIBS_DIR=/out/$(dirname $(find /usr/ -name libc.so)) \
+ && mkdir -p $LIBS_DIR/ \
+ && cp -rf /build/prom/build/libprom.so \
+           /build/promhttp/build/libpromhttp.so \
+       $LIBS_DIR/ \
+ && mkdir -p /out/usr/include/ \
+ && cp -rf /build/prom/include/* \
+           /build/promhttp/include/* \
+       /out/usr/include/ \
+ # Preserve license file.
+ && mkdir -p /out/usr/share/licenses/prometheus-client-c/ \
+ && cp /build/LICENSE /out/usr/share/licenses/prometheus-client-c/
+
+
+
+
+#
 # Stage 'dist-mongoc' creates mongo-c-driver distribution.
 #
 
@@ -79,10 +148,13 @@ RUN apt-get install -y --no-install-recommends --no-install-suggests \
             libevent-dev \
             libssl-dev \
             libpq-dev libmariadb-dev libsqlite3-dev \
-            libhiredis-dev
+            libhiredis-dev \
+            libmicrohttpd-dev
 
 # Install mongo-c-driver distribution.
 COPY --from=dist-mongoc /out/ /
+# Install prometheus-client-c distribution.
+COPY --from=dist-libprom /out/ /
 
 # Prepare local Coturn sources for building.
 COPY CMakeLists.txt \
@@ -142,6 +214,8 @@ RUN chown -R nobody:nogroup /out/var/lib/coturn/
 
 # Re-export mongo-c-driver distribution.
 COPY --from=dist-mongoc /out/ /out/
+# Re-export prometheus-client-c distribution.
+COPY --from=dist-libprom /out/ /out/
 
 
 
@@ -168,6 +242,7 @@ RUN apt-get update \
             libssl1.1 \
             libpq5 libmariadb3 libsqlite3-0 \
             libhiredis0.14 \
+            libmicrohttpd12 \
  # Cleanup unnecessary stuff.
  && rm -rf /var/lib/apt/lists/*
 

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -183,7 +183,9 @@ RUN if [ "${coturn_git_ref}" != 'HEAD' ]; then true \
  && true; fi
 
 # Build Coturn from sources.
-RUN ./configure --prefix=/usr \
+# TODO: Remove `LDFLAGS` with next Coturn release containing `-latomic` flag in `configure`.
+RUN LDFLAGS='-latomic' \
+    ./configure --prefix=/usr \
                 --turndbdir=/var/lib/coturn \
                 --disable-rpath \
                 --sysconfdir=/etc/coturn \
@@ -237,6 +239,7 @@ RUN apt-get update \
  && update-ca-certificates \
  # Install Coturn dependencies.
  && apt-get install -y --no-install-recommends --no-install-suggests \
+            libatomic1 \
             libevent-2.1-6 libevent-core-2.1-6 libevent-extra-2.1-6 \
             libevent-openssl-2.1-6 libevent-pthreads-2.1-6 \
             libssl1.1 \

--- a/docker/coturn/tests/main.bats
+++ b/docker/coturn/tests/main.bats
@@ -116,3 +116,12 @@
   [ "$status" -eq 0 ]
   [ ! "$output" = '' ]
 }
+
+@test "Prometheus supported" {
+  # Support of Prometheus is not displayed in the output,
+  # but using --prometheus flag does the job.
+  run docker run --rm --platform $PLATFORM --entrypoint sh $IMAGE -c \
+    "turnserver -o --log-file=stdout --prometheus | grep 'Version Coturn'"
+  [ "$status" -eq 0 ]
+  [ ! "$output" = '' ]
+}


### PR DESCRIPTION
Fixes instrumentisto/coturn-docker-image#37
Superseeds instrumentisto/coturn-docker-image#39

This PR is based on @SammyEnigma's work, with a few improvements:
- use upstream original repo instead of a fork
- test prometheus support

