### PR TITLE
Reduce code duplication when printing userdb

### DIFF
--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -744,35 +744,7 @@ static void cli_print_configuration(struct cli_session *cs) {
     myprintf(cs, "\n");
 
     if (turn_params.default_users_db.persistent_users_db.userdb[0]) {
-      switch (turn_params.default_users_db.userdb_type) {
-#if !defined(TURN_NO_SQLITE)
-      case TURN_USERDB_TYPE_SQLITE:
-        cli_print_str(cs, "SQLite", "DB type", 0);
-        break;
-#endif
-#if !defined(TURN_NO_PQ)
-      case TURN_USERDB_TYPE_PQ:
-        cli_print_str(cs, "Postgres", "DB type", 0);
-        break;
-#endif
-#if !defined(TURN_NO_MYSQL)
-      case TURN_USERDB_TYPE_MYSQL:
-        cli_print_str(cs, "MySQL/MariaDB", "DB type", 0);
-        break;
-#endif
-#if !defined(TURN_NO_MONGO)
-      case TURN_USERDB_TYPE_MONGO:
-        cli_print_str(cs, "MongoDB", "DB type", 0);
-        break;
-#endif
-#if !defined(TURN_NO_HIREDIS)
-      case TURN_USERDB_TYPE_REDIS:
-        cli_print_str(cs, "redis", "DB type", 0);
-        break;
-#endif
-      default:
-        cli_print_str(cs, "unknown", "DB type", 0);
-      };
+      cli_print_str(cs, userdb_type_to_string(turn_params.default_users_db.userdb_type), "DB type", 0);
       cli_print_str(cs, turn_params.default_users_db.persistent_users_db.userdb, "DB", 0);
     } else {
       cli_print_str(cs, "none", "DB type", 0);
@@ -2125,35 +2097,7 @@ static void write_pc_page(ioa_socket_handle s) {
         https_print_empty_row(sb, 2);
 
         if (turn_params.default_users_db.persistent_users_db.userdb[0]) {
-          switch (turn_params.default_users_db.userdb_type) {
-#if !defined(TURN_NO_SQLITE)
-          case TURN_USERDB_TYPE_SQLITE:
-            https_print_str(sb, "SQLite", "DB type", 0);
-            break;
-#endif
-#if !defined(TURN_NO_PQ)
-          case TURN_USERDB_TYPE_PQ:
-            https_print_str(sb, "Postgres", "DB type", 0);
-            break;
-#endif
-#if !defined(TURN_NO_MYSQL)
-          case TURN_USERDB_TYPE_MYSQL:
-            https_print_str(sb, "MySQL/MariaDB", "DB type", 0);
-            break;
-#endif
-#if !defined(TURN_NO_MONGO)
-          case TURN_USERDB_TYPE_MONGO:
-            https_print_str(sb, "MongoDB", "DB type", 0);
-            break;
-#endif
-#if !defined(TURN_NO_HIREDIS)
-          case TURN_USERDB_TYPE_REDIS:
-            https_print_str(sb, "redis", "DB type", 0);
-            break;
-#endif
-          default:
-            https_print_str(sb, "unknown", "DB type", 0);
-          };
+          https_print_str(sb, userdb_type_to_string(turn_params.default_users_db.userdb_type), "DB type", 0);
           if (is_superuser()) {
             https_print_str(sb, turn_params.default_users_db.persistent_users_db.userdb, "DB", 0);
           }

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -68,6 +68,35 @@ static TURN_MUTEX_DECLARE(o_to_realm_mutex);
 static ur_string_map *o_to_realm = NULL;
 static secrets_list_t realms_list;
 
+static char userdb_type_unknown[] = "Unknown";
+static char userdb_type_sqlite[] = "SQLite";
+static char userdb_type_postgresql[] = "PostgreSQL";
+static char userdb_type_mysql[] = "MySQL/MariaDB";
+static char userdb_type_mongo[] = "MongoDB";
+static char userdb_type_redis[] = "Redis";
+
+const char *userdb_type_to_string(TURN_USERDB_TYPE t) {
+  switch (t) {
+  case TURN_USERDB_TYPE_SQLITE:
+    return userdb_type_sqlite;
+    break;
+  case TURN_USERDB_TYPE_PQ:
+    return userdb_type_postgresql;
+    break;
+  case TURN_USERDB_TYPE_MYSQL:
+    return userdb_type_mysql;
+    break;
+  case TURN_USERDB_TYPE_MONGO:
+    return userdb_type_mongo;
+    break;
+  case TURN_USERDB_TYPE_REDIS:
+    return userdb_type_redis;
+    break;
+  default:
+    return userdb_type_unknown;
+  };
+}
+
 void lock_realms(void) { ur_string_map_lock(realms); }
 
 void unlock_realms(void) { ur_string_map_unlock(realms); }

--- a/src/apps/relay/userdb.h
+++ b/src/apps/relay/userdb.h
@@ -92,25 +92,11 @@ struct auth_message {
 };
 
 enum _TURN_USERDB_TYPE {
-#if !defined(TURN_NO_SQLITE)
-  TURN_USERDB_TYPE_UNKNOWN = -1,
-  TURN_USERDB_TYPE_SQLITE = 0
-#else
-  TURN_USERDB_TYPE_UNKNOWN = 0
-#endif
-#if !defined(TURN_NO_PQ)
-  ,
-  TURN_USERDB_TYPE_PQ
-#endif
-#if !defined(TURN_NO_MYSQL)
-  ,
-  TURN_USERDB_TYPE_MYSQL
-#endif
-#if !defined(TURN_NO_MONGO)
-  ,
-  TURN_USERDB_TYPE_MONGO
-#endif
-  ,
+  TURN_USERDB_TYPE_UNKNOWN,
+  TURN_USERDB_TYPE_SQLITE,
+  TURN_USERDB_TYPE_PQ,
+  TURN_USERDB_TYPE_MYSQL,
+  TURN_USERDB_TYPE_MONGO,
   TURN_USERDB_TYPE_REDIS
 };
 
@@ -173,6 +159,7 @@ typedef struct _default_users_db_t {
 
 /////////////////////////////////////////////
 
+const char *userdb_type_to_string(TURN_USERDB_TYPE t);
 realm_params_t *get_realm(char *name);
 void set_default_realm_name(char *realm);
 int change_total_quota(char *realm, int value);


### PR DESCRIPTION
TURN_USERDB_TYPE enum does not need to be "dynamic" based on what libraries actually available during the build - all potentially supported DB options are now enumerated.
Printing (to log or http) the DB type name is done with much less code (using a helper function `userdb_type_to_string`)