### PR TITLE
added warnings for prometheus apt unavailability

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Management interfaces:
 
 Monitoring:
  * Redis can be used for status and statistics storage and notification
- * [prometheus](https://prometheus.io/) interface
+ * [prometheus](https://prometheus.io/) interface (unavailable on apt package)
 
 Message integrity digest algorithms:
 

--- a/README.turnserver
+++ b/README.turnserver
@@ -287,11 +287,13 @@ Flags:
 
 --prometheus		Enable prometheus metrics. By default it is
 			disabled. Would listen on port 9641 under the path /metrics
-			also the path / on this port can be used as a health check
- --prometheus-username-labels	Enable labeling prometheus traffic
-			metrics with client usernames. Labeling with client usernames is
-			disabled by default, because this may cause memory leaks when using
-			authentication with ephemeral usernames (e.g. TURN REST API).
+			also the path / on this port can be used as a health check. 
+			Unavailable on apt installations.
+			
+--prometheus-username-labels	Enable labeling prometheus traffic
+		metrics with client usernames. Labeling with client usernames is
+		disabled by default, because this may cause memory leaks when using
+		authentication with ephemeral usernames (e.g. TURN REST API).
 
 --prometheus-port	Prometheus listener port (Default: 9641).
 

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -192,6 +192,8 @@
 #
 # You can simply run the turnserver and access the port 9641 and path /metrics
 #
+# This is currently unavailable on apt installations
+#
 # For more info on the prometheus exporter and metrics
 # https://prometheus.io/docs/introduction/overview/
 # https://prometheus.io/docs/concepts/data_model/


### PR DESCRIPTION
added some warnings that the prometheus implementation is unavailable when installing through apt
coturn/coturn#1133