### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper-compat (= 13),
                libssl-dev (>= 1.0.0~),
                postgresql-client,
                sqlite3
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0
 Homepage: https://github.com/coturn/coturn/
 Vcs-Git: https://github.com/coturn/coturn.git -b debian/master
 Vcs-Browser: https://github.com/coturn/coturn/tree/debian/master

--- a/debian/copyright
+++ b/debian/copyright
@@ -23,7 +23,7 @@ Comment:
 
 Files: debian/*
 Copyright: 2012 Daniel Pocock <daniel@pocock.com.au>
-	   2013, 2014 Oleg Moskalenko <mom040267@gmail.com>
+           2013, 2014 Oleg Moskalenko <mom040267@gmail.com>
 License: GPL-3+
 Comment:
  The GPL can be found in /usr/share/common-licenses/GPL-3

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,3 @@
-Name: coturn
 Contact: https://groups.google.com/forum/#!forum/turn-server-project-rfc5766-turn-server
 Changelog: https://github.com/coturn/coturn/blob/master/ChangeLog
 Donation: https://coturn.net/


### PR DESCRIPTION
Fix some issues reported by lintian

* debian/copyright: use spaces rather than tabs to start continuation lines. ([tab-in-license-text](https://lintian.debian.org/tags/tab-in-license-text))

* Remove obsolete field Name from debian/upstream/metadata (already present in machine-readable debian/copyright).

* Update standards version to 4.6.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/coturn/38176af4-1674-4715-9891-f614006d0169.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/38176af4-1674-4715-9891-f614006d0169/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/38176af4-1674-4715-9891-f614006d0169/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/38176af4-1674-4715-9891-f614006d0169/diffoscope)).
