### PR TITLE
[turncommon] depend on OpenSSL

### DIFF
--- a/src/apps/common/CMakeLists.txt
+++ b/src/apps/common/CMakeLists.txt
@@ -37,6 +37,11 @@ if(hiredis_FOUND)
 else()
     list(APPEND COMMON_DEFINED TURN_NO_HIREDIS)
 endif()
+
+find_package(OpenSSL REQUIRED Crypto SSL)
+list(APPEND COMMON_LIBS OpenSSL::Crypto)
+list(APPEND COMMON_LIBS OpenSSL::SSL)
+
 message("COMMON_LIBS:${COMMON_LIBS}")
 
 add_library(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})


### PR DESCRIPTION
Maybe only one is strictly required, but the list of headers used in `ns_turn_openssl.h` includes things from both targets.

I think this correctly resolves #242. I can now compile coturn on MacOS without having to manually specify any `-I` include directory for OpenSSL. (I do specify `OPENSSL_ROOT_DIR`, of course.)

How come this works on Linux? Is the `Libevent::openssl` target forwarding the OpenSSL include directories?
That's another line of investigation if you don't like this solution.
