### PR TITLE
Disable SSL renegotiation

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -295,7 +295,7 @@ static ioa_socket_handle dtls_server_input_handler(dtls_listener_relay_server_ty
 	SSL_set_accept_state(connecting_ssl);
 
 	SSL_set_bio(connecting_ssl, NULL, wbio);
-	SSL_set_options(connecting_ssl, SSL_OP_COOKIE_EXCHANGE);
+	SSL_set_options(connecting_ssl, SSL_OP_COOKIE_EXCHANGE | SSL_OP_NO_RENEGOTIATION);
 
 	SSL_set_max_cert_list(connecting_ssl, 655350);
 
@@ -581,7 +581,8 @@ static int create_new_connected_udp_socket(
 
 		SSL_set_bio(connecting_ssl, NULL, wbio);
 
-		SSL_set_options(connecting_ssl, SSL_OP_COOKIE_EXCHANGE);
+		SSL_set_options(connecting_ssl, SSL_OP_COOKIE_EXCHANGE | SSL_OP_NO_RENEGOTIATION);
+
 		SSL_set_max_cert_list(connecting_ssl, 655350);
 		int rc = ssl_read(ret->fd, connecting_ssl, server->sm.m.sm.nd.nbh,
 				server->verbose);

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -1428,6 +1428,7 @@ static void set_socket_ssl(ioa_socket_handle s, SSL *ssl)
 		if(ssl) {
 			SSL_set_app_data(ssl,s);
 			SSL_set_info_callback(ssl, (ssl_info_callback_t)ssl_info_callback);
+			SSL_set_options(ssl, SSL_OP_NO_RENEGOTIATION);
 		}
 	}
 }


### PR DESCRIPTION
Disable SSL renegotiation by setting `SSL_OP_NO_RENEGOTIATION` on SSL connection (both TLS and DTLS)

Fixes #892

Tested by connecting to running server and asking for renegotiation:
```
#openssl s_client -connect localhost:443
...
---

RENEGOTIATING
4398376448:error:14094153:SSL routines:ssl3_read_bytes:no renegotiation:ssl/record/rec_layer_s3.c:1561:
```
and DTLS
```
#openssl s_client -connect localhost:443 -dtls1
...
---

RENEGOTIATING
4572587520:error:14102199:SSL routines:dtls1_read_bytes:too many warn alerts:ssl/record/rec_layer_d1.c:586:
```