### PR TITLE
Don't set socket buffer size for UDP socket

### DIFF
--- a/src/apps/peer/udpserver.c
+++ b/src/apps/peer/udpserver.c
@@ -84,8 +84,6 @@ static int udp_create_server_socket(server_type* server,
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"Cannot bind udp server socket to device %s\n",server->ifname);
   }
 
-  set_sock_buf_size(udp_fd,UR_SERVER_SOCK_BUF_SIZE);
-  
   if(addr_bind(udp_fd,server_addr,1,1,UDP_SOCKET)<0) return -1;
   
   socket_set_nonblocking(udp_fd);

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -759,8 +759,6 @@ static int create_server_socket(dtls_listener_relay_server_type* server, int rep
 
 	  server->udp_listen_s = create_ioa_socket_from_fd(server->e, udp_listen_fd, NULL, UDP_SOCKET, LISTENER_SOCKET, NULL, &(server->addr));
 
-	  set_sock_buf_size(udp_listen_fd,UR_SERVER_SOCK_BUF_SIZE);
-
 	  if(sock_bind_to_device(udp_listen_fd, (unsigned char*)server->ifname)<0) {
 		  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"Cannot bind listener socket to device %s\n",server->ifname);
 	  }
@@ -842,8 +840,6 @@ static int reopen_server_socket(dtls_listener_relay_server_type* server, evutil_
 		/* some UDP sessions may fail due to the race condition here */
 
 		set_socket_options(server->udp_listen_s);
-
-		set_sock_buf_size(udp_listen_fd, UR_SERVER_SOCK_BUF_SIZE);
 
 		if (sock_bind_to_device(udp_listen_fd, (unsigned char*) server->ifname) < 0) {
 				TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -797,8 +797,6 @@ int set_socket_options_fd(evutil_socket_t fd, SOCKET_TYPE st, int family)
 	if(fd<0)
 		return 0;
 
-	set_sock_buf_size(fd,UR_CLIENT_SOCK_BUF_SIZE);
-
 	if(is_tcp_socket(st)) { /* <<== FREEBSD fix */
 		struct linger so_linger;
 		so_linger.l_onoff = 1;
@@ -897,7 +895,6 @@ ioa_socket_handle create_unbound_relay_ioa_socket(ioa_engine_handle e, int famil
 			perror("UDP socket");
 			return NULL;
 		}
-		set_sock_buf_size(fd, UR_CLIENT_SOCK_BUF_SIZE);
 		break;
 	case TCP_SOCKET:
 		fd = socket(family, RELAY_STREAM_SOCKET_TYPE, RELAY_STREAM_SOCKET_PROTOCOL);
@@ -905,7 +902,6 @@ ioa_socket_handle create_unbound_relay_ioa_socket(ioa_engine_handle e, int famil
 			perror("TCP socket");
 			return NULL;
 		}
-		set_sock_buf_size(fd, UR_CLIENT_SOCK_BUF_SIZE);
 		break;
 	default:
 		/* we do not support other sockets in the relay position */


### PR DESCRIPTION
`UR_CLIENT_SOCK_BUF_SIZE` and `UR_SERVER_SOCK_BUF_SIZE` are too small for high bandwidth (approximately 4Mbps or higher).
It causes UDP packet receive errors.
This change removes `set_sock_buf_size()` from `set_socket_options_fd()`.
The socket buffer size is determined by the kernel and it is controllable through the sysctl command etc.