### PR TITLE
Fix small issues reported by cppcheck

### DIFF
--- a/src/apps/common/hiredis_libevent2.c
+++ b/src/apps/common/hiredis_libevent2.c
@@ -240,7 +240,11 @@ redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int
 	  port=port0;
 
   ac = redisAsyncConnect(ip, port);
-  if (ac->err) {
+  if (!ac) {
+  	fprintf(stderr,"Error: redisAsyncConnect returned NULL\n");
+  	return NULL;
+  }
+  else if (ac->err) {
   	fprintf(stderr,"Error: %s:%s\n", ac->errstr, ac->c.errstr);
   	return NULL;
   }

--- a/src/apps/common/hiredis_libevent2.c
+++ b/src/apps/common/hiredis_libevent2.c
@@ -240,7 +240,7 @@ redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int
 	  port=port0;
 
   ac = redisAsyncConnect(ip, port);
-  if (!ac) {
+  if (ac->err) {
   	fprintf(stderr,"Error: %s:%s\n", ac->errstr, ac->c.errstr);
   	return NULL;
   }

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -2451,7 +2451,7 @@ int main(int argc, char **argv)
 		}
         }
 
-	if(use_cli && cli_password[0]==0 && use_cli) {
+	if(use_cli && cli_password[0]==0) {
 		TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "\nCONFIG ERROR: Empty cli-password, and so telnet cli interface is disabled! Please set a non empty cli-password!\n");
 		use_cli = 0;
 	}
@@ -2753,8 +2753,7 @@ static void adjust_key_file_name(char *fn, const char* file_title, int critical)
 	  strncpy(fn,full_path_to_file,sizeof(turn_params.cert_file)-1);
 	  fn[sizeof(turn_params.cert_file)-1]=0;
 
-	  if(full_path_to_file)
-	    free(full_path_to_file);
+	  free(full_path_to_file);
 	  return;
 	}
 

--- a/src/apps/relay/tls_listener.c
+++ b/src/apps/relay/tls_listener.c
@@ -66,15 +66,17 @@ static void server_input_handler(struct evconnlistener *l, evutil_socket_t fd,
 
 	tls_listener_relay_server_type * server = (tls_listener_relay_server_type*) arg;
 
+	if (!server)
+	{
+		return;
+	}
+
 	if(!(server->connect_cb)) {
 		socket_closesocket(fd);
 		return;
 	}
 
 	FUNCSTART;
-
-	if (!server)
-		return;
 
 	bcopy(sa,&(server->sm.m.sm.nd.src_addr),socklen);
 
@@ -133,15 +135,17 @@ static void sctp_server_input_handler(struct evconnlistener *l, evutil_socket_t 
 
 	tls_listener_relay_server_type * server = (tls_listener_relay_server_type*) arg;
 
+	if (!server)
+	{
+		return;
+	}
+
 	if(!(server->connect_cb)) {
 		socket_closesocket(fd);
 		return;
 	}
 
 	FUNCSTART;
-
-	if (!server)
-		return;
 
 	bcopy(sa,&(server->sm.m.sm.nd.src_addr),socklen);
 

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -837,7 +837,7 @@ int stun_is_channel_message_str(const uint8_t *buf, size_t *blen, uint16_t* chnu
 
 			if(mandatory_padding) {
 				return 0;
-			} else if ((datalen_actual < datalen_header) || (datalen_header == 0)) {
+			} else if (datalen_header == 0) {
 				return 0;
 			} else {
 				uint16_t diff = datalen_actual - datalen_header;


### PR DESCRIPTION
- Redundant checks for variable values
- Potential nullptr dereference
- Double check for the same variable

Run with:
```
cppcheck --inline-suppr --language=c --enable=warning,performance --force .
```