### PR TITLE
Cleanup logs on turnserver start

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -1120,8 +1120,6 @@ char *find_config_file(const char *config_file, int print_file_name) {
         FILE *f = fopen(fn, "r");
         if (f) {
           fclose(f);
-          if (print_file_name)
-            print_abs_file_name("", "Config", fn);
           full_path_to_config_file = fn;
           break;
         }
@@ -1148,8 +1146,6 @@ char *find_config_file(const char *config_file, int print_file_name) {
             f = fopen(fn, "r");
             if (f) {
               fclose(f);
-              if (print_file_name)
-                print_abs_file_name("", "Config", fn);
               full_path_to_config_file = fn;
               break;
             }
@@ -1241,19 +1237,34 @@ unsigned long get_system_number_of_cpus(void) {
 #if defined(WINDOWS)
   SYSTEM_INFO sysInfo;
   GetSystemInfo(&sysInfo);
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System cpu num is %d\n", sysInfo.dwNumberOfProcessors);
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System enable num is 0x%X\n", sysInfo.dwActiveProcessorMask);
+  // TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System cpu num is %d\n", sysInfo.dwNumberOfProcessors);
   return sysInfo.dwNumberOfProcessors;
 #else
 #if defined(_SC_NPROCESSORS_ONLN)
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System cpu num is %ld \n", sysconf(_SC_NPROCESSORS_CONF));
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System enable num is %ld\n", sysconf(_SC_NPROCESSORS_ONLN));
+  // TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System cpu num is %ld \n", sysconf(_SC_NPROCESSORS_CONF));
   return sysconf(_SC_NPROCESSORS_CONF);
 #else
   // GNU way
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System cpu num is %d\n", get_nprocs_conf());
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System enable num is %d\n", get_nprocs());
+  // TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System cpu num is %d\n", get_nprocs_conf());
   return get_nprocs_conf();
+#endif
+#endif
+}
+
+unsigned long get_system_active_number_of_cpus(void) {
+#if defined(WINDOWS)
+  SYSTEM_INFO sysInfo;
+  GetSystemInfo(&sysInfo);
+  // TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System enable num is 0x%X\n", sysInfo.dwActiveProcessorMask);
+  return sysInfo.dwActiveProcessorMask;
+#else
+#if defined(_SC_NPROCESSORS_ONLN)
+  // TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System enable num is %ld\n", sysconf(_SC_NPROCESSORS_ONLN));
+  return sysconf(_SC_NPROCESSORS_ONLN);
+#else
+  // GNU way
+  // TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "System enable num is %d\n", get_nprocs());
+  return get_nprocs();
 #endif
 #endif
 }

--- a/src/apps/common/apputils.h
+++ b/src/apps/common/apputils.h
@@ -213,6 +213,7 @@ int get_raw_socket_ttl(evutil_socket_t fd, int family);
 void ignore_sigpipe(void);
 unsigned long set_system_parameters(int max_resources);
 unsigned long get_system_number_of_cpus(void);
+unsigned long get_system_active_number_of_cpus(void);
 
 ///////////////////////// MTU //////////////////////////
 

--- a/src/apps/common/win/getopt.h
+++ b/src/apps/common/win/getopt.h
@@ -77,8 +77,9 @@ struct option /* specification for a long form option...	*/
   int val;          /* its associated status value		*/
 };
 
-enum                 /* permitted values for its `has_arg' field...	*/
-{ no_argument = 0,   /* option never takes an argument	*/
+enum /* permitted values for its `has_arg' field...	*/
+{
+  no_argument = 0,   /* option never takes an argument	*/
   required_argument, /* option always requires an argument	*/
   optional_argument  /* option may take an argument		*/
 };

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -397,7 +397,6 @@ ioa_engine_handle create_ioa_engine(super_memory_t *sm, struct event_base *eb, t
       e->deallocate_eb = 0;
     } else {
       e->event_base = turn_event_base_new();
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "IO method (engine own thread): %s\n", event_base_get_method(e->event_base));
       e->deallocate_eb = 1;
     }
 

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -1293,8 +1293,6 @@ void setup_admin_thread(void) {
     set_ssl_ctx(adminserver.e, &turn_params);
   }
 
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "IO method (admin thread): %s\n", event_base_get_method(adminserver.event_base));
-
   {
     struct bufferevent *pair[2];
 

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4811,7 +4811,7 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
     server->mobile_connections_map = ur_map_create();
   server->acme_redirect = acme_redirect;
 
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "turn server id=%d created\n", (int)id);
+  TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "turn server id=%d created\n", (int)id);
 
   server->check_origin = check_origin;
   server->no_tcp_relay = no_tcp_relay;


### PR DESCRIPTION
Reformatting and removing some duplications:
- Some lines have WARNING WARNING: cleaned up.
- Lines printed using perror: only LOG_ mechanism should be used.
- Printing IO mechanism (epoll for example) for each thread: selected mechanism logged once
- Duplicate lines (perror and also LOG): duplication removed
- Duplicates: clean up (because calling function multiple times - configuration load)