### PR TITLE
Fix memory corruption on socket close

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -1492,6 +1492,12 @@ void close_ioa_socket(ioa_socket_handle s) {
 
     close_socket_net_data(s);
 
+    if (s->session && s->session->client_socket == s) {
+      // Detaching client socket from super session to prevent mem corruption
+      // in case client_to_be_allocated_timeout_handler gets triggered
+      s->session->client_socket = NULL;
+    }
+
     s->session = NULL;
     s->sub_session = NULL;
     s->magic = 0;


### PR DESCRIPTION
Fix memory corruption introduced by commit c8663f4a91cd2d88f1d0e65144158c7bcfe8b35c

If there was an unsuccessful session registration in open_client_connection_session, it adds a timer (before it didn't).

Later during runtime, at session destruction, it removes the client_socket in close_ioa_socket. Then the timer gets triggered and runs the cleanup method client_to_be_allocated_timeout_handler and tries to access the stored client_socket. This then fails as it already was freed.

The fix just sets the client_socket pointer to null and then the timer should detect this and not access already freed memory.

The issue affects version 4.6.0, 4.6.0-r0 and 4.6.0-r1.