### PR TITLE
Fix issue #118 by changing systemd service type from notify to exec

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -564,7 +564,7 @@ Options with values:
 			fits the address, then it is denied.
 
 --pidfile 		File name to store the pid of the process.
-			Default is /var/run/turnserver.pid (if superuser account is used) or
+			Default is /run/turnserver/turnserver.pid (if superuser account is used) or
 			/var/tmp/turnserver.pid .
 
 --acme-redirect  <URL>	Redirect ACME/RFC8555 (like Let's Encrypt challenge) requests, i.e.

--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -622,10 +622,10 @@ syslog
 # allowed-peer-ip=83.166.68.45
 
 # File name to store the pid of the process.
-# Default is /var/run/turnserver.pid (if superuser account is used) or
+# Default is /run/turnserver/turnserver.pid (if superuser account is used) or
 # /var/tmp/turnserver.pid .
 #
-#pidfile="/var/run/turnserver.pid"
+#pidfile="/run/turnserver/turnserver.pid"
 
 # Require authentication of the STUN Binding request.
 # By default, the clients are allowed anonymous access to the STUN Binding functionality.

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -649,10 +649,10 @@
 # allowed-peer-ip=83.166.68.45
 
 # File name to store the pid of the process.
-# Default is /var/run/turnserver.pid (if superuser account is used) or
+# Default is /run/turnserver/turnserver.pid (if superuser account is used) or
 # /var/tmp/turnserver.pid .
 #
-#pidfile="/var/run/turnserver.pid"
+#pidfile="/run/turnserver/turnserver.pid"
 
 # Require authentication of the STUN Binding request.
 # By default, the clients are allowed anonymous access to the STUN Binding functionality.

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -812,7 +812,7 @@ fits the address, then it is denied.
 .B
 \fB\-\-pidfile\fP
 File name to store the pid of the process.
-Default is /var/run/turnserver.pid (if superuser account is used) or
+Default is /run/turnserver/turnserver.pid (if superuser account is used) or
 /var/tmp/turnserver.pid .
 .TP
 .B

--- a/rpm/turnserver.init.el
+++ b/rpm/turnserver.init.el
@@ -6,7 +6,7 @@
 # description: RFC 5766 TURN Server
 #
 # processname: turnserver
-# pidfile: /var/run/turnserver/turnserver.pid
+# pidfile: /run/turnserver/turnserver.pid
 # config: /etc/turnserver/turnserver.conf
 #
 ### BEGIN INIT INFO
@@ -22,7 +22,7 @@
 TURN=/usr/bin/turnserver
 PROG=turnserver
 TURNCFG=/etc/turnserver/$PROG.conf
-PID_FILE=/var/run/turnserver/$PROG.pid
+PID_FILE=/run/turnserver/$PROG.pid
 LOCK_FILE=/var/lock/subsys/$PROG
 DEFAULTS=/etc/sysconfig/$PROG
 RETVAL=0

--- a/rpm/turnserver.service.fc
+++ b/rpm/turnserver.service.fc
@@ -6,10 +6,11 @@ After=syslog.target network.target
 [Service]
 User=turnserver
 Group=turnserver
-Type=notify
+Type=exec
+PIDFile=/var/run/turnserver.pid
 EnvironmentFile=/etc/sysconfig/turnserver
 ExecStart=/usr/bin/turnserver -c /etc/turnserver/turnserver.conf $EXTRA_OPTIONS
-ExecStopPost=/usr/bin/rm -f /var/run/turnserver/turnserver.pid
+ExecStopPost=/usr/bin/rm -f /var/run/turnserver.pid
 Restart=on-abort
 
 LimitCORE=infinity

--- a/rpm/turnserver.service.fc
+++ b/rpm/turnserver.service.fc
@@ -7,10 +7,10 @@ After=syslog.target network.target
 User=turnserver
 Group=turnserver
 Type=exec
-PIDFile=/var/run/turnserver.pid
+PIDFile=/run/turnserver/turnserver.pid
 EnvironmentFile=/etc/sysconfig/turnserver
 ExecStart=/usr/bin/turnserver -c /etc/turnserver/turnserver.conf $EXTRA_OPTIONS
-ExecStopPost=/usr/bin/rm -f /var/run/turnserver.pid
+ExecStopPost=/usr/bin/rm -f /run/turnserver/turnserver.pid
 Restart=on-abort
 
 LimitCORE=infinity

--- a/rpm/turnserver.spec
+++ b/rpm/turnserver.spec
@@ -119,7 +119,6 @@ install -m755 rpm/turnserver.init.el \
 		$RPM_BUILD_ROOT/%{_sysconfdir}/rc.d/init.d/turnserver
 %else
 sed -i -e "s/#pidfile/pidfile/g" \
-    -e "s:/var/run/turnserver.pid:/var/run/turnserver/turnserver.pid:g" \
     $RPM_BUILD_ROOT/%{_sysconfdir}/%{name}/turnserver.conf.default
 mkdir -p $RPM_BUILD_ROOT/%{_unitdir}
 install -m755 rpm/turnserver.service.fc \

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -35,6 +35,9 @@
 #include "prom_server.h"
 #endif
 
+#if defined(__linux__) || defined(__LINUX__) || defined(__linux) || defined(linux__) || defined(LINUX) || defined(__LINUX) || defined(LINUX__)
+#include <linux/version.h>
+#endif
 
 #if (defined LIBRESSL_VERSION_NUMBER && OPENSSL_VERSION_NUMBER == 0x20000000L)
 #undef OPENSSL_VERSION_NUMBER
@@ -2207,10 +2210,6 @@ static void print_features(unsigned long mfn)
 	TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Default Net Engine version: %d (%s)\n\n=====================================================\n\n", (int)turn_params.net_engine_version, turn_params.net_engine_version_txt[(int)turn_params.net_engine_version]);
 
 }
