### PR TITLE
Fix brew for MacOS CI build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI macoS
+name: C/C++ CI MacOS
 
 on:
   push:
@@ -13,6 +13,15 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
+        # Unlink and re-link to prevent errors when github mac runner images
+        # install python outside of brew, for example:
+        # https://github.com/orgs/Homebrew/discussions/3895
+        # https://github.com/actions/setup-python/issues/577
+        # https://github.com/actions/runner-images/issues/6459
+        # https://github.com/actions/runner-images/issues/6507
+        # https://github.com/actions/runner-images/issues/2322
+        brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
+
         brew update
         brew install \
             wget \


### PR DESCRIPTION
MacOS CI build started to fail in the PRs because when upgrading python it was not possible to override one existing file (related to 2to3 package).    Apparently this happens because MacOS runners some times have python versions not installed/compatible with brew.

Example of the failure: https://github.com/coturn/coturn/actions/runs/3850951324

The proposed workaround is taken from here: https://github.com/actions/runner-images/issues/2322