### PR TITLE
Dockerfile: Install `telnet` tool for easier debugging

### DIFF
--- a/docker/coturn/alpine/Dockerfile
+++ b/docker/coturn/alpine/Dockerfile
@@ -192,6 +192,9 @@ RUN apk update \
  # Install `dig` tool for `detect-external-ip.sh`.
  && apk add --no-cache \
         bind-tools \
+ # Install `telnet` tool for easier debugging.
+ && apk add --no-cache \
+        busybox-extras \
  # Cleanup unnecessary stuff.
  && rm -rf /var/cache/apk/*
 

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -191,6 +191,9 @@ RUN apt-get update \
  # Install `dig` tool for `detect-external-ip.sh`.
  && apt-get install -y --no-install-recommends --no-install-suggests \
             dnsutils \
+ # Install `telnet` tool for easier debugging.
+ && apt-get install -y --no-install-recommends --no-install-suggests \
+            telnet \
  # Cleanup unnecessary stuff.
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hello,

I have been setting up coturn and I've had to run `apt update && apt install -y telnet` so many times to telnet in to the cli so I figured I'd try to make it easier by just adding it into the docker image.

Feel free to close if this isn't something you want upstream. Thanks!