### PR TITLE
Remove unnecessary declaration from header file

### DIFF
--- a/src/apps/common/ns_turn_utils.h
+++ b/src/apps/common/ns_turn_utils.h
@@ -76,7 +76,6 @@ extern volatile turn_time_t _log_time_value;
 extern int use_new_log_timestamp_format;
 
 void rtpprintf(const char *format, ...);
-int vrtpprintf(TURN_LOG_LEVEL level, const char *format, va_list args);
 void reset_rtpprintf(void);
 void set_logfile(const char *fn);
 void rollover_logfile(void);


### PR DESCRIPTION
Remove unnecessary declaration.

The implementation of the vrtpprintf function has been removed in commit 5e87c444693b39e11cabc498450dacbef30ec64a.