### PR TITLE
increase log timestamp resolution to milliseconds

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -238,9 +238,17 @@ Flags:
 			name will be constructed as-is, without PID and date appendage.
 			This option can be used, for example, together with the logrotate tool.
 
---new-log-timestamp				Enable full ISO-8601 timestamp in all logs.
+--new-log-timestamp				Enable timestamp formatting (see also
+			--new-log-timestamp-format). If not given, seconds since turnserver
+			start will be used as timestamp.
 
---new-log-timestamp-format    	<format>	Set timestamp format (in strftime(1) format)
+--new-log-timestamp-format    	<format>	Set the timestamp format to use
+			(see strftime(3)). Default: "%FT%T%z" (ISO-8601 timestamp). If the
+			given format ends with %N , the time gets formatted as UTC timestamp
+			whereby %N gets replaced with the microseconds part of the current
+			time if the execuing machine provides a monotonic clock (otherwise
+			%N gets ignored). Ignored unless timestamp formatting is enabled
+			(see option --new-log-timestamp).
 
 --log-binding					Log STUN binding request. It is now disabled by default to avoid DoS attacks.
 

--- a/src/apps/common/ns_turn_utils.h
+++ b/src/apps/common/ns_turn_utils.h
@@ -57,6 +57,8 @@ typedef enum {
   TURN_LOG_LEVEL_ERROR
 } TURN_LOG_LEVEL;
 
+extern TURN_LOG_LEVEL app_log_level;
+
 #define TURN_VERBOSE_NONE (0)
 #define TURN_VERBOSE_NORMAL (1)
 #define TURN_VERBOSE_EXTRA (2)

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -2042,9 +2042,13 @@ static void set_option(int c, char *value) {
     if (turn_params.verbose != TURN_VERBOSE_EXTRA) {
       if (get_bool_value(value)) {
         turn_params.verbose = TURN_VERBOSE_NORMAL;
+        app_log_level = TURN_LOG_LEVEL_DEBUG;
       } else {
         turn_params.verbose = TURN_VERBOSE_NONE;
+        app_log_level = TURN_LOG_LEVEL_INFO; // the default
       }
+    } else {
+      app_log_level = TURN_LOG_LEVEL_DEBUG;
     }
     break;
   case 'V':


### PR DESCRIPTION
If --new-log-timestamp is enabled and the --new-log-timestamp-format ends with %N, the time gets formatted as UTC timestamp whereby %N gets replaced by the microseconds part of the current time.