### PR TITLE
Fix : Issue 51563 in oss-fuzz

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1926,7 +1926,7 @@ void print_hmac(const char *name, const void *s, size_t len)
 int stun_check_message_integrity_by_key_str(turn_credential_type ct, uint8_t *buf, size_t len, hmackey_t key, password_t pwd, SHATYPE shatype)
 {
 	int res = 0;
-	uint8_t new_hmac[MAXSHASIZE];
+	uint8_t new_hmac[MAXSHASIZE] = NULL;
 	unsigned int shasize;
 	const uint8_t *old_hmac = NULL;
 

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1926,7 +1926,7 @@ void print_hmac(const char *name, const void *s, size_t len)
 int stun_check_message_integrity_by_key_str(turn_credential_type ct, uint8_t *buf, size_t len, hmackey_t key, password_t pwd, SHATYPE shatype)
 {
 	int res = 0;
-	uint8_t new_hmac[MAXSHASIZE] = NULL;
+	uint8_t new_hmac[MAXSHASIZE] = {0};
 	unsigned int shasize;
 	const uint8_t *old_hmac = NULL;
 


### PR DESCRIPTION
```
==6418==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x4e7530 in bcmp /src/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:906:10
    #1 0x55463d in stun_check_message_integrity_by_key_str coturn/src/client/ns_turn_msg.c:1989:5
    #2 0x554acc in stun_check_message_integrity_str coturn/src/client/ns_turn_msg.c:2008:9
    #3 0x5358c0 in LLVMFuzzerTestOneInput coturn/fuzz/FuzzStun.c:37:5
    #4 0x43ede3 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #5 0x42a542 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:324:6
    #6 0x42fdec in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:860:9
    #7 0x459322 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #8 0x7f4cb21790b2 in __libc_start_main /build/glibc-eX1tMB/glibc-2.31/csu/libc-start.c:308:16
    #9 0x42070d in _start
  Uninitialized value was created by an allocation of 'new_hmac' in the stack frame of function 'stun_check_message_integrity_by_key_str'
    #0 0x5538c0 in stun_check_message_integrity_by_key_str coturn/src/client/ns_turn_msg.c:1927
```