### PR TITLE
Use inline functions for errno checks

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -743,7 +743,7 @@ int handle_socket_error(void) {
     /* Out of memory.
      * Must close connection.
      */
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"Out of memory!\n");
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Out of memory!\n");
     return 0;
   }
   if (socket_eacces()) {
@@ -756,7 +756,7 @@ int handle_socket_error(void) {
   }
 
   /* Something unexpected happened */
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"Unexpected error! (errno = %d)\n", socket_errno());
+  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Unexpected error! (errno = %d)\n", socket_errno());
   return 0;
 }
 

--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -239,7 +239,7 @@ int sock_bind_to_device(evutil_socket_t fd, const unsigned char *ifname) {
     strncpy(ifr.ifr_name, (const char *)ifname, sizeof(ifr.ifr_name));
 
     if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, (void *)&ifr, sizeof(ifr)) < 0) {
-      if (errno == EPERM)
+      if (socket_eperm())
         perror("You must obtain superuser privileges to bind a socket to device");
       else
         perror("Cannot bind socket to device");
@@ -268,12 +268,12 @@ int addr_connect(evutil_socket_t fd, const ioa_addr *addr, int *out_errno) {
       } else {
         return -1;
       }
-    } while (err < 0 && errno == EINTR);
+    } while (err < 0 && socket_eintr());
 
     if (out_errno)
-      *out_errno = errno;
+      *out_errno = socket_errno();
 
-    if (err < 0 && errno != EINPROGRESS)
+    if (err < 0 && !socket_einprogress())
       perror("Connect");
 
     return err;
@@ -294,19 +294,19 @@ int addr_bind(evutil_socket_t fd, const ioa_addr *addr, int reusable, int debug,
     if (addr->ss.sa_family == AF_INET) {
       do {
         ret = bind(fd, (const struct sockaddr *)addr, sizeof(struct sockaddr_in));
-      } while (ret < 0 && errno == EINTR);
+      } while (ret < 0 && socket_eintr());
     } else if (addr->ss.sa_family == AF_INET6) {
       const int off = 0;
       setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (const char *)&off, sizeof(off));
       do {
         ret = bind(fd, (const struct sockaddr *)addr, sizeof(struct sockaddr_in6));
-      } while (ret < 0 && errno == EINTR);
+      } while (ret < 0 && socket_eintr());
     } else {
       return -1;
     }
     if (ret < 0) {
       if (debug) {
-        int err = errno;
+        int err = socket_errno();
         perror("bind");
         char str[129];
         addr_to_string(addr, (uint8_t *)str);
@@ -549,7 +549,7 @@ int set_socket_df(evutil_socket_t fd, int family, int value) {
 #endif
     }
     if (ret < 0) {
-      int err = errno;
+      int err = socket_errno();
       perror("set socket df:");
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: set sockopt failed: fd=%d, err=%d, family=%d\n", __FUNCTION__, fd, err,
                     family);
@@ -707,61 +707,57 @@ int get_socket_mtu(evutil_socket_t fd, int family, int verbose) {
 //////////////////// socket error handle ////////////////////
 
 int handle_socket_error(void) {
-  switch (errno) {
-  case EINTR:
+  if (socket_eintr()) {
     /* Interrupted system call.
      * Just ignore.
      */
     return 1;
-  case ENOBUFS:
-    /* No buffers, temporary condition.
-     * Just ignore and try later.
+  }
+  if (socket_enobufs()) {
+    /* Interrupted system call.
+     * Just ignore.
      */
     return 1;
-  case EAGAIN:
-#if defined(EWOULDBLOCK)
-#if (EWOULDBLOCK != EAGAIN)
-  case EWOULDBLOCK:
-#endif
-#endif
+  }
+  if (socket_ewouldblock() || socket_eagain()) {
     return 1;
-  case EMSGSIZE:
-    return 1;
-  case EBADF:
+  }
+  if (socket_ebadf()) {
     /* Invalid socket.
      * Must close connection.
      */
     return 0;
-#if defined(__unix__) || defined(unix) || defined(__APPLE__)
-  case EHOSTDOWN:
+  }
+  if (socket_ehostdown()) {
     /* Host is down.
      * Just ignore, might be an attacker
      * sending fake ICMP messages.
      */
     return 1;
-#endif
-  case ECONNRESET:
-  case ECONNREFUSED:
+  }
+  if (socket_econnreset() || socket_econnrefused()) {
     /* Connection reset by peer. */
     return 0;
-  case ENOMEM:
+  }
+  if (socket_enomem()) {
     /* Out of memory.
      * Must close connection.
      */
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Out of memory!\n");
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"Out of memory!\n");
     return 0;
-  case EACCES:
+  }
+  if (socket_eacces()) {
     /* Permission denied.
      * Just ignore, we might be blocked
      * by some firewall policy. Try again
      * and hope for the best.
      */
     return 1;
-  default:
-    /* Something unexpected happened */
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Unexpected error! (errno = %d)\n", errno);
-    return 0;
   }
+
+  /* Something unexpected happened */
+  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"Unexpected error! (errno = %d)\n", socket_errno());
+  return 0;
 }
 
 //////////////////// Misc utils //////////////////////////////

--- a/src/apps/common/hiredis_libevent2.c
+++ b/src/apps/common/hiredis_libevent2.c
@@ -81,7 +81,7 @@ static void redisLibeventReadEvent(int fd, short event, void *arg) {
       int len = 0;
       do {
         len = recv(fd, buf, sizeof(buf), MSG_PEEK);
-      } while ((len < 0) && (errno == EINTR));
+      } while ((len < 0) && socket_eintr());
       if (len < 1) {
         e->invalid = 1;
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Redis connection broken: e=0x%lx\n", __FUNCTION__, ((unsigned long)e));

--- a/src/apps/peer/udpserver.c
+++ b/src/apps/peer/udpserver.c
@@ -48,14 +48,14 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
 
   do {
     len = recvfrom(fd, buffer.buf, sizeof(buffer.buf) - 1, 0, (struct sockaddr *)&remote_addr, (socklen_t *)&slen);
-  } while (len < 0 && (errno == EINTR));
+  } while (len < 0 && socket_eintr());
 
   buffer.len = len;
 
   if (len >= 0) {
     do {
       len = sendto(fd, buffer.buf, buffer.len, 0, (const struct sockaddr *)&remote_addr, (socklen_t)slen);
-    } while (len < 0 && ((errno == EINTR) || (errno == ENOBUFS) || (errno == EAGAIN)));
+    } while (len < 0 && (socket_eintr() || socket_enobufs() || socket_eagain()));
   }
 }
 

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -479,7 +479,7 @@ static int create_new_connected_udp_socket(dtls_listener_relay_server_type *serv
   ioa_socket_handle ret = (ioa_socket *)malloc(sizeof(ioa_socket));
   if (!ret) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate new socket structure\n", __FUNCTION__);
-    close(udp_fd);
+    socket_closesocket(udp_fd);
     return -1;
   }
 
