### PR TITLE
configure: support MariaDB Connector/C

### DIFF
--- a/configure
+++ b/configure
@@ -945,7 +945,7 @@ fi
 ###########################
 
 if [ -z "${TURN_NO_MYSQL}" ] ; then
-    if testpkg_db mariadb || testpkg_db mysqlclient || test_mysql_config; then
+    if testpkg_db libmariadb || testpkg_db mariadb || testpkg_db mysqlclient || test_mysql_config; then
         ${ECHO_CMD} "MySQL found."
     else
         ${ECHO_CMD} "MySQL not found. Building without MySQL support."


### PR DESCRIPTION
If libmariadb is installed from the MariaDB server package, the pc file
is "mariadb.pc". But when MariaDB Connector/C is used, it's actually
"libmariadb.pc". This commit adds the latter to the detection.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>