### PR TITLE
Fix off-by-one when terminating gcm_nonce

### DIFF
--- a/src/apps/oauth/oauth.c
+++ b/src/apps/oauth/oauth.c
@@ -337,7 +337,7 @@ int main(int argc, char **argv)
         nonce_size=OAUTH_GCM_NONCE_SIZE;
       } 
       strncpy(gcm_nonce,nonce_val,nonce_size);
-      gcm_nonce[ nonce_size + 1 ]='\0';
+      gcm_nonce[ nonce_size ]='\0';
       break;
     case 'p':
       //token-mac-key


### PR DESCRIPTION
The `gcm_nonce` character array is `12 + 1` chars long. Writing to `gcm_nonce[12 + 1]` overflows the array by one char.