### PR TITLE
Make per-user prometheus statistics optional

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -284,6 +284,9 @@ Flags:
  --prometheus		Enable prometheus metrics. By default it is
 			disabled. Would listen on port 9641 unther the path /metrics
 			also the path / on this port can be used as a health check
+--no-user-prom-metrics		Disable prometheus per-user metrics. It is
+			enabled by default. If it is disabled prometheus will collect
+			only overall total metrics without {realm,user} labels.
 
 -h			Help.
 

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -198,6 +198,11 @@
 #
 #prometheus
 
+# Disable prometheus per-user metrics
+# If uncommented prometheus will collect only overall total metrics without {realm,user} labels.
+#
+#no-user-prom-metrics
+
 # TURN REST API flag.
 # (Time Limited Long Term Credential)
 # Flag that sets a special authorization option that is based upon authentication secret.

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -173,6 +173,7 @@ TURN_CREDENTIALS_NONE, /* ct */
 0, /* user_quota */
 #if !defined(TURN_NO_PROMETHEUS)
 0, /* prometheus disabled by default */
+0, /* collect per-user metrics by default */
 #endif
 ///////////// Users DB //////////////
 { (TURN_USERDB_TYPE)0, {"\0"}, {0,NULL, {NULL,0}} },
@@ -559,6 +560,8 @@ static char Usage[] = "Usage: turnserver [options]\n"
 #if !defined(TURN_NO_PROMETHEUS)
 " --prometheus					Enable prometheus metrics. It is disabled by default. If it is enabled it will listen on port 9641 unther the path /metrics\n"
 "						also the path / on this port can be used as a health check\n"
+" --no-user-prom-metrics		Disable prometheus per-user metrics. It is enabled by default. If it is disabled prometheus will collect\n"
+"						only overall total metrics without {realm,user} labels.\n"
 #endif
 " --use-auth-secret				TURN REST API flag.\n"
 "						Flag that sets a special authorization option that is based upon authentication secret\n"
