### PR TITLE
Fix error of make command in Cygwin environment

### DIFF
--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -49,7 +49,7 @@
 
 #include <signal.h>
 
-#if !defined(WINDOWS)
+#if !defined(WINDOWS) && !defined(__CYGWIN__) && !defined(__CYGWIN32__) && !defined(__CYGWIN64__)
 #include <sys/syscall.h>
 #include <unistd.h>
 #ifdef SYS_gettid


### PR DESCRIPTION
Environment:
- Windows 10
- Cygwin 2.925

make output:
```
<command-line>: note: this is the location of the previous definition
src/apps/common/ns_turn_utils.c:53:10: fatal error: sys/syscall.h: No such file or directory
   53 | #include <sys/syscall.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
In file included from src/client/ns_turn_ioaddr.h:34,
                 from src/client/ns_turn_msg.h:34,
                 from src/apps/common/stun_buffer.h:34,
                 from src/apps/common/stun_buffer.c:31:
src/ns_turn_defs.h:223: warning: "TURN_NO_SCTP" redefined
  223 | #define TURN_NO_SCTP
      |
<command-line>: note: this is the location of the previous definition
make: *** [Makefile:127: bin/turnutils_oauth] Error 1
```