### PR TITLE
Malformed response to mobility refresh request

### DIFF
--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -1770,7 +1770,6 @@ static int handle_turn_refresh(turn_turnserver *server,
 										{
 											const uint8_t *field = (const uint8_t *) get_version(server);
 											size_t fsz = strlen(get_version(server));
-											size_t len = ioa_network_buffer_get_size(nbh);
 											stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_SOFTWARE, field, fsz);
 											ioa_network_buffer_set_size(nbh, len);
 										}

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -1770,16 +1770,19 @@ static int handle_turn_refresh(turn_turnserver *server,
 										{
 											const uint8_t *field = (const uint8_t *) get_version(server);
 											size_t fsz = strlen(get_version(server));
+											size_t len = ioa_network_buffer_get_size(nbh);
 											stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_SOFTWARE, field, fsz);
 											ioa_network_buffer_set_size(nbh, len);
 										}
 
 										if(message_integrity) {
+											size_t len = ioa_network_buffer_get_size(nbh);
 											stun_attr_add_integrity_str(server->ct,ioa_network_buffer_data(nbh),&len,ss->hmackey,ss->pwd,SHATYPE_DEFAULT);
 											ioa_network_buffer_set_size(nbh,len);
 										}
 
 										if ((server->fingerprint) || ss->enforce_fingerprints) {
+											size_t len = ioa_network_buffer_get_size(nbh);
 											if (stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &len) < 0) {
 												*err_code = 500;
 												ioa_network_buffer_delete(server->e, nbh);


### PR DESCRIPTION
Hello, and thank you for this great project!

When sending a mobility refresh request, the server is responding with an invalid stun packet. Specifically, only the last 24 bytes generated for message integrity are sent.

Request:
![image](https://user-images.githubusercontent.com/4522385/193647719-c9038761-86fe-4eb3-b899-20cdd5084796.png)

Response:
![image](https://user-images.githubusercontent.com/4522385/193647883-31c919e0-f7ae-4db2-9b82-028bd8cdb24f.png)


This appears to be caused by the buffer length not being updated when `STUN_ATTRIBUTE_SOFTWARE` is added to the response, as it's being assigned to a `len` variable scoped to that conditional. 

As a result, the next call to `stun_get_command_message_len_str` when handling message integrity returns `-1` and resizes the buffer, etc.

Passing in the original `len` to `stun_attr_add_str` for attribute software fixes the issue, but apologies if this is not the right way to fix this!