### PR TITLE
Configurable username labelling in Prometheus metrics

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -284,9 +284,9 @@ Flags:
  --prometheus		Enable prometheus metrics. By default it is
 			disabled. Would listen on port 9641 unther the path /metrics
 			also the path / on this port can be used as a health check
- --prometheus-no-username-labels	Disable labeling prometheus traffic
+ --prometheus-username-labels	Enable labeling prometheus traffic
 			metrics with client usernames. Labeling with client usernames is
-			enabled by default, however this may cause memory leaks when using
+			disabled by default, beacuse this may cause memory leaks when using
 			authentication with ephemeral usernames (e.g. TURN REST API).
 
 -h			Help.

--- a/README.turnserver
+++ b/README.turnserver
@@ -284,6 +284,10 @@ Flags:
  --prometheus		Enable prometheus metrics. By default it is
 			disabled. Would listen on port 9641 unther the path /metrics
 			also the path / on this port can be used as a health check
+ --prometheus-no-username-labels	Disable labeling prometheus traffic
+			metrics with client usernames. Labeling with client usernames is
+			enabled by default, however this may cause memory leaks when using
+			authentication with ephemeral usernames (e.g. TURN REST API).
 
 -h			Help.
 

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -429,6 +429,13 @@ initially used by the session).
 Enable prometheus metrics. By default it is
 disabled. Would listen on port 9641 unther the path /metrics
 also the path / on this port can be used as a health check
+.TP
+.B
+\fB\-\-prometheus\-no\-username\-labels\fP
+Disable labeling prometheus traffic
+metrics with client usernames. Labeling with client usernames is
+enabled by default, however this may cause memory leaks when using
+authentication with ephemeral usernames (e.g. TURN REST API).
 .RE
 .TP
 .B

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -431,10 +431,10 @@ disabled. Would listen on port 9641 unther the path /metrics
 also the path / on this port can be used as a health check
 .TP
 .B
-\fB\-\-prometheus\-no\-username\-labels\fP
-Disable labeling prometheus traffic
+\fB\-\-prometheus\-username\-labels\fP
+Enable labeling prometheus traffic
 metrics with client usernames. Labeling with client usernames is
-enabled by default, however this may cause memory leaks when using
+disabled by default, beacuse this may cause memory leaks when using
 authentication with ephemeral usernames (e.g. TURN REST API).
 .RE
 .TP

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -173,7 +173,7 @@ TURN_CREDENTIALS_NONE, /* ct */
 0, /* user_quota */
 #if !defined(TURN_NO_PROMETHEUS)
 0, /* prometheus disabled by default */
-1, /* prometheus username labelling enabled by default when prometheus is enabled */
+0, /* prometheus username labelling disabled by default when prometheus is enabled */
 #endif
 ///////////// Users DB //////////////
 { (TURN_USERDB_TYPE)0, {"\0"}, {0,NULL, {NULL,0}} },
@@ -560,7 +560,7 @@ static char Usage[] = "Usage: turnserver [options]\n"
 #if !defined(TURN_NO_PROMETHEUS)
 " --prometheus					Enable prometheus metrics. It is disabled by default. If it is enabled it will listen on port 9641 unther the path /metrics\n"
 "						also the path / on this port can be used as a health check\n"
-" --prometheus-no-username-labels		When metrics are enabled, do not label metrics with client usernames.\n"
+" --prometheus-username-labels			When metrics are enabled, add labels with client usernames.\n"
 #endif
 " --use-auth-secret				TURN REST API flag.\n"
 "						Flag that sets a special authorization option that is based upon authentication secret\n"
