### PR TITLE
Replace srand/rand with srandom/random

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -1193,6 +1193,14 @@ void turn_srandom(void) {
 #endif
 }
 
+long turn_random(void) {
+#if defined(WINDOWS)
+  return rand();
+#else
+  return random();
+#endif
+}
+
 unsigned long set_system_parameters(int max_resources) {
   turn_srandom();
 

--- a/src/apps/common/apputils.h
+++ b/src/apps/common/apputils.h
@@ -277,6 +277,7 @@ struct event_base *turn_event_base_new(void);
 //////////// Random /////////////////////
 
 void turn_srandom(void);
+long turn_random(void);
 
 ///////////////////////////////////////////////////////
 

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1679,22 +1679,20 @@ void generate_aes_128_key(char *filePath, unsigned char *returnedKey) {
   int part;
   FILE *fptr;
   char key[16];
-  struct timespec times;
-  clock_gettime(CLOCK_REALTIME, &times);
-  srand(times.tv_nsec);
+  turn_srandom();
 
   for (i = 0; i < 16; i++) {
     part = (rand() % 3);
     if (part == 0) {
-      key[i] = (rand() % 10) + 48;
+      key[i] = (turn_random() % 10) + 48;
     }
 
     else if (part == 1) {
-      key[i] = (rand() % 26) + 65;
+      key[i] = (turn_random() % 26) + 65;
     }
 
     else if (part == 2) {
-      key[i] = (rand() % 26) + 97;
+      key[i] = (turn_random() % 26) + 97;
     }
   }
   fptr = fopen(filePath, "w");

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -92,7 +92,7 @@ int stun_method_str(uint16_t method, char *smethod) {
   return ret;
 }
 
-long turn_random(void) {
+long turn_random_number(void) {
   long ret = 0;
   if (!RAND_bytes((unsigned char *)&ret, sizeof(ret)))
 #if defined(WINDOWS)
@@ -108,7 +108,7 @@ static void turn_random_tid_size(void *id) {
   if (!RAND_bytes((unsigned char *)ar, 12)) {
     size_t i;
     for (i = 0; i < 3; ++i) {
-      ar[i] = (uint32_t)turn_random();
+      ar[i] = (uint32_t)turn_random_number();
     }
   }
 }
@@ -1100,7 +1100,7 @@ uint16_t stun_set_channel_bind_request_str(uint8_t *buf, size_t *len, const ioa_
                                            uint16_t channel_number) {
 
   if (!STUN_VALID_CHANNEL(channel_number)) {
-    channel_number = 0x4000 + ((uint16_t)(((uint32_t)turn_random()) % (0x7FFF - 0x4000 + 1)));
+    channel_number = 0x4000 + ((uint16_t)(((uint32_t)turn_random_number()) % (0x7FFF - 0x4000 + 1)));
   }
 
   stun_init_request_str(STUN_METHOD_CHANNEL_BIND, buf, len);
@@ -2429,7 +2429,7 @@ static void generate_random_nonce(unsigned char *nonce, size_t sz) {
   if (!RAND_bytes(nonce, (int)sz)) {
     size_t i;
     for (i = 0; i < sz; ++i) {
-      nonce[i] = (unsigned char)turn_random();
+      nonce[i] = (unsigned char)turn_random_number();
     }
   }
 }


### PR DESCRIPTION
- srandom/random provide stronger randomness characteristics than srand/rand in some operating systems.
- usage of srand/rand is not very consistent in coturn.

There is room for more refactoring and use apputils helper functions in ns_turn_msg.c too but i'm not sure that dependency from "client" module to "apps" module is a good idea yet.

Thx @0xdea
