### PR TITLE
Fix a warning

### DIFF
--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -31,13 +31,7 @@
 #include "mainrelay.h"
 
 //////////// Backward compatibility with OpenSSL 1.0.x //////////////
-#define HAVE_OPENSSL11_API (!(OPENSSL_VERSION_NUMBER < 0x10100001L || defined LIBRESSL_VERSION_NUMBER))
-
-#ifndef HAVE_SSL_CTX_UP_REF
-#define HAVE_SSL_CTX_UP_REF HAVE_OPENSSL11_API
-#endif
-
-#if !HAVE_SSL_CTX_UP_REF
+#if (OPENSSL_VERSION_NUMBER < 0x10100001L || defined LIBRESSL_VERSION_NUMBER)
 #define SSL_CTX_up_ref(ctx) CRYPTO_add(&(ctx)->references, 1, CRYPTO_LOCK_SSL_CTX)
 #endif
 


### PR DESCRIPTION
There are too many defines that are, eventually, used in one place so just inlining.

Current code generates following warning:
```
warning: macro expansion producing 'defined' has undefined behavior [-Wexpansion-to-defined]
```

With the fix there is no warning
