### PR TITLE
Fix cmake build on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,8 @@ IF(MSVC)
 ENDIF(MSVC)
 
 IF(APPLE)
-	add_compile_definitions("TURN_NO_THREAD_BARRIERS=1")
-endif()
+    add_compile_definitions("TURN_NO_THREAD_BARRIERS=1")
+ENDIF()
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,10 @@ IF(MSVC)
     add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 ENDIF(MSVC)
 
+IF(APPLE)
+	add_compile_definitions("TURN_NO_THREAD_BARRIERS=1")
+endif()
+
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(GenerateExportHeader)


### PR DESCRIPTION
macOS does not have `pthread_barrier_*` so need to define `TURN_NO_THREAD_BARRIERS` as a workaround

Fixes #946 

Tests plan: 
- run cmake to generate make files
- run make to build turnserver
- run `examples/run_tests.sh` and pass successfully