### PR TITLE
Backlog fifo

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -101,6 +101,8 @@ static void socket_output_handler_bev(struct bufferevent *bev, void* arg);
 static void socket_input_handler_bev(struct bufferevent *bev, void* arg);
 static void eventcb_bev(struct bufferevent *bev, short events, void *arg);
 
+static int send_ssl_backlog_buffers(ioa_socket_handle s);
+
 static int set_accept_cb(ioa_socket_handle s, accept_cb acb, void *arg);
 
 static void close_socket_net_data(ioa_socket_handle s);
@@ -3105,7 +3107,7 @@ static int ssl_send(ioa_socket_handle s, const char* buffer, int len, int verbos
 	}
 }
 
-int send_ssl_backlog_buffers(ioa_socket_handle s)
+static int send_ssl_backlog_buffers(ioa_socket_handle s)
 {
 	int ret = 0;
 	if(s) {

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -101,8 +101,6 @@ static void socket_output_handler_bev(struct bufferevent *bev, void* arg);
 static void socket_input_handler_bev(struct bufferevent *bev, void* arg);
 static void eventcb_bev(struct bufferevent *bev, short events, void *arg);
 
-static int send_ssl_backlog_buffers(ioa_socket_handle s);
-
 static int set_accept_cb(ioa_socket_handle s, accept_cb acb, void *arg);
 
 static void close_socket_net_data(ioa_socket_handle s);
@@ -268,6 +266,9 @@ static stun_buffer_list_elem *get_elem_from_buffer_list(stun_buffer_list *bufs)
 		ret=bufs->head;
 		bufs->head=ret->next;
 		--bufs->tsz;
+		if(bufs->tsz == 0) {
+			bufs->tail = NULL;
+		}
 
 		ret->next=NULL;
 		ret->buf.len = 0;
@@ -285,11 +286,12 @@ static void pop_elem_from_buffer_list(stun_buffer_list *bufs)
 		stun_buffer_list_elem *ret = bufs->head;
 		bufs->head=ret->next;
 		--bufs->tsz;
+		if(bufs->tsz == 0) {
+			bufs->tail = NULL;
+		}
 		free(ret);
 	}
 }
-
-
 
 static stun_buffer_list_elem *new_blist_elem(ioa_engine_handle e)
 {
@@ -313,8 +315,14 @@ static stun_buffer_list_elem *new_blist_elem(ioa_engine_handle e)
 
 static inline void add_elem_to_buffer_list(stun_buffer_list *bufs, stun_buffer_list_elem *buf_elem)
 {
-	buf_elem->next = bufs->head;
-	bufs->head = buf_elem;
+	// We want a queue, so add to tail
+	if(bufs->tail) {
+		bufs->tail->next = buf_elem;
+	} else {
+		bufs->head = buf_elem;
+	}
+	buf_elem->next = NULL;
+	bufs->tail = buf_elem;
 	bufs->tsz += 1;
 }
 
@@ -3097,7 +3105,7 @@ static int ssl_send(ioa_socket_handle s, const char* buffer, int len, int verbos
 	}
 }
 
-static int send_ssl_backlog_buffers(ioa_socket_handle s)
+int send_ssl_backlog_buffers(ioa_socket_handle s)
 {
 	int ret = 0;
 	if(s) {

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -77,6 +77,7 @@ typedef struct _stun_buffer_list_elem {
 
 typedef struct _stun_buffer_list {
 	stun_buffer_list_elem *head;
+	stun_buffer_list_elem *tail;
 	size_t tsz;
 } stun_buffer_list;
 
@@ -176,6 +177,7 @@ struct _ioa_socket
 	SOCKET_TYPE st;
 	SOCKET_APP_TYPE sat;
 	SSL* ssl;
+	ioa_timer_handle ssl_client_conn_tmr;
 	uint32_t ssl_renegs;
 	int in_write;
 	int bound;
@@ -258,6 +260,8 @@ void delete_socket_from_parent(ioa_socket_handle s);
 
 void add_socket_to_map(ioa_socket_handle s, ur_addr_map *amap);
 void delete_socket_from_map(ioa_socket_handle s);
+
+int send_ssl_backlog_buffers(ioa_socket_handle s);
 
 int is_connreset(void);
 int would_block(void);

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -261,8 +261,6 @@ void delete_socket_from_parent(ioa_socket_handle s);
 void add_socket_to_map(ioa_socket_handle s, ur_addr_map *amap);
 void delete_socket_from_map(ioa_socket_handle s);
 
-int send_ssl_backlog_buffers(ioa_socket_handle s);
-
 int is_connreset(void);
 int would_block(void);
 int udp_send(ioa_socket_handle s, const ioa_addr* dest_addr, const char* buffer, int len);

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -177,7 +177,6 @@ struct _ioa_socket
 	SOCKET_TYPE st;
 	SOCKET_APP_TYPE sat;
 	SSL* ssl;
-	ioa_timer_handle ssl_client_conn_tmr;
 	uint32_t ssl_renegs;
 	int in_write;
 	int bound;


### PR DESCRIPTION
Modify SSL backlog buffer from LIFO to queue/FIFO

If data ends up in the ssl_backlog_buffer because we are waiting for a handshake to finish, then this change ensures that the data is sent out in the proper order once the handshake completes.  Previous code was sending in LIFO order.