-
-#if defined(__linux__) || defined(__LINUX__) || defined(__linux) || defined(linux__) || defined(LINUX) || defined(__LINUX) || defined(LINUX__)
-#include <linux/version.h>
-#endif
 
 static void set_network_engine(void)
 {

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -120,7 +120,7 @@ TURN_VERBOSE_NONE, /* verbose */
 0, /* no_software_attribute */
 0, /* web_admin_listen_on_workers */
 0, /* do_not_use_config_file */
-"/var/run/turnserver.pid", /* pidfile */
+"/run/turnserver/turnserver.pid", /* pidfile */
 "", /* acme_redirect */
 DEFAULT_STUN_PORT, /* listener_port*/
 DEFAULT_STUN_TLS_PORT, /* tls_listener_port */
@@ -653,7 +653,7 @@ static char Usage[] = "Usage: turnserver [options]\n"
 " --denied-peer-ip=<ip[-ip]> 			Specifies an ip or range of ips that are not allowed to connect to the turn server.\n"
 "						Multiple denied-peer-ip can be set.\n"
 " --pidfile <\"pid-file-name\">			File name to store the pid of the process.\n"
-"						Default is /var/run/turnserver.pid (if superuser account is used) or\n"
+"						Default is /run/turnserver/turnserver.pid (if superuser account is used) or\n"
 "						/var/tmp/turnserver.pid .\n"
 " --acme-redirect <URL>				Redirect ACME, i.e. HTTP GET requests matching '^/.well-known/acme-challenge/(.*)' to '<URL>$1'.\n"
 "						Default is '', i.e. no special handling for such requests.\n"
@@ -2584,7 +2584,8 @@ int main(int argc, char **argv)
 			TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "%s\n", s);
 
 			{
-				const char *pfs[] = {"/var/run/turnserver.pid",
+				const char *pfs[] = {"/run/turnserver/turnserver.pid",
+						"/var/run/turnserver.pid",
 						"/var/spool/turnserver.pid",
 						"/var/turnserver.pid",
 						"/var/tmp/turnserver.pid",

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -120,7 +120,11 @@ TURN_VERBOSE_NONE, /* verbose */
 0, /* no_software_attribute */
 0, /* web_admin_listen_on_workers */
 0, /* do_not_use_config_file */
+#if (defined(__linux__) || defined(__LINUX__) || defined(__linux) || defined(linux__) || defined(LINUX) || defined(__LINUX) || defined(LINUX__)) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
 "/run/turnserver/turnserver.pid", /* pidfile */
+#else /* BSD and old linux */
+"/var/run/turnserver/turnserver.pid", /* pidfile */
+#endif /* Linux */
 "", /* acme_redirect */
 DEFAULT_STUN_PORT, /* listener_port*/
 DEFAULT_STUN_TLS_PORT, /* tls_listener_port */
@@ -653,7 +657,11 @@ static char Usage[] = "Usage: turnserver [options]\n"
 " --denied-peer-ip=<ip[-ip]> 			Specifies an ip or range of ips that are not allowed to connect to the turn server.\n"
 "						Multiple denied-peer-ip can be set.\n"
 " --pidfile <\"pid-file-name\">			File name to store the pid of the process.\n"
+#if (defined(__linux__) || defined(__LINUX__) || defined(__linux) || defined(linux__) || defined(LINUX) || defined(__LINUX) || defined(LINUX__)) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
 "						Default is /run/turnserver/turnserver.pid (if superuser account is used) or\n"
+#else /* BSD and old linux */
+"						Default is /var/run/turnserver/turnserver.pid (if superuser account is used) or\n"
+#endif /* Linux */
 "						/var/tmp/turnserver.pid .\n"
 " --acme-redirect <URL>				Redirect ACME, i.e. HTTP GET requests matching '^/.well-known/acme-challenge/(.*)' to '<URL>$1'.\n"
 "						Default is '', i.e. no special handling for such requests.\n"
@@ -2584,8 +2592,13 @@ int main(int argc, char **argv)
 			TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "%s\n", s);
 
 			{
-				const char *pfs[] = {"/run/turnserver/turnserver.pid",
+				const char *pfs[] = {
+#if (defined(__linux__) || defined(__LINUX__) || defined(__linux) || defined(linux__) || defined(LINUX) || defined(__LINUX) || defined(LINUX__)) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
+						"/run/turnserver/turnserver.pid",
+						"/run/turnserver.pid",
+#else /* BSD and old linux */
 						"/var/run/turnserver.pid",
+#endif /* Linux */
 						"/var/spool/turnserver.pid",
 						"/var/turnserver.pid",
 						"/var/tmp/turnserver.pid",


### PR DESCRIPTION
The first commit fix the issue #118 that prevent the process to start as coturn never send the notification to systemd thus preventing the startup.

Secont commit fix the default pid path to conform to Filesystem Hierarchy Standard