### PR TITLE
Fix MSVC CI build

### DIFF
--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -48,7 +48,6 @@
 
 #if defined(WINDOWS)
 #include <process.h>
-#include <windows.h>
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>


### PR DESCRIPTION
Removing windows.h inclusion, not needed with ws2tcpip.h. Causes some struct redefinitions.