### PR TITLE
Store git version information in Docker image metadata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
 

--- a/docker/coturn/Makefile
+++ b/docker/coturn/Makefile
@@ -90,6 +90,8 @@ define docker.buildx
 		--platform $(platform) \
 		$(if $(call eq,$(no-cache),yes),--no-cache --pull,) \
 		$(if $(call eq,$(git-ref),),,--build-arg coturn_git_ref=$(git-ref)) \
+		--build-arg coturn_github_server_url=$${GITHUB_SERVER_URL:-https://github.com} \
+		--build-arg coturn_github_repository=$${GITHUB_REPOSITORY:-coturn/coturn} \
 		--label org.opencontainers.image.version=`git describe` \
 		--label org.opencontainers.image.revision=`git show --pretty=format:%H --no-patch` \
 		-f docker/coturn/$(dockerfile)/Dockerfile \

--- a/docker/coturn/Makefile
+++ b/docker/coturn/Makefile
@@ -90,6 +90,8 @@ define docker.buildx
 		--platform $(platform) \
 		$(if $(call eq,$(no-cache),yes),--no-cache --pull,) \
 		$(if $(call eq,$(git-ref),),,--build-arg coturn_git_ref=$(git-ref)) \
+		--label org.opencontainers.image.version=`git describe` \
+		--label org.opencontainers.image.revision=`git show --pretty=format:%H --no-patch` \
 		-f docker/coturn/$(dockerfile)/Dockerfile \
 		-t $(namespace)/$(NAME):$(tag) ./
 endef

--- a/docker/coturn/Makefile
+++ b/docker/coturn/Makefile
@@ -97,8 +97,8 @@ define docker.buildx
 		--label org.opencontainers.image.source=$(github_url)/$(github_repo) \
 		--label org.opencontainers.image.revision=$(strip \
 			$(shell git show --pretty=format:%H --no-patch)) \
-		--label org.opencontainers.image.version=$(strip \
-			$(shell git describe --tags --dirty --match='docker/*')) \
+		--label org.opencontainers.image.version=$(subst docker/,,$(strip \
+			$(shell git describe --tags --dirty --match='docker/*'))) \
 		-f docker/coturn/$(dockerfile)/Dockerfile \
 		-t $(namespace)/$(NAME):$(tag) ./
 endef

--- a/docker/coturn/Makefile
+++ b/docker/coturn/Makefile
@@ -85,15 +85,20 @@ define docker.buildx
 	$(eval platform := $(strip $(5)))
 	$(eval no-cache := $(strip $(6)))
 	$(eval args := $(strip $(7)))
+	$(eval github_url := $(strip $(or $(GITHUB_SERVER_URL),https://github.com)))
+	$(eval github_repo := $(strip $(or $(GITHUB_REPOSITORY),coturn/coturn)))
 	cd ../../ && \
 	docker buildx build --force-rm $(args) \
 		--platform $(platform) \
 		$(if $(call eq,$(no-cache),yes),--no-cache --pull,) \
 		$(if $(call eq,$(git-ref),),,--build-arg coturn_git_ref=$(git-ref)) \
-		--build-arg coturn_github_server_url=$${GITHUB_SERVER_URL:-https://github.com} \
-		--build-arg coturn_github_repository=$${GITHUB_REPOSITORY:-coturn/coturn} \
-		--label org.opencontainers.image.version=`git describe` \
-		--label org.opencontainers.image.revision=`git show --pretty=format:%H --no-patch` \
+		--build-arg coturn_github_url=$(github_url) \
+		--build-arg coturn_github_repo=$(github_repo) \
+		--label org.opencontainers.image.source=$(github_url)/$(github_repo) \
+		--label org.opencontainers.image.revision=$(strip \
+			$(shell git show --pretty=format:%H --no-patch)) \
+		--label org.opencontainers.image.version=$(strip \
+			$(shell git describe --tags --dirty --match='docker/*')) \
 		-f docker/coturn/$(dockerfile)/Dockerfile \
 		-t $(namespace)/$(NAME):$(tag) ./
 endef

--- a/docker/coturn/alpine/Dockerfile
+++ b/docker/coturn/alpine/Dockerfile
@@ -119,10 +119,13 @@ WORKDIR /app/
 
 # Use Coturn sources from Git if `coturn_git_ref` is specified.
 ARG coturn_git_ref=HEAD
+ARG coturn_github_server_url=https://github.com
+ARG coturn_github_repository=coturn/coturn
+
 RUN if [ "${coturn_git_ref}" != 'HEAD' ]; then true \
  && rm -rf /app/* \
  && git init \
- && git remote add origin https://github.com/coturn/coturn \
+ && git remote add origin ${coturn_github_server_url}/${coturn_github_repository} \
  && git fetch --depth=1 origin "${coturn_git_ref}" \
  && git checkout FETCH_HEAD \
  && true; fi

--- a/docker/coturn/alpine/Dockerfile
+++ b/docker/coturn/alpine/Dockerfile
@@ -119,13 +119,13 @@ WORKDIR /app/
 
 # Use Coturn sources from Git if `coturn_git_ref` is specified.
 ARG coturn_git_ref=HEAD
-ARG coturn_github_server_url=https://github.com
-ARG coturn_github_repository=coturn/coturn
+ARG coturn_github_url=https://github.com
+ARG coturn_github_repo=coturn/coturn
 
 RUN if [ "${coturn_git_ref}" != 'HEAD' ]; then true \
  && rm -rf /app/* \
  && git init \
- && git remote add origin ${coturn_github_server_url}/${coturn_github_repository} \
+ && git remote add origin ${coturn_github_url}/${coturn_github_repo} \
  && git fetch --depth=1 origin "${coturn_git_ref}" \
  && git checkout FETCH_HEAD \
  && true; fi
@@ -175,8 +175,6 @@ COPY --from=dist-libprom /out/ /out/
 
 # https://hub.docker.com/_/alpine
 FROM alpine:${alpine_ver} AS runtime
-
-LABEL org.opencontainers.image.source="https://github.com/coturn/coturn"
 
 # Update system packages.
 RUN apk update \

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -118,13 +118,13 @@ WORKDIR /app/
 
 # Use Coturn sources from Git if `coturn_git_ref` is specified.
 ARG coturn_git_ref=HEAD
-ARG coturn_github_server_url=https://github.com
-ARG coturn_github_repository=coturn/coturn
+ARG coturn_github_url=https://github.com
+ARG coturn_github_repo=coturn/coturn
 
 RUN if [ "${coturn_git_ref}" != 'HEAD' ]; then true \
  && rm -rf /app/* \
  && git init \
- && git remote add origin ${coturn_github_server_url}/${coturn_github_repository} \
+ && git remote add origin ${coturn_github_url}/${coturn_github_repo} \
  && git fetch --depth=1 origin "${coturn_git_ref}" \
  && git checkout FETCH_HEAD \
  && true; fi
@@ -176,8 +176,6 @@ COPY --from=dist-libprom /out/ /out/
 
 # https://hub.docker.com/_/debian
 FROM debian:${debian_ver}-slim AS runtime
-
-LABEL org.opencontainers.image.source="https://github.com/coturn/coturn"
 
 # Update system packages.
 RUN apt-get update \

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -118,10 +118,13 @@ WORKDIR /app/
 
 # Use Coturn sources from Git if `coturn_git_ref` is specified.
 ARG coturn_git_ref=HEAD
+ARG coturn_github_server_url=https://github.com
+ARG coturn_github_repository=coturn/coturn
+
 RUN if [ "${coturn_git_ref}" != 'HEAD' ]; then true \
  && rm -rf /app/* \
  && git init \
- && git remote add origin https://github.com/coturn/coturn \
+ && git remote add origin ${coturn_github_server_url}/${coturn_github_repository} \
  && git fetch --depth=1 origin "${coturn_git_ref}" \
  && git checkout FETCH_HEAD \
  && true; fi


### PR DESCRIPTION
I have added labels to the image so that it is explicit which revision was used to build a container.

I have also tweaked the Dockerfile to work better when you have forked the repository.