### PR TITLE
Replace bcopy with memcpy

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -1066,14 +1066,14 @@ void convert_oauth_key_data_raw(const oauth_key_data_raw *raw, oauth_key_data *o
 		oakd->timestamp = (turn_time_t)raw->timestamp;
 		oakd->lifetime = raw->lifetime;
 
-		bcopy(raw->as_rs_alg,oakd->as_rs_alg,sizeof(oakd->as_rs_alg));
-		bcopy(raw->kid,oakd->kid,sizeof(oakd->kid));
+		memcpy(oakd->as_rs_alg,raw->as_rs_alg,sizeof(oakd->as_rs_alg));
+		memcpy(oakd->kid,raw->kid,sizeof(oakd->kid));
 
 		if(raw->ikm_key[0]) {
 			size_t ikm_key_size = 0;
 			char *ikm_key = (char*)base64_decode(raw->ikm_key,strlen(raw->ikm_key),&ikm_key_size);
 			if(ikm_key) {
-				bcopy(ikm_key,oakd->ikm_key,ikm_key_size);
+				memcpy(oakd->ikm_key,ikm_key,ikm_key_size);
 				oakd->ikm_key_size = ikm_key_size;
 				free(ikm_key);
 			}

--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -642,7 +642,7 @@ int get_canonic_origin(const char* o, char *co, int sz)
 					const char *host = evhttp_uri_get_host(uri);
 					if(host && host[0]) {
 						char otmp[STUN_MAX_ORIGIN_SIZE+STUN_MAX_ORIGIN_SIZE];
-						bcopy(scheme,otmp,schlen);
+						memcpy(otmp,scheme,schlen);
 						otmp[schlen]=0;
 
 						{

--- a/src/apps/relay/acme.c
+++ b/src/apps/relay/acme.c
@@ -73,7 +73,7 @@ int try_acme_redirect(char *req, size_t len, const char *url,
 #ifdef LIBEV_OK
 	ioa_network_buffer_handle nbh_acme = ioa_network_buffer_allocate(s->e);
 	uint8_t *data = ioa_network_buffer_data(nbh_acme);
-	bcopy(http_response, data, rlen);
+	memcpy(data, http_response, rlen);
 	ioa_network_buffer_set_size(nbh_acme, rlen);
 	send_data_from_ioa_socket_nbh(s, NULL, nbh_acme, TTL_IGNORE, TOS_IGNORE, NULL);
 #else

--- a/src/apps/relay/dbdrivers/dbd_mongo.c
+++ b/src/apps/relay/dbdrivers/dbd_mongo.c
@@ -223,7 +223,7 @@ static int mongo_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
 					TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format: string length=%d (must be %d): user %s\n", (int)length, (int)sz, usname);
 				} else {
 					char kval[sizeof(hmackey_t) + sizeof(hmackey_t) + 1];
-					bcopy(value, kval, sz);
+					memcpy(kval, value, sz);
 					kval[sz] = 0;
 					if(convert_string_key_to_binary(kval, key, sz / 2) < 0) {
 						TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key: %s, user %s\n", kval, usname);

--- a/src/apps/relay/dbdrivers/dbd_mysql.c
+++ b/src/apps/relay/dbdrivers/dbd_mysql.c
@@ -323,7 +323,7 @@ static int mysql_get_auth_secrets(secrets_list_t *sl, uint8_t *realm) {
 							if(lengths) {
 								size_t sz = lengths[0];
 								char auth_secret[TURN_LONG_STRING_SIZE];
-								bcopy(row[0],auth_secret,sz);
+								memcpy(auth_secret,row[0],sz);
 								auth_secret[sz]=0;
 								add_to_secrets_list(sl,auth_secret);
 							}
@@ -366,7 +366,7 @@ static int mysql_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
 							TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format: string length=%d (must be %d): user %s\n",(int)lengths[0],(int)sz,usname);
 						} else {
 							char kval[sizeof(hmackey_t)+sizeof(hmackey_t)+1];
-							bcopy(row[0],kval,sz);
+							memcpy(kval,row[0],sz);
 							kval[sz]=0;
 							if(convert_string_key_to_binary(kval, key, sz/2)<0) {
 								TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key: %s, user %s\n",kval,usname);
@@ -409,23 +409,23 @@ static int mysql_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key) {
 					unsigned long *lengths = mysql_fetch_lengths(mres);
 					if(lengths) {
 						STRCPY(key->kid,kid);
-						bcopy(row[0],key->ikm_key,lengths[0]);
+						memcpy(key->ikm_key,row[0],lengths[0]);
 						key->ikm_key[lengths[0]]=0;
 
 						char stimestamp[128];
-						bcopy(row[1],stimestamp,lengths[1]);
+						memcpy(stimestamp,row[1],lengths[1]);
 						stimestamp[lengths[1]]=0;
 						key->timestamp = (uint64_t)strtoull(stimestamp,NULL,10);
 
 						char slifetime[128];
-						bcopy(row[2],slifetime,lengths[2]);
+						memcpy(slifetime,row[2],lengths[2]);
 						slifetime[lengths[2]]=0;
 						key->lifetime = (uint32_t)strtoul(slifetime,NULL,10);
 
-						bcopy(row[3],key->as_rs_alg,lengths[3]);
+						memcpy(key->as_rs_alg,row[3],lengths[3]);
 						key->as_rs_alg[lengths[3]]=0;
 
-						bcopy(row[4],key->realm,lengths[4]);
+						memcpy(key->realm,row[4],lengths[4]);
 						key->realm[lengths[4]]=0;
 
 						ret = 0;
@@ -465,26 +465,26 @@ static int mysql_list_oauth_keys(secrets_list_t *kids,secrets_list_t *teas,secre
 					unsigned long *lengths = mysql_fetch_lengths(mres);
 					if(lengths) {
 
-						bcopy(row[0],key->ikm_key,lengths[0]);
+						memcpy(key->ikm_key,row[0],lengths[0]);
 						key->ikm_key[lengths[0]]=0;
 
 						char stimestamp[128];
-						bcopy(row[1],stimestamp,lengths[1]);
+						memcpy(stimestamp,row[1],lengths[1]);
 						stimestamp[lengths[1]]=0;
 						key->timestamp = (uint64_t)strtoull(stimestamp,NULL,10);
 
 						char slifetime[128];
-						bcopy(row[2],slifetime,lengths[2]);
+						memcpy(slifetime,row[2],lengths[2]);
 						slifetime[lengths[2]]=0;
 						key->lifetime = (uint32_t)strtoul(slifetime,NULL,10);
 
-						bcopy(row[3],key->as_rs_alg,lengths[3]);
+						memcpy(key->as_rs_alg,row[3],lengths[3]);
 						key->as_rs_alg[lengths[3]]=0;
 
-						bcopy(row[4],key->realm,lengths[4]);
+						memcpy(key->realm,row[4],lengths[4]);
 						key->realm[lengths[4]]=0;
 
-						bcopy(row[5],key->kid,lengths[5]);
+						memcpy(key->kid,row[5],lengths[5]);
 						key->kid[lengths[5]]=0;
 
 						if(kids) {
@@ -999,11 +999,11 @@ static int mysql_get_ip_list(const char *kind, ip_range_list_t * list) {
 							if(lengths) {
 								size_t sz = lengths[0];
 								char kval[TURN_LONG_STRING_SIZE];
-								bcopy(row[0],kval,sz);
+								memcpy(kval,row[0],sz);
 								kval[sz]=0;
 								sz = lengths[1];
 								char rval[TURN_LONG_STRING_SIZE];
-								bcopy(row[1],rval,sz);
+								memcpy(rval,row[1],sz);
 								rval[sz]=0;
 								add_ip_list_range(kval,rval,list);
 							}
@@ -1043,7 +1043,7 @@ static void mysql_reread_realms(secrets_list_t * realms_list) {
 								if(lengths) {
 									size_t sz = lengths[0];
 									char oval[513];
-									bcopy(row[0],oval,sz);
+									memcpy(oval,row[0],sz);
 									oval[sz]=0;
 									char *rval=strdup(row[1]);
 									get_realm(rval);
@@ -1106,15 +1106,15 @@ static void mysql_reread_realms(secrets_list_t * realms_list) {
 							if(lengths) {
 								char rval[513];
 								size_t sz = lengths[0];
-								bcopy(row[0],rval,sz);
+								memcpy(rval,row[0],sz);
 								rval[sz]=0;
 								char oval[513];
 								sz = lengths[1];
-								bcopy(row[1],oval,sz);
+								memcpy(oval,row[1],sz);
 								oval[sz]=0;
 								char vval[513];
 								sz = lengths[2];
-								bcopy(row[2],vval,sz);
+								memcpy(vval,row[2],sz);
 								vval[sz]=0;
 								realm_params_t* rp = get_realm(rval);
 								if(!strcmp(oval,"max-bps"))

--- a/src/apps/relay/http_server.c
+++ b/src/apps/relay/http_server.c
@@ -66,7 +66,7 @@ static void write_http_echo(ioa_socket_handle s)
 			snprintf(content_http,sizeof(content_http)-1,"<!DOCTYPE html>\r\n<html>\r\n  <head>\r\n    <title>%s</title>\r\n  </head>\r\n  <body>\r\n    <b>%s</b> <br> <b><i>use https connection for the admin session</i></b>\r\n  </body>\r\n</html>\r\n",title,title);
 			snprintf(data_http,sizeof(data_http)-1,"HTTP/1.0 200 OK\r\nServer: %s\r\nContent-Type: text/html; charset=UTF-8\r\nContent-Length: %d\r\n\r\n%.906s",TURN_SOFTWARE,(int)strlen(content_http),content_http);
 			len_http = strlen(data_http);
-			bcopy(data_http,data,len_http);
+			memcpy(data,data_http,len_http);
 			ioa_network_buffer_set_size(nbh_http,len_http);
 			send_data_from_ioa_socket_nbh(s, NULL, nbh_http, TTL_IGNORE, TOS_IGNORE,NULL);
 		}
@@ -342,7 +342,7 @@ void str_buffer_append(struct str_buffer* sb, const char* str)
 			sb->capacity += len + 1024;
 			sb->buffer = (char*)realloc(sb->buffer,sb->capacity);
 		}
-		bcopy(str,sb->buffer+sb->sz,len+1);
+		memcpy(sb->buffer+sb->sz,str,len+1);
 		sb->sz += len;
 	}
 }

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -487,7 +487,7 @@ static void auth_server_receive_message(struct bufferevent *bev, void *ptr)
       if(get_user_key(am.in_oauth,&(am.out_oauth),&(am.max_session_time),am.username,am.realm,key,am.in_buffer.nbh)<0) {
     	  am.success = 0;
       } else {
-    	  bcopy(key,am.key,sizeof(hmackey_t));
+    	  memcpy(am.key,key,sizeof(hmackey_t));
     	  am.success = 1;
       }
     }
@@ -937,7 +937,7 @@ static int send_message_from_listener_to_client(ioa_engine_handle e, ioa_network
 	addr_cpy(&(mm.m.tc.destination),destination);
 	mm.m.tc.nbh = ioa_network_buffer_allocate(e);
 	ioa_network_buffer_header_init(mm.m.tc.nbh);
-	bcopy(ioa_network_buffer_data(nbh),ioa_network_buffer_data(mm.m.tc.nbh),ioa_network_buffer_get_size(nbh));
+	memcpy(ioa_network_buffer_data(mm.m.tc.nbh),ioa_network_buffer_data(nbh),ioa_network_buffer_get_size(nbh));
 	ioa_network_buffer_set_size(mm.m.tc.nbh,ioa_network_buffer_get_size(nbh));
 
 	struct evbuffer *output = bufferevent_get_output(turn_params.listener.out_buf);

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -322,7 +322,7 @@ static void add_buffer_to_buffer_list(stun_buffer_list *bufs, char *buf, size_t 
 {
 	if(bufs && buf && (bufs->tsz<MAX_SOCKET_BUFFER_BACKLOG)) {
 	  stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)malloc(sizeof(stun_buffer_list_elem));
-	  bcopy(buf,buf_elem->buf.buf,len);
+	  memcpy(buf_elem->buf.buf,buf,len);
 	  buf_elem->buf.len = len;
 	  buf_elem->buf.offset = 0;
 	  buf_elem->buf.coffset = 0;
@@ -419,7 +419,7 @@ ioa_engine_handle create_ioa_engine(super_memory_t *sm,
 					TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,"FATAL: cannot create preferable timeval for %d secs (%d number)\n",predef_timer_intervals[t],t);
 					exit(-1);
 				} else {
-					bcopy(ptv,&(e->predef_timers[t]),sizeof(struct timeval));
+					memcpy(&(e->predef_timers[t]),ptv,sizeof(struct timeval));
 					e->predef_timer_intervals[t] = predef_timer_intervals[t];
 				}
 			}
@@ -1138,7 +1138,7 @@ static void tcp_listener_input_handler(struct evconnlistener *l, evutil_socket_t
 	ioa_socket_handle list_s = (ioa_socket_handle) arg;
 
 	ioa_addr client_addr;
-	bcopy(sa,&client_addr,socklen);
+	memcpy(&client_addr,sa,socklen);
 
 	addr_debug_print(((list_s->e) && list_s->e->verbose), &client_addr,"tcp accepted from");
 

--- a/src/apps/relay/tls_listener.c
+++ b/src/apps/relay/tls_listener.c
@@ -78,7 +78,7 @@ static void server_input_handler(struct evconnlistener *l, evutil_socket_t fd,
 
 	FUNCSTART;
 
-	bcopy(sa,&(server->sm.m.sm.nd.src_addr),socklen);
+	memcpy(&(server->sm.m.sm.nd.src_addr),sa,socklen);
 
 	addr_debug_print(server->verbose, &(server->sm.m.sm.nd.src_addr),"tcp or tls connected to");
 
@@ -147,7 +147,7 @@ static void sctp_server_input_handler(struct evconnlistener *l, evutil_socket_t 
 
 	FUNCSTART;
 
-	bcopy(sa,&(server->sm.m.sm.nd.src_addr),socklen);
+	memcpy(&(server->sm.m.sm.nd.src_addr),sa,socklen);
 
 	addr_debug_print(server->verbose, &(server->sm.m.sm.nd.src_addr),"sctp or tls/sctp connected to");
 

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -934,7 +934,7 @@ static int run_cli_input(struct cli_session* cs, const char *buf0, unsigned int 
 	if(cs && buf0 && cs->ts && cs->bev) {
 
 		char *buf = (char*)malloc(len+1);
-		bcopy(buf0,buf,len);
+		memcpy(buf,buf0,len);
 		buf[len]=0;
 
 		char *cmd = buf;

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -117,7 +117,7 @@ void get_default_realm_options(realm_options_t* ro)
 {
 	if(ro) {
 		lock_realms();
-		bcopy(&(default_realm_params_ptr->options),ro,sizeof(realm_options_t));
+		memcpy(ro,&(default_realm_params_ptr->options),sizeof(realm_options_t));
 		unlock_realms();
 	}
 }
@@ -142,7 +142,7 @@ realm_params_t* get_realm(char* name)
 			return (realm_params_t*)value;
 		} else {
 			realm_params_t *ret = (realm_params_t*)malloc(sizeof(realm_params_t));
-			bcopy(default_realm_params_ptr,ret,sizeof(realm_params_t));
+			memcpy(ret,default_realm_params_ptr,sizeof(realm_params_t));
 			STRCPY(ret->options.name,name);
 			value = (ur_string_map_value_type)ret;
 			ur_string_map_put(realms, key, value);
@@ -159,7 +159,7 @@ realm_params_t* get_realm(char* name)
 int get_realm_data(char* name, realm_params_t* rp)
 {
 	lock_realms();
-	bcopy(get_realm(name),rp,sizeof(realm_params_t));
+	memcpy(rp,get_realm(name),sizeof(realm_params_t));
 	unlock_realms();
 	return 0;
 }
@@ -173,7 +173,7 @@ int get_realm_options_by_origin(char *origin, realm_options_t* ro)
 		TURN_MUTEX_UNLOCK(&o_to_realm_mutex);
 		realm_params_t rp;
 		get_realm_data(realm, &rp);
-		bcopy(&(rp.options),ro,sizeof(realm_options_t));
+		memcpy(ro,&(rp.options),sizeof(realm_options_t));
 		free(realm);
 		return 1;
 	} else {
@@ -187,7 +187,7 @@ void get_realm_options_by_name(char *realm, realm_options_t* ro)
 {
 	realm_params_t rp;
 	get_realm_data(realm, &rp);
-	bcopy(&(rp.options),ro,sizeof(realm_options_t));
+	memcpy(ro,&(rp.options),sizeof(realm_options_t));
 }
 
 int change_total_quota(char *realm, int value)
@@ -465,7 +465,7 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 						TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Encoded oAuth token is too large\n");
 						return -1;
 					}
-					bcopy(value,etoken.token,(size_t)len);
+					memcpy(etoken.token,value,(size_t)len);
 					etoken.size = (size_t)len;
 
 					const char* server_name = (char*)turn_params.oauth_server_name;
@@ -515,10 +515,10 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 							}
 						}
 
-						bcopy(dot.enc_block.mac_key,key,dot.enc_block.key_length);
+						memcpy(key,dot.enc_block.mac_key,dot.enc_block.key_length);
 
 						if(rawKey.realm[0]) {
-							bcopy(rawKey.realm,realm,sizeof(rawKey.realm));
+							memcpy(realm,rawKey.realm,sizeof(rawKey.realm));
 						}
 
 						ret = 0;
@@ -622,7 +622,7 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 
 	if(ret==0) {
 		size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
-		bcopy(ukey,key,sz);
+		memcpy(key,ukey,sz);
 		return 0;
 	}
 

--- a/src/apps/uclient/mainuclient.c
+++ b/src/apps/uclient/mainuclient.c
@@ -414,7 +414,7 @@ int main(int argc, char **argv)
 
 				if(pwd) {
 					if(pwd_length>0) {
-						bcopy(pwd,g_upwd,pwd_length);
+						memcpy(g_upwd,pwd,pwd_length);
 						g_upwd[pwd_length]=0;
 					}
 				}

--- a/src/apps/uclient/startuclient.c
+++ b/src/apps/uclient/startuclient.c
@@ -321,7 +321,7 @@ int read_mobility_ticket(app_ur_conn_info *clnet_info, stun_buffer *message)
 			if(smid_len>0 && (((size_t)smid_len)<sizeof(clnet_info->s_mobile_id))) {
 				const uint8_t* smid_val = stun_attr_get_value(s_mobile_id_sar);
 				if(smid_val) {
-					bcopy(smid_val, clnet_info->s_mobile_id, (size_t)smid_len);
+					memcpy(clnet_info->s_mobile_id, smid_val, (size_t)smid_len);
 					clnet_info->s_mobile_id[smid_len] = 0;
 					if (clnet_verbose)
 						TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
@@ -614,7 +614,7 @@ static int clnet_allocate(int verbose,
 		  }
 
 		  app_ur_conn_info ci;
-		  bcopy(clnet_info,&ci,sizeof(ci));
+		  memcpy(&ci,clnet_info,sizeof(ci));
 		  ci.fd = -1;
 		  ci.ssl = NULL;
 		  clnet_info->fd = -1;

--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -678,7 +678,7 @@ static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info 
 
 		if(is_tcp_data) {
 		  if ((int)elem->in_buffer.len == clmessage_length) {
-		    bcopy((elem->in_buffer.buf), &mi, sizeof(message_info));
+		    memcpy(&mi, (elem->in_buffer.buf), sizeof(message_info));
 		    miset=1;
 		  } else {
 			/* TODO: make a more clean fix */ 
@@ -730,7 +730,7 @@ static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info 
 
 				const uint8_t* data = stun_attr_get_value(sar);
 
-				bcopy(data, &mi, sizeof(message_info));
+				memcpy(&mi, data, sizeof(message_info));
 				miset=1;
 			}
 
@@ -786,7 +786,7 @@ static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info 
 					return rc;
 				}
 
-				bcopy(elem->in_buffer.buf + 4, &mi, sizeof(message_info));
+				memcpy(&mi, elem->in_buffer.buf + 4, sizeof(message_info));
 				miset=1;
 				applen = elem->in_buffer.len -4;
 			}
@@ -1644,7 +1644,7 @@ int add_integrity(app_ur_conn_info *clnet_info, stun_buffer *message)
 				stun_attr_add_str(message->buf, (size_t*)&(message->len), STUN_ATTRIBUTE_OAUTH_ACCESS_TOKEN,
 					(const uint8_t*)etoken.token, (int)etoken.size);
 
-				bcopy(otoken.enc_block.mac_key,clnet_info->key,otoken.enc_block.key_length);
+				memcpy(clnet_info->key,otoken.enc_block.mac_key,otoken.enc_block.key_length);
 				clnet_info->key_set = 1;
 			}
 

--- a/src/client++/TurnMsgLib.h
+++ b/src/client++/TurnMsgLib.h
@@ -211,7 +211,7 @@ public:
 		_sz = sz;
 		_value=(uint8_t*)malloc(_sz);
 		if(ptr)
-			bcopy(ptr,_value,_sz);
+			memcpy(_value,ptr,_sz);
 	}
 
 	/**
@@ -241,7 +241,7 @@ public:
 		_sz = sz;
 		_value=(uint8_t*)malloc(_sz);
 		if(value)
-			bcopy(value,_value,_sz);
+			memcpy(_value,value,_sz);
 	}
 
 	/**

--- a/src/client/ns_turn_ioaddr.c
+++ b/src/client/ns_turn_ioaddr.c
@@ -107,7 +107,7 @@ uint32_t addr_hash(const ioa_addr *addr)
 		ret = hash_int32(addr->s4.sin_addr.s_addr + addr->s4.sin_port);
 	} else {
 		uint64_t a[2];
-		bcopy(&(addr->s6.sin6_addr), &a, sizeof(a));
+		memcpy(&a, &(addr->s6.sin6_addr), sizeof(a));
 		ret = (uint32_t)((hash_int64(a[0])<<3) + (hash_int64(a[1] + addr->s6.sin6_port)));
 	}
 	return ret;
@@ -123,7 +123,7 @@ uint32_t addr_hash_no_port(const ioa_addr *addr)
 		ret = hash_int32(addr->s4.sin_addr.s_addr);
 	} else {
 		uint64_t a[2];
-		bcopy(&(addr->s6.sin6_addr), &a, sizeof(a));
+		memcpy(&a, &(addr->s6.sin6_addr), sizeof(a));
 		ret = (uint32_t)((hash_int64(a[0])<<3) + (hash_int64(a[1])));
 	}
 	return ret;
@@ -131,17 +131,17 @@ uint32_t addr_hash_no_port(const ioa_addr *addr)
 
 void addr_cpy(ioa_addr* dst, const ioa_addr* src) {
 	if(dst && src)
-		bcopy(src,dst,sizeof(ioa_addr));
+		memcpy(dst,src,sizeof(ioa_addr));
 }
 
 void addr_cpy4(ioa_addr* dst, const struct sockaddr_in* src) {
 	if(src && dst)
-		bcopy(src,dst,sizeof(struct sockaddr_in));
+		memcpy(dst,src,sizeof(struct sockaddr_in));
 }
 
 void addr_cpy6(ioa_addr* dst, const struct sockaddr_in6* src) {
 	if(src && dst)
-		bcopy(src,dst,sizeof(struct sockaddr_in6));
+		memcpy(dst,src,sizeof(struct sockaddr_in6));
 }
 
 int addr_eq(const ioa_addr* a1, const ioa_addr *a2) {
@@ -247,7 +247,7 @@ int make_ioa_addr(const uint8_t* saddr0, int port, ioa_addr *addr) {
 
     	if(addr_result->ai_family == family) {
     		if (addr_result->ai_family == AF_INET) {
-    			bcopy(addr_result->ai_addr, addr, addr_result->ai_addrlen);
+    			memcpy(addr, addr_result->ai_addr, addr_result->ai_addrlen);
     			addr->s4.sin_port = nswap16(port);
 #if defined(TURN_HAS_SIN_LEN) /* tested when configured */
     			addr->s4.sin_len = sizeof(struct sockaddr_in);
@@ -255,7 +255,7 @@ int make_ioa_addr(const uint8_t* saddr0, int port, ioa_addr *addr) {
     			found = 1;
     			break;
     		} else if (addr_result->ai_family == AF_INET6) {
-    			bcopy(addr_result->ai_addr, addr, addr_result->ai_addrlen);
+    			memcpy(addr, addr_result->ai_addr, addr_result->ai_addrlen);
     			addr->s6.sin6_port = nswap16(port);
 #if defined(SIN6_LEN) /* this define is required by IPv6 if used */
     			addr->s6.sin6_len = sizeof(struct sockaddr_in6);

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -87,7 +87,7 @@ int stun_method_str(uint16_t method, char *smethod)
 	};
 
 	if(smethod) {
-		bcopy(s,smethod,strlen(s)+1);
+		memcpy(smethod,s,strlen(s)+1);
 	}
 
 	return ret;
@@ -302,7 +302,7 @@ static void generate_enc_password(const char* pwd, char *result, const unsigned 
 	if(!orig_salt) {
 		generate_random_nonce(salt, PWD_SALT_SIZE);
 	} else {
-		bcopy(orig_salt,salt,PWD_SALT_SIZE);
+		memcpy(salt,orig_salt,PWD_SALT_SIZE);
 		salt[PWD_SALT_SIZE]=0;
 	}
 	unsigned char rsalt[PWD_SALT_SIZE*2+1];
@@ -310,7 +310,7 @@ static void generate_enc_password(const char* pwd, char *result, const unsigned 
 	result[0]='$';
 	result[1]='5';
 	result[2]='$';
-	bcopy((char*)rsalt,result+3,PWD_SALT_SIZE+PWD_SALT_SIZE);
+	memcpy(result+3,(char*)rsalt,PWD_SALT_SIZE+PWD_SALT_SIZE);
 	result[3+PWD_SALT_SIZE+PWD_SALT_SIZE]='$';
 	unsigned char* out = (unsigned char*)(result+3+PWD_SALT_SIZE+PWD_SALT_SIZE+1);
 	{
@@ -536,7 +536,7 @@ int stun_is_error_response_str(const uint8_t* buf, size_t len, int *err_code, ui
     				  size_t msg_len = stun_attr_get_len(sar) - 4;
     				  if(msg_len>(err_msg_size-1))
     					  msg_len=err_msg_size - 1;
-    				  bcopy(val+4, err_msg, msg_len);
+    				  memcpy(err_msg, val+4, msg_len);
     				  err_msg[msg_len]=0;
     			  }
     		  }
@@ -563,7 +563,7 @@ int stun_is_challenge_response_str(const uint8_t* buf, size_t len, int *err_code
 			const uint8_t *value = stun_attr_get_value(sar);
 			if(value) {
 				size_t vlen = (size_t)stun_attr_get_len(sar);
-				bcopy(value,realm,vlen);
+				memcpy(realm,value,vlen);
 				realm[vlen]=0;
 
 				{
@@ -574,7 +574,7 @@ int stun_is_challenge_response_str(const uint8_t* buf, size_t len, int *err_code
 							vlen = (size_t)stun_attr_get_len(sar);
 							if(vlen>0) {
 								if(server_name) {
-									bcopy(value,server_name,vlen);
+									memcpy(server_name,value,vlen);
 								}
 								found_oauth = 1;
 							}
@@ -587,7 +587,7 @@ int stun_is_challenge_response_str(const uint8_t* buf, size_t len, int *err_code
 					value = stun_attr_get_value(sar);
 					if(value) {
 						vlen = (size_t)stun_attr_get_len(sar);
-						bcopy(value,nonce,vlen);
+						memcpy(nonce,value,vlen);
 						nonce[vlen]=0;
 						if(oauth) {
 							*oauth = found_oauth;
@@ -1219,18 +1219,18 @@ int stun_tid_equals(const stun_tid *id1, const stun_tid *id2) {
 void stun_tid_cpy(stun_tid *id1, const stun_tid *id2) {
   if(!id1) return;
   if(!id2) return;
-  bcopy((const void*)(id2->tsx_id),(void*)(id1->tsx_id),STUN_TID_SIZE);
+  memcpy((void*)(id1->tsx_id),(const void*)(id2->tsx_id),STUN_TID_SIZE);
 }
 
 static void stun_tid_string_cpy(uint8_t* s, const stun_tid* id) {
   if(s && id) {
-    bcopy((const void*)(id->tsx_id),s,STUN_TID_SIZE);
+    memcpy(s,(const void*)(id->tsx_id),STUN_TID_SIZE);
   }
 }
 
 static void stun_tid_from_string(const uint8_t* s, stun_tid* id) {
   if(s && id) {
-    bcopy(s,(void*)(id->tsx_id),STUN_TID_SIZE);
+    memcpy((void*)(id->tsx_id),s,STUN_TID_SIZE);
   }
 }
 
@@ -1342,7 +1342,7 @@ uint64_t stun_attr_get_reservation_token_value(stun_attr_ref attr)  {
     const uint8_t* value = stun_attr_get_value(attr);
     if(value && (stun_attr_get_len(attr) == 8)) {
       uint64_t token;
-      bcopy(value, &token, sizeof(uint64_t));
+      memcpy(&token, value, sizeof(uint64_t));
       return nswap64(token);
     }
   }
@@ -1474,7 +1474,7 @@ int stun_attr_add_str(uint8_t* buf, size_t *len, uint16_t attr, const uint8_t* a
     
     attr_start_16t[0]=nswap16(attr);
     attr_start_16t[1]=nswap16(alen);
-    if(alen>0) bcopy(avalue,attr_start+4,alen);
+    if(alen>0) memcpy(attr_start+4,avalue,alen);
 	
 	// Write 0 padding to not leak data
 	memset(attr_start+4+alen, 0, paddinglen);
@@ -2159,7 +2159,7 @@ int calculate_key(char *key, size_t key_size,
 {
 	UNUSED_ARG(key_size);
 
-	bcopy(key,new_key,new_key_size);
+	memcpy(new_key,key,new_key_size);
 
 	return 0;
 }
@@ -2169,7 +2169,7 @@ int convert_oauth_key_data(const oauth_key_data *oakd0, oauth_key *key, char *er
 	if(oakd0 && key) {
 
 		oauth_key_data oakd_obj;
-		bcopy(oakd0,&oakd_obj,sizeof(oauth_key_data));
+		memcpy(&oakd_obj,oakd0,sizeof(oauth_key_data));
 		oauth_key_data *oakd = &oakd_obj;
 
 		if(!(oakd->ikm_key_size)) {
@@ -2196,7 +2196,7 @@ int convert_oauth_key_data(const oauth_key_data *oakd0, oauth_key *key, char *er
 
 		STRCPY(key->kid,oakd->kid);
 
-		bcopy(oakd->ikm_key,key->ikm_key,sizeof(key->ikm_key));
+		memcpy(key->ikm_key,oakd->ikm_key,sizeof(key->ikm_key));
 		key->ikm_key_size = oakd->ikm_key_size;
 
 		key->timestamp = oakd->timestamp;
@@ -2332,7 +2332,7 @@ int encode_oauth_token_normal(const uint8_t *server_name, encoded_oauth_token *e
 		*((uint16_t*)(orig_field+len)) = nswap16(dtoken->enc_block.key_length);
 		len +=2;
 
-		bcopy(dtoken->enc_block.mac_key,orig_field+len,dtoken->enc_block.key_length);
+		memcpy(orig_field+len,dtoken->enc_block.mac_key,dtoken->enc_block.key_length);
 		len += dtoken->enc_block.key_length;
 
 		*((uint64_t*)(orig_field+len)) = nswap64(dtoken->enc_block.timestamp);
@@ -2362,7 +2362,7 @@ int encode_oauth_token_normal(const uint8_t *server_name, encoded_oauth_token *e
 		EVP_CIPHER_CTX_cleanup(&ctx);
 
 		size_t sn_len = strlen((const char*)server_name);
-		bcopy(server_name,encoded_field+outl,sn_len);
+		memcpy(encoded_field+outl,server_name,sn_len);
 		outl += sn_len;
 
 		const EVP_MD *md = get_auth_type(key->auth_alg);
@@ -2376,7 +2376,7 @@ int encode_oauth_token_normal(const uint8_t *server_name, encoded_oauth_token *e
 
 		update_hmac_len(key->auth_alg, &hmac_len);
 
-		bcopy(encoded_field + outl, encoded_field + outl - sn_len, hmac_len);
+		memcpy(encoded_field + outl - sn_len, encoded_field + outl, hmac_len);
 		outl -= sn_len;
 		outl += hmac_len; //encoded+hmac
 
@@ -2422,9 +2422,9 @@ int decode_oauth_token_normal(const uint8_t *server_name, const encoded_oauth_to
        		}
        		unsigned char efield[MAX_ENCODED_OAUTH_TOKEN_SIZE];
        		unsigned char check_mac[MAXSHASIZE];
-       		bcopy(encoded_field,efield,encoded_field_size);
+       		memcpy(efield,encoded_field,encoded_field_size);
        		size_t sn_len = strlen((const char*)server_name);
-       		bcopy(server_name,efield+encoded_field_size,sn_len);
+       		memcpy(efield+encoded_field_size,server_name,sn_len);
 		    if (!HMAC(md, key->auth_key, key->auth_key_size, efield, encoded_field_size+sn_len, check_mac, &hmac_len)) {
 		    	return -1;
 		    }
@@ -2459,7 +2459,7 @@ int decode_oauth_token_normal(const uint8_t *server_name, const encoded_oauth_to
 		dtoken->enc_block.key_length = nswap16(*((uint16_t*)(decoded_field+len)));
 		len += 2;
 
-		bcopy(decoded_field+len,dtoken->enc_block.mac_key,dtoken->enc_block.key_length);
+		memcpy(dtoken->enc_block.mac_key,decoded_field+len,dtoken->enc_block.key_length);
 		len += dtoken->enc_block.key_length;
 
 		dtoken->enc_block.timestamp = nswap64(*((uint64_t*)(decoded_field+len)));
@@ -2493,7 +2493,7 @@ static int encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_toke
 
 		unsigned char nonce[OAUTH_GCM_NONCE_SIZE];
 		if(nonce0) {
-			bcopy(nonce0,nonce,sizeof(nonce));
+			memcpy(nonce,nonce0,sizeof(nonce));
 		} else {
 			generate_random_nonce(nonce, sizeof(nonce));
 		}
@@ -2503,17 +2503,17 @@ static int encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_toke
 		*((uint16_t*)(orig_field+len)) = nswap16(OAUTH_GCM_NONCE_SIZE);
 		len +=2;
 
-		bcopy(nonce,orig_field+len,OAUTH_GCM_NONCE_SIZE);
+		memcpy(orig_field+len,nonce,OAUTH_GCM_NONCE_SIZE);
 		len += OAUTH_GCM_NONCE_SIZE;
 
 		*((uint16_t*)(orig_field+len)) = nswap16(dtoken->enc_block.key_length);
 		len +=2;
 
-		bcopy(dtoken->enc_block.mac_key,orig_field+len,dtoken->enc_block.key_length);
+		memcpy(orig_field+len,dtoken->enc_block.mac_key,dtoken->enc_block.key_length);
 		len += dtoken->enc_block.key_length;
 
 		uint64_t ts = nswap64(dtoken->enc_block.timestamp);
-		bcopy( &ts, (orig_field+len), sizeof(ts));
+		memcpy( (orig_field+len), &ts, sizeof(ts));
 		len += sizeof(ts);
 
 		*((uint32_t*)(orig_field+len)) = nswap32(dtoken->enc_block.lifetime);
@@ -2556,7 +2556,7 @@ static int encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_toke
 
 		outl=0;
 		unsigned char *encoded_field = (unsigned char*)etoken->token;
-		bcopy(orig_field,encoded_field,OAUTH_GCM_NONCE_SIZE + 2);
+		memcpy(encoded_field,orig_field,OAUTH_GCM_NONCE_SIZE + 2);
 		encoded_field += OAUTH_GCM_NONCE_SIZE + 2;
 		unsigned char *start_field = orig_field + OAUTH_GCM_NONCE_SIZE + 2;
 		len -= OAUTH_GCM_NONCE_SIZE + 2;
@@ -2589,7 +2589,7 @@ static int decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oaut
 	if(server_name && etoken && key && dtoken) {
 
 		unsigned char snl[2];
-		bcopy((const unsigned char*)(etoken->token),snl,2);
+		memcpy(snl,(const unsigned char*)(etoken->token),2);
 		const unsigned char *csnl = snl;
 
 		uint16_t nonce_len = nswap16(*((const uint16_t*)csnl));
@@ -2604,10 +2604,10 @@ static int decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oaut
 		const unsigned char* encoded_field = (const unsigned char*)(etoken->token + nonce_len + 2);
 		unsigned int encoded_field_size = (unsigned int)etoken->size - nonce_len - 2 - OAUTH_GCM_TAG_SIZE;
 		const unsigned char* nonce = ((const unsigned char*)etoken->token + 2);
-                bcopy(nonce,dtoken->enc_block.nonce,nonce_len);
+                memcpy(dtoken->enc_block.nonce,nonce,nonce_len);
 
 		unsigned char tag[OAUTH_GCM_TAG_SIZE];
-		bcopy(((const unsigned char*)etoken->token) + nonce_len + 2 + encoded_field_size, tag ,sizeof(tag));
+		memcpy(tag, ((const unsigned char*)etoken->token) + nonce_len + 2 + encoded_field_size, sizeof(tag));
 
 		unsigned char decoded_field[MAX_ENCODED_OAUTH_TOKEN_SIZE];
 
@@ -2686,16 +2686,16 @@ static int decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oaut
 		dtoken->enc_block.key_length = nswap16(*((uint16_t*)(decoded_field+len)));
 		len += 2;
 
-		bcopy(decoded_field+len,dtoken->enc_block.mac_key,dtoken->enc_block.key_length);
+		memcpy(dtoken->enc_block.mac_key,decoded_field+len,dtoken->enc_block.key_length);
 		len += dtoken->enc_block.key_length;
 
 		uint64_t ts;
-		bcopy((decoded_field+len),&ts,sizeof(ts));
+		memcpy(&ts,(decoded_field+len),sizeof(ts));
 		dtoken->enc_block.timestamp = nswap64(ts);
 		len += sizeof(ts);
 
 		uint32_t lt;
-		bcopy((decoded_field+len),&lt,sizeof(lt));
+		memcpy(&lt,(decoded_field+len),sizeof(lt));
 		dtoken->enc_block.lifetime = nswap32(lt);
 		len += sizeof(lt);
 

--- a/src/client/ns_turn_msg_addr.c
+++ b/src/client/ns_turn_msg_addr.c
@@ -96,7 +96,7 @@ int stun_addr_encode(const ioa_addr* ca, uint8_t *cfield, int *clen, int xor_ed,
       ((uint16_t*)cfield)[1]=ca->s6.sin6_port;
       
       /* Address */
-      bcopy(&ca->s6.sin6_addr, ((uint8_t*)cfield)+4, 16);
+      memcpy(((uint8_t*)cfield)+4, &ca->s6.sin6_addr, 16);
     }
 
   } else {
@@ -149,7 +149,7 @@ int stun_addr_decode(ioa_addr* ca, const uint8_t *cfield, int len, int xor_ed, u
     ca->s6.sin6_port = ((const uint16_t*)cfield)[1];
 
     /* Address */
-    bcopy(((const uint8_t*)cfield)+4, &ca->s6.sin6_addr, 16);
+    memcpy(&ca->s6.sin6_addr, ((const uint8_t*)cfield)+4, 16);
 
     if (xor_ed) {
 

--- a/src/server/ns_turn_allocation.c
+++ b/src/server/ns_turn_allocation.c
@@ -578,7 +578,7 @@ tcp_connection *create_tcp_connection(uint8_t server_id, allocation *a, stun_tid
 	memset(tc,0,sizeof(tcp_connection));
 	addr_cpy(&(tc->peer_addr),peer_addr);
 	if(tid)
-		bcopy(tid,&(tc->tid),sizeof(stun_tid));
+		memcpy(&(tc->tid),tid,sizeof(stun_tid));
 	tc->owner = a;
 
 	int found = 0;

--- a/src/server/ns_turn_maps.c
+++ b/src/server/ns_turn_maps.c
@@ -983,7 +983,7 @@ static string_list* string_list_add(string_list* sl, const ur_string_map_key_typ
   elem->list.next=sl;
   elem->key_size = strlen(key)+1;
   elem->key=(char*)malloc(elem->key_size);
-  bcopy(key,elem->key,elem->key_size);
+  memcpy(elem->key,key,elem->key_size);
   elem->value=value;
   return &(elem->list);
 }

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -644,7 +644,7 @@ static int mobile_id_to_string(mobile_id_t mid, char *dst, size_t dst_sz)
 		return -1;
 	}
 
-	bcopy(s, dst, output_length);
+	memcpy(dst, s, output_length);
 
 	free(s);
 
@@ -1052,7 +1052,7 @@ static int handle_turn_allocate(turn_turnserver *server,
 						*reason = (const uint8_t *)"User name is too long";
 						break;
 					}
-					bcopy(value,username,ulen);
+					memcpy(username,value,ulen);
 					username[ulen]=0;
 					if(!is_secure_string(username,1)) {
 						TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: wrong username: %s\n", __FUNCTION__, (char*)username);
@@ -1474,16 +1474,16 @@ static int handle_turn_allocate(turn_turnserver *server,
 static void copy_auth_parameters(ts_ur_super_session *orig_ss, ts_ur_super_session *ss) {
 	if(orig_ss && ss) {
 		dec_quota(ss);
-		bcopy(orig_ss->nonce,ss->nonce,sizeof(ss->nonce));
+		memcpy(ss->nonce,orig_ss->nonce,sizeof(ss->nonce));
 		ss->nonce_expiration_time = orig_ss->nonce_expiration_time;
-		bcopy(&(orig_ss->realm_options),&(ss->realm_options),sizeof(ss->realm_options));
-		bcopy(orig_ss->username,ss->username,sizeof(ss->username));
+		memcpy(&(ss->realm_options),&(orig_ss->realm_options),sizeof(ss->realm_options));
+		memcpy(ss->username,orig_ss->username,sizeof(ss->username));
 		ss->hmackey_set = orig_ss->hmackey_set;
-		bcopy(orig_ss->hmackey,ss->hmackey,sizeof(ss->hmackey));
+		memcpy(ss->hmackey,orig_ss->hmackey,sizeof(ss->hmackey));
 		ss->oauth = orig_ss->oauth;
-		bcopy(orig_ss->origin,ss->origin,sizeof(ss->origin));
+		memcpy(ss->origin,orig_ss->origin,sizeof(ss->origin));
 		ss->origin_set = orig_ss->origin_set;
-		bcopy(orig_ss->pwd,ss->pwd,sizeof(ss->pwd));
+		memcpy(ss->pwd,orig_ss->pwd,sizeof(ss->pwd));
 		ss->max_session_time_auth = orig_ss->max_session_time_auth;
 		inc_quota(ss,ss->username);
 	}
@@ -1541,7 +1541,7 @@ static int handle_turn_refresh(turn_turnserver *server,
 					if(smid_len>0 && (((size_t)smid_len)<sizeof(smid))) {
 						const uint8_t* smid_val = stun_attr_get_value(sar);
 						if(smid_val) {
-							bcopy(smid_val, smid, (size_t)smid_len);
+							memcpy(smid, smid_val, (size_t)smid_len);
 							mid = string_to_mobile_id(smid);
 							if(is_allocation_valid(a) && (mid != ss->old_mobile_id)) {
 								*err_code = 400;
@@ -2073,7 +2073,7 @@ static void tcp_peer_connection_completed_callback(int success, void *arg)
 				uint8_t *data = ioa_network_buffer_data(nbh_test);
 				const char* data_test="111.111.111.111.111";
 				len_test = strlen(data_test);
-				bcopy(data_test,data,len_test);
+				memcpy(data,data_test,len_test);
 				ioa_network_buffer_set_size(nbh_test,len_test);
 				send_data_from_ioa_socket_nbh(tc->peer_s, NULL, nbh_test, TTL_IGNORE, TOS_IGNORE, NULL);
 			}
@@ -3279,11 +3279,11 @@ static void resume_processing_after_username_check(int success,  int oauth, int 
 			turn_turnserver *server = (turn_turnserver *)ss->server;
 
 			if(success) {
-				bcopy(hmackey,ss->hmackey,sizeof(hmackey_t));
+				memcpy(ss->hmackey,hmackey,sizeof(hmackey_t));
 				ss->hmackey_set = 1;
 				ss->oauth = oauth;
 				ss->max_session_time_auth = (turn_time_t)max_session_time;
-				bcopy(pwd,ss->pwd,sizeof(password_t));
+				memcpy(ss->pwd,pwd,sizeof(password_t));
 				if(realm && realm[0] && strcmp((char*)realm,ss->realm_options.name)) {
 					dec_quota(ss);
 					get_realm_options_by_name((char*)realm, &(ss->realm_options));
@@ -3393,7 +3393,7 @@ static int check_stun_auth(turn_turnserver *server,
 		}
 
 		alen = min((size_t)stun_attr_get_len(sar),sizeof(realm)-1);
-		bcopy(stun_attr_get_value(sar),realm,alen);
+		memcpy(realm,stun_attr_get_value(sar),alen);
 		realm[alen]=0;
 
 		if(!is_secure_string(realm,0)) {
@@ -3418,7 +3418,7 @@ static int check_stun_auth(turn_turnserver *server,
 				}
 				return -1;
 			} else {
-				bcopy(ss->realm_options.name,realm,sizeof(ss->realm_options.name));
+				memcpy(realm,ss->realm_options.name,sizeof(ss->realm_options.name));
 			}
 		}
 	}
@@ -3435,7 +3435,7 @@ static int check_stun_auth(turn_turnserver *server,
 	}
 
 	alen = min((size_t)stun_attr_get_len(sar),sizeof(usname)-1);
-	bcopy(stun_attr_get_value(sar),usname,alen);
+	memcpy(usname,stun_attr_get_value(sar),alen);
 	usname[alen]=0;
 
 	if(!is_secure_string(usname,1)) {
@@ -3475,7 +3475,7 @@ static int check_stun_auth(turn_turnserver *server,
 		}
 
 		alen = min((size_t)stun_attr_get_len(sar),sizeof(nonce)-1);
-		bcopy(stun_attr_get_value(sar),nonce,alen);
+		memcpy(nonce,stun_attr_get_value(sar),alen);
 		nonce[alen]=0;
 
 		/* Stale Nonce check: */
@@ -3662,7 +3662,7 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 						if(sarlen>0) {
 							++norigins;
 							char *o = (char*)malloc(sarlen+1);
-							bcopy(stun_attr_get_value(sar),o,sarlen);
+							memcpy(o,stun_attr_get_value(sar),sarlen);
 							o[sarlen]=0;
 							char *corigin = (char*)malloc(STUN_MAX_ORIGIN_SIZE+1);
 							corigin[0]=0;
@@ -3718,7 +3718,7 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 						int sarlen = stun_attr_get_len(sar);
 						if(sarlen>0) {
 							char *o = (char*)malloc(sarlen+1);
-							bcopy(stun_attr_get_value(sar),o,sarlen);
+							memcpy(o,stun_attr_get_value(sar),sarlen);
 							o[sarlen]=0;
 							char *corigin = (char*)malloc(STUN_MAX_ORIGIN_SIZE+1);
 							corigin[0]=0;
@@ -4040,7 +4040,7 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
 					memset(software, 0, sizeof(software));
 					if(newsz>sizeof(software))
 						newsz = sizeof(software);
-					bcopy(get_version(server),software,oldsz);
+					memcpy(software,get_version(server),oldsz);
 					size_t len = ioa_network_buffer_get_size(nbh);
 					stun_attr_add_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_SERVER, software, newsz);
 					ioa_network_buffer_set_size(nbh, len);
@@ -4094,7 +4094,7 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
 			memset(software, 0, sizeof(software));
 			if(newsz>sizeof(software))
 				newsz = sizeof(software);
-			bcopy(get_version(server),software,oldsz);
+			memcpy(software,get_version(server),oldsz);
 			size_t len = ioa_network_buffer_get_size(nbh);
 			stun_attr_add_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_SERVER, software, newsz);
 			ioa_network_buffer_set_size(nbh, len);


### PR DESCRIPTION
Replace all instances of `bcopy` with memcpy.

Inspired by https://github.com/coturn/coturn/pull/855