### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,14 +7,13 @@ Uploaders: Oleg Moskalenko <mom040267@gmail.com>,
 Build-Depends: debhelper-compat (= 13),
                default-libmysqlclient-dev,
                default-mysql-client,
-               dpkg-dev (>= 1.16.1~),
                libsystemd-dev [linux-any],
                pkg-config,
-               libevent-dev (>= 2.0.1~),
+               libevent-dev,
                libhiredis-dev,
                libpq-dev,
                libsqlite3-dev,
-               libssl-dev (>= 1.0.0~),
+               libssl-dev,
                postgresql-client,
                sqlite3
 Standards-Version: 4.6.1
@@ -28,7 +27,7 @@ Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
 Depends: adduser,
          sqlite3,
-         lsb-base (>= 3.0-6),
+         lsb-base,
          telnet | telnet-client,
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/coturn/c0e03d65-4b3b-45b2-a213-11607cafdbb8.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package coturn: lines which differ (wdiff format)
* Depends: adduser, sqlite3, [-lsb-base (>= 3.0-6),-] {+lsb-base,+} telnet | telnet-client, libc6 (>= 2.34), libevent-core-2.1-7 (>= 2.1.8-stable), libevent-extra-2.1-7 (>= 2.1.8-stable), libevent-openssl-2.1-7 (>= 2.1.8-stable), libevent-pthreads-2.1-7 (>= 2.1.8-stable), libhiredis0.14 (>= 0.14.0), libmariadb3 (>= 3.0.0), libpq5 (>= 8.4~), libsqlite3-0 (>= 3.6.0), libssl3 (>= 3.0.0), libsystemd0

No differences were encountered between the control files of package \*\*coturn-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/c0e03d65-4b3b-45b2-a213-11607cafdbb8/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/c0e03d65-4b3b-45b2-a213-11607cafdbb8/diffoscope)).
