### PR TITLE
Increase version to 4.6.0

### DIFF
--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -31,8 +31,8 @@
 #ifndef __IOADEFS__
 #define __IOADEFS__
 
-#define TURN_SERVER_VERSION "4.5.2"
-#define TURN_SERVER_VERSION_NAME "dan Eider"
+#define TURN_SERVER_VERSION "4.6.0"
+#define TURN_SERVER_VERSION_NAME "Gorst"
 #define TURN_SOFTWARE "Coturn-" TURN_SERVER_VERSION " '" TURN_SERVER_VERSION_NAME "'"
 
 #if (defined(__unix__) || defined(unix)) && !defined(USG)


### PR DESCRIPTION
Increase the version number for the 4.6.0 release.
It uses the codename Gorst.