### PR TITLE
Replace bzero with memset

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -980,7 +980,7 @@ char *base64_encode(const unsigned char *data,
 void build_base64_decoding_table() {
 
     decoding_table = (char*)malloc(256);
-    bzero(decoding_table,256);
+    memset(decoding_table, 0, 256);
 
     int i;
     for (i = 0; i < 64; i++)
@@ -1061,7 +1061,7 @@ void convert_oauth_key_data_raw(const oauth_key_data_raw *raw, oauth_key_data *o
 {
 	if(raw && oakd) {
 
-		bzero(oakd,sizeof(oauth_key_data));
+		memset(oakd,0,sizeof(oauth_key_data));
 
 		oakd->timestamp = (turn_time_t)raw->timestamp;
 		oakd->lifetime = raw->lifetime;

--- a/src/apps/common/hiredis_libevent2.c
+++ b/src/apps/common/hiredis_libevent2.c
@@ -251,7 +251,7 @@ redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int
 
   /* Create container for context and r/w events */
   e = (struct redisLibeventEvents*)malloc(sizeof(struct redisLibeventEvents));
-  bzero(e,sizeof(struct redisLibeventEvents));
+  memset(e, 0, sizeof(struct redisLibeventEvents));
 
   e->allocated = 1;
   e->context = ac;

--- a/src/apps/common/stun_buffer.c
+++ b/src/apps/common/stun_buffer.c
@@ -34,7 +34,7 @@
 
 int stun_init_buffer(stun_buffer *buf) {
   if(!buf) return -1;
-  bzero(buf->buf,sizeof(buf->buf));
+  memset(buf->buf, 0, sizeof(buf->buf));
   buf->len=0;
   buf->offset=0;
   buf->coffset=0;

--- a/src/apps/natdiscovery/natdiscovery.c
+++ b/src/apps/natdiscovery/natdiscovery.c
@@ -631,8 +631,8 @@ int main(int argc, char **argv)
 	set_logfile("stdout");
 	set_system_parameters(0);
 
-	bzero(local_addr_string, sizeof(local_addr_string));
-	bzero(local2_addr_string, sizeof(local2_addr_string));
+	memset(local_addr_string, 0, sizeof(local_addr_string));
+	memset(local2_addr_string, 0, sizeof(local2_addr_string));
 	addr_set_any(&remote_addr);
 	addr_set_any(&other_addr);
 	addr_set_any(&reflexive_addr);

--- a/src/apps/oauth/oauth.c
+++ b/src/apps/oauth/oauth.c
@@ -62,14 +62,14 @@ static int setup_ikm_key(const char *kid,
                         const char *as_rs_alg, 
                         oauth_key *key) { 
 
-        bzero(key,sizeof(*key));
+        memset(key, 0, sizeof(*key));
 
         oauth_key_data okd;
-        bzero(&okd,sizeof(okd));
+        memset(&okd, 0, sizeof(okd));
 
         {
                 oauth_key_data_raw okdr;
-                bzero(&okdr,sizeof(okdr));
+                memset(&okdr, 0, sizeof(okdr));
 
                 STRCPY(okdr.kid,kid);
                 STRCPY(okdr.ikm_key,ikm_key);
@@ -103,7 +103,7 @@ static int encode_token(const char* server_name,
 
 
         oauth_token ot;
-        bzero(&ot,sizeof(ot));
+        memset(&ot, 0, sizeof(ot));
 
         const size_t mac_key_length=strlen(mac_key);
         ot.enc_block.key_length = (uint16_t)mac_key_length;
@@ -112,7 +112,7 @@ static int encode_token(const char* server_name,
         ot.enc_block.lifetime = token_lifetime;
 
         encoded_oauth_token etoken;
-        bzero(&etoken,sizeof(etoken));
+        memset(&etoken, 0, sizeof(etoken));
 
         // TODO: avoid this hack
         if (!*gcm_nonce) gcm_nonce=NULL;
@@ -135,10 +135,10 @@ static int validate_decode_token(const char* server_name,
                         const char* base64encoded_etoken, oauth_token* dot) {
 
         
-        bzero((dot),sizeof(*dot));
+        memset((dot), 0, sizeof(*dot));
 
         encoded_oauth_token etoken;
-        bzero(&etoken,sizeof(etoken));
+        memset(&etoken, 0, sizeof(etoken));
 
         const size_t base64encoded_etoken_length=strlen(base64encoded_etoken);
         const unsigned char *tmp = base64_decode(base64encoded_etoken,base64encoded_etoken_length,&etoken.size);

--- a/src/apps/peer/udpserver.c
+++ b/src/apps/peer/udpserver.c
@@ -106,7 +106,7 @@ static server_type* init_server(int verbose, const char* ifname, char **local_ad
 
   if(!server) return server;
 
-  bzero(server,sizeof(server_type));
+  memset(server, 0, sizeof(server_type));
 
   server->verbose=verbose;
 

--- a/src/apps/relay/dbdrivers/dbd_mongo.c
+++ b/src/apps/relay/dbdrivers/dbd_mongo.c
@@ -89,7 +89,7 @@ static MONGO * get_mongodb_connection(void) {
 		mongoc_log_set_handler(&mongo_logger, NULL);
 
 		mydbconnection = (MONGO *) malloc(sizeof(MONGO));
-		bzero(mydbconnection, sizeof(MONGO));
+		memset(mydbconnection, 0, sizeof(MONGO));
 
 		mydbconnection->uri = mongoc_uri_new(pud->userdb);
 
@@ -266,7 +266,7 @@ static int mongo_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key) {
 
 	int ret = -1;
 
-	bzero(key,sizeof(oauth_key_data_raw));
+	memset(key, 0, sizeof(oauth_key_data_raw));
 	STRCPY(key->kid,kid);
 
 	if (!cursor) {
@@ -526,7 +526,7 @@ static int mongo_list_oauth_keys(secrets_list_t *kids,secrets_list_t *teas,secre
     bson_iter_t iter;
     while (mongoc_cursor_next(cursor, &item)) {
 
-    	bzero(key,sizeof(oauth_key_data_raw));
+    	memset(key, 0, sizeof(oauth_key_data_raw));
     	if (bson_iter_init(&iter, item) && bson_iter_find(&iter, "kid") && BSON_ITER_HOLDS_UTF8(&iter)) {
     		STRCPY(key->kid,bson_iter_utf8(&iter, &length));
     	}

--- a/src/apps/relay/dbdrivers/dbd_mysql.c
+++ b/src/apps/relay/dbdrivers/dbd_mysql.c
@@ -70,7 +70,7 @@ static void MyconninfoFree(Myconninfo *co) {
 		if(co->cert) free(co->cert);
 		if(co->capath) free(co->capath);
 		if(co->cipher) free(co->cipher);
-		bzero(co,sizeof(Myconninfo));
+		memset(co,0,sizeof(Myconninfo));
 	}
 }
 
@@ -104,7 +104,7 @@ char* decryptPassword(char* in, const unsigned char* mykey){
 
 static Myconninfo *MyconninfoParse(char *userdb, char **errmsg) {
 	Myconninfo *co = (Myconninfo*)malloc(sizeof(Myconninfo));
-	bzero(co,sizeof(Myconninfo));
+	memset(co,0,sizeof(Myconninfo));
 	if(userdb) {
 		char *s0=strdup(userdb);
 		char *s = s0;

--- a/src/apps/relay/dbdrivers/dbd_redis.c
+++ b/src/apps/relay/dbdrivers/dbd_redis.c
@@ -61,13 +61,13 @@ static void RyconninfoFree(Ryconninfo *co) {
 		if(co->host) free(co->host);
 		if(co->dbname) free(co->dbname);
 		if(co->password) free(co->password);
-		bzero(co,sizeof(Ryconninfo));
+		memset(co, 0, sizeof(Ryconninfo));
 	}
 }
 
 static Ryconninfo *RyconninfoParse(const char *userdb, char **errmsg) {
 	Ryconninfo *co = (Ryconninfo*) malloc(sizeof(Ryconninfo));
-	bzero(co,sizeof(Ryconninfo));
+	memset(co, 0, sizeof(Ryconninfo));
 	if (userdb) {
 		char *s0 = strdup(userdb);
 		char *s = s0;
@@ -459,7 +459,7 @@ static int redis_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key) {
   redisContext * rc = get_redis_connection();
   if(rc) {
 	char s[TURN_LONG_STRING_SIZE];
-	bzero(key,sizeof(oauth_key_data_raw));
+	memset(key, 0, sizeof(oauth_key_data_raw));
 	STRCPY(key->kid,kid);
 	snprintf(s,sizeof(s),"hgetall turn/oauth/kid/%s", (const char*)kid);
 	redisReply *reply = (redisReply *)redisCommand(rc, s);

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -506,7 +506,7 @@ static int create_new_connected_udp_socket(
 		return -1;
 	}
 
-	bzero(ret, sizeof(ioa_socket));
+	memset(ret, 0, sizeof(ioa_socket));
 
 	ret->magic = SOCKET_MAGIC;
 

--- a/src/apps/relay/http_server.c
+++ b/src/apps/relay/http_server.c
@@ -111,7 +111,7 @@ static struct headers_list * post_parse(char *data, size_t data_len)
 			char *fmarker = NULL;
 			char *fsplit = strtok_r(post_data, "&", &fmarker);
 			struct headers_list *list = (struct headers_list*)malloc(sizeof(struct headers_list));
-			bzero(list,sizeof(struct headers_list));
+			memset(list,0,sizeof(struct headers_list));
 			while (fsplit != NULL) {
 				char *vmarker = NULL;
 				char *key = strtok_r(fsplit, "=", &vmarker);
@@ -165,13 +165,13 @@ static struct http_request* parse_http_request_1(struct http_request* ret, char*
 				const char *query = evhttp_uri_get_query(uri);
 				if(query) {
 					struct evkeyvalq* kv = (struct evkeyvalq*)malloc(sizeof(struct evkeyvalq));
-					bzero(kv,sizeof(struct evkeyvalq));
+					memset(kv,0,sizeof(struct evkeyvalq));
 					if(evhttp_parse_query_str(query, kv)<0) {
 						free(ret);
 						ret = NULL;
 					} else {
 						ret->headers = (struct http_headers*)malloc(sizeof(struct http_headers));
-						bzero(ret->headers,sizeof(struct http_headers));
+						memset(ret->headers,0,sizeof(struct http_headers));
 						ret->headers->uri_headers = kv;
 					}
 				}
@@ -187,7 +187,7 @@ static struct http_request* parse_http_request_1(struct http_request* ret, char*
 					if(body && body[0]) {
 						if(!ret->headers) {
 							ret->headers = (struct http_headers*)malloc(sizeof(struct http_headers));
-							bzero(ret->headers,sizeof(struct http_headers));
+							memset(ret->headers,0,sizeof(struct http_headers));
 						}
 						ret->headers->post_headers = post_parse(body,strlen(body));
 					}
@@ -208,7 +208,7 @@ struct http_request* parse_http_request(char* request) {
 	if(request) {
 
 		ret = (struct http_request*)malloc(sizeof(struct http_request));
-		bzero(ret,sizeof(struct http_request));
+		memset(ret,0,sizeof(struct http_request));
 
 		if(strstr(request,"GET ") == request) {
 			ret->rtype = HRT_GET;
@@ -327,7 +327,7 @@ struct str_buffer {
 struct str_buffer* str_buffer_new(void)
 {
 	struct str_buffer* ret = (struct str_buffer*)malloc(sizeof(struct str_buffer));
-	bzero(ret,sizeof(struct str_buffer));
+	memset(ret,0,sizeof(struct str_buffer));
 	ret->buffer = (char*)malloc(1);
 	ret->buffer[0] = 0;
 	ret->capacity = 1;

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -2355,7 +2355,7 @@ int main(int argc, char **argv)
 
 #endif
 
-	bzero(&turn_params.default_users_db,sizeof(default_users_db_t));
+	memset(&turn_params.default_users_db,0,sizeof(default_users_db_t));
 	turn_params.default_users_db.ram_db.static_accounts = ur_string_map_create(free);
 
 	if(strstr(argv[0],"turnadmin"))

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -596,7 +596,7 @@ static int send_socket_to_relay(turnserver_id id, uint64_t cid, stun_tid *tid, i
 	int ret = -1;
 
 	struct message_to_relay sm;
-	bzero(&sm,sizeof(struct message_to_relay));
+	memset(&sm,0, sizeof(struct message_to_relay));
 	sm.t = rmt;
 
 	ioa_socket_handle s_to_delete = s;
@@ -727,7 +727,7 @@ int send_session_cancellation_to_relay(turnsession_id sid)
 	int ret = 0;
 
 	struct message_to_relay sm;
-	bzero(&sm,sizeof(struct message_to_relay));
+	memset(&sm,0,sizeof(struct message_to_relay));
 	sm.t = RMT_CANCEL_SESSION;
 
 	turnserver_id id = (turnserver_id)(sid / TURN_SESSION_ID_FACTOR);
@@ -1800,7 +1800,7 @@ static void* run_auth_server_thread(void *arg)
 
 	} else {
 
-		bzero(as,sizeof(struct auth_server));
+		memset(as,0,sizeof(struct auth_server));
 
 		as->id = id;
 
@@ -1861,7 +1861,7 @@ static void* run_admin_server_thread(void *arg)
 
 static void setup_admin_server(void)
 {
-	bzero(&adminserver,sizeof(struct admin_server));
+	memset(&adminserver,0,sizeof(struct admin_server));
 	adminserver.listen_fd = -1;
 	adminserver.verbose = turn_params.verbose;
 
@@ -1946,7 +1946,7 @@ void setup_server(void)
 
 void init_listener(void)
 {
-	bzero(&turn_params.listener,sizeof(struct listener_server));
+	memset(&turn_params.listener,0,sizeof(struct listener_server));
 }
 
 ///////////////////////////////

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -913,7 +913,7 @@ ioa_socket_handle create_unbound_relay_ioa_socket(ioa_engine_handle e, int famil
 	}
 
 	ret = (ioa_socket*)malloc(sizeof(ioa_socket));
-	bzero(ret,sizeof(ioa_socket));
+	memset(ret,0,sizeof(ioa_socket));
 
 	ret->magic = SOCKET_MAGIC;
 
@@ -1357,7 +1357,7 @@ ioa_socket_handle create_ioa_socket_from_fd(ioa_engine_handle e,
 	}
 
 	ret = (ioa_socket*)malloc(sizeof(ioa_socket));
-	bzero(ret,sizeof(ioa_socket));
+	memset(ret,0,sizeof(ioa_socket));
 
 	ret->magic = SOCKET_MAGIC;
 
@@ -1640,7 +1640,7 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s)
 			return ret;
 		}
 
-		bzero(ret,sizeof(ioa_socket));
+		memset(ret,0,sizeof(ioa_socket));
 
 		ret->magic = SOCKET_MAGIC;
 
@@ -2669,7 +2669,7 @@ static int socket_input_worker(ioa_socket_handle s)
 			if(s->read_cb) {
 				ioa_net_data nd;
 
-				bzero(&nd,sizeof(ioa_net_data));
+				memset(&nd,0,sizeof(ioa_net_data));
 				addr_cpy(&(nd.src_addr),&remote_addr);
 				nd.nbh = buf_elem;
 				nd.recv_ttl = ttl;
@@ -3913,11 +3913,11 @@ struct _super_memory {
 static void init_super_memory_region(super_memory_t *r)
 {
 	if(r) {
-		bzero(r,sizeof(super_memory_t));
+		memset(r,0,sizeof(super_memory_t));
 
 		r->super_memory = (char**)malloc(sizeof(char*));
 		r->super_memory[0] = (char*)malloc(TURN_SM_SIZE);
-		bzero(r->super_memory[0],TURN_SM_SIZE);
+		memset(r->super_memory[0],0,TURN_SM_SIZE);
 
 		r->sm_allocated = (size_t*)malloc(sizeof(size_t*));
 		r->sm_allocated[0] = 0;
@@ -3954,7 +3954,7 @@ void* allocate_super_memory_region_func(super_memory_t *r, size_t size, const ch
 
 	if(!r) {
 		ret = malloc(size);
-		bzero(ret, size);
+		memset(ret, 0, size);
 		return ret;
 	}
 
@@ -3988,7 +3988,7 @@ void* allocate_super_memory_region_func(super_memory_t *r, size_t size, const ch
 			r->sm_chunk += 1;
 			r->super_memory = (char**)realloc(r->super_memory,(r->sm_chunk+1) * sizeof(char*));
 			r->super_memory[r->sm_chunk] = (char*)malloc(TURN_SM_SIZE);
-			bzero(r->super_memory[r->sm_chunk],TURN_SM_SIZE);
+			memset(r->super_memory[r->sm_chunk],0,TURN_SM_SIZE);
 			r->sm_allocated = (size_t*)realloc(r->sm_allocated,(r->sm_chunk+1) * sizeof(size_t*));
 			r->sm_allocated[r->sm_chunk] = 0;
 			region = r->super_memory[r->sm_chunk];
@@ -3998,7 +3998,7 @@ void* allocate_super_memory_region_func(super_memory_t *r, size_t size, const ch
 		{
 			char* ptr = region + *rsz;
 
-			bzero(ptr, size);
+			memset(ptr, 0, size);
 
 			*rsz += size;
 
@@ -4010,7 +4010,7 @@ void* allocate_super_memory_region_func(super_memory_t *r, size_t size, const ch
 
 	if(!ret) {
 		ret = malloc(size);
-		bzero(ret, size);
+		memset(ret, 0, size);
 	}
 
 	return ret;

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -1156,7 +1156,7 @@ static void cliserver_input_handler(struct evconnlistener *l, evutil_socket_t fd
 	addr_debug_print(adminserver.verbose, (ioa_addr*)sa,"CLI connected to");
 
 	struct cli_session *clisession = (struct cli_session*)malloc(sizeof(struct cli_session));
-	bzero(clisession,sizeof(struct cli_session));
+	memset(clisession,0,sizeof(struct cli_session));
 
 	clisession->rp = get_realm(NULL);
 
@@ -3015,7 +3015,7 @@ static void write_https_oauth_show_keys(ioa_socket_handle s, const char* kid)
 					} else {
 
 						oauth_key_data okd;
-						bzero(&okd,sizeof(okd));
+						memset(&okd, 0, sizeof(okd));
 
 						convert_oauth_key_data_raw(&key, &okd);
 
@@ -3023,7 +3023,7 @@ static void write_https_oauth_show_keys(ioa_socket_handle s, const char* kid)
 						size_t err_msg_size = sizeof(err_msg) - 1;
 
 						oauth_key okey;
-						bzero(&okey,sizeof(okey));
+						memset(&okey, 0, sizeof(okey));
 
 						if (convert_oauth_key_data(&okd, &okey, err_msg, err_msg_size) < 0) {
 							str_buffer_append(sb,err_msg);
@@ -3295,7 +3295,7 @@ static void handle_logon_request(ioa_socket_handle s, struct http_request* hr)
 		struct admin_session* as = (struct admin_session*)s->special_session;
 		if(!as) {
 			as = (struct admin_session*)malloc(sizeof(struct admin_session));
-			bzero(as,sizeof(struct admin_session));
+			memset(as,0,sizeof(struct admin_session));
 			s->special_session = as;
 			s->special_session_size = sizeof(struct admin_session);
 		}
@@ -3692,7 +3692,7 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh)
 							msg = "You must enter the key value.";
 						} else {
 							oauth_key_data_raw key;
-							bzero(&key,sizeof(key));
+							memset(&key, 0, sizeof(key));
 							STRCPY(key.kid,add_kid);
 
 							if(add_lt && add_lt[0]) {

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -251,7 +251,7 @@ static void must_set_admin_origin(void *origin0)
 void init_secrets_list(secrets_list_t *sl)
 {
 	if(sl) {
-		bzero(sl,sizeof(secrets_list_t));
+		memset(sl,0,sizeof(secrets_list_t));
 	}
 }
 
@@ -424,7 +424,7 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 				if (dbd && dbd->get_oauth_key) {
 
 					oauth_key_data_raw rawKey;
-					bzero(&rawKey,sizeof(rawKey));
+					memset(&rawKey,0,sizeof(rawKey));
 
 					int gres = (*(dbd->get_oauth_key))(usname,&rawKey);
 					if(gres<0)
@@ -440,7 +440,7 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 					}
 
 					oauth_key_data okd;
-					bzero(&okd,sizeof(okd));
+					memset(&okd,0,sizeof(okd));
 
 					convert_oauth_key_data_raw(&rawKey, &okd);
 
@@ -448,7 +448,7 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 					size_t err_msg_size = sizeof(err_msg) - 1;
 
 					oauth_key okey;
-					bzero(&okey,sizeof(okey));
+					memset(&okey, 0, sizeof(okey));
 
 					if (convert_oauth_key_data(&okd, &okey, err_msg, err_msg_size) < 0) {
 						TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s\n", err_msg);
@@ -456,10 +456,10 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 					}
 
 					oauth_token dot;
-					bzero((&dot),sizeof(dot));
+					memset((&dot), 0, sizeof(dot));
 
 					encoded_oauth_token etoken;
-					bzero(&etoken,sizeof(etoken));
+					memset(&etoken, 0, sizeof(etoken));
 
 					if((size_t)len > sizeof(etoken.token)) {
 						TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Encoded oAuth token is too large\n");
@@ -639,7 +639,7 @@ uint8_t *start_user_check(turnserver_id id, turn_credential_type ct, int in_oaut
 	*postpone_reply = 1;
 
 	struct auth_message am;
-	bzero(&am,sizeof(struct auth_message));
+	memset(&am, 0, sizeof(struct auth_message));
 	am.id = id;
 	am.ct = ct;
 	am.in_oauth = in_oauth;
@@ -1168,7 +1168,7 @@ const ip_range_list_t* ioa_get_blacklist(ioa_engine_handle e)
 ip_range_list_t* get_ip_list(const char *kind)
 {
 	ip_range_list_t *ret = (ip_range_list_t*) malloc(sizeof(ip_range_list_t));
-	bzero(ret,sizeof(ip_range_list_t));
+	memset(ret,0,sizeof(ip_range_list_t));
 
 	const turn_dbdriver_t * dbd = get_dbdriver();
 	if (dbd && dbd->get_ip_list && !turn_params.no_dynamic_ip_list) {

--- a/src/apps/rfc5769/rfc5769check.c
+++ b/src/apps/rfc5769/rfc5769check.c
@@ -96,24 +96,24 @@ static int check_oauth(void) {
 					printf("\n");
 
 				oauth_token ot;
-				bzero(&ot,sizeof(ot));
+				memset(&ot, 0, sizeof(ot));
 				ot.enc_block.key_length = (uint16_t)mac_key_length;
 				STRCPY(ot.enc_block.mac_key,mac_key);
 				ot.enc_block.timestamp = token_timestamp;
 				ot.enc_block.lifetime = token_lifetime;
 
 				oauth_token dot;
-				bzero((&dot),sizeof(dot));
+				memset((&dot), 0, sizeof(dot));
 				oauth_key key;
-				bzero(&key,sizeof(key));
+				memset(&key, 0, sizeof(key));
 
 				{
 					oauth_key_data okd;
-					bzero(&okd,sizeof(okd));
+					memset(&okd, 0, sizeof(okd));
 
 					{
 					  oauth_key_data_raw okdr;
-					  bzero(&okdr,sizeof(okdr));
+					  memset(&okdr, 0, sizeof(okdr));
 
 						STRCPY(okdr.kid,kid);
 						STRCPY(okdr.ikm_key,base64encoded_ltp);
@@ -141,7 +141,7 @@ static int check_oauth(void) {
 
 				{
 					encoded_oauth_token etoken;
-					bzero(&etoken,sizeof(etoken));
+					memset(&etoken, 0, sizeof(etoken));
 
 					if (encode_oauth_token((const uint8_t *) server_name, &etoken,
 							&key, &ot, (const uint8_t*)gcm_nonce) < 0) {

--- a/src/apps/stunclient/stunclient.c
+++ b/src/apps/stunclient/stunclient.c
@@ -253,7 +253,7 @@ static int run_stunclient(const char* rip, int rport, int *port, int *rfc5780, i
 	int new_udp_fd = -1;
 	stun_buffer buf;
 
-	bzero(&remote_addr, sizeof(remote_addr));
+	memset(&remote_addr, 0, sizeof(remote_addr));
 	if (make_ioa_addr((const uint8_t*) rip, rport, &remote_addr) < 0)
 		err(-1, NULL);
 
@@ -418,7 +418,7 @@ int main(int argc, char **argv)
   set_logfile("stdout");
   set_system_parameters(0);
   
-  bzero(local_addr, sizeof(local_addr));
+  memset(local_addr, 0, sizeof(local_addr));
 
   while ((c = getopt(argc, argv, "p:L:f")) != -1) {
     switch(c) {

--- a/src/apps/uclient/mainuclient.c
+++ b/src/apps/uclient/mainuclient.c
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
 
 	set_system_parameters(0);
 
-	bzero(local_addr, sizeof(local_addr));
+	memset(local_addr, 0, sizeof(local_addr));
 
 	while ((c = getopt(argc, argv, "a:d:p:l:n:L:m:e:r:u:w:i:k:z:W:C:E:F:o:bZvsyhcxXgtTSAPDNOUMRIGBJ")) != -1) {
 		switch (c){

--- a/src/apps/uclient/startuclient.c
+++ b/src/apps/uclient/startuclient.c
@@ -226,12 +226,12 @@ static int clnet_connect(uint16_t clnet_remote_port, const char *remote_address,
 	clnet_fd = -1;
 	connect_err = 0;
 
-	bzero(&remote_addr, sizeof(ioa_addr));
+	memset(&remote_addr, 0, sizeof(ioa_addr));
 	if (make_ioa_addr((const uint8_t*) remote_address, clnet_remote_port,
 			&remote_addr) < 0)
 		return -1;
 
-	bzero(&local_addr, sizeof(ioa_addr));
+	memset(&local_addr, 0, sizeof(ioa_addr));
 
 	clnet_fd = socket(remote_addr.ss.sa_family,
 			use_sctp ? SCTP_CLIENT_STREAM_SOCKET_TYPE : (use_tcp ? CLIENT_STREAM_SOCKET_TYPE : CLIENT_DGRAM_SOCKET_TYPE),
@@ -1542,7 +1542,7 @@ void tcp_data_connect(app_ur_session *elem, uint32_t cid)
 	int i = (int)(elem->pinfo.tcp_conn_number-1);
 	elem->pinfo.tcp_conn=(app_tcp_conn_info**)realloc(elem->pinfo.tcp_conn,elem->pinfo.tcp_conn_number*sizeof(app_tcp_conn_info*));
 	elem->pinfo.tcp_conn[i]=(app_tcp_conn_info*)malloc(sizeof(app_tcp_conn_info));
-	bzero(elem->pinfo.tcp_conn[i],sizeof(app_tcp_conn_info));
+	memset(elem->pinfo.tcp_conn[i],0,sizeof(app_tcp_conn_info));
 
 	elem->pinfo.tcp_conn[i]->tcp_data_fd = clnet_fd;
 	elem->pinfo.tcp_conn[i]->cid = cid;

--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -116,7 +116,7 @@ static int refresh_channel(app_ur_session* elem, uint16_t method, uint32_t lt);
 
 static app_ur_session* init_app_session(app_ur_session *ss) {
   if(ss) {
-    bzero(ss,sizeof(app_ur_session));
+    memset(ss, 0, sizeof(app_ur_session));
     ss->pinfo.fd=-1;
   }
   return ss;
@@ -1005,7 +1005,7 @@ static int start_client(const char *remote_address, int port,
     ss_rtcp = create_new_ss();
 
   app_ur_conn_info clnet_info_probe; /* for load balancing probe */
-  bzero(&clnet_info_probe,sizeof(clnet_info_probe));
+  memset(&clnet_info_probe, 0, sizeof(clnet_info_probe));
   clnet_info_probe.fd = -1;
 
   app_ur_conn_info *clnet_info=&(ss->pinfo);
@@ -1099,7 +1099,7 @@ static int start_c2c(const char *remote_address, int port,
     ss2_rtcp = create_new_ss();
 
   app_ur_conn_info clnet_info_probe; /* for load balancing probe */
-  bzero(&clnet_info_probe,sizeof(clnet_info_probe));
+  memset(&clnet_info_probe, 0, sizeof(clnet_info_probe));
   clnet_info_probe.fd = -1;
 
   app_ur_conn_info *clnet_info1=&(ss1->pinfo);

--- a/src/client/ns_turn_ioaddr.c
+++ b/src/client/ns_turn_ioaddr.c
@@ -44,7 +44,7 @@ uint32_t get_ioa_addr_len(const ioa_addr* addr) {
 
 void addr_set_any(ioa_addr *addr) {
 	if(addr)
-		bzero(addr,sizeof(ioa_addr));
+		memset(addr, 0, sizeof(ioa_addr));
 }
 
 int addr_any(const ioa_addr* addr) {
@@ -203,7 +203,7 @@ int make_ioa_addr(const uint8_t* saddr0, int port, ioa_addr *addr) {
 	  }
   }
 
-  bzero(addr, sizeof(ioa_addr));
+  memset(addr, 0, sizeof(ioa_addr));
   if((len == 0)||
      (inet_pton(AF_INET, saddr, &addr->s4.sin_addr) == 1)) {
     addr->s4.sin_family = AF_INET;

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -634,7 +634,7 @@ uint16_t stun_make_error_response(uint16_t method) {
 
 void stun_init_buffer_str(uint8_t *buf, size_t *len) {
   *len=STUN_HEADER_LENGTH;
-  bzero(buf,*len);
+  memset(buf, 0, *len);
 }
 
 void stun_init_command_str(uint16_t message_type, uint8_t* buf, size_t *len) {
@@ -1124,7 +1124,7 @@ uint16_t stun_set_channel_bind_request_str(uint8_t* buf, size_t *len,
   
   if(!peer_addr) {
     ioa_addr ca;
-    bzero(&ca,sizeof(ioa_addr));
+    memset(&ca, 0, sizeof(ioa_addr));
     
     if(stun_attr_add_addr_str(buf,len,STUN_ATTRIBUTE_XOR_PEER_ADDRESS, &ca)<0) return 0;
   } else {
@@ -1477,7 +1477,7 @@ int stun_attr_add_str(uint8_t* buf, size_t *len, uint16_t attr, const uint8_t* a
     if(alen>0) bcopy(avalue,attr_start+4,alen);
 	
 	// Write 0 padding to not leak data
-	bzero(attr_start+4+alen, paddinglen);
+	memset(attr_start+4+alen, 0, paddinglen);
 
     return 0;
   }
@@ -2071,7 +2071,7 @@ int stun_attr_get_padding_len_str(stun_attr_ref attr) {
 int stun_attr_add_padding_str(uint8_t *buf, size_t *len, uint16_t padding_len)
 {
 	uint8_t avalue[0xFFFF];
-	bzero(avalue,padding_len);
+	memset(avalue, 0, padding_len);
 
 	return stun_attr_add_str(buf, len, STUN_ATTRIBUTE_PADDING, avalue, padding_len);
 }
@@ -2192,7 +2192,7 @@ int convert_oauth_key_data(const oauth_key_data *oakd0, oauth_key *key, char *er
 			return -1;
 		}
 
-		bzero(key,sizeof(oauth_key));
+		memset(key, 0, sizeof(oauth_key));
 
 		STRCPY(key->kid,oakd->kid);
 
@@ -2326,7 +2326,7 @@ int encode_oauth_token_normal(const uint8_t *server_name, encoded_oauth_token *e
 	if(server_name && etoken && key && dtoken && (dtoken->enc_block.key_length<=128)) {
 
 		unsigned char orig_field[MAX_ENCODED_OAUTH_TOKEN_SIZE];
-		bzero(orig_field,sizeof(orig_field));
+		memset(orig_field, 0, sizeof(orig_field));
 
 		size_t len = 0;
 		*((uint16_t*)(orig_field+len)) = nswap16(dtoken->enc_block.key_length);
@@ -2489,7 +2489,7 @@ static int encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_toke
 	if(server_name && etoken && key && dtoken && (dtoken->enc_block.key_length<=MAXSHASIZE)) {
 
 		unsigned char orig_field[MAX_ENCODED_OAUTH_TOKEN_SIZE];
-		bzero(orig_field,sizeof(orig_field));
+		memset(orig_field, 0, sizeof(orig_field));
 
 		unsigned char nonce[OAUTH_GCM_NONCE_SIZE];
 		if(nonce0) {

--- a/src/server/ns_turn_allocation.c
+++ b/src/server/ns_turn_allocation.c
@@ -40,7 +40,7 @@ static turn_permission_info* get_from_turn_permission_hashtable(turn_permission_
 
 void init_allocation(void *owner, allocation* a, ur_map *tcp_connections) {
   if(a) {
-    bzero(a,sizeof(allocation));
+    memset(a, 0, sizeof(allocation));
     a->owner = owner;
     a->tcp_connections = tcp_connections;
     init_turn_permission_hashtable(&(a->addr_to_perm));
@@ -185,14 +185,14 @@ void turn_permission_clean(turn_permission_info* tinfo)
 		IOA_EVENT_DEL(tinfo->lifetime_ev);
 		lm_map_foreach(&(tinfo->chns), (foreachcb_type) delete_channel_info_from_allocation_map);
 		lm_map_clean(&(tinfo->chns));
-		bzero(tinfo,sizeof(turn_permission_info));
+		memset(tinfo, 0, sizeof(turn_permission_info));
 	}
 }
 
 static void init_turn_permission_hashtable(turn_permission_hashtable *map)
 {
 	if (map)
-		bzero(map,sizeof(turn_permission_hashtable));
+		memset(map, 0, sizeof(turn_permission_hashtable));
 }
 
 static void free_turn_permission_hashtable(turn_permission_hashtable *map)
@@ -273,7 +273,7 @@ static void ch_info_clean(ch_info* c) {
 			c->kernel_channel = 0;
 		}
 		IOA_EVENT_DEL(c->lifetime_ev);
-		bzero(c,sizeof(ch_info));
+		memset(c, 0, sizeof(ch_info));
 	}
 }
 
@@ -436,7 +436,7 @@ turn_permission_info* allocation_add_permission(allocation *a, const ioa_addr* a
 			}
 		}
 
-		bzero(slot,sizeof(turn_permission_slot));
+		memset(slot, 0, sizeof(turn_permission_slot));
 		slot->info.allocated = 1;
 		turn_permission_info *elem = &(slot->info);
 		addr_cpy(&(elem->addr), addr);
@@ -487,7 +487,7 @@ ch_info *ch_map_get(ch_map* map, uint16_t chnum, int new_chn)
 			size_t old_sz_mem = old_sz * sizeof(ch_info*);
 			a->extra_chns = (ch_info**)realloc(a->extra_chns,old_sz_mem + sizeof(ch_info*));
 			a->extra_chns[old_sz] = (ch_info*)malloc(sizeof(ch_info));
-			bzero(a->extra_chns[old_sz],sizeof(ch_info));
+			memset(a->extra_chns[old_sz],0,sizeof(ch_info));
 			a->extra_sz += 1;
 
 			return a->extra_chns[old_sz];
@@ -575,7 +575,7 @@ tcp_connection *create_tcp_connection(uint8_t server_id, allocation *a, stun_tid
 		}
 	}
 	tcp_connection *tc = (tcp_connection*)malloc(sizeof(tcp_connection));
-	bzero(tc,sizeof(tcp_connection));
+	memset(tc,0,sizeof(tcp_connection));
 	addr_cpy(&(tc->peer_addr),peer_addr);
 	if(tid)
 		bcopy(tid,&(tc->tid),sizeof(stun_tid));

--- a/src/server/ns_turn_maps.c
+++ b/src/server/ns_turn_maps.c
@@ -239,7 +239,7 @@ int ur_map_unlock(const ur_map* map) {
 void lm_map_init(lm_map *map)
 {
 	if(map) {
-		bzero(map,sizeof(lm_map));
+		memset(map, 0, sizeof(lm_map));
 	}
 }
 
@@ -590,7 +590,7 @@ static void addr_list_free(addr_list_header* slh) {
     if(slh->extra_list) {
       free(slh->extra_list);
     }
-    bzero(slh,sizeof(addr_list_header));
+    memset(slh, 0, sizeof(addr_list_header));
   }
 }
     
@@ -802,7 +802,7 @@ static const addr_elem* addr_list_get_const(const addr_list_header* slh, const i
 
 void ur_addr_map_init(ur_addr_map* map) {
   if(map) {
-    bzero(map,sizeof(ur_addr_map));
+    memset(map, 0, sizeof(ur_addr_map));
     map->magic=MAGIC_HASH;
   }
 }
@@ -813,7 +813,7 @@ void ur_addr_map_clean(ur_addr_map* map) {
     for(i=0;i<ADDR_MAP_SIZE;i++) {
       addr_list_free(&(map->lists[i]));
     }
-    bzero(map,sizeof(ur_addr_map));
+    memset(map, 0, sizeof(ur_addr_map));
   }
 }
 
@@ -1052,7 +1052,7 @@ static string_list_header* get_string_list_header(ur_string_map *map, const ur_s
 
 static int ur_string_map_init(ur_string_map* map) {
   if(map) {
-    bzero(map,sizeof(ur_string_map));
+    memset(map, 0, sizeof(ur_string_map));
     map->magic=MAGIC_HASH;
 
     TURN_MUTEX_INIT_RECURSIVE(&(map->mutex));

--- a/src/server/ns_turn_maps_rtcp.c
+++ b/src/server/ns_turn_maps_rtcp.c
@@ -178,7 +178,7 @@ static int rtcp_map_init(rtcp_map* map, ioa_engine_handle e) {
 
 rtcp_map* rtcp_map_create(ioa_engine_handle e) {
   rtcp_map *map=(rtcp_map*)malloc(sizeof(rtcp_map));
-  bzero(map,sizeof(rtcp_map));
+  memset(map,0,sizeof(rtcp_map));
   if(rtcp_map_init(map,e)<0) {
     free(map);
     return NULL;
@@ -196,7 +196,7 @@ int rtcp_map_put(rtcp_map* map, rtcp_token_type token, ioa_socket_handle s) {
   else {
     rtcp_alloc_type *value=(rtcp_alloc_type*)malloc(sizeof(rtcp_alloc_type));
     if(!value) return -1;
-    bzero(value,sizeof(rtcp_alloc_type));
+    memset(value,0,sizeof(rtcp_alloc_type));
     value->s=s;
     value->t=turn_time() + RTCP_TIMEOUT;
     value->token=token;

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -367,7 +367,7 @@ static inline ioa_socket_handle get_relay_socket_ss(ts_ur_super_session *ss, int
 
 void turn_session_info_init(struct turn_session_info* tsi) {
 	if(tsi) {
-		bzero(tsi,sizeof(struct turn_session_info));
+		memset(tsi, 0, sizeof(struct turn_session_info));
 	}
 }
 
@@ -796,7 +796,7 @@ static ts_ur_super_session* create_new_ss(turn_turnserver* server) {
 	//printf("%s: 111.111: session size=%lu\n",__FUNCTION__,(unsigned long)sizeof(ts_ur_super_session));
 	//
 	ts_ur_super_session *ss = (ts_ur_super_session*)malloc(sizeof(ts_ur_super_session));
-	bzero(ss,sizeof(ts_ur_super_session));
+	memset(ss,0,sizeof(ts_ur_super_session));
 	ss->server = server;
 	get_default_realm_options(&(ss->realm_options));
 	put_session_into_map(ss);
@@ -2210,7 +2210,7 @@ static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg)
 		}
 
 		stun_tid tid;
-		bzero(&tid,sizeof(stun_tid));
+		memset(&tid, 0, sizeof(stun_tid));
 		int err_code=0;
 		tc = create_tcp_connection(server->id, a, &tid, peer_addr, &err_code);
 		if(!tc) {
@@ -4037,7 +4037,7 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
 					size_t oldsz = strlen(get_version(server));
 					size_t newsz = (((oldsz)>>2) + 1)<<2;
 					uint8_t software[120];
-					bzero(software,sizeof(software));
+					memset(software, 0, sizeof(software));
 					if(newsz>sizeof(software))
 						newsz = sizeof(software);
 					bcopy(get_version(server),software,oldsz);
@@ -4091,7 +4091,7 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
 			size_t oldsz = strlen(get_version(server));
 			size_t newsz = (((oldsz)>>2) + 1)<<2;
 			uint8_t software[120];
-			bzero(software,sizeof(software));
+			memset(software, 0, sizeof(software));
 			if(newsz>sizeof(software))
 				newsz = sizeof(software);
 			bcopy(get_version(server),software,oldsz);
@@ -4386,7 +4386,7 @@ static int create_relay_connection(turn_turnserver* server,
 
 				IOA_CLOSE_SOCKET(newelem->s);
 
-				bzero(newelem, sizeof(relay_endpoint_session));
+				memset(newelem, 0, sizeof(relay_endpoint_session));
 				newelem->s = s;
 			}
 
@@ -4400,7 +4400,7 @@ static int create_relay_connection(turn_turnserver* server,
 
 			IOA_CLOSE_SOCKET(newelem->s);
 
-			bzero(newelem, sizeof(relay_endpoint_session));
+			memset(newelem, 0, sizeof(relay_endpoint_session));
 			newelem->s = NULL;
 
 			int res = create_relay_ioa_sockets(server->e,
@@ -4951,7 +4951,7 @@ void init_turn_server(turn_turnserver* server,
 	if (!server)
 		return;
 
-	bzero(server,sizeof(turn_turnserver));
+	memset(server, 0, sizeof(turn_turnserver));
 
 	server->e = e;
 	server->id = id;


### PR DESCRIPTION
Replace all instances of `bzero` with memset by find-replace-edit.
This is straightforward replacement which is suboptimal in a few cases (for example we could use calloc instead of malloc+memset(0))

Inspired by #855