### PR TITLE
Fix duplicate prometheus metric report

### DIFF
--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -131,14 +131,12 @@ void prom_set_finished_traffic(const char* realm, const char* user, unsigned lon
 
 void prom_inc_allocation(SOCKET_TYPE type) {
   if (turn_params.prometheus == 1){
-    prom_gauge_inc(turn_total_allocations, (const char*[]) {"all"});
     prom_gauge_inc(turn_total_allocations, (const char*[]) {socket_type_name(type)});
   }
 }
 
 void prom_dec_allocation(SOCKET_TYPE type) {
   if (turn_params.prometheus == 1){
-    prom_gauge_dec(turn_total_allocations, (const char*[]) {"all"});
     prom_gauge_dec(turn_total_allocations, (const char*[]) {socket_type_name(type)});
   }
 }


### PR DESCRIPTION
Prometheus would aggregate across all labels (when not specifying)
In this scenario `turn_total_allocations` does not need separate label "type=all" as such in this case the result would be double the actual amount