### PR TITLE
Fix ubuntu 16 build with GH action checkout version to v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
             wget https://github.com/digitalocean/prometheus-client-c/releases/download/v0.1.3/libpromhttp-dev-0.1.3-Linux.deb && \
             apt install ./libprom-dev-0.1.3-Linux.deb ./libpromhttp-dev-0.1.3-Linux.deb && \
             rm ./libprom-dev-0.1.3-Linux.deb ./libpromhttp-dev-0.1.3-Linux.deb
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: configure
       run: ./configure
     - name: make


### PR DESCRIPTION
Builds started to fail in ubuntu 16.04: https://github.com/coturn/coturn/actions/runs/6368822745/job/17288499081?pr=1280

It is apparently related to the glib version using by node: https://github.com/actions/checkout/issues/1474

The simplest solution I found is to use checkout@v3 that I think should be fine given that we only need to use it to download the repo code. 