### PR TITLE
Fix for performance regression caused by CVE-2020-4067 fix

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -297,15 +297,15 @@ static stun_buffer_list_elem *new_blist_elem(ioa_engine_handle e)
 
 	if(!ret) {
 	  ret = (stun_buffer_list_elem *)malloc(sizeof(stun_buffer_list_elem));
-	  if (ret) {
-		ret->next = NULL;
-	  } else {
-		TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate memory for STUN buffer!\n", __FUNCTION__);
-	  }
 	}
 
 	if(ret) {
-	  bzero(&ret->buf, sizeof(stun_buffer));
+	  ret->buf.len = 0;
+	  ret->buf.offset = 0;
+	  ret->buf.coffset = 0;
+	  ret->next = NULL;
+	} else {
+	  TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate memory for STUN buffer!\n", __FUNCTION__);
 	}
 
 	return ret;

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1448,8 +1448,10 @@ int stun_attr_add_str(uint8_t* buf, size_t *len, uint16_t attr, const uint8_t* a
   int clen = stun_get_command_message_len_str(buf,*len);
   int newlen = clen + 4 + alen;
   int newlenrem4=newlen & 0x00000003;
+  int paddinglen = 0;
   if(newlenrem4) {
-    newlen=newlen+(4-newlenrem4);
+	paddinglen=4-newlenrem4;
+    newlen=newlen+paddinglen;
   }
   if(newlen>=MAX_STUN_MESSAGE_SIZE) return -1;
   else {
@@ -1463,6 +1465,10 @@ int stun_attr_add_str(uint8_t* buf, size_t *len, uint16_t attr, const uint8_t* a
     attr_start_16t[0]=nswap16(attr);
     attr_start_16t[1]=nswap16(alen);
     if(alen>0) bcopy(avalue,attr_start+4,alen);
+	
+	// Write 0 padding to not leak data
+	bzero(attr_start+4+alen, paddinglen);
+
     return 0;
   }
 }


### PR DESCRIPTION
Overall flamegraph:![image](https://user-images.githubusercontent.com/180439/119133333-c48d5200-ba09-11eb-81ec-4c8f5ae4a605.png)

Zoom in on udp_server_input_handler:
![image](https://user-images.githubusercontent.com/180439/119133453-e71f6b00-ba09-11eb-912a-71682b682a20.png)

Zoom in on socket_input_handler:
![image](https://user-images.githubusercontent.com/180439/119134062-ad9b2f80-ba0a-11eb-9161-803288fd5604.png)

In the above flamegraphs you can see that the majority of time in **udp_server_input_handler** and **socket_input_handler** is being spent in memset. This is because both eventually call **new_blist_elem()** which ends up zeroing the entire stun_buffer_list_elem struct before returning. The stun_buffer_list_elem is almost 64kb in size and this causes performance issues on high traffic servers.

With this change, we zero out any padding bytes explicitly in stun_attr_add_str() and avoid zeroing out the entire stun buffer.