### PR TITLE
Remove unused include that breaks OpenBSD

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -43,7 +43,6 @@
 #if defined(__unix__) || defined(unix)
 #include <pthread.h>
 #include <sys/resource.h>
-#include <sys/sysinfo.h>
 #include <sys/time.h>
 #endif
 


### PR DESCRIPTION
PR #855 introduced new include <ssys/sysinfo.h> 
It is not required for compilation or turnserver function but breaks OpenBSD build (which does not have this file)
This PR removes the include to restore OpenBSD build compatibility

Fixes #1162

Test Plan:
TBD - need some one to test build