### PR TITLE
Fix build with libressl 3.4.0+

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -1833,7 +1833,7 @@ int ssl_read(evutil_socket_t fd, SSL* ssl, ioa_network_buffer_handle nbh, int ve
 	BIO* rbio = BIO_new_mem_buf(buffer, old_buffer_len);
 	BIO_set_mem_eof_return(rbio, -1);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER < 0x3040000fL)
 	ssl->rbio = rbio;
 #else
 	SSL_set0_rbio(ssl,rbio);
@@ -1928,7 +1928,7 @@ int ssl_read(evutil_socket_t fd, SSL* ssl, ioa_network_buffer_handle nbh, int ve
 	if(ret>0) {
 		ioa_network_buffer_add_offset_size(nbh, (uint16_t)buf_size, 0, (size_t)ret);
 	}
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined LIBRESSL_VERSION_NUMBER
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER < 0x3040000fL)
 	ssl->rbio = NULL;
 	BIO_free(rbio);
 #else


### PR DESCRIPTION
SSL will become opaque in LibreSSL 3.4.x, hence the code reaching inside
it will result in build breakage.
SSL_set0_rbio() now available in libressl.