### PR TITLE
Fix missing strncpy in fix_stun_check_message_integrity_str

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1966,10 +1966,12 @@ int stun_check_message_integrity_str(turn_credential_type ct, uint8_t *buf, size
   hmackey_t key;
   password_t pwd;
 
-  if (ct == TURN_CREDENTIALS_SHORT_TERM)
-    strncpy((char *)pwd, (const char *)upwd, sizeof(password_t));
-  else if (stun_produce_integrity_key_str(uname, realm, upwd, key, shatype) < 0)
+  if (ct == TURN_CREDENTIALS_SHORT_TERM) {
+    len = strncpy((char *)pwd, (const char *)upwd, sizeof(password_t) - 1);
+    pwd[sizeof(password_t) - 1] = 0
+  } else if (stun_produce_integrity_key_str(uname, realm, upwd, key, shatype) < 0) {
     return -1;
+  }
 
   return stun_check_message_integrity_by_key_str(ct, buf, len, key, pwd, shatype);
 }

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1968,7 +1968,7 @@ int stun_check_message_integrity_str(turn_credential_type ct, uint8_t *buf, size
 
   if (ct == TURN_CREDENTIALS_SHORT_TERM) {
     len = strncpy((char *)pwd, (const char *)upwd, sizeof(password_t) - 1);
-    pwd[sizeof(password_t) - 1] = 0
+    pwd[sizeof(password_t) - 1] = 0;
   } else if (stun_produce_integrity_key_str(uname, realm, upwd, key, shatype) < 0) {
     return -1;
   }


### PR DESCRIPTION
Add missing null termination for string composed at fix_stun_check_message_integrity_str.

The function fix_stun_check_message_integrity_str is only used in uclient and rfc5769check test applications.

Thx @0xdea