### PR TITLE
Update example turnserver.conf file to reflect that dh2066 is default

### DIFF
--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -488,7 +488,7 @@ pkey=/etc/ssl/private/privkey.pem
 #dh1066
 
 # Use custom DH TLS key, stored in PEM format in the file.
-# Flags --dh566 and --dh2066 are ignored when the DH key is taken from a file.
+# Flags --dh566 and --dh1066 are ignored when the DH key is taken from a file.
 #
 #dh-file=<DH-PEM-file-name>
 

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -500,7 +500,7 @@
 #dh1066
 
 # Use custom DH TLS key, stored in PEM format in the file.
-# Flags --dh566 and --dh2066 are ignored when the DH key is taken from a file.
+# Flags --dh566 and --dh1066 are ignored when the DH key is taken from a file.
 #
 #dh-file=<DH-PEM-file-name>
 


### PR DESCRIPTION
Sample configuration file mentions --dh2066 which does not exist in code (assumed by default when --dh1066 and --dh566 are omitted and no --dh-file is provided)

Fixes #550 

Test Plan:
N/A