### PR TITLE
Use single SSL_CTX for DTLS support

### DIFF
--- a/examples/run_tests.sh
+++ b/examples/run_tests.sh
@@ -33,3 +33,12 @@ else
     echo FAIL
 	exit $?
 fi
+
+echo 'Running turn client DTLS'
+../bin/turnutils_uclient -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+if [ $? -eq 0 ]; then
+    echo OK
+else
+    echo FAIL
+	exit $?
+fi

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -279,18 +279,7 @@ static ioa_socket_handle dtls_server_input_handler(dtls_listener_relay_server_ty
 	timeout.tv_usec = 0;
 	BIO_ctrl(wbio, BIO_CTRL_DGRAM_SET_RECV_TIMEOUT, 0, &timeout);
 
-#if DTLSv1_2_SUPPORTED
-	if(get_dtls_version(ioa_network_buffer_data(nbh),
-							(int)ioa_network_buffer_get_size(nbh)) == 1) {
-		connecting_ssl = SSL_new(server->e->dtls_ctx_v1_2);
-	} else {
-		connecting_ssl = SSL_new(server->e->dtls_ctx);
-	}
-#else
-	{
-		connecting_ssl = SSL_new(server->e->dtls_ctx);
-	}
-#endif
+	connecting_ssl = SSL_new(server->e->dtls_ctx);
 
 	SSL_set_accept_state(connecting_ssl);
 
@@ -573,18 +562,7 @@ static int create_new_connected_udp_socket(
 		timeout.tv_usec = 0;
 		BIO_ctrl(wbio, BIO_CTRL_DGRAM_SET_RECV_TIMEOUT, 0, &timeout);
 
-#if DTLSv1_2_SUPPORTED
-		if(get_dtls_version(ioa_network_buffer_data(server->sm.m.sm.nd.nbh),
-							(int)ioa_network_buffer_get_size(server->sm.m.sm.nd.nbh)) == 1) {
-			connecting_ssl = SSL_new(server->e->dtls_ctx_v1_2);
-		} else {
-			connecting_ssl = SSL_new(server->e->dtls_ctx);
-		}
-#else
-		{
-			connecting_ssl = SSL_new(server->e->dtls_ctx);
-		}
-#endif
+		connecting_ssl = SSL_new(server->e->dtls_ctx);
 
 		SSL_set_accept_state(connecting_ssl);
 
@@ -965,8 +943,6 @@ void setup_dtls_callbacks(SSL_CTX *ctx) {
   /* If client has to authenticate, then  */
   SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, dtls_verify_callback);
 #endif
-
-  SSL_CTX_set_read_ahead(ctx, 1);
 
   SSL_CTX_set_cookie_generate_cb(ctx, generate_cookie);
   SSL_CTX_set_cookie_verify_cb(ctx, verify_cookie);

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3258,7 +3258,7 @@ static void openssl_load_certificates(void)
 #else
         set_ctx(&turn_params.dtls_ctx,"DTLS",DTLSv1_server_method()); // < openssl-1.0.2
 #endif
-        if(!turn_params.no_tlsv1) {
+        if(!turn_params.no_tlsv1 || !turn_params.no_tlsv1_1) {
             SSL_CTX_set_options(turn_params.dtls_ctx, SSL_OP_NO_DTLSv1);
         }
 #else // OPENSSL_VERSION_NUMBER < 0x10100000L

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -83,34 +83,31 @@ char HTTP_ALPN[128] = "http/1.1";
 #define DEFAULT_GENERAL_RELAY_SERVERS_NUMBER (1)
 
 turn_params_t turn_params = {
-	NULL,
-#if DTLS_SUPPORTED
-NULL,
-#endif
-
+NULL, /* tls_ctx */
+NULL, /* dtls_ctx */
 DH_2066, "", "", "",
 "turn_server_cert.pem","turn_server_pkey.pem", "", "",
 0,0,0,
 #if !TLS_SUPPORTED
-1,
+	1,
 #else
-0,
+	0,
 #endif
 
 #if !DTLS_SUPPORTED
-1,
+	1,
 #else
-0,
+	0,
 #endif
 
 NULL, PTHREAD_MUTEX_INITIALIZER,
 
 //////////////// Common params ////////////////////
-TURN_VERBOSE_NONE, /* verbose */
-0, /* turn_daemon */
-0, /* no_software_attribute */
-0, /* web_admin_listen_on_workers */
-0, /* do_not_use_config_file */
+	TURN_VERBOSE_NONE, /* verbose */
+	0, /* turn_daemon */
+	0, /* no_software_attribute */
+	0, /* web_admin_listen_on_workers */
+	0, /* do_not_use_config_file */
 "/var/run/turnserver.pid", /* pidfile */
 "", /* acme_redirect */
 DEFAULT_STUN_PORT, /* listener_port*/

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -180,9 +180,6 @@ typedef struct _turn_params_ {
   
 #if DTLS_SUPPORTED
   SSL_CTX *dtls_ctx;
-#if DTLSv1_2_SUPPORTED
-  SSL_CTX *dtls_ctx_v1_2;
-#endif
 #endif
   
   DH_KEY_SIZE dh_key_size;

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -177,10 +177,7 @@ typedef struct _turn_params_ {
 //////////////// OpenSSL group //////////////////////
 
   SSL_CTX *tls_ctx;
-  
-#if DTLS_SUPPORTED
   SSL_CTX *dtls_ctx;
-#endif
   
   DH_KEY_SIZE dh_key_size;
   

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -337,9 +337,6 @@ static void update_ssl_ctx(evutil_socket_t sock, short events, update_ssl_ctx_cb
 #if DTLS_SUPPORTED
 	replace_one_ssl_ctx(&e->dtls_ctx, params->dtls_ctx);
 #endif
-#if DTLSv1_2_SUPPORTED
-	replace_one_ssl_ctx(&e->dtls_ctx_v1_2, params->dtls_ctx_v1_2);
-#endif
 	struct event *next = args->next;
 	pthread_mutex_unlock(&turn_params.tls_mutex);
 

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -142,9 +142,7 @@ struct _ioa_engine
   rtcp_map *map_rtcp;
   stun_buffer_list bufs;
   SSL_CTX *tls_ctx;
-#if DTLS_SUPPORTED
   SSL_CTX *dtls_ctx;
-#endif
   turn_time_t jiffie; /* bandwidth check interval */
   ioa_timer_handle timer_ev;
   char cmsg[TURN_CMSG_SZ+1];

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -145,9 +145,6 @@ struct _ioa_engine
 #if DTLS_SUPPORTED
   SSL_CTX *dtls_ctx;
 #endif
-#if DTLSv1_2_SUPPORTED
-  SSL_CTX *dtls_ctx_v1_2;
-#endif
   turn_time_t jiffie; /* bandwidth check interval */
   ioa_timer_handle timer_ev;
   char cmsg[TURN_CMSG_SZ+1];


### PR DESCRIPTION
Similar to #989, use a single SSL context for all versions of DTLS protocol

- Add support for modern API (protocol version independent APIs)
- Add DTLS test to the CI test
- Removing calls to `SSL_CTX_set_read_ahead` in DTLS context (does nothing as DTLS is datagram protocol - we always get the whole datagram so this call has no impact)

Fixes #924