### PR TITLE
Change rpm systemd service type from notify to exec

### DIFF
--- a/rpm/turnserver.service.fc
+++ b/rpm/turnserver.service.fc
@@ -6,7 +6,8 @@ After=syslog.target network.target
 [Service]
 User=turnserver
 Group=turnserver
-Type=notify
+Type=exec
+PIDFile=/var/run/turnserver/turnserver.pid
 EnvironmentFile=/etc/sysconfig/turnserver
 ExecStart=/usr/bin/turnserver -c /etc/turnserver/turnserver.conf $EXTRA_OPTIONS
 ExecStopPost=/usr/bin/rm -f /var/run/turnserver/turnserver.pid


### PR DESCRIPTION
Fix the issue https://github.com/coturn/coturn/issues/118 that prevent the process to start as coturn never send the notification to systemd thus preventing the startup.

Cherry-picked from #990 thanks to @rapsys