### PR TITLE
Build CI with prometheus support

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -19,6 +19,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y \
+            wget \
             libevent-dev \
             libssl-dev \
             libpq-dev libmariadb-dev libsqlite3-dev \
@@ -26,6 +27,12 @@ jobs:
             libmongoc-dev \
             libmicrohttpd-dev
     - uses: actions/checkout@v3
+    - name: Prometheus support
+      run: |
+        wget https://github.com/digitalocean/prometheus-client-c/releases/download/v0.1.3/libprom-dev-0.1.3-Linux.deb && \
+            wget https://github.com/digitalocean/prometheus-client-c/releases/download/v0.1.3/libpromhttp-dev-0.1.3-Linux.deb && \
+            sudo apt install ./libprom-dev-0.1.3-Linux.deb ./libpromhttp-dev-0.1.3-Linux.deb && \
+            rm ./libprom-dev-0.1.3-Linux.deb ./libpromhttp-dev-0.1.3-Linux.deb
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
         apt-get install -y \
             build-essential pkgconf
         apt-get install -y \
+            wget \
             libevent-dev \
             libssl-dev \
             libpq-dev libsqlite3-dev \
@@ -32,6 +33,10 @@ jobs:
             libmicrohttpd-dev
         if [ ${{ matrix.os }}  = 'ubuntu:16.04' ]; then apt-get install -y libmariadb-client-lgpl-dev; fi
         if [ ${{ matrix.os }} != 'ubuntu:16.04' ]; then apt-get install -y libmariadb-dev; fi
+        wget https://github.com/digitalocean/prometheus-client-c/releases/download/v0.1.3/libprom-dev-0.1.3-Linux.deb && \
+            wget https://github.com/digitalocean/prometheus-client-c/releases/download/v0.1.3/libpromhttp-dev-0.1.3-Linux.deb && \
+            apt install ./libprom-dev-0.1.3-Linux.deb ./libpromhttp-dev-0.1.3-Linux.deb && \
+            rm ./libprom-dev-0.1.3-Linux.deb ./libpromhttp-dev-0.1.3-Linux.deb
     - uses: actions/checkout@v3
     - name: configure
       run: ./configure

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -70,7 +70,11 @@ int start_prometheus_server(void){
 
   promhttp_set_active_collector_registry(NULL);
 
-  unsigned int flags = MHD_USE_DUAL_STACK | MHD_USE_ERROR_LOG;
+  unsigned int flags = MHD_USE_DUAL_STACK 
+#if MHD_USE_ERROR_LOG
+                     | MHD_USE_ERROR_LOG
+#endif
+                     ;
   if (MHD_is_feature_supported(MHD_FEATURE_EPOLL)) {
   #if MHD_USE_EPOLL_INTERNAL_THREAD
     flags |= MHD_USE_EPOLL_INTERNAL_THREAD;

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -75,7 +75,7 @@ int start_prometheus_server(void){
   #if MHD_USE_EPOLL_INTERNAL_THREAD
     flags |= MHD_USE_EPOLL_INTERNAL_THREAD;
   #else
-    flags |= MHD_USE_EPOLL_INTERNALLY; //ubuntu 16.04
+    flags |= MHD_USE_SELECT_INTERNALLY; //ubuntu 16.04
   #endif
   } else {
     flags |= MHD_USE_SELECT_INTERNALLY;

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -72,7 +72,11 @@ int start_prometheus_server(void){
 
   unsigned int flags = MHD_USE_DUAL_STACK | MHD_USE_ERROR_LOG;
   if (MHD_is_feature_supported(MHD_FEATURE_EPOLL)) {
+  #if MHD_USE_EPOLL_INTERNAL_THREAD
     flags |= MHD_USE_EPOLL_INTERNAL_THREAD;
+  #else
+    flags |= MHD_USE_EPOLL_INTERNALLY; //ubuntu 16.04
+  #endif
   } else {
     flags |= MHD_USE_SELECT_INTERNALLY;
   }


### PR DESCRIPTION
Install dependencies and build with prometheus support during CI builds

Ubuntu 16.04 has issues supporting `MHD_USE_EPOLL_INTERNAL_THREAD` so disabling it (using SELECT)
Should not impact anything as the only reason we use Ubuntu 16.04 is to validate build against openssl-1.0.2

Fixes  #998