### PR TITLE
Explicitly state minimum Windows version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,13 @@ IF(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 ENDIF(MSVC)
 
+IF(WIN32)
+    # Explicitly state minimum Windows version to compile against
+    # This affects which APIs that are available in for example winsock
+    # 0x0601 == Windows 7
+    add_definitions(-D_WIN32_WINNT=0x0601)
+ENDIF(WIN32)
+
 SET(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libs")
 if (BUILD_SHARED_LIBS)
     add_definitions(-DBUILD_SHARED_LIBS)


### PR DESCRIPTION
This pull request is a split of PR #1061

Depending on build system the code will be built against different Windows versions (see comments in old PR).

According to https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt you should define _WIN32_WINNT to the oldest supported platform. And since https://github.com/coturn/coturn/issues/1044 states coturn should support >= Windows 7, I have set it to 0x0601.