### PR TITLE
Performance: Don't bzero the entire stun_buffer_list_elem

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -297,15 +297,15 @@ static stun_buffer_list_elem *new_blist_elem(ioa_engine_handle e)
 
 	if(!ret) {
 	  ret = (stun_buffer_list_elem *)malloc(sizeof(stun_buffer_list_elem));
-	  if (ret) {
-		ret->next = NULL;
-	  } else {
-		TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate memory for STUN buffer!\n", __FUNCTION__);
-	  }
 	}
 
 	if(ret) {
-	  bzero(&ret->buf, sizeof(stun_buffer));
+	  ret->buf.len = 0;
+	  ret->buf.offset = 0;
+	  ret->buf.coffset = 0;
+	  ret->next = NULL;
+	} else {
+	  TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate memory for STUN buffer!\n", __FUNCTION__);
 	}
 
 	return ret;


### PR DESCRIPTION
On high traffic servers bzero -> memset takes a significant amount of time because each stun_buffer_list_elem can be ~64kb