### PR TITLE
configure: don't link in libintl

### DIFF
--- a/configure
+++ b/configure
@@ -708,7 +708,6 @@ if ! [ ${ER} -eq 0 ] ; then
     echo "CYGWIN ?"
 fi
 testlib wldap64
-testlib intl
 testlib nsl
 testlib resolv
 


### PR DESCRIPTION
libintl isn't used, so there is no need to link coturn to it.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Hi all,

We realized in [OpenWrt telephony repo](https://github.com/openwrt/telephony/pull/725) that coturn links to libintl even though it's not actually using it. In favor of a small footprint I'd suggest to drop the intl test from configure.

Kind regards,
Seb