### PR TITLE
added MHD_FLAG to make promhttp daemon use dual_stack

### DIFF
--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -60,7 +60,7 @@ int start_prometheus_server(void){
   promhttp_set_active_collector_registry(NULL);
 
 
-  struct MHD_Daemon *daemon = promhttp_start_daemon(MHD_USE_SELECT_INTERNALLY, DEFAULT_PROM_SERVER_PORT, NULL, NULL);
+  struct MHD_Daemon *daemon = promhttp_start_daemon(MHD_USE_SELECT_INTERNALLY | MHD_USE_DUAL_STACK, DEFAULT_PROM_SERVER_PORT, NULL, NULL);
   if (daemon == NULL) {
     return -1;
   }


### PR DESCRIPTION
on our IPV6 only backend, we need the prometheus exporter to also use IPV6