### PR TITLE
Add current allocations number gauge metric

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -3722,6 +3722,12 @@ void turn_report_allocation_set(void *a, turn_time_t lifetime, int refresh)
 					send_message_to_redis(e->rch, "publish", key, "%s lifetime=%lu", status, (unsigned long)lifetime);
 				}
 #endif
+#if !defined(TURN_NO_PROMETHEUS)
+				{
+					if (!refresh)
+						prom_inc_allocation();
+				}
+#endif
 			}
 		}
 	}
@@ -3777,6 +3783,7 @@ void turn_report_allocation_delete(void *a)
 						prom_set_finished_traffic(NULL, (const char*)ss->username, (unsigned long)(ss->t_received_packets), (unsigned long)(ss->t_received_bytes), (unsigned long)(ss->t_sent_packets), (unsigned long)(ss->t_sent_bytes), false);
 						prom_set_finished_traffic(NULL, (const char*)ss->username, (unsigned long)(ss->t_peer_received_packets), (unsigned long)(ss->t_peer_received_bytes), (unsigned long)(ss->t_peer_sent_packets), (unsigned long)(ss->t_peer_sent_bytes), true);
 					}
+					prom_dec_allocation();
 				}
 #endif
 			}

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -24,6 +24,8 @@ prom_counter_t *turn_total_traffic_peer_rcvb;
 prom_counter_t *turn_total_traffic_peer_sentp;
 prom_counter_t *turn_total_traffic_peer_sentb;
 
+prom_gauge_t *turn_total_allocations_number;
+
 
 int start_prometheus_server(void){
   if (turn_params.prometheus == 0){
@@ -56,6 +58,9 @@ int start_prometheus_server(void){
   turn_total_traffic_peer_rcvb = prom_collector_registry_must_register_metric(prom_counter_new("turn_total_traffic_peer_rcvb", "Represents total finished sessions peer received bytes", 0, NULL));
   turn_total_traffic_peer_sentp = prom_collector_registry_must_register_metric(prom_counter_new("turn_total_traffic_peer_sentp", "Represents total finished sessions peer sent packets", 0, NULL));
   turn_total_traffic_peer_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_total_traffic_peer_sentb", "Represents total finished sessions peer sent bytes", 0, NULL));
+
+  // Create total allocations number gauge metric
+  turn_total_allocations_number = prom_collector_registry_must_register_metric(prom_gauge_new("turn_total_allocations_number", "Represents current allocations number", 0, NULL));
 
   promhttp_set_active_collector_registry(NULL);
 
@@ -93,6 +98,18 @@ void prom_set_finished_traffic(const char* realm, const char* user, unsigned lon
       prom_counter_add(turn_total_traffic_sentp, sentp, NULL);
       prom_counter_add(turn_total_traffic_sentb, sentb, NULL);
     }
+  }
+}
+
+void prom_inc_allocation(void) {
+  if (turn_params.prometheus == 1){
+    prom_gauge_inc(turn_total_allocations_number, NULL);
+  }
+}
+
+void prom_dec_allocation(void) {
+  if (turn_params.prometheus == 1){
+    prom_gauge_dec(turn_total_allocations_number, NULL);
   }
 }
 

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -24,7 +24,7 @@ prom_counter_t *turn_total_traffic_peer_rcvb;
 prom_counter_t *turn_total_traffic_peer_sentp;
 prom_counter_t *turn_total_traffic_peer_sentb;
 
-prom_gauge_t *turn_total_allocations_number;
+prom_gauge_t *turn_total_allocations;
 
 
 int start_prometheus_server(void){
@@ -66,7 +66,7 @@ int start_prometheus_server(void){
   turn_total_traffic_peer_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_total_traffic_peer_sentb", "Represents total finished sessions peer sent bytes", 0, NULL));
 
   // Create total allocations number gauge metric
-  turn_total_allocations_number = prom_collector_registry_must_register_metric(prom_gauge_new("turn_total_allocations_number", "Represents current allocations number", 0, NULL));
+  turn_total_allocations = prom_collector_registry_must_register_metric(prom_gauge_new("turn_total_allocations", "Represents current allocations number", 0, NULL));
 
   promhttp_set_active_collector_registry(NULL);
 
@@ -112,13 +112,13 @@ void prom_set_finished_traffic(const char* realm, const char* user, unsigned lon
 
 void prom_inc_allocation(void) {
   if (turn_params.prometheus == 1){
-    prom_gauge_inc(turn_total_allocations_number, NULL);
+    prom_gauge_inc(turn_total_allocations, NULL);
   }
 }
 
 void prom_dec_allocation(void) {
   if (turn_params.prometheus == 1){
-    prom_gauge_dec(turn_total_allocations_number, NULL);
+    prom_gauge_dec(turn_total_allocations, NULL);
   }
 }
 

--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -46,6 +46,8 @@ extern prom_counter_t *turn_total_traffic_peer_rcvb;
 extern prom_counter_t *turn_total_traffic_peer_sentp;
 extern prom_counter_t *turn_total_traffic_peer_sentb;
 
+extern prom_gauge_t *turn_total_allocations_number;
+
 #define TURN_ALLOC_STR_MAX_SIZE (20)
 
 #ifdef __cplusplus
@@ -56,6 +58,9 @@ extern "C" {
 int start_prometheus_server(void);
 
 void prom_set_finished_traffic(const char* realm, const char* user, unsigned long rsvp, unsigned long rsvb, unsigned long sentp, unsigned long sentb, bool peer);
+
+void prom_inc_allocation(void);
+void prom_dec_allocation(void);
 
 #endif /* TURN_NO_PROMETHEUS */
 


### PR DESCRIPTION
Hello, I would like to propose new metric to prometheus: it is the gauge metric of total current allocations number. It doesn't create any detailed lables in order not to increase memory consumption and only keeps one counter. I believe it may be useful e.g. for draining coturn instance before termination by auto-scaling group or simply as one of the current load metrics.
Thank you for your attention!