### PR TITLE
Add warning and disable web admin if no-tls option used

### DIFF
--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -723,6 +723,7 @@ cli-password=CHANGE_ME
 # Enable Web-admin support on https. By default it is Disabled.
 # If it is enabled it also enables a http a simple static banner page
 # with a small reminder that the admin page is available only on https.
+# Not supported if no-tls option used
 #
 #web-admin
 

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -725,6 +725,7 @@
 # Enable Web-admin support on https. By default it is Disabled.
 # If it is enabled it also enables a http a simple static banner page
 # with a small reminder that the admin page is available only on https.
+# Not supported if no-tls option used
 #
 #web-admin
 

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3076,6 +3076,11 @@ int main(int argc, char **argv) {
     }
   }
 
+  if (use_web_admin && turn_params.no_tls) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "CONFIG: WARNING: web-admin support not compatible witn --no-tls option.\n");
+    use_web_admin = 0;
+  }
+
   openssl_setup();
 
   int local_listeners = 0;


### PR DESCRIPTION
Fixes https://github.com/coturn/coturn/issues/1239

https to web ui freeze in browser if no_tls option used, because no tls stuff initialized.
This PR add warning about this and comment aboute this in default config