### PR TITLE
Add explicit SIGTERM and SIGINT handlers.

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3839,10 +3839,9 @@ static void reload_ssl_certs(evutil_socket_t sock, short events, void *args) {
 }
 
 static void shutdown_handler(evutil_socket_t sock, short events, void *args) {
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Caught signal, terminating\n");
+  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Terminating on signal %d\n", sock);
   turn_params.stop_turn_server = 1;
 
-  UNUSED_ARG(sock);
   UNUSED_ARG(events);
   UNUSED_ARG(args);
 }


### PR DESCRIPTION
coturn running inside a docker container runs as PID 1, however PID 1 has special signal handling semantics (see the note at the bottom of the section [here](https://docs.docker.com/engine/reference/run/#foreground)). coturn relies on the default behaviour of SIGTERM to terminate the process, however as no signal handler is explicitly installed, it doesn't respond to SIGTERM when running inside a container. This PR fixes this problem by installing explicit signal handlers for SIGINT and SIGTERM, which trigger the same termination mechanism as the admin interface "halt" command.

This is a port of wireapp#6 for upstream.