### PR TITLE
Fixed assignment to freed memory leading to a segfault

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -2945,8 +2945,8 @@ static void eventcb_bev(struct bufferevent *bev, short events, void *arg)
 			{
 				tcp_connection *tc = s->sub_session;
 				if (tc) {
-					delete_tcp_connection(tc);
 					s->sub_session = NULL;
+					delete_tcp_connection(tc);
 				}
 			}
 				break;


### PR DESCRIPTION
After testing the latest docker image I noticed segfaults appearing at random moments. The segfault is reproducible under this conditions:

- one client with an allocation redirecting the requests to a local webservice
- 150 concurrent peer requests executed with siege (a cli http benchmark tool)

Under normal conditions the segfault appears only under concurrent use (~150 users), but running coturn with valgrind leads to a deterministic memory access error with just one peer request.

The cause lies in `ns_turn_server.c` in `tcp_peer_accept_connection() `
```
tc->peer_s = s;
...
set_ioa_socket_sub_session(s,tc);
```
After this there is a cycle between the `ioa_socket_handle s` and the `tcp_connection tc`. `tc->peer_s->sub_session == tc`

Now the actual erroneous assignment happens in the committed file `ns_ioalib_engine_impl.c` . After the call to `delete_tcp_connection(tc);` the tc and its peer socket `tc->peer_s` both are freed. But because of the cycle this means, that s is freed. Therefore the assignment `s->sub_session = NULL;` accesses freed memory.

The fix is simple: Do the assignment first.

I have no idea why this error started appearing now after all the years. I guess that's the famous Undefined Behavior™ .