### PR TITLE
Reduce usage of TURN_NO_PROMETHEUS

### DIFF
--- a/src/apps/relay/CMakeLists.txt
+++ b/src/apps/relay/CMakeLists.txt
@@ -22,6 +22,7 @@ set(HEADER_FILES
     turn_ports.h
     userdb.h
     dbdrivers/dbdriver.h
+    prom_server.h
     )
 
 set(SOURCE_FILES
@@ -37,6 +38,7 @@ set(SOURCE_FILES
     acme.c
     userdb.c
     dbdrivers/dbdriver.c
+    prom_server.c
     )
 
 find_package(SQLite)

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -31,9 +31,7 @@
 #include "mainrelay.h"
 #include "dbdrivers/dbdriver.h"
 
-#if !defined(TURN_NO_PROMETHEUS)
 #include "prom_server.h"
-#endif
 
 #if defined(WINDOWS)
     #include <Iphlpapi.h>
@@ -218,11 +216,9 @@ turn_params_t turn_params = {
     0, /* bps_capacity_allocated */
     0, /* total_quota */
     0, /* user_quota */
-    #if !defined(TURN_NO_PROMETHEUS)
     0, /* prometheus disabled by default */
     DEFAULT_PROM_SERVER_PORT, /* prometheus port */
     0, /* prometheus username labelling disabled by default when prometheus is enabled */
-    #endif
 
     ///////////// Users DB //////////////
     { (TURN_USERDB_TYPE)0, {"\0","\0"}, {0,NULL, {NULL,0}} },
@@ -2032,7 +2028,6 @@ static void set_option(int c, char *value)
         turn_params.use_redis_statsdb = 1;
         break;
 #endif
-#if !defined(TURN_NO_PROMETHEUS)
 	case PROMETHEUS_OPT:
 		turn_params.prometheus = 1;
 		break;
@@ -2042,7 +2037,6 @@ static void set_option(int c, char *value)
 	case PROMETHEUS_ENABLE_USERNAMES_OPT:
 		turn_params.prometheus_username_labels = 1;
 		break;
-#endif
 	case AUTH_SECRET_OPT:
 		turn_params.use_auth_secret_with_timestamp = 1;
         use_tltc = 1;
@@ -3131,19 +3125,7 @@ int main(int argc, char **argv)
 #endif
 
 	drop_privileges();
-#if !defined(TURN_NO_PROMETHEUS)
-	int prometheus_status = start_prometheus_server();
-	if (prometheus_status < 0) {
-	  TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Could not start Prometheus collector!\n");
-	}
-	else if (prometheus_status == 1) {
-	  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Prometheus collector disabled, not started.\n");
-	}
-	else {
-	  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Prometheus collector started successfully.\n");
-	}
-#endif
-
+	start_prometheus_server();
 
 	run_listener_server(&(turn_params.listener));
 

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -307,11 +307,9 @@ typedef struct _turn_params_ {
   band_limit_t bps_capacity_allocated;
   vint total_quota;
   vint user_quota;
-  #if !defined(TURN_NO_PROMETHEUS)
   int prometheus;
   int prometheus_port;
-  int  prometheus_username_labels;
-  #endif
+  int prometheus_username_labels;
 
 
 /////// Users DB ///////////

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -38,9 +38,7 @@
 
 #include "ns_ioalib_impl.h"
 
-#if !defined(TURN_NO_PROMETHEUS)
 #include "prom_server.h"
-#endif
 
 #if TLS_SUPPORTED
 #include <event2/bufferevent_ssl.h>

--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -2,6 +2,8 @@
 #ifndef __PROM_SERVER_H__
 #define __PROM_SERVER_H__
 
+#define DEFAULT_PROM_SERVER_PORT (9641)
+
 #if !defined(TURN_NO_PROMETHEUS)
 
 #include <signal.h>
@@ -19,8 +21,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif /* __clplusplus */
-
-#define DEFAULT_PROM_SERVER_PORT (9641)
 
 extern prom_counter_t *turn_new_allocation;
 extern prom_counter_t *turn_refreshed_allocation;
@@ -55,12 +55,15 @@ extern "C" {
 #endif
 
 
-int start_prometheus_server(void);
+void start_prometheus_server(void);
 
 void prom_set_finished_traffic(const char* realm, const char* user, unsigned long rsvp, unsigned long rsvb, unsigned long sentp, unsigned long sentb, bool peer);
 
 void prom_inc_allocation(void);
 void prom_dec_allocation(void);
+#else
+
+void start_prometheus_server(void);
 
 #endif /* TURN_NO_PROMETHEUS */
 


### PR DESCRIPTION
`TURN_NO_PROMETHEUS` is defined when prometheus libraries are not present and any prometheus functionality must be disabled

While all above is correct, it does not require ifdef-ing out all related code.
For example, prometheus related fields in turn_params do not need to be compiled out. Same for certain function parameters.

This PR reduces amount of places in code where `TURN_NO_PROMETHEUS` is used to make code simpler by moving as much usage of this define into prom_server.h/c files and compiling them unconditionally.

- Always compile/link prom_server.c
- Move many TURN_NO_PROMETHEUS decisions into prom_server.c