@@ -663,7 +663,7 @@ start_udp_cycle:
     do {
       bsize = recvfrom(fd, ioa_network_buffer_data(elem), ioa_network_buffer_get_capacity_udp(), flags,
                        (struct sockaddr *)&(server->sm.m.sm.nd.src_addr), (socklen_t *)&slen);
-    } while (bsize < 0 && (errno == EINTR));
+    } while (bsize < 0 && socket_eintr());
 
     conn_reset = is_connreset();
     to_block = would_block();
@@ -681,7 +681,7 @@ start_udp_cycle:
 
   if (bsize < 0) {
     if (!to_block && !conn_reset) {
-      int ern = errno;
+      int ern = socket_errno();
       perror(__FUNCTION__);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: recvfrom error %d\n", __FUNCTION__, ern);
     }

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -88,11 +88,11 @@ static void barrier_wait_func(const char *func, int line) {
   do {
     br = pthread_barrier_wait(&barrier);
     if ((br < 0) && (br != PTHREAD_BARRIER_SERIAL_THREAD)) {
-      int err = errno;
+      int err = socket_errno();
       perror("barrier wait");
       printf("%s:%s:%d: %d\n", __FUNCTION__, func, line, err);
     }
-  } while (((br < 0) && (br != PTHREAD_BARRIER_SERIAL_THREAD)) && (errno == EINTR));
+  } while (((br < 0) && (br != PTHREAD_BARRIER_SERIAL_THREAD)) && socket_eintr());
 #else
   UNUSED_ARG(func);
   UNUSED_ARG(line);

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -1555,14 +1555,14 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
 
       if (addr_bind(udp_fd, &(s->local_addr), 1, 1, UDP_SOCKET) < 0) {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot bind new detached udp server socket to local addr\n");
-        close(udp_fd);
+        socket_closesocket(udp_fd);
         return ret;
       }
 
       int connect_err = 0;
       if (addr_connect(udp_fd, &(s->remote_addr), &connect_err) < 0) {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot connect new detached udp server socket to remote addr\n");
-        close(udp_fd);
+        socket_closesocket(udp_fd);
         return ret;
       }
       set_raw_socket_ttl_options(udp_fd, s->local_addr.ss.sa_family);
@@ -1580,7 +1580,7 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
     if (!ret) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate new socket structure\n", __FUNCTION__);
       if (udp_fd >= 0)
-        close(udp_fd);
+        socket_closesocket(udp_fd);
       return ret;
     }
 
