### PR TITLE
Preserve file timestamps when using install(1)

### DIFF
--- a/configure
+++ b/configure
@@ -461,12 +461,12 @@ else
 	type install 2>>/dev/null
 	ER=$?
 	if [ ${ER} -eq 0 ] ; then
-		INSTALL_PROGRAM="install"
-		INSTALL_MAN="install"
-		INSTALL_SCRIPT="install"
-		INSTALL_SHARED_LIB="install"
-		INSTALL_STATIC_LIB="install"
-		INSTALL_DATA="install"
+		INSTALL_PROGRAM="install -p"
+		INSTALL_MAN="install -p -m 0644"
+		INSTALL_SCRIPT="install -p"
+		INSTALL_SHARED_LIB="install -p"
+		INSTALL_STATIC_LIB="install -p"
+		INSTALL_DATA="install -p"
 		MKDIR="install -d"
 	else
 		INSTALL_PROGRAM="cp -pf"


### PR DESCRIPTION
- Preserve file timestamps when using `install`
- Use permissions `0644` rather than default `0755` for installing man pages

The alternative calls of `cp` are using `cp -p` as well (if `install` is unavailable).