### PR TITLE
Add macOS build action

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,13 +18,13 @@ jobs:
             wget \
             pkg-config \
             libevent \
-            openssl \
+            openssl@1.1 \
             sqlite \
             hiredis \
             mongo-c-driver \
             libmicrohttpd
     - name: configure
-      run: ./configure
+      run: PKG_CONFIG_PATH=/usr/local/Cellar/openssl@1.1 ./configure ./configure
     - name: make
       run: make
     - name: make check

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,33 @@
+name: C/C++ CI macoS
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+
+jobs:
+  builds:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        brew update
+        brew install \
+            wget \
+            libevent \
+            openssl \
+            sqlite \
+            hiredis \
+            mongo-c-driver \
+            libmicrohttpd
+    - uses: actions/checkout@v3
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: apps tests
+      run: cd examples && ./run_tests.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,13 +16,13 @@ jobs:
         brew update
         brew install \
             wget \
+            pkg-config \
             libevent \
             openssl \
             sqlite \
             hiredis \
             mongo-c-driver \
             libmicrohttpd
-    - uses: actions/checkout@v3
     - name: configure
       run: ./configure
     - name: make

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
             mongo-c-driver \
             libmicrohttpd
     - name: configure
-      run: PKG_CONFIG_PATH=/usr/local/Cellar/openssl@1.1 ./configure ./configure
+      run: PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig ./configure
     - name: make
       run: make
     - name: make check


### PR DESCRIPTION
Fixes #1051 

This adds basic PR build action on macOS to confirm we keep builds green for developers using mac