### PR TITLE
Fix memleak in pgsql_reread_realms

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_pgsql.c
+++ b/src/apps/relay/dbdrivers/dbd_pgsql.c
@@ -777,7 +777,10 @@ static void pgsql_reread_realms(secrets_list_t *realms_list) {
             if (rval) {
               get_realm(rval);
               ur_string_map_value_type value = strdup(rval);
-              ur_string_map_put(o_to_realm_new, (ur_string_map_key_type)oval, value);
+              int ret = ur_string_map_put(o_to_realm_new, (ur_string_map_key_type)oval, value);
+              if (ret == -1) {
+                free(rval);
+              }
             }
           }
         }

--- a/src/apps/relay/dbdrivers/dbd_pgsql.c
+++ b/src/apps/relay/dbdrivers/dbd_pgsql.c
@@ -779,7 +779,7 @@ static void pgsql_reread_realms(secrets_list_t *realms_list) {
               ur_string_map_value_type value = strdup(rval);
               int ret = ur_string_map_put(o_to_realm_new, (ur_string_map_key_type)oval, value);
               if (ret == -1) {
-                free(rval);
+                free(value);
               }
             }
           }


### PR DESCRIPTION
Fixes #1259

If `ur_string_map_put ` fails then the string that was just `strdup`-ed will leak memory 
Now the return value is checked and memory free-ed in case of failure