### PR TITLE
Repair MSVC CI builds

### DIFF
--- a/src/apps/relay/libtelnet.c
+++ b/src/apps/relay/libtelnet.c
@@ -43,8 +43,10 @@
 #include "libtelnet.h"
 
 /* inlinable functions */
-#if defined(__GNUC__) || __STDC_VERSION__ >= 199901L
+#if defined(__GNUC__)
 # define INLINE __inline__
+#elif __STDC_VERSION__ >= 199901L
+# define INLINE inline
 #else
 # define INLINE
 #endif


### PR DESCRIPTION
The MSVC CI pipelines broke in #1056 due to the bump in C standard version.