### PR TITLE
Update openssl API use to non-deprecated version

### DIFF
--- a/src/apps/uclient/mainuclient.c
+++ b/src/apps/uclient/mainuclient.c
@@ -502,41 +502,41 @@ int main(int argc, char **argv)
 			csuite=cipher_suite;
 
 		if(use_tcp) {
-		  root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(SSLv23_client_method());
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	#if TLSv1_2_SUPPORTED
+			root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(TLSv1_2_client_method());
+	#elif TLSv1_1_SUPPORTED
+			root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(TLSv1_1_client_method());
+	#else
+			root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(TLSv1_client_method());
+	#endif
 		  SSL_CTX_set_cipher_list(root_tls_ctx[root_tls_ctx_num], csuite);
-		  root_tls_ctx_num++;
-
-		  root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(TLSv1_client_method());
+#else // OPENSSL_VERSION_NUMBER >= 0x10100000L
+		  root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(TLS_client_method());
 		  SSL_CTX_set_cipher_list(root_tls_ctx[root_tls_ctx_num], csuite);
-		  root_tls_ctx_num++;
-
-#if TLSv1_1_SUPPORTED
-		  root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(TLSv1_1_client_method());
-		  SSL_CTX_set_cipher_list(root_tls_ctx[root_tls_ctx_num], csuite);
-		  root_tls_ctx_num++;
-#if TLSv1_2_SUPPORTED
-		  root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(TLSv1_2_client_method());
-		  SSL_CTX_set_cipher_list(root_tls_ctx[root_tls_ctx_num], csuite);
-		  root_tls_ctx_num++;
 #endif
-#endif
+		  root_tls_ctx_num++;
 		} else {
 #if !DTLS_SUPPORTED
 		  fprintf(stderr,"ERROR: DTLS is not supported.\n");
 		  exit(-1);
 #else
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 		  if(OPENSSL_VERSION_NUMBER < 0x10000000L) {
 		  	TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "WARNING: OpenSSL version is rather old, DTLS may not be working correctly.\n");
 		  }
-		  root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(DTLSv1_client_method());
+	#if DTLSv1_2_SUPPORTED
+			root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(DTLSv1_2_client_method());
+	#else
+			root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(DTLSv1_client_method());
+	#endif
+			SSL_CTX_set_cipher_list(root_tls_ctx[root_tls_ctx_num], csuite);
+#else // OPENSSL_VERSION_NUMBER >= 0x10100000L
+		  root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(DTLS_client_method());
 		  SSL_CTX_set_cipher_list(root_tls_ctx[root_tls_ctx_num], csuite);
-		  root_tls_ctx_num++;
-#if DTLSv1_2_SUPPORTED
-		  root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(DTLSv1_2_client_method());
-		  SSL_CTX_set_cipher_list(root_tls_ctx[root_tls_ctx_num], csuite);
-		  root_tls_ctx_num++;
 #endif
 #endif
+		  root_tls_ctx_num++;
 		}
 	}
 

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -108,7 +108,7 @@ long turn_random(void)
 static void turn_random_tid_size(void *id)
 {
 	uint32_t *ar=(uint32_t*)id;
-	if(!RAND_pseudo_bytes((unsigned char *)ar,12)) {
+	if(!RAND_bytes((unsigned char *)ar,12)) {
 		size_t i;
 		for(i=0;i<3;++i) {
 			ar[i] = (uint32_t)turn_random();


### PR DESCRIPTION
Use version independent APIs for openssl-1.1.0 and above

Tested with turnutils_uclient against a turnserver with TLS and DTLS modes