@@ -787,6 +790,7 @@ enum EXTRA_OPTS {
 	CHANNEL_LIFETIME_OPT,
 	PERMISSION_LIFETIME_OPT,
 	PROMETHEUS_OPT,
+	NO_USER_PROM_METRICS_OPT,
 	AUTH_SECRET_OPT,
 	NO_AUTH_PINGS_OPT,
 	NO_DYNAMIC_IP_LIST_OPT,
@@ -902,6 +906,7 @@ static const struct myoption long_options[] = {
 #endif
 #if !defined(TURN_NO_PROMETHEUS)
 				{ "prometheus", optional_argument, NULL, PROMETHEUS_OPT },
+				{ "no-user-prom-metrics", optional_argument, NULL, NO_USER_PROM_METRICS_OPT },
 #endif
 				{ "use-auth-secret", optional_argument, NULL, AUTH_SECRET_OPT },
 				{ "static-auth-secret", required_argument, NULL, STATIC_AUTH_SECRET_VAL_OPT },
@@ -1533,6 +1538,9 @@ static void set_option(int c, char *value)
 #if !defined(TURN_NO_PROMETHEUS)
 	case PROMETHEUS_OPT:
 		turn_params.prometheus = 1;
+		break;
+	case NO_USER_PROM_METRICS_OPT:
+		turn_params.no_user_prom_metrics = 1;
 		break;
 #endif
 	case AUTH_SECRET_OPT:

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -319,6 +319,7 @@ typedef struct _turn_params_ {
   vint user_quota;
   #if !defined(TURN_NO_PROMETHEUS)
   int  prometheus;
+  int  no_user_prom_metrics;
   #endif
 
 

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -31,19 +31,21 @@ int start_prometheus_server(void){
   }
   prom_collector_registry_default_init();
   
-  const char *label[] = {"realm", "user"};
+  if (turn_params.no_user_prom_metrics == 0) {
+    const char *label[] = {"realm", "user"};
 
-  // Create traffic counter metrics
-  turn_traffic_rcvp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_rcvp", "Represents finished sessions received packets", 2, label));
-  turn_traffic_rcvb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_rcvb", "Represents finished sessions received bytes", 2, label));
-  turn_traffic_sentp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_sentp", "Represents finished sessions sent packets", 2, label));
-  turn_traffic_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_sentb", "Represents finished sessions sent bytes", 2, label));
+    // Create traffic counter metrics
+    turn_traffic_rcvp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_rcvp", "Represents finished sessions received packets", 2, label));
+    turn_traffic_rcvb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_rcvb", "Represents finished sessions received bytes", 2, label));
+    turn_traffic_sentp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_sentp", "Represents finished sessions sent packets", 2, label));
+    turn_traffic_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_sentb", "Represents finished sessions sent bytes", 2, label));
 
-  // Create finished sessions traffic for peers counter metrics
-  turn_traffic_peer_rcvp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_rcvp", "Represents finished sessions peer received packets", 2, label));
-  turn_traffic_peer_rcvb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_rcvb", "Represents finished sessions peer received bytes", 2, label));
-  turn_traffic_peer_sentp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_sentp", "Represents finished sessions peer sent packets", 2, label));
-  turn_traffic_peer_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_sentb", "Represents finished sessions peer sent bytes", 2, label));
+    // Create finished sessions traffic for peers counter metrics
+    turn_traffic_peer_rcvp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_rcvp", "Represents finished sessions peer received packets", 2, label));
+    turn_traffic_peer_rcvb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_rcvb", "Represents finished sessions peer received bytes", 2, label));
+    turn_traffic_peer_sentp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_sentp", "Represents finished sessions peer sent packets", 2, label));
+    turn_traffic_peer_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_sentb", "Represents finished sessions peer sent bytes", 2, label));
+  }
 
   // Create total finished traffic counter metrics
   turn_total_traffic_rcvp = prom_collector_registry_must_register_metric(prom_counter_new("turn_total_traffic_rcvp", "Represents total finished sessions received packets", 0, NULL));
@@ -73,20 +75,24 @@ void prom_set_finished_traffic(const char* realm, const char* user, unsigned lon
     const char *label[] = {realm, user};
 
     if (peer){
-      prom_counter_add(turn_traffic_peer_rcvp, rsvp, label);
-      prom_counter_add(turn_traffic_peer_rcvb, rsvb, label);
-      prom_counter_add(turn_traffic_peer_sentp, sentp, label);
-      prom_counter_add(turn_traffic_peer_sentb, sentb, label);
+      if (turn_params.no_user_prom_metrics == 0) {
+        prom_counter_add(turn_traffic_peer_rcvp, rsvp, label);
+        prom_counter_add(turn_traffic_peer_rcvb, rsvb, label);
+        prom_counter_add(turn_traffic_peer_sentp, sentp, label);
+        prom_counter_add(turn_traffic_peer_sentb, sentb, label);
+      }
 
       prom_counter_add(turn_total_traffic_peer_rcvp, rsvp, NULL);
       prom_counter_add(turn_total_traffic_peer_rcvb, rsvb, NULL);
       prom_counter_add(turn_total_traffic_peer_sentp, sentp, NULL);
       prom_counter_add(turn_total_traffic_peer_sentb, sentb, NULL);
     } else {
-      prom_counter_add(turn_traffic_rcvp, rsvp, label);
-      prom_counter_add(turn_traffic_rcvb, rsvb, label);
-      prom_counter_add(turn_traffic_sentp, sentp, label);
-      prom_counter_add(turn_traffic_sentb, sentb, label);
+      if (turn_params.no_user_prom_metrics == 0) {
+        prom_counter_add(turn_traffic_rcvp, rsvp, label);
+        prom_counter_add(turn_traffic_rcvb, rsvb, label);
+        prom_counter_add(turn_traffic_sentp, sentp, label);
+        prom_counter_add(turn_traffic_sentb, sentb, label);
+      }
 
       prom_counter_add(turn_total_traffic_rcvp, rsvp, NULL);
       prom_counter_add(turn_total_traffic_rcvb, rsvb, NULL);


### PR DESCRIPTION
Hello! In our project we use coturn with Prometheus metrics in conjunction with the short-term credentials mechanism (REST API).
I found out that this combination leads to memory leak inside Prometheus exporter library. Each TURN allocate request with new short-time credentials creates new username which is actually a combination of a timestamp with the username according to draft https://datatracker.ietf.org/doc/html/draft-uberti-rtcweb-turn-rest-00#section-2.2
This temporary username is not kept by coturn itself however Prometheus exporter keeps all usernames in-memory to propagate per-user metrics. I suggest to make per-user metrics gathering optional since disabling it solves the described issue.