### PR TITLE
Use epoll for promhttp server if supported. 

### DIFF
--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -70,7 +70,7 @@ int start_prometheus_server(void){
 
   promhttp_set_active_collector_registry(NULL);
 
-  unsigned int flags = MHD_USE_DUAL_STACK;
+  unsigned int flags = MHD_USE_DUAL_STACK | MHD_USE_ERROR_LOG;
   if (MHD_is_feature_supported(MHD_FEATURE_EPOLL)) {
     flags |= MHD_USE_EPOLL_INTERNAL_THREAD;
   } else {

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -70,7 +70,13 @@ int start_prometheus_server(void){
 
   promhttp_set_active_collector_registry(NULL);
 
-  struct MHD_Daemon *daemon = promhttp_start_daemon(MHD_USE_SELECT_INTERNALLY | MHD_USE_DUAL_STACK, turn_params.prometheus_port, NULL, NULL);
+  unsigned int flags = MHD_USE_DUAL_STACK;
+  if (MHD_is_feature_supported(MHD_FEATURE_EPOLL)) {
+    flags |= MHD_USE_EPOLL_INTERNAL_THREAD;
+  } else {
+    flags |= MHD_USE_SELECT_INTERNALLY;
+  }
+  struct MHD_Daemon *daemon = promhttp_start_daemon(flags, turn_params.prometheus_port, NULL, NULL);
   if (daemon == NULL) {
     return -1;
   }


### PR DESCRIPTION
Before:
```
./bin/turnserver --prometheus -m 32
...
Socket descriptor larger than FD_SETSIZE: 2660 > 1024
0: : ERROR: Could not start Prometheus collector!
```

After:
```
./bin/turnserver --prometheus -m 32
...
0: : Prometheus collector started successfully.
```

Also added `MHD_USE_ERROR_LOG` so the actual problems during startup of promhttp are printed. Without it the `Socket descriptor larger than FD_SETSIZE: 2660 > 1024` error was not visible and finding the cause of the startup problems of promhttp was not obvious at first.