### PR TITLE
Fix: Return correct error code for `create_relay_connection` in case of `RESERVATION-TOKEN` failure

### DIFF
--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4241,7 +4241,7 @@ static int create_relay_connection(turn_turnserver *server, ts_ur_super_session 
           ioa_socket_tobeclosed(s)) {
 
         IOA_CLOSE_SOCKET(s);
-        *err_code = 404;
+        *err_code = 508;
         *reason = (const uint8_t *)"Cannot find reserved socket";
         return -1;
       }


### PR DESCRIPTION
Fixes #1266 

According to RFC 5766, [section 6.2](https://www.rfc-editor.org/rfc/rfc5766#section-6.2) point no. 5, the turn server needs to reject the request with 508 (Insufficient Capacity) error code when the given RESERVATION-TOKEN is not valid.