@@ -789,7 +789,7 @@ enum EXTRA_OPTS {
 	CHANNEL_LIFETIME_OPT,
 	PERMISSION_LIFETIME_OPT,
 	PROMETHEUS_OPT,
-	PROMETHEUS_DISABLE_USERNAMES_OPT,
+	PROMETHEUS_ENABLE_USERNAMES_OPT,
 	AUTH_SECRET_OPT,
 	NO_AUTH_PINGS_OPT,
 	NO_DYNAMIC_IP_LIST_OPT,
@@ -905,7 +905,7 @@ static const struct myoption long_options[] = {
 #endif
 #if !defined(TURN_NO_PROMETHEUS)
 				{ "prometheus", optional_argument, NULL, PROMETHEUS_OPT },
-				{ "prometheus-no-username-labels", optional_argument, NULL, PROMETHEUS_DISABLE_USERNAMES_OPT },
+				{ "prometheus-username-labels", optional_argument, NULL, PROMETHEUS_ENABLE_USERNAMES_OPT },
 #endif
 				{ "use-auth-secret", optional_argument, NULL, AUTH_SECRET_OPT },
 				{ "static-auth-secret", required_argument, NULL, STATIC_AUTH_SECRET_VAL_OPT },
@@ -1538,8 +1538,8 @@ static void set_option(int c, char *value)
 	case PROMETHEUS_OPT:
 		turn_params.prometheus = 1;
 		break;
-	case PROMETHEUS_DISABLE_USERNAMES_OPT:
-		turn_params.prometheus_username_labels = 0;
+	case PROMETHEUS_ENABLE_USERNAMES_OPT:
+		turn_params.prometheus_username_labels = 1;
 		break;
 #endif
 	case AUTH_SECRET_OPT:

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -173,6 +173,7 @@ TURN_CREDENTIALS_NONE, /* ct */
 0, /* user_quota */
 #if !defined(TURN_NO_PROMETHEUS)
 0, /* prometheus disabled by default */
+1, /* prometheus username labelling enabled by default when prometheus is enabled */
 #endif
 ///////////// Users DB //////////////
 { (TURN_USERDB_TYPE)0, {"\0"}, {0,NULL, {NULL,0}} },
@@ -559,6 +560,7 @@ static char Usage[] = "Usage: turnserver [options]\n"
 #if !defined(TURN_NO_PROMETHEUS)
 " --prometheus					Enable prometheus metrics. It is disabled by default. If it is enabled it will listen on port 9641 unther the path /metrics\n"
 "						also the path / on this port can be used as a health check\n"
+" --prometheus-no-username-labels		When metrics are enabled, do not label metrics with client usernames.\n"
 #endif
 " --use-auth-secret				TURN REST API flag.\n"
 "						Flag that sets a special authorization option that is based upon authentication secret\n"
@@ -787,6 +789,7 @@ enum EXTRA_OPTS {
 	CHANNEL_LIFETIME_OPT,
 	PERMISSION_LIFETIME_OPT,
 	PROMETHEUS_OPT,
+	PROMETHEUS_DISABLE_USERNAMES_OPT,
 	AUTH_SECRET_OPT,
 	NO_AUTH_PINGS_OPT,
 	NO_DYNAMIC_IP_LIST_OPT,
@@ -902,6 +905,7 @@ static const struct myoption long_options[] = {
 #endif
 #if !defined(TURN_NO_PROMETHEUS)
 				{ "prometheus", optional_argument, NULL, PROMETHEUS_OPT },
+				{ "prometheus-no-username-labels", optional_argument, NULL, PROMETHEUS_DISABLE_USERNAMES_OPT },
 #endif
 				{ "use-auth-secret", optional_argument, NULL, AUTH_SECRET_OPT },
 				{ "static-auth-secret", required_argument, NULL, STATIC_AUTH_SECRET_VAL_OPT },
@@ -1533,6 +1537,9 @@ static void set_option(int c, char *value)
 #if !defined(TURN_NO_PROMETHEUS)
 	case PROMETHEUS_OPT:
 		turn_params.prometheus = 1;
+		break;
+	case PROMETHEUS_DISABLE_USERNAMES_OPT:
+		turn_params.prometheus_username_labels = 0;
 		break;
 #endif
 	case AUTH_SECRET_OPT:

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -319,6 +319,7 @@ typedef struct _turn_params_ {
   vint user_quota;
   #if !defined(TURN_NO_PROMETHEUS)
   int  prometheus;
+  int  prometheus_username_labels;
   #endif
 
 

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -30,20 +30,26 @@ int start_prometheus_server(void){
     return 1;
   }
   prom_collector_registry_default_init();
-  
-  const char *label[] = {"realm", "user"};
+
+  const char *label[] = {"realm", NULL};
+  size_t nlabels = 1;
+
+  if (turn_params.prometheus_username_labels) {
+    label[1] = "user";
+    nlabels++;
+  }
 
   // Create traffic counter metrics
-  turn_traffic_rcvp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_rcvp", "Represents finished sessions received packets", 2, label));
-  turn_traffic_rcvb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_rcvb", "Represents finished sessions received bytes", 2, label));
-  turn_traffic_sentp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_sentp", "Represents finished sessions sent packets", 2, label));
-  turn_traffic_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_sentb", "Represents finished sessions sent bytes", 2, label));
+  turn_traffic_rcvp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_rcvp", "Represents finished sessions received packets", nlabels, label));
+  turn_traffic_rcvb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_rcvb", "Represents finished sessions received bytes", nlabels, label));
+  turn_traffic_sentp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_sentp", "Represents finished sessions sent packets", nlabels, label));
+  turn_traffic_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_sentb", "Represents finished sessions sent bytes", nlabels, label));
 
   // Create finished sessions traffic for peers counter metrics
-  turn_traffic_peer_rcvp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_rcvp", "Represents finished sessions peer received packets", 2, label));
-  turn_traffic_peer_rcvb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_rcvb", "Represents finished sessions peer received bytes", 2, label));
-  turn_traffic_peer_sentp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_sentp", "Represents finished sessions peer sent packets", 2, label));
-  turn_traffic_peer_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_sentb", "Represents finished sessions peer sent bytes", 2, label));
+  turn_traffic_peer_rcvp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_rcvp", "Represents finished sessions peer received packets", nlabels, label));
+  turn_traffic_peer_rcvb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_rcvb", "Represents finished sessions peer received bytes", nlabels, label));
+  turn_traffic_peer_sentp = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_sentp", "Represents finished sessions peer sent packets", nlabels, label));
+  turn_traffic_peer_sentb = prom_collector_registry_must_register_metric(prom_counter_new("turn_traffic_peer_sentb", "Represents finished sessions peer sent bytes", nlabels, label));
 
   // Create total finished traffic counter metrics
   turn_total_traffic_rcvp = prom_collector_registry_must_register_metric(prom_counter_new("turn_total_traffic_rcvp", "Represents total finished sessions received packets", 0, NULL));
@@ -70,7 +76,10 @@ int start_prometheus_server(void){
 void prom_set_finished_traffic(const char* realm, const char* user, unsigned long rsvp, unsigned long rsvb, unsigned long sentp, unsigned long sentb, bool peer){
   if (turn_params.prometheus == 1){
 
-    const char *label[] = {realm, user};
+    const char *label[] = {realm, NULL};
+    if (turn_params.prometheus_username_labels){
+      label[1] = user;
+    }
 
     if (peer){
       prom_counter_add(turn_traffic_peer_rcvp, rsvp, label);


### PR DESCRIPTION
When Prometheus metrics are enabled, traffic metrics are labelled with client username, which permits tracking traffic usage on a per-client basis. However, the TURN REST API authentication scheme uses ephemeral usernames, and so authenticating with a new username will cause a new label value to be generated. As prometheus-client-c doesn't garbage collect old metrics labels, this means that memory usage will grow over time, corresponding to clients authenticating with new usernames.

This change adds a new option `--prometheus-no-username-labels`, which will disable the use of username labels when traffic metrics are record, which should eliminate the memory leak issue. This should address issue #666.