### PR TITLE
Improve Docker tagging by tracking OS version (#1226)

### DIFF
--- a/docker/coturn/CHANGELOG.md
+++ b/docker/coturn/CHANGELOG.md
@@ -4,6 +4,23 @@ Coturn TURN server Docker image changelog
 
 
 
+## [4.6.2-r4] · 2023-07-04
+[4.6.2-r4]: /../../tree/docker/4.6.2-r4
+
+### Added
+
+- Additional tags with major OS version. ([#1230], [#1226])
+
+### Security updated
+
+- [Debian Linux] "bookworm" 20230703: <https://github.com/docker-library/official-images/commit/e4358612aca01fd8aa393e7b3d590d45ae72e9af>
+
+[#1226]: /../../issues/1226
+[#1230]: /../../pull/1230
+
+
+
+
 ## [4.6.2-r3] · 2023-06-15
 [4.6.2-r3]: /../../tree/docker/4.6.2-r3
 

--- a/docker/coturn/CONTRIBUTING.md
+++ b/docker/coturn/CONTRIBUTING.md
@@ -43,7 +43,7 @@ At the moment `coturn/coturn` Docker image's [workflow is automated][1] via [Git
 
 To produce a new release (version tag) of `coturn/coturn` Docker image, perform the following steps:
 
-1. Upgrade the image version correctly in [`Makefile`] by bumping up either the `COTURN_VER` (if Coturn has changed it version) or the `BUILD_REV` (if anything else in the image has been changed). If the `COTURN_VER` has changed, the `BUILD_REV` may be reset to `0`.
+1. Upgrade the image version correctly in [`Makefile`] by bumping up either the `COTURN_VER` (if Coturn has changed it version) or the `BUILD_REV` (if anything else in the image has been changed). If the `COTURN_VER` has changed, the `BUILD_REV` may be reset to `0` (DO NOT reset when `ALPINE_VER`/`DEBIAN_VER` changes).
 
 2. Complete an existing [CHANGELOG] or fill up a new one for the new version declared in [`Makefile`].
 

--- a/docker/coturn/Makefile
+++ b/docker/coturn/Makefile
@@ -28,6 +28,12 @@ COTURN_VER ?= 4.6.2
 COTURN_MIN_VER = $(strip $(shell echo $(COTURN_VER) | cut -d '.' -f1,2))
 COTURN_MAJ_VER = $(strip $(shell echo $(COTURN_VER) | cut -d '.' -f1))
 
+ALPINE_VER := alpine$(strip $(shell grep -m1 'alpine_ver=' alpine/Dockerfile \
+                                    | cut -d '=' -f2 \
+                                    | cut -d '.' -f1,2))
+DEBIAN_VER := $(strip $(shell grep -m1 'debian_ver=' debian/Dockerfile \
+                              | cut -d '=' -f2))
+
 BUILD_REV ?= 3
 
 NAME := coturn
@@ -36,8 +42,8 @@ REGISTRIES := $(strip $(subst $(comma), ,\
 	$(shell grep -m1 'registry: \["' ../../.github/workflows/docker.yml \
 	        | cut -d':' -f2 | tr -d '"][')))
 ALL_IMAGES := \
-	debian:$(COTURN_VER)-r$(BUILD_REV)-debian,$(COTURN_VER)-debian,$(COTURN_MIN_VER)-debian,$(COTURN_MAJ_VER)-debian,debian,$(COTURN_VER)-r$(BUILD_REV),$(COTURN_VER),$(COTURN_MIN_VER),$(COTURN_MAJ_VER),latest \
-	alpine:$(COTURN_VER)-r$(BUILD_REV)-alpine,$(COTURN_VER)-alpine,$(COTURN_MIN_VER)-alpine,$(COTURN_MAJ_VER)-alpine,alpine
+	debian:$(COTURN_VER)-r$(BUILD_REV)-debian,$(COTURN_VER)-debian,$(COTURN_MIN_VER)-debian,$(COTURN_MAJ_VER)-debian,debian,$(COTURN_VER)-r$(BUILD_REV)-$(DEBIAN_VER),$(COTURN_VER)-$(DEBIAN_VER),$(COTURN_MIN_VER)-$(DEBIAN_VER),$(COTURN_MAJ_VER)-$(DEBIAN_VER),$(DEBIAN_VER),$(COTURN_VER)-r$(BUILD_REV),$(COTURN_VER),$(COTURN_MIN_VER),$(COTURN_MAJ_VER),latest \
+	alpine:$(COTURN_VER)-r$(BUILD_REV)-alpine,$(COTURN_VER)-alpine,$(COTURN_MIN_VER)-alpine,$(COTURN_MAJ_VER)-alpine,alpine,$(COTURN_VER)-r$(BUILD_REV)-$(ALPINE_VER),$(COTURN_VER)-$(ALPINE_VER),$(COTURN_MIN_VER)-$(ALPINE_VER),$(COTURN_MAJ_VER)-$(ALPINE_VER),$(ALPINE_VER)
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Default is first image from ALL_IMAGES list.

--- a/docker/coturn/README.md
+++ b/docker/coturn/README.md
@@ -15,8 +15,8 @@ Coturn TURN server Docker image
 
 ## Supported tags and respective `Dockerfile` links
 
-- [`4.6.2-r3`, `4.6.2-r3-debian`, `4.6.2`, `4.6.2-debian`, `4.6`, `4.6-debian`, `4`, `4-debian`, `debian`, `latest`][d1]
-- [`4.6.2-r3-alpine`, `4.6.2-alpine`, `4.6-alpine`, `4-alpine`, `alpine`][d2]
+- [`4.6.2-r3`, `4.6.2-r3-debian`, `4.6.2-r3-bookworm`, `4.6.2`, `4.6.2-debian`, `4.6.2-bookworm`, `4.6`, `4.6-debian`, `4.6-bookworm`, `4`, `4-debian`, `4-bookworm`, `debian`, `bookworm`, `latest`][d1]
+- [`4.6.2-r3-alpine`, `4.6.2-r3-alpine3.18`, `4.6.2-alpine`, `4.6.2-alpine3.18`, `4.6-alpine`, `4.6-alpine3.18`, `4-alpine`, `4-alpine3.18`, `alpine`, `alpine3.18`][d2]
 
 
 
@@ -169,7 +169,7 @@ This is a multi-platform image.
 
 ### `<X.Y.Z>-r<N>-<dist>`/`<X.Y.Z.W>-r<N>-<dist>`
 
-Concrete `N` image revision tag of the concrete `X.Y.Z` (or `X.Y.Z.W`) Coturn version on the concrete `dist` (`alpine` or `debian`).
+Concrete `N` image revision tag of the concrete `X.Y.Z` (or `X.Y.Z.W`) Coturn version on the concrete `dist` (`alpine3.18`, or `bookworm`, or latest `alpine`/`debian`).
 
 Once built, it's never updated.
 
@@ -178,7 +178,7 @@ This is a multi-platform image.
 
 ### `<X.Y.Z>-r<N>-<dist>-<arch>`/`<X.Y.Z.W>-r<N>-<dist>-<arch>`
 
-Concrete `N` image revision tag of the concrete `X.Y.Z` (or `X.Y.Z.W`) Coturn version on the concrete `dist` (`alpine` or `debian`) and `arch`.
+Concrete `N` image revision tag of the concrete `X.Y.Z` (or `X.Y.Z.W`) Coturn version on the concrete `dist` (`alpine3.18`, or `bookworm`, or latest `alpine`/`debian`) and `arch`.
 
 Once build, it's never updated.
 
@@ -187,14 +187,14 @@ This is a single-platform image.
 
 ### `edge-<dist>`
 
-Latest tag of the latest `master` branch of Coturn on the concrete `dist` (`alpine` or `debian`).
+Latest tag of the latest `master` branch of Coturn on the concrete `dist` (`alpine3.18`, or `bookworm`, or latest `alpine`/`debian`).
 
 This is a multi-platform image.
 
 
 ### `edge-<dist>-<arch>`
 
-Latest tag of the latest `master` branch of Coturn on the concrete `dist` (`alpine` or `debian`) and `arch`.
+Latest tag of the latest `master` branch of Coturn on the concrete `dist` (`alpine3.18`, or `bookworm`, or latest `alpine`/`debian`) and `arch`.
 
 This is a single-platform image.
 

--- a/docker/coturn/README.md
+++ b/docker/coturn/README.md
@@ -187,14 +187,14 @@ This is a single-platform image.
 
 ### `edge-<dist>`
 
-Latest tag of the latest `master` branch of Coturn on the concrete `dist` (`alpine3.18`, or `bookworm`, or latest `alpine`/`debian`).
+Latest tag of the latest `master` branch of Coturn on the concrete `dist` (latest `alpine`/`debian`).
 
 This is a multi-platform image.
 
 
 ### `edge-<dist>-<arch>`
 
-Latest tag of the latest `master` branch of Coturn on the concrete `dist` (`alpine3.18`, or `bookworm`, or latest `alpine`/`debian`) and `arch`.
+Latest tag of the latest `master` branch of Coturn on the concrete `dist` (latest `alpine`/`debian`) and `arch`.
 
 This is a single-platform image.
 


### PR DESCRIPTION
Resolves #1226

Adds additional Docker tags with concrete OS versions (`alpine3.18`/`bookworm`).