### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper-compat (= 13),
                libssl-dev (>= 1.0.0~),
                postgresql-client,
                sqlite3
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Homepage: https://github.com/coturn/coturn/
 Vcs-Git: https://github.com/coturn/coturn.git -b debian/master
 Vcs-Browser: https://github.com/coturn/coturn/tree/debian/master

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,4 +1,4 @@
 #
 # No pgp upstream signature is used
 #
-coturn source: debian-watch-does-not-check-gpg-signature
+coturn source: debian-watch-does-not-check-openpgp-signature


### PR DESCRIPTION
Fix some issues reported by lintian

* Update renamed lintian tag names in lintian overrides. ([renamed-tag](https://lintian.debian.org/tags/renamed-tag))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/coturn/a69b9082-1537-4fe7-bffe-dcbf7b8ff3dc.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/a69b9082-1537-4fe7-bffe-dcbf7b8ff3dc/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a69b9082-1537-4fe7-bffe-dcbf7b8ff3dc/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a69b9082-1537-4fe7-bffe-dcbf7b8ff3dc/diffoscope)).
