### PR TITLE
Add CI tests in older ubuntu version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,19 +11,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-    runs-on: ${{ matrix.os }}
+        os: [ 'ubuntu:16.04', 'ubuntu:20.04', 'ubuntu:22.04' ]
+    runs-on: ubuntu-latest
+    container: ${{ matrix.os }}
     steps:
     - name: Install dependencies
+      # Set env variable or otherwise tzdata package requires interaction
+      env:
+        DEBIAN_FRONTEND: noninteractive 
       run: |
-        sudo apt-get update
-        sudo apt-get install -y \
+        apt-get update
+        apt-get install -y \
+            build-essential pkgconf
+        apt-get install -y \
             libevent-dev \
             libssl-dev \
-            libpq-dev libmariadb-dev libsqlite3-dev \
+            libpq-dev libsqlite3-dev \
             libhiredis-dev \
             libmongoc-dev \
             libmicrohttpd-dev
+        if [ ${{ matrix.os }}  = 'ubuntu:16.04' ]; then apt-get install -y libmariadb-client-lgpl-dev; fi
+        if [ ${{ matrix.os }} != 'ubuntu:16.04' ]; then apt-get install -y libmariadb-dev; fi
     - uses: actions/checkout@v3
     - name: configure
       run: ./configure


### PR DESCRIPTION
This should help catching issues like the one in #978 with older versions of openssl or other libraries used 