### PR TITLE
Better detect SCTP protocol

### DIFF
--- a/configure
+++ b/configure
@@ -1015,6 +1015,8 @@ if [ -z "${TURN_NO_SCTP}" ] ; then
     if [ -z "${TURN_SCTP_INCLUDE}" ] ; then
 		if [ -f /usr/include/netinet/sctp.h ] ; then
 	    	TURN_SCTP_INCLUDE="-DTURN_SCTP_INCLUDE=\"</usr/include/netinet/sctp.h>\""
+        else
+            TURN_NO_SCTP="-DTURN_NO_SCTP"
 		fi
     else
 		TURN_SCTP_INCLUDE="-DTURN_SCTP_INCLUDE=\"\\\"${TURN_SCTP_INCLUDE}\\\"\""

--- a/configure
+++ b/configure
@@ -1015,8 +1015,8 @@ if [ -z "${TURN_NO_SCTP}" ] ; then
     if [ -z "${TURN_SCTP_INCLUDE}" ] ; then
 		if [ -f /usr/include/netinet/sctp.h ] ; then
 	    	TURN_SCTP_INCLUDE="-DTURN_SCTP_INCLUDE=\"</usr/include/netinet/sctp.h>\""
-        else
-            TURN_NO_SCTP="-DTURN_NO_SCTP"
+		else
+	    	TURN_NO_SCTP="-DTURN_NO_SCTP"
 		fi
     else
 		TURN_SCTP_INCLUDE="-DTURN_SCTP_INCLUDE=\"\\\"${TURN_SCTP_INCLUDE}\\\"\""

--- a/src/apps/relay/CMakeLists.txt
+++ b/src/apps/relay/CMakeLists.txt
@@ -93,6 +93,8 @@ else()
     list(APPEND turnserver_DEFINED TURN_NO_PROMETHEUS)
 endif()
 
+list(APPEND turnserver_DEFINED TURN_NO_SCTP)
+
 add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEAD_FILES})
 target_link_libraries(${PROJECT_NAME} PRIVATE turn_server ${turnserver_LIBS})
 target_include_directories(${PROJECT_NAME} PRIVATE ${turnserver_include_dirs})

--- a/src/apps/relay/tls_listener.c
+++ b/src/apps/relay/tls_listener.c
@@ -273,7 +273,7 @@ static int sctp_create_server_listener(tls_listener_relay_server_type* server) {
 
   tls_listen_fd = socket(server->addr.ss.sa_family, SCTP_CLIENT_STREAM_SOCKET_TYPE, SCTP_CLIENT_STREAM_SOCKET_PROTOCOL);
   if (tls_listen_fd < 0) {
-    perror("socket");
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,"Cannot create SCTP socket listener: %d %d\n",SCTP_CLIENT_STREAM_SOCKET_TYPE, SCTP_CLIENT_STREAM_SOCKET_PROTOCOL);
     return -1;
   }
 

--- a/src/apps/relay/tls_listener.c
+++ b/src/apps/relay/tls_listener.c
@@ -273,7 +273,7 @@ static int sctp_create_server_listener(tls_listener_relay_server_type* server) {
 
   tls_listen_fd = socket(server->addr.ss.sa_family, SCTP_CLIENT_STREAM_SOCKET_TYPE, SCTP_CLIENT_STREAM_SOCKET_PROTOCOL);
   if (tls_listen_fd < 0) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,"Cannot create SCTP socket listener: %d %d\n",SCTP_CLIENT_STREAM_SOCKET_TYPE, SCTP_CLIENT_STREAM_SOCKET_PROTOCOL);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,"Cannot create SCTP socket listener\n");
     return -1;
   }
 


### PR DESCRIPTION
turnserver includes support for SCTP and tries to initialize listener sockets with SCTP protocol. On machines where SCTP definitions exist but the protocol is not provided - socket() returns error which shows up as `socket: protocol not supported`

This change improves a few related pieces of code:
- Log error instead of perror
- config script detect sctp.h and if not present - defines TURN_NO_SCTP
- CMake fully disables SCTP (for now - requires custom module to detect SCTP presence)

Fixes #492 