### PR TITLE
Use a single SSL context instead of 5 for TLS connections

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -83,13 +83,7 @@ char HTTP_ALPN[128] = "http/1.1";
 #define DEFAULT_GENERAL_RELAY_SERVERS_NUMBER (1)
 
 turn_params_t turn_params = {
-NULL, NULL,
-#if TLSv1_1_SUPPORTED
-	NULL,
-#if TLSv1_2_SUPPORTED
-	NULL,
-#endif
-#endif
+NULL,
 #if DTLS_SUPPORTED
 NULL,
 #endif
@@ -3235,17 +3229,17 @@ static void openssl_load_certificates(void)
 {
 	pthread_mutex_lock(&turn_params.tls_mutex);
 	if(!turn_params.no_tls) {
-		set_ctx(&turn_params.tls_ctx_ssl23,"SSL23",SSLv23_server_method()); /*compatibility mode */
+		set_ctx(&turn_params.tls_ctx,"TLS1.0", TLS_server_method()); /*compatibility mode */
 		if(!turn_params.no_tlsv1) {
-			set_ctx(&turn_params.tls_ctx_v1_0,"TLS1.0",TLSv1_server_method());
+			set_ctx(&turn_params.tls_ctx,"TLS1.0",TLSv1_server_method());
 		}
 #if TLSv1_1_SUPPORTED
 		if(!turn_params.no_tlsv1_1) {
-			set_ctx(&turn_params.tls_ctx_v1_1,"TLS1.1",TLSv1_1_server_method());
+			set_ctx(&turn_params.tls_ctx,"TLS1.1",TLSv1_1_server_method());
 		}
 #if TLSv1_2_SUPPORTED
 		if(!turn_params.no_tlsv1_2) {
-			set_ctx(&turn_params.tls_ctx_v1_2,"TLS1.2",TLSv1_2_server_method());
+			set_ctx(&turn_params.tls_ctx,"TLS1.2",TLSv1_2_server_method());
 		}
 #endif
 #endif

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3229,17 +3229,17 @@ static void openssl_load_certificates(void)
 {
 	pthread_mutex_lock(&turn_params.tls_mutex);
 	if(!turn_params.no_tls) {
-		set_ctx(&turn_params.tls_ctx,"TLS1.0", TLS_server_method()); /*compatibility mode */
+		set_ctx(&turn_params.tls_ctx,"TLS", TLS_server_method()); /*compatibility mode */
 		if(!turn_params.no_tlsv1) {
-			set_ctx(&turn_params.tls_ctx,"TLS1.0",TLSv1_server_method());
+			SSL_CTX_set_options(&turn_params.tls_ctx, SSL_OP_NO_TLSv1);
 		}
 #if TLSv1_1_SUPPORTED
 		if(!turn_params.no_tlsv1_1) {
-			set_ctx(&turn_params.tls_ctx,"TLS1.1",TLSv1_1_server_method());
+			SSL_CTX_set_options(&turn_params.tls_ctx, SSL_OP_NO_TLSv1_1);
 		}
 #if TLSv1_2_SUPPORTED
 		if(!turn_params.no_tlsv1_2) {
-			set_ctx(&turn_params.tls_ctx,"TLS1.2",TLSv1_2_server_method());
+			SSL_CTX_set_options(&turn_params.tls_ctx, SSL_OP_NO_TLSv1_2);
 		}
 #endif
 #endif

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -176,16 +176,7 @@ typedef struct _turn_params_ {
 
 //////////////// OpenSSL group //////////////////////
 
-  SSL_CTX *tls_ctx_ssl23;
-  
-  SSL_CTX *tls_ctx_v1_0;
-  
-#if TLSv1_1_SUPPORTED
-  SSL_CTX *tls_ctx_v1_1;
-#if TLSv1_2_SUPPORTED
-  SSL_CTX *tls_ctx_v1_2;
-#endif
-#endif
+  SSL_CTX *tls_ctx;
   
 #if DTLS_SUPPORTED
   SSL_CTX *dtls_ctx;

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -339,14 +339,7 @@ static void update_ssl_ctx(evutil_socket_t sock, short events, update_ssl_ctx_cb
 
 	/* No mutex with "e" as these are only used in the same event loop */
 	pthread_mutex_lock(&turn_params.tls_mutex);
-	replace_one_ssl_ctx(&e->tls_ctx_ssl23, params->tls_ctx_ssl23);
-	replace_one_ssl_ctx(&e->tls_ctx_v1_0, params->tls_ctx_v1_0);
-#if TLSv1_1_SUPPORTED
-	replace_one_ssl_ctx(&e->tls_ctx_v1_1, params->tls_ctx_v1_1);
-#if TLSv1_2_SUPPORTED
-	replace_one_ssl_ctx(&e->tls_ctx_v1_2, params->tls_ctx_v1_2);
-#endif
-#endif
+	replace_one_ssl_ctx(&e->tls_ctx, params->tls_ctx);
 #if DTLS_SUPPORTED
 	replace_one_ssl_ctx(&e->dtls_ctx, params->dtls_ctx);
 #endif

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -2411,34 +2411,11 @@ static int socket_input_worker(ioa_socket_handle s)
 			if(s->bev) {
 				TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: 0x%lx, st=%d, sat=%d: bev already exist\n", __FUNCTION__,(long)s, s->st, s->sat);
 			}
-			switch(tls_type) {
-#if TLSv1_2_SUPPORTED
-			case TURN_TLS_v1_2:
-				if(s->e->tls_ctx_v1_2) {
-					set_socket_ssl(s,SSL_new(s->e->tls_ctx_v1_2));
-				}
-				break;
-#endif
-#if TLSv1_1_SUPPORTED
-			case TURN_TLS_v1_1:
-				if(s->e->tls_ctx_v1_1) {
-					set_socket_ssl(s,SSL_new(s->e->tls_ctx_v1_1));
-				}
-				break;
-#endif
-			case TURN_TLS_v1_0:
-				if(s->e->tls_ctx_v1_0) {
-					set_socket_ssl(s,SSL_new(s->e->tls_ctx_v1_0));
-				}
-				break;
-			default:
-				if(s->e->tls_ctx_ssl23) {
-					set_socket_ssl(s,SSL_new(s->e->tls_ctx_ssl23));
-				} else {
-					s->tobeclosed = 1;
-					return 0;
-				}
-			};
+
+			if(s->e->tls_ctx) {
+				set_socket_ssl(s,SSL_new(s->e->tls_ctx));
+			}
+
 			if(s->ssl) {
 				s->bev = bufferevent_openssl_socket_new(s->e->event_base,
 								s->fd,
@@ -2477,34 +2454,9 @@ static int socket_input_worker(ioa_socket_handle s)
 			if(s->bev) {
 				TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: 0x%lx, st=%d, sat=%d: bev already exist\n", __FUNCTION__,(long)s, s->st, s->sat);
 			}
-			switch(tls_type) {
-#if TLSv1_2_SUPPORTED
-			case TURN_TLS_v1_2:
-				if(s->e->tls_ctx_v1_2) {
-					set_socket_ssl(s,SSL_new(s->e->tls_ctx_v1_2));
-				}
-				break;
-#endif
-#if TLSv1_1_SUPPORTED
-			case TURN_TLS_v1_1:
-				if(s->e->tls_ctx_v1_1) {
-					set_socket_ssl(s,SSL_new(s->e->tls_ctx_v1_1));
-				}
-				break;
-#endif
-			case TURN_TLS_v1_0:
-				if(s->e->tls_ctx_v1_0) {
-					set_socket_ssl(s,SSL_new(s->e->tls_ctx_v1_0));
-				}
-				break;
-			default:
-				if(s->e->tls_ctx_ssl23) {
-					set_socket_ssl(s,SSL_new(s->e->tls_ctx_ssl23));
-				} else {
-					s->tobeclosed = 1;
-					return 0;
-				}
-			};
+			if(s->e->tls_ctx) {
+				set_socket_ssl(s,SSL_new(s->e->tls_ctx));
+			}
 			if(s->ssl) {
 				s->bev = bufferevent_openssl_socket_new(s->e->event_base,
 								s->fd,
@@ -3506,7 +3458,7 @@ int register_callback_on_ioa_socket(ioa_engine_handle e, ioa_socket_handle s, in
 #if TLS_SUPPORTED
 						if(!(s->ssl)) {
 							//??? how we can get to this point ???
-							set_socket_ssl(s,SSL_new(e->tls_ctx_ssl23));
+							set_socket_ssl(s,SSL_new(e->tls_ctx));
 							s->bev = bufferevent_openssl_socket_new(s->e->event_base,
 											s->fd,
 											s->ssl,

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -141,14 +141,7 @@ struct _ioa_engine
   turnipports* tp;
   rtcp_map *map_rtcp;
   stun_buffer_list bufs;
-  SSL_CTX *tls_ctx_ssl23;
-  SSL_CTX *tls_ctx_v1_0;
-#if TLSv1_1_SUPPORTED
-  SSL_CTX *tls_ctx_v1_1;
-#if TLSv1_2_SUPPORTED
-  SSL_CTX *tls_ctx_v1_2;
-#endif
-#endif
+  SSL_CTX *tls_ctx;
 #if DTLS_SUPPORTED
   SSL_CTX *dtls_ctx;
 #endif


### PR DESCRIPTION
All versions of TLS can be supported using a single SSL_CTX - setting minimal/maximal supported version should be done using, for example, `SSL_CTX_set_options(&turn_params.tls_ctx, SSL_OP_NO_TLSv1);` (or using `SSL_CTX_set_max_proto_version` for openssl-1.1.0 and newer)

`SSL_CTX_set_max_proto_version` is not used (yet) and might introduce breakage if using openssl-1.1.1 and newer without API compatibility mode.

This is a first in series of changes to rework openssl usage.

Links:
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_options.html
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_max_proto_version.html