### PR TITLE
Add ability to configure prometheus listener port

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -286,6 +286,8 @@ Flags:
 			disabled. Would listen on port 9641 under the path /metrics
 			also the path / on this port can be used as a health check
 
+--prometheus-port	Prometheus listener port (Default: 9641).
+
 -h			Help.
 
 Options with values:

--- a/README.turnserver
+++ b/README.turnserver
@@ -281,8 +281,9 @@ Flags:
 			check: across the session, all requests must have the same
 			main ORIGIN attribute value (if the ORIGIN was
 			initially used by the session).
- --prometheus		Enable prometheus metrics. By default it is
-			disabled. Would listen on port 9641 unther the path /metrics
+
+--prometheus		Enable prometheus metrics. By default it is
+			disabled. Would listen on port 9641 under the path /metrics
 			also the path / on this port can be used as a health check
 
 -h			Help.

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -422,12 +422,11 @@ The flag that sets the origin consistency
 check: across the session, all requests must have the same
 main ORIGIN attribute value (if the ORIGIN was
 initially used by the session).
-.RS
 .TP
 .B
 \fB\-\-prometheus\fP
 Enable prometheus metrics. By default it is
-disabled. Would listen on port 9641 unther the path /metrics
+disabled. Would listen on port 9641 under the path /metrics
 also the path / on this port can be used as a health check
 .RE
 .TP

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -428,6 +428,10 @@ initially used by the session).
 Enable prometheus metrics. By default it is
 disabled. Would listen on port 9641 under the path /metrics
 also the path / on this port can be used as a health check
+.TP
+.B
+\fB\-\-prometheus\-port\fP
+Prometheus listener port (Default: 9641).
 .RE
 .TP
 .B

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -557,7 +557,7 @@ static char Usage[] = "Usage: turnserver [options]\n"
 "						The connection string has the same parameters as redis-userdb connection string.\n"
 #endif
 #if !defined(TURN_NO_PROMETHEUS)
-" --prometheus					Enable prometheus metrics. It is disabled by default. If it is enabled it will listen on port 9641 unther the path /metrics\n"
+" --prometheus					Enable prometheus metrics. It is disabled by default. If it is enabled it will listen on port 9641 under the path /metrics\n"
 "						also the path / on this port can be used as a health check\n"
 #endif
 " --use-auth-secret				TURN REST API flag.\n"

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -173,6 +173,7 @@ TURN_CREDENTIALS_NONE, /* ct */
 0, /* user_quota */
 #if !defined(TURN_NO_PROMETHEUS)
 0, /* prometheus disabled by default */
+DEFAULT_PROM_SERVER_PORT, /* prometheus port */
 #endif
 ///////////// Users DB //////////////
 { (TURN_USERDB_TYPE)0, {"\0"}, {0,NULL, {NULL,0}} },
@@ -559,6 +560,7 @@ static char Usage[] = "Usage: turnserver [options]\n"
 #if !defined(TURN_NO_PROMETHEUS)
 " --prometheus					Enable prometheus metrics. It is disabled by default. If it is enabled it will listen on port 9641 under the path /metrics\n"
 "						also the path / on this port can be used as a health check\n"
+" --prometheus-port		<port>		Prometheus metrics port (Default: 9641).\n"
 #endif
 " --use-auth-secret				TURN REST API flag.\n"
 "						Flag that sets a special authorization option that is based upon authentication secret\n"
@@ -787,6 +789,7 @@ enum EXTRA_OPTS {
 	CHANNEL_LIFETIME_OPT,
 	PERMISSION_LIFETIME_OPT,
 	PROMETHEUS_OPT,
+	PROMETHEUS_PORT_OPT,
 	AUTH_SECRET_OPT,
 	NO_AUTH_PINGS_OPT,
 	NO_DYNAMIC_IP_LIST_OPT,
@@ -902,6 +905,7 @@ static const struct myoption long_options[] = {
 #endif
 #if !defined(TURN_NO_PROMETHEUS)
 				{ "prometheus", optional_argument, NULL, PROMETHEUS_OPT },
+				{ "prometheus-port", optional_argument, NULL, PROMETHEUS_PORT_OPT },
 #endif
 				{ "use-auth-secret", optional_argument, NULL, AUTH_SECRET_OPT },
 				{ "static-auth-secret", required_argument, NULL, STATIC_AUTH_SECRET_VAL_OPT },
@@ -1533,6 +1537,9 @@ static void set_option(int c, char *value)
 #if !defined(TURN_NO_PROMETHEUS)
 	case PROMETHEUS_OPT:
 		turn_params.prometheus = 1;
+		break;
+	case PROMETHEUS_PORT_OPT:
+		turn_params.prometheus_port = atoi(value);
 		break;
 #endif
 	case AUTH_SECRET_OPT:

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -318,7 +318,8 @@ typedef struct _turn_params_ {
   vint total_quota;
   vint user_quota;
   #if !defined(TURN_NO_PROMETHEUS)
-  int  prometheus;
+  int prometheus;
+  int prometheus_port;
   #endif
 
 

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -60,7 +60,7 @@ int start_prometheus_server(void){
   promhttp_set_active_collector_registry(NULL);
 
 
-  struct MHD_Daemon *daemon = promhttp_start_daemon(MHD_USE_SELECT_INTERNALLY, DEFAULT_PROM_SERVER_PORT, NULL, NULL);
+  struct MHD_Daemon *daemon = promhttp_start_daemon(MHD_USE_SELECT_INTERNALLY, turn_params.prometheus_port, NULL, NULL);
   if (daemon == NULL) {
     return -1;
   }


### PR DESCRIPTION
This introduces a new `--prometheus-port` parameter. Default values is still `9641`.