### PR TITLE
WINDOWS: unsigned long should not be used to store pointers

### DIFF
--- a/src/apps/common/CMakeLists.txt
+++ b/src/apps/common/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 if(MSVC OR MINGW)
     list(APPEND COMMON_DEFINED WINDOWS)
-	list(APPEND COMMON_LIBS Ws2_32 netapi32)
+	list(APPEND COMMON_LIBS ws2_32 netapi32)
 endif()
 
 find_package(OpenSSL REQUIRED COMPONENTS Crypto SSL)

--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -49,7 +49,7 @@
 #endif
 
 #if defined(WINDOWS)
-	#include <DSRole.h>
+	#include <dsrole.h>
 #endif
 
 #if defined(_MSC_VER)

--- a/src/apps/relay/CMakeLists.txt
+++ b/src/apps/relay/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT HAVE_THREAD_BARRIERS)
 endif()
 
 if(MSVC OR MINGW)
-    list(APPEND turnserver_LIBS Iphlpapi)
+    list(APPEND turnserver_LIBS iphlpapi)
 endif()
 
 set(HEADER_FILES

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -34,7 +34,7 @@
 #include "prom_server.h"
 
 #if defined(WINDOWS)
-    #include <Iphlpapi.h>
+    #include <iphlpapi.h>
 
     #define WORKING_BUFFER_SIZE 15000
     #define MAX_TRIES 3

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -45,7 +45,7 @@
 
 #if defined(WINDOWS)
 #include <ws2tcpip.h>
-#include <Windows.h>
+#include <windows.h>
 #include <process.h>
 #else
 #include <sys/socket.h>

--- a/src/server/ns_turn_maps.h
+++ b/src/server/ns_turn_maps.h
@@ -45,7 +45,7 @@ typedef struct _ur_map ur_map;
 //////////////// Common Definitions //////
 
 typedef uint64_t ur_map_key_type;
-typedef unsigned long ur_map_value_type;
+typedef uintptr_t ur_map_value_type;
 
 typedef void (*ur_map_del_func)(ur_map_value_type);
 
@@ -158,7 +158,7 @@ int lm_map_foreach_arg(lm_map* map, foreachcb_arg_type func, void* arg);
 
 //////////////// UR ADDR MAP //////////////////
 
-typedef unsigned long ur_addr_map_value_type;
+typedef uintptr_t ur_addr_map_value_type;
 
 #define ADDR_MAP_SIZE (1024)
 #define ADDR_ARRAY_SIZE (4)


### PR DESCRIPTION
On LLP64 systems (read Windows) unsigned long is only 4 bytes wide, which makes it very unsuitable for storing pointers.
-----
Additional comments:
uintptr_t since c99 or uintptr_t since C++11
see: https://cplusplus.com/reference/cstdint/, https://en.cppreference.com/w/c/types/integer, https://en.cppreference.com/w/cpp/types/integer

C11 re-enabled in #1056
