### PR TITLE
use santisied psql string

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_pgsql.c
+++ b/src/apps/relay/dbdrivers/dbd_pgsql.c
@@ -82,7 +82,7 @@ static PGconn *get_pqdb_connection(void) {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot open PostgreSQL DB connection: <%s>, runtime error\n",
                         pud->userdb_sanitized);
         } else if (!donot_print_connection_success) {
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "PostgreSQL DB connection success: %s\n", pud->userdb);
+          TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "PostgreSQL DB connection success: %s\n", pud->userdb_sanitized);
           donot_print_connection_success = 1;
         }
       }


### PR DESCRIPTION
Noticed the plaintext password of my postgresql server in my coturn logs, but postgresql errors would return the password sanitised. Simple fix to log the sanitised string.

![image](https://user-images.githubusercontent.com/112147643/213053494-c8a5d226-0b04-4c8d-9b52-3e1330291a39.png)


Signed-off-by: r3g_5z <june@girlboss.ceo>