### PR TITLE
Implement non-blocking recvfrom on Windows

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -621,8 +621,9 @@ start_udp_cycle:
 
   ssize_t bsize = 0;
 #if defined(WINDOWS)
-  // TODO: implement it!!!
   int flags = 0;
+  u_long iMode = 1;
+  ioctlsocket(fd, FIONBIO, &iMode);
 #else
   int flags = MSG_DONTWAIT;
 #endif
@@ -632,6 +633,11 @@ start_udp_cycle:
 
   int conn_reset = is_connreset();
   int to_block = would_block();
+
+#if defined(WINDOWS)
+  iMode = 0;
+  ioctlsocket(fd, FIONBIO, &iMode);
+#endif
 
   if (bsize < 0) {
 
@@ -645,8 +651,9 @@ start_udp_cycle:
 #if defined(MSG_ERRQUEUE)
 
 #if defined(WINDOWS)
-    // TODO: implement it!!!
     int eflags = MSG_ERRQUEUE;
+    iMode = 1;
+    ioctlsocket(fd, FIONBIO, &iMode);
 #else
     // Linux
     int eflags = MSG_ERRQUEUE | MSG_DONTWAIT;
@@ -667,6 +674,11 @@ start_udp_cycle:
 
     conn_reset = is_connreset();
     to_block = would_block();
+
+#if defined(WINDOWS)
+    iMode = 0;
+    ioctlsocket(fd, FIONBIO, &iMode);
+#endif
 
 #endif
 


### PR DESCRIPTION
This pull request is a split of PR #1061

As @KangLin pointed out in the original PR those sockets should ideally be permanently non-blocking for performance reasons, but they are NOT at the moment.
Someone with more knowledge about the code in dtls_listener.c should probably have a look if it would be feasible to change the sockets to non-blocking already at creation, similar to what is done in udpserver.c...