### PR TITLE
Fix long log line printing

### DIFF
--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -548,10 +548,10 @@ void turn_log_func_default(TURN_LOG_LEVEL level, const char* format, ...)
 	}
 	so_far += snprintf(s + so_far, sizeof(s)-100, (level == TURN_LOG_LEVEL_ERROR) ? ": ERROR: " : ": ");
 	so_far += vsnprintf(s + so_far,sizeof(s) - (so_far+1), format, args);
-    if(so_far > MAX_RTPPRINTF_BUFFER_SIZE+1)
-    {
-        so_far=MAX_RTPPRINTF_BUFFER_SIZE+1;
-    }
+	if(so_far > MAX_RTPPRINTF_BUFFER_SIZE+1)
+	{
+		so_far=MAX_RTPPRINTF_BUFFER_SIZE+1;
+	}
 	if(!no_stdout_log)
 		fwrite(s, so_far, 1, stdout);
 	/* write to syslog or to log file */

--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -539,7 +539,6 @@ void turn_log_func_default(TURN_LOG_LEVEL level, const char* format, ...)
 	/* Fix for Issue 24, raised by John Selbie: */
 #define MAX_RTPPRINTF_BUFFER_SIZE (1024)
 	char s[MAX_RTPPRINTF_BUFFER_SIZE+1];
-#undef MAX_RTPPRINTF_BUFFER_SIZE
 	size_t so_far = 0;
 	if (use_new_log_timestamp_format) {
 		time_t now = time(NULL);
@@ -549,6 +548,10 @@ void turn_log_func_default(TURN_LOG_LEVEL level, const char* format, ...)
 	}
 	so_far += snprintf(s + so_far, sizeof(s)-100, (level == TURN_LOG_LEVEL_ERROR) ? ": ERROR: " : ": ");
 	so_far += vsnprintf(s + so_far,sizeof(s) - (so_far+1), format, args);
+    if(so_far > MAX_RTPPRINTF_BUFFER_SIZE+1)
+    {
+        so_far=MAX_RTPPRINTF_BUFFER_SIZE+1;
+    }
 	if(!no_stdout_log)
 		fwrite(s, so_far, 1, stdout);
 	/* write to syslog or to log file */


### PR DESCRIPTION
`vsnprintf` will stop at the max buffer size as provided in its 2nd argument

But the return value is `The number of characters that would have been written if n had been sufficiently large` meaning it can be larger than actual buffer size
`fwrite` will actually use the larger, incorrect number and dump unrelated memory to log (and crash with high confidence)

Test:
- Query admin interface with super long path (>16KB) - crash
- With the fix - no crash with the same input, log line cut off