### PR TITLE
Do not write outside of a buffer in admin interface

### DIFF
--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -1202,10 +1202,10 @@ static void web_admin_input_handler(ioa_socket_handle s, int event_type,
 	int to_be_closed = 0;
 
 	int buffer_size = (int)ioa_network_buffer_get_size(in_buffer->nbh);
-    if (buffer_size >= UDP_STUN_BUFFER_SIZE) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "%s: request is too big: %d\n", __FUNCTION__,  buffer_size);
-        to_be_closed = 1;
-    }
+	if (buffer_size >= UDP_STUN_BUFFER_SIZE) {
+		TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "%s: request is too big: %d\n", __FUNCTION__,  buffer_size);
+		to_be_closed = 1;
+	}
 	else if (buffer_size > 0) {
 		
 		SOCKET_TYPE st = get_ioa_socket_type(s);

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -1202,7 +1202,12 @@ static void web_admin_input_handler(ioa_socket_handle s, int event_type,
 	int to_be_closed = 0;
 
 	int buffer_size = (int)ioa_network_buffer_get_size(in_buffer->nbh);
-	if (buffer_size > 0) {
+    buffer_size = UDP_STUN_BUFFER_SIZE+1;
+    if (buffer_size >= UDP_STUN_BUFFER_SIZE) {
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "%s: request is too big: %d\n", __FUNCTION__,  buffer_size);
+        to_be_closed = 1;
+    }
+	else if (buffer_size > 0) {
 		
 		SOCKET_TYPE st = get_ioa_socket_type(s);
 		

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -1202,7 +1202,6 @@ static void web_admin_input_handler(ioa_socket_handle s, int event_type,
 	int to_be_closed = 0;
 
 	int buffer_size = (int)ioa_network_buffer_get_size(in_buffer->nbh);
-    buffer_size = UDP_STUN_BUFFER_SIZE+1;
     if (buffer_size >= UDP_STUN_BUFFER_SIZE) {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "%s: request is too big: %d\n", __FUNCTION__,  buffer_size);
         to_be_closed = 1;


### PR DESCRIPTION
Writing outside of a buffer can only happen if incoming HTTP request is longer than UDP_STUN_BUFFER_SIZE (16KB).

This change validates that the request is no longer than the buffer size and drops it if it is the case

Fixes #342

Test plan:
- Run in debugger and send a 16KB request using curl - response returns, logs correct
- Send 16KB + 1b request - warning logged and request dropped