@@ -1787,7 +1787,7 @@ int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int ve
 
   do {
     len = SSL_read(ssl, new_buffer, buf_size);
-  } while (len < 0 && (errno == EINTR));
+  } while (len < 0 && socket_eintr());
 
   int if2 = SSL_is_init_finished(ssl);
 
@@ -1814,7 +1814,7 @@ int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int ve
 
     ret = 0;
 
-  } else if (len < 0 && ((errno == ENOBUFS) || (errno == EAGAIN))) {
+  } else if (len < 0 && (socket_enobufs() || socket_eagain())) {
     if (eve(verbose)) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: ENOBUFS/EAGAIN\n", __FUNCTION__);
     }
@@ -1843,7 +1843,7 @@ int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int ve
         ret = 0;
         break;
       case SSL_ERROR_SYSCALL: {
-        int err = errno;
+        int err = socket_errno();
         if (handle_socket_error()) {
           ret = 0;
         } else {
@@ -1922,7 +1922,7 @@ static int socket_readerr(evutil_socket_t fd, ioa_addr *orig_addr) {
 
     do {
       len = recvmsg(fd, &msg, flags);
-    } while (len < 0 && (errno == EINTR));
+    } while (len < 0 && socket_eintr());
 
   } while ((len > 0) && (try_cycle++ < MAX_ERRORS_IN_UDP_BATCH));
 
@@ -1952,9 +1952,9 @@ int udp_recvfrom(evutil_socket_t fd, ioa_addr *orig_addr, const ioa_addr *like_a
 #if defined(_MSC_VER) || !defined(CMSG_SPACE)
   do {
     len = recvfrom(fd, buffer, buf_size, flags, (struct sockaddr *)orig_addr, (socklen_t *)&slen);
-  } while (len < 0 && (errno == EINTR));
+  } while (len < 0 && socket_eintr());
   if (len < 0 && errcode)
-    *errcode = (uint32_t)errno;
+    *errcode = (uint32_t)socket_errno();
 #else
   struct msghdr msg;
   struct iovec iov;
@@ -1980,7 +1980,7 @@ try_again:
 
   do {
     len = recvmsg(fd, &msg, flags);
-  } while (len < 0 && (errno == EINTR));
+  } while (len < 0 && socket_eintr());
 
 #if defined(MSG_ERRQUEUE)
 
@@ -1997,7 +1997,7 @@ try_again:
     // try again...
     do {
       len = recvmsg(fd, &msg, flags);
-    } while (len < 0 && (errno == EINTR));
+    } while (len < 0 && socket_eintr());
   }
 #endif
 
@@ -2090,7 +2090,7 @@ static TURN_TLS_TYPE check_tentative_tls(ioa_socket_raw fd) {
 
   do {
     len = (int)recv(fd, s, sizeof(s), MSG_PEEK);
-  } while (len < 0 && (errno == EINTR));
+  } while (len < 0 && socket_eintr());
 
   if (len > 0 && ((size_t)len == sizeof(s))) {
     if ((s[0] == 22) && (s[1] == 3) && (s[5] == 1) && (s[9] == 3)) {
@@ -2932,13 +2932,13 @@ try_start:
 
   do {
     rc = SSL_write(ssl, buffer, len);
-  } while (rc < 0 && errno == EINTR);
+  } while (rc < 0 && socket_eintr());
 
   if (eve(verbose)) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: after write: %d\n", __FUNCTION__, rc);
   }
 
-  if (rc < 0 && ((errno == ENOBUFS) || (errno == EAGAIN))) {
+  if (rc < 0 && (socket_enobufs() || socket_eagain())) {
     if (eve(verbose)) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: ENOBUFS/EAGAIN\n", __FUNCTION__);
     }
@@ -2972,7 +2972,7 @@ try_start:
     case SSL_ERROR_WANT_READ:
       return 0;
     case SSL_ERROR_SYSCALL: {
-      int err = errno;
+      int err = socket_errno();
       if (!handle_socket_error()) {
         if (s->st == DTLS_SOCKET) {
           if (is_connreset()) {
@@ -3036,21 +3036,14 @@ static int send_ssl_backlog_buffers(ioa_socket_handle s) {
 }
 
 int is_connreset(void) {
-  switch (errno) {
-  case ECONNRESET:
-  case ECONNREFUSED:
+  if (socket_econnreset() || socket_econnrefused()) {
     return 1;
-  default:;
   }
   return 0;
 }
 
 int would_block(void) {
-#if defined(EWOULDBLOCK)
-  if (errno == EWOULDBLOCK)
-    return 1;
-#endif
-  return (errno == EAGAIN);
+  return socket_ewouldblock();
 }
 
 int udp_send(ioa_socket_handle s, const ioa_addr *dest_addr, const char *buffer, int len) {
@@ -3085,16 +3078,16 @@ int udp_send(ioa_socket_handle s, const ioa_addr *dest_addr, const char *buffer,
 
       do {
         rc = sendto(fd, buffer, len, 0, (const struct sockaddr *)dest_addr, (socklen_t)slen);
-      } while (((rc < 0) && (errno == EINTR)) || ((rc < 0) && is_connreset() && (++cycle < TRIAL_EFFORTS_TO_SEND)));
+      } while (((rc < 0) && socket_eintr()) || ((rc < 0) && is_connreset() && (++cycle < TRIAL_EFFORTS_TO_SEND)));
 
     } else {
       do {
         rc = send(fd, buffer, len, 0);
-      } while (((rc < 0) && (errno == EINTR)) || ((rc < 0) && is_connreset() && (++cycle < TRIAL_EFFORTS_TO_SEND)));
+      } while (((rc < 0) && socket_eintr()) || ((rc < 0) && is_connreset() && (++cycle < TRIAL_EFFORTS_TO_SEND)));
     }
 
     if (rc < 0) {
-      if ((errno == ENOBUFS) || (errno == EAGAIN)) {
+      if (socket_enobufs() || socket_eagain()) {
         // Lost packet due to overload ... fine.
         rc = len;
       } else if (is_connreset()) {
@@ -3197,7 +3190,7 @@ int send_data_from_ioa_socket_nbh(ioa_socket_handle s, ioa_addr *dest_addr, ioa_
             if (ret < 0) {
               s->tobeclosed = 1;
 #if defined(EADDRNOTAVAIL)
-              int perr = errno;
+              int perr = socket_errno();
 #endif
               perror("udp send");
 #if defined(EADDRNOTAVAIL)

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -3042,9 +3042,7 @@ int is_connreset(void) {
   return 0;
 }
 
-int would_block(void) {
-  return socket_ewouldblock();
-}
+int would_block(void) { return socket_ewouldblock(); }
 
 int udp_send(ioa_socket_handle s, const ioa_addr *dest_addr, const char *buffer, int len) {
   int rc = 0;

--- a/src/apps/relay/tls_listener.c
+++ b/src/apps/relay/tls_listener.c
@@ -264,7 +264,7 @@ static int sctp_create_server_listener(tls_listener_relay_server_type *server) {
   }
 
   if (addr_bind(tls_listen_fd, &server->addr, 1, 0, SCTP_SOCKET) < 0) {
-    close(tls_listen_fd);
+    socket_closesocket(tls_listen_fd);
     return -1;
   }
 

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -836,7 +836,7 @@ static void close_cli_session(struct cli_session *cs) {
     BUFFEREVENT_FREE(cs->bev);
 
     if (cs->fd >= 0) {
-      close(cs->fd);
+      socket_closesocket(cs->fd);
       cs->fd = -1;
     }
 

--- a/src/apps/stunclient/stunclient.c
+++ b/src/apps/stunclient/stunclient.c
@@ -305,7 +305,7 @@ static int run_stunclient(const char *rip, int rport, int *port, int *rfc5780, i
 
     do {
       len = sendto(udp_fd, buf.buf, buf.len, 0, (struct sockaddr *)&remote_addr, (socklen_t)slen);
-    } while (len < 0 && (socket_eintr() || socket_enobufs()|| socket_eagain()));
+    } while (len < 0 && (socket_eintr() || socket_enobufs() || socket_eagain()));
 
     if (len < 0)
       err(-1, NULL);

--- a/src/apps/stunclient/stunclient.c
+++ b/src/apps/stunclient/stunclient.c
@@ -150,7 +150,7 @@ static int run_stunclient(const char *rip, int rport, int *port, int *rfc5780, i
 
     do {
       len = sendto(udp_fd, req.getRawBuffer(), req.getSize(), 0, (struct sockaddr *)&remote_addr, (socklen_t)slen);
-    } while (len < 0 && ((errno == EINTR) || (errno == ENOBUFS) || (errno == EAGAIN)));
+    } while (len < 0 && (socket_eintr() || socket_enobufs() || socket_eagain()));
 
     if (len < 0)
       err(-1, NULL);
@@ -164,7 +164,7 @@ static int run_stunclient(const char *rip, int rport, int *port, int *rfc5780, i
 
   {
     if (new_udp_fd >= 0) {
-      close(udp_fd);
+      socket_closesocket(udp_fd);
       udp_fd = new_udp_fd;
       new_udp_fd = -1;
     }
@@ -184,7 +184,7 @@ static int run_stunclient(const char *rip, int rport, int *port, int *rfc5780, i
         ptr += len;
         break;
       }
-    } while (len < 0 && (errno == EINTR));
+    } while (len < 0 && socket_eintr());
 
     if (recvd > 0)
       len = recvd;
@@ -305,7 +305,7 @@ static int run_stunclient(const char *rip, int rport, int *port, int *rfc5780, i
 
     do {
       len = sendto(udp_fd, buf.buf, buf.len, 0, (struct sockaddr *)&remote_addr, (socklen_t)slen);
-    } while (len < 0 && ((errno == EINTR) || (errno == ENOBUFS) || (errno == EAGAIN)));
+    } while (len < 0 && (socket_eintr() || socket_enobufs()|| socket_eagain()));
 
     if (len < 0)
       err(-1, NULL);
@@ -338,7 +338,7 @@ static int run_stunclient(const char *rip, int rport, int *port, int *rfc5780, i
         ptr += len;
         break;
       }
-    } while (len < 0 && ((errno == EINTR) || (errno == EAGAIN)));
+    } while (len < 0 && (socket_eintr() || socket_eagain()));
 
     if (recvd > 0)
       len = recvd;

--- a/src/apps/uclient/startuclient.c
+++ b/src/apps/uclient/startuclient.c
@@ -130,8 +130,8 @@ static SSL *tls_connect(ioa_socket_raw fd, ioa_addr *remote_addr, int *try_again
   do {
     do {
       rc = SSL_connect(ssl);
-    } while (rc < 0 && errno == EINTR);
-    int orig_errno = errno;
+    } while (rc < 0 && socket_eintr());
+    int orig_errno = socket_errno();
     if (rc > 0) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: client session connected with cipher %s, method=%s\n", __FUNCTION__,
                     SSL_get_cipher(ssl), turn_get_ssl_method(ssl, NULL));
@@ -586,7 +586,7 @@ beg_allocate:
           SSL_free(ssl);
           fd = -1;
         } else if (fd >= 0) {
-          close(fd);
+          socket_closesocket(fd);
           fd = -1;
           ssl = NULL;
         }
@@ -608,7 +608,7 @@ beg_allocate:
         SSL_shutdown(ssl);
         SSL_free(ssl);
       } else if (fd >= 0) {
-        close(fd);
+        socket_closesocket(fd);
       }
     }
 

--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -226,7 +226,7 @@ int send_buffer(app_ur_conn_info *clnet_info, stun_buffer *message, int data_con
       int len = 0;
       do {
         len = SSL_write(ssl, buffer, (int)message->len);
-      } while (len < 0 && ((errno == EINTR) || (errno == ENOBUFS)));
+      } while (len < 0 && (socket_eintr() || socket_enobufs()));
 
       if (len == (int)message->len) {
         if (clnet_verbose) {
@@ -276,7 +276,7 @@ int send_buffer(app_ur_conn_info *clnet_info, stun_buffer *message, int data_con
     while (left > 0) {
       do {
         rc = send(fd, buffer, left, 0);
-      } while (rc <= 0 && ((errno == EINTR) || (errno == ENOBUFS) || (errno == EAGAIN)));
+      } while (rc <= 0 && (socket_eintr() || socket_enobufs() || socket_eagain()));
       if (rc > 0) {
         left -= (size_t)rc;
         buffer += rc;
@@ -335,7 +335,7 @@ static int wait_fd(int fd, unsigned int cycle) {
         }
       }
       rc = select(fd + 1, &fds, NULL, NULL, &timeout);
-      if ((rc < 0) && (errno == EINTR)) {
+      if ((rc < 0) && socket_eintr()) {
         gettimeofday(&ctime, NULL);
       } else {
         break;
@@ -391,9 +391,7 @@ recv_again:
 
     do {
       rc = recv(fd, message->buf, sizeof(message->buf) - 1, 0);
-      if (rc < 0 && errno == EAGAIN && sync)
-        errno = EINTR;
-    } while (rc < 0 && (errno == EINTR));
+    } while (rc < 0 && (socket_eintr() || (socket_eagain() && sync)));
 
     if (rc < 0) {
       return -1;
@@ -415,9 +413,9 @@ recv_again:
       rc = 0;
       do {
         rc = SSL_read(ssl, message->buf, sizeof(message->buf) - 1);
-        if (rc < 0 && errno == EAGAIN && sync)
+        if (rc < 0 && socket_eagain() && sync)
           continue;
-      } while (rc < 0 && (errno == EINTR));
+      } while (rc < 0 && socket_eintr());
 
       if (rc > 0) {
 
@@ -480,9 +478,9 @@ recv_again:
       rc = 0;
       do {
         rc = SSL_read(ssl, message->buf, sizeof(message->buf) - 1);
-        if (rc < 0 && errno == EAGAIN && sync)
+        if (rc < 0 && socket_eagain() && sync)
           continue;
-      } while (rc < 0 && (errno == EINTR));
+      } while (rc < 0 && socket_eintr());
 
       if (rc > 0) {
 
@@ -538,10 +536,7 @@ recv_again:
 
     do {
       rc = recv(fd, message->buf, sizeof(message->buf) - 1, MSG_PEEK);
-      if ((rc < 0) && (errno == EAGAIN) && sync) {
-        errno = EINTR;
-      }
-    } while (rc < 0 && (errno == EINTR));
+    } while (rc < 0 && (socket_eintr() || (socket_eagain() && sync)));
 
     if (rc > 0) {
       int mlen = rc;
@@ -566,9 +561,7 @@ recv_again:
         while (rsf < mlen && cycle++ < 128) {
           do {
             rcr = recv(fd, message->buf + rsf, (size_t)mlen - (size_t)rsf, 0);
-            if (rcr < 0 && errno == EAGAIN && sync)
-              errno = EINTR;
-          } while (rcr < 0 && (errno == EINTR));
+          } while (rcr < 0 && (socket_eintr() || (socket_eagain() && sync)));
 
           if (rcr > 0)
             rsf += rcr;
@@ -1312,7 +1305,7 @@ static void timer_handler(evutil_socket_t fd, short event, void *arg) {
     if (done > 5 && (dos || random_disconnect)) {
       for (i = 0; i < total_clients; ++i) {
         if (elems[i]) {
-          close(elems[i]->pinfo.fd);
+          socket_closesocket(elems[i]->pinfo.fd);
           elems[i]->pinfo.fd = -1;
         }
       }

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -108,9 +108,7 @@ static inline uint64_t _ioa_ntoh64(uint64_t v) {
 #define ioa_hton64 _ioa_ntoh64
 
 #if defined(WINDOWS)
-static inline int socket_errno(void) {
-	return WSAGetLastError();
-}
+static inline int socket_errno(void) { return WSAGetLastError(); }
 static inline int socket_enomem(void) { return socket_errno() == WSA_NOT_ENOUGH_MEMORY; }
 static inline int socket_eintr(void) { return socket_errno() == WSAEINTR; }
 static inline int socket_ebadf(void) { return socket_errno() == WSAEBADF; }
@@ -124,9 +122,7 @@ static inline int socket_econnrefused(void) { return socket_errno() == WSAECONNR
 static inline int socket_ehostdown(void) { return socket_errno() == WSAEHOSTDOWN; }
 static inline int socket_emsgsize(void) { return socket_errno() == WSAEMSGSIZE; }
 #else
-static inline int socket_errno(void) {
-	return errno;
-}
+static inline int socket_errno(void) { return errno; }
 static inline int socket_eperm(void) { return socket_errno() == EPERM; }
 static inline int socket_enomem(void) { return socket_errno() == ENOMEM; }
 static inline int socket_eintr(void) { return socket_errno() == EINTR; }

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -108,8 +108,7 @@ static inline uint64_t _ioa_ntoh64(uint64_t v) {
 #define ioa_hton64 _ioa_ntoh64
 
 #if defined(WINDOWS)
-static inline int socket_errno(void)
-{
+static inline int socket_errno(void) {
 	return WSAGetLastError();
 }
 static inline int socket_enomem(void) { return socket_errno() == WSA_NOT_ENOUGH_MEMORY; }
@@ -125,8 +124,7 @@ static inline int socket_econnrefused(void) { return socket_errno() == WSAECONNR
 static inline int socket_ehostdown(void) { return socket_errno() == WSAEHOSTDOWN; }
 static inline int socket_emsgsize(void) { return socket_errno() == WSAEMSGSIZE; }
 #else
-static inline int socket_errno(void)
-{
+static inline int socket_errno(void) {
 	return errno;
 }
 static inline int socket_eperm(void) { return socket_errno() == EPERM; }

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -107,6 +107,47 @@ static inline uint64_t _ioa_ntoh64(uint64_t v) {
 #define ioa_ntoh64 _ioa_ntoh64
 #define ioa_hton64 _ioa_ntoh64
 
+#if defined(WINDOWS)
+static inline int socket_errno(void)
+{
+	return WSAGetLastError();
+}
+static inline int socket_enomem(void) { return socket_errno() == WSA_NOT_ENOUGH_MEMORY; }
+static inline int socket_eintr(void) { return socket_errno() == WSAEINTR; }
+static inline int socket_ebadf(void) { return socket_errno() == WSAEBADF; }
+static inline int socket_eacces(void) { return socket_errno() == WSAEACCES; }
+static inline int socket_enobufs(void) { return socket_errno() == WSAENOBUFS; }
+static inline int socket_eagain(void) { return socket_errno() == WSATRY_AGAIN; }
+static inline int socket_ewouldblock(void) { return socket_errno() == WSAEWOULDBLOCK; }
+static inline int socket_einprogress(void) { return socket_errno() == WSAEINPROGRESS; }
+static inline int socket_econnreset(void) { return socket_errno() == WSAECONNRESET; }
+static inline int socket_econnrefused(void) { return socket_errno() == WSAECONNREFUSED; }
+static inline int socket_ehostdown(void) { return socket_errno() == WSAEHOSTDOWN; }
+static inline int socket_emsgsize(void) { return socket_errno() == WSAEMSGSIZE; }
+#else
+static inline int socket_errno(void)
+{
+	return errno;
+}
+static inline int socket_eperm(void) { return socket_errno() == EPERM; }
+static inline int socket_enomem(void) { return socket_errno() == ENOMEM; }
+static inline int socket_eintr(void) { return socket_errno() == EINTR; }
+static inline int socket_ebadf(void) { return socket_errno() == EBADF; }
+static inline int socket_eacces(void) { return socket_errno() == EACCES; }
+static inline int socket_enobufs(void) { return socket_errno() == ENOBUFS; }
+static inline int socket_eagain(void) { return socket_errno() == EAGAIN; }
+#if defined(EWOULDBLOCK)
+static inline int socket_ewouldblock(void) { return socket_errno() == EWOULDBLOCK; }
+#else
+static inline int socket_ewouldblock(void) { return socket_errno() == EAGAIN; }
+#endif
+static inline int socket_einprogress(void) { return socket_errno() == EINPROGRESS; }
+static inline int socket_econnreset(void) { return socket_errno() == ECONNRESET; }
+static inline int socket_econnrefused(void) { return socket_errno() == ECONNREFUSED; }
+static inline int socket_ehostdown(void) { return socket_errno() == EHOSTDOWN; }
+static inline int socket_emsgsize(void) { return socket_errno() == EMSGSIZE; }
+#endif
+
 #define BUFFEREVENT_FREE(be)                                                                                           \
   do {                                                                                                                 \
     if (be) {                                                                                                          \


### PR DESCRIPTION
Since winsock do not use errno, and have different error codes, this is needed to be windows compatible

This pull request is a split of PR #1061