### PR TITLE
Optional build info compiled into turnserver binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type)
 if("debug" STREQUAL build_type)
     add_definitions(-D_DEBUG)
 endif()
+if(DEFINED TURN_SERVER_BUILD_INFO)
+    add_definitions(-DTURN_SERVER_BUILD_INFO=${TURN_SERVER_BUILD_INFO})
+endif()
 
 IF(MSVC)
     # This option is to enable the /MP switch for Visual Studio 2005 and above compilers

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -33,7 +33,10 @@
 
 #define TURN_SERVER_VERSION "4.6.0"
 #define TURN_SERVER_VERSION_NAME "Gorst"
-#define TURN_SOFTWARE "Coturn-" TURN_SERVER_VERSION " '" TURN_SERVER_VERSION_NAME "'"
+#ifndef TURN_SERVER_BUILD_INFO
+#define TURN_SERVER_BUILD_INFO ""
+#endif
+#define TURN_SOFTWARE "Coturn-" TURN_SERVER_VERSION " '" TURN_SERVER_VERSION_NAME "'" TURN_SERVER_BUILD_INFO
 
 #if (defined(__unix__) || defined(unix)) && !defined(USG)
 #include <sys/param.h>


### PR DESCRIPTION
Example usage with make:

make CPPFLAGS="-DTURN_SERVER_BUILD_INFO=\"\\\" git: $(git rev-parse HEAD) build: 123\\\"\""

Example usage with cmake:

cmake .. -DTURN_SERVER_BUILD_INFO="\" git: $(git rev-parse HEAD) build: 123\""