### PR TITLE
Update to fix duplicate stdout log output

### DIFF
--- a/src/apps/natdiscovery/natdiscovery.c
+++ b/src/apps/natdiscovery/natdiscovery.c
@@ -634,6 +634,7 @@ int main(int argc, char **argv)
 	if (socket_init()) return -1;
 
 	set_logfile("stdout");
+	set_no_stdout_log(1);
 	set_system_parameters(0);
 
 	memset(local_addr_string, 0, sizeof(local_addr_string));

--- a/src/apps/oauth/oauth.c
+++ b/src/apps/oauth/oauth.c
@@ -275,6 +275,7 @@ int main(int argc, char **argv)
   int c=0;
 
   set_logfile("stdout");
+  set_no_stdout_log(1);
   set_system_parameters(0);
 
   while ((c = getopt_long(argc, argv, "hvedi:j:k:l:m:n:o:p:q:r:t:u:",long_options, &option_index)) != -1) {

--- a/src/apps/peer/mainudpserver.c
+++ b/src/apps/peer/mainudpserver.c
@@ -69,6 +69,7 @@ int main(int argc, char **argv)
 	IS_TURN_SERVER = 1;
 
 	set_logfile("stdout");
+	set_no_stdout_log(1);
 	set_system_parameters(0);
 
 	while ((c = getopt(argc, argv, "d:p:L:v")) != -1)

--- a/src/apps/rfc5769/rfc5769check.c
+++ b/src/apps/rfc5769/rfc5769check.c
@@ -218,6 +218,7 @@ int main(int argc, const char **argv)
 		print_extra = 1;
 
 	set_logfile("stdout");
+	set_no_stdout_log(1);
 	set_system_parameters(0);
 
 	{

--- a/src/apps/stunclient/stunclient.c
+++ b/src/apps/stunclient/stunclient.c
@@ -424,6 +424,7 @@ int main(int argc, char **argv)
   if (socket_init()) return -1;
 
   set_logfile("stdout");
+  set_no_stdout_log(1);
   set_system_parameters(0);
   
   memset(local_addr, 0, sizeof(local_addr));

--- a/src/apps/uclient/mainuclient.c
+++ b/src/apps/uclient/mainuclient.c
@@ -191,6 +191,7 @@ int main(int argc, char **argv)
 #endif
 
 	set_logfile("stdout");
+	set_no_stdout_log(1);
 
 	set_execdir();
 


### PR DESCRIPTION
Disables default log output to stdout if stdout is set as logfile.

When execute `turnutils_stunclient` , the output will be duplicated as in the following example.

```
$ ./turnutils_stunclient stun.example.com
0: : IPv4. UDP reflexive addr: 203.0.113.1:10000
0: : IPv4. UDP reflexive addr: 203.0.113.1:10000
```

This is because stdout is set in `set_logfile` and furthermore log output to stdout is done by default.

In this change, call `set_no_stdout_log` to disable default log output to stdout when stdout is set as logfile.

This solves the problem of duplicate output to stdout of the same log.