### PR TITLE
Properly calculate size for sm_allocated

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -3878,7 +3878,7 @@ static void init_super_memory_region(super_memory_t *r)
 		r->super_memory = (char**)malloc(sizeof(char*));
 		r->super_memory[0] = (char*)calloc(1, TURN_SM_SIZE);
 
-		r->sm_allocated = (size_t*)malloc(sizeof(size_t*));
+		r->sm_allocated = (size_t*)malloc(sizeof(size_t));
 		r->sm_allocated[0] = 0;
 
 		r->sm_total_sz = TURN_SM_SIZE;
@@ -3946,7 +3946,7 @@ void* allocate_super_memory_region_func(super_memory_t *r, size_t size, const ch
 			r->sm_chunk += 1;
 			r->super_memory = (char**)realloc(r->super_memory,(r->sm_chunk+1) * sizeof(char*));
 			r->super_memory[r->sm_chunk] = (char*)calloc(1, TURN_SM_SIZE);
-			r->sm_allocated = (size_t*)realloc(r->sm_allocated,(r->sm_chunk+1) * sizeof(size_t*));
+			r->sm_allocated = (size_t*)realloc(r->sm_allocated,(r->sm_chunk+1) * sizeof(size_t));
 			r->sm_allocated[r->sm_chunk] = 0;
 			region = r->super_memory[r->sm_chunk];
 			rsz = r->sm_allocated + r->sm_chunk;


### PR DESCRIPTION
The `sm_allocated` field is an array of `size_t` values. Therefore its size must be calculated as `n * sizeof(size_t)`.

Our static code analysis tool complained:
```
Sizeof not portable (SIZEOF_MISMATCH)
suspicious_sizeof: Passing argument r->sm_allocated of type size_t * and argument (r->sm_chunk + 1) * 8UL /* sizeof (size_t *) */ to function realloc is suspicious. In this case, sizeof (size_t *) is equal to sizeof (size_t), but this is not a portable assumption.
```

Fix: #1045