### PR TITLE
uclient: Show error on invalid peer options specification

### DIFF
--- a/src/apps/uclient/mainuclient.c
+++ b/src/apps/uclient/mainuclient.c
@@ -453,6 +453,10 @@ int main(int argc, char **argv)
 	}
 
 	if (!c2c) {
+                if(!peer_address[0]) {
+                        fprintf(stderr,"Either -e peer_address or -y must be specified\n");
+                        return -1;
+                }
 
 		if (make_ioa_addr((const uint8_t*) peer_address, peer_port, &peer_addr) < 0) {
 			return -1;


### PR DESCRIPTION
If none of -e and -y options are specified, currently client sends peer address 0.0.0.0:some_port to turn server, which results in Forbidden IP error in 4.5.2.
Since the turn server didn't return any errors until 4.5.1.x, there are some misunderstanding examples lacking these options (and misleading Q&As around Issues and stackoverflow etc.: `use 4.5.1.3` ).

This adds an error message to guide users to specify either -e or -y option.
