### PR TITLE
bugfix: fix broken type label of turn_total_allocations gauge

### DIFF
--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -147,13 +147,15 @@ void prom_set_finished_traffic(const char *realm, const char *user, unsigned lon
 
 void prom_inc_allocation(SOCKET_TYPE type) {
   if (turn_params.prometheus == 1) {
-    prom_gauge_inc(turn_total_allocations, (const char *[]){socket_type_name(type)});
+    const char *label[] = {socket_type_name(type)};
+    prom_gauge_inc(turn_total_allocations, label);
   }
 }
 
 void prom_dec_allocation(SOCKET_TYPE type) {
   if (turn_params.prometheus == 1) {
-    prom_gauge_dec(turn_total_allocations, (const char *[]){socket_type_name(type)});
+    const char *label[] = {socket_type_name(type)};
+    prom_gauge_dec(turn_total_allocations, label);
   }
 }
 


### PR DESCRIPTION
It's not working when constructing it in-place, likely this is undefined behaviour.