### PR TITLE
Cleanup unused include of header files

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -40,20 +40,12 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <limits.h>
-#include <ifaddrs.h>
-#include <getopt.h>
 #include <locale.h>
 #include <libgen.h>
 #include <fcntl.h>
 
-#include <pthread.h>
-
 #include <signal.h>
 
-#include <sys/types.h>
-#include <sys/time.h>
-#include <sys/stat.h>
 #include <sys/resource.h>
 
 #if !defined(TURN_NO_SCTP) && defined(TURN_SCTP_INCLUDE)

--- a/src/apps/common/hiredis_libevent2.c
+++ b/src/apps/common/hiredis_libevent2.c
@@ -28,9 +28,6 @@
  * SUCH DAMAGE.
  */
 
-#include <stdlib.h>
-#include <stdarg.h>
-
 #if !defined(TURN_NO_HIREDIS)
 
 #include "hiredis_libevent2.h"

--- a/src/apps/oauth/oauth.c
+++ b/src/apps/oauth/oauth.c
@@ -28,7 +28,6 @@
  * SUCH DAMAGE.
  */
 
-#include <err.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/apps/relay/dbdrivers/dbd_sqlite.c
+++ b/src/apps/relay/dbdrivers/dbd_sqlite.c
@@ -37,7 +37,6 @@
 #include <sqlite3.h>
 
 #include <unistd.h>
-#include <sys/types.h>
 #include <pwd.h>
 
 #include <pthread.h>

--- a/src/apps/relay/libtelnet.c
+++ b/src/apps/relay/libtelnet.c
@@ -22,7 +22,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#include <string.h>
 #include <stdarg.h>
 
 /* Win32 compatibility */

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -33,21 +33,9 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <limits.h>
-#include <ifaddrs.h>
-#include <getopt.h>
-#include <locale.h>
-#include <libgen.h>
-
-#include <pthread.h>
-
-#include <signal.h>
 
 #include "libtelnet.h"
 
-#include <sys/types.h>
-#include <sys/time.h>
-#include <sys/stat.h>
 #include <sys/resource.h>
 
 #include <event2/bufferevent.h>

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -32,24 +32,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h>
-#include <limits.h>
-#include <ifaddrs.h>
-#include <getopt.h>
-#include <locale.h>
-#include <libgen.h>
-
 #include <pthread.h>
 
-#include <signal.h>
-
-#include <sys/types.h>
-#include <sys/time.h>
-#include <sys/stat.h>
 #include <sys/resource.h>
 
 #include <event2/bufferevent.h>
-#include <event2/buffer.h>
 
 #include "userdb.h"
 #include "dbdrivers/dbdriver.h"

--- a/src/apps/uclient/mainuclient.c
+++ b/src/apps/uclient/mainuclient.c
@@ -31,7 +31,6 @@
 #include "apputils.h"
 #include "uclient.h"
 #include "ns_turn_utils.h"
-#include "apputils.h"
 #include "session.h"
 #include "stun_buffer.h"
 
@@ -40,9 +39,6 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-
-#include <sys/types.h>
-#include <sys/stat.h>
 
 #include "ns_turn_openssl.h"
 

--- a/src/server/ns_turn_maps_rtcp.c
+++ b/src/server/ns_turn_maps_rtcp.c
@@ -30,7 +30,6 @@
 
 #include "ns_turn_maps_rtcp.h"
 
-#include "ns_turn_utils.h"
 #include "ns_turn_ioaddr.h"
 
 ////////////////////////////////////////////

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -32,7 +32,6 @@
 
 #include "ns_turn_utils.h"
 #include "ns_turn_allocation.h"
-#include "ns_turn_msg_addr.h"
 #include "ns_turn_ioalib.h"
 #include "../apps/relay/ns_ioalib_impl.h"
 


### PR DESCRIPTION
Using clang-tidy to detect unused header files

Inspired by #855

Test Plan:
- Rebuild all on mac, review no warnings/errors
- Pass builds/docker build - review for no issues 