### PR TITLE
Use log4cplus(#1344)

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -24,7 +24,8 @@ jobs:
             libpq-dev libmariadb-dev libsqlite3-dev \
             libhiredis-dev \
             libmongoc-dev \
-            libmicrohttpd-dev
+            libmicrohttpd-dev \
+            liblog4cplus-dev
     - uses: actions/checkout@v4
     - name: Prometheus support
       run: |

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -39,7 +39,7 @@ jobs:
       SOURCE_DIR:  ${{github.workspace}}\.cache\source
       TOOLS_DIR:   ${{github.workspace}}\.cache\tools
       INSTALL_DIR: ${{github.workspace}}\.cache\install_msvc_${{matrix.triplet}}_${{matrix.BUILD_TYPE}}
-      VCPKGGITCOMMITID: acc3bcf76b84ae5041c86ab55fe138ae7b8255c7
+      VCPKGGITCOMMITID: 0e47c1985273129e4d0ee52ff73bed9125555de8
       VCPKG_PLATFORM_TOOLSET: ${{matrix.VCPKG_PLATFORM_TOOLSET}}
       CMAKE_GENERATOR_PLATFORM: ${{matrix.CMAKE_GENERATOR_PLATFORM}}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,8 @@ jobs:
             libpq-dev libsqlite3-dev \
             libhiredis-dev \
             libmongoc-dev \
-            libmicrohttpd-dev
+            libmicrohttpd-dev \
+            liblog4cplus-dev
         if [ ${{ matrix.os }}  = 'ubuntu:16.04' ]; then apt-get install -y libmariadb-client-lgpl-dev; fi
         if [ ${{ matrix.os }} != 'ubuntu:16.04' ]; then apt-get install -y libmariadb-dev; fi
         wget https://github.com/digitalocean/prometheus-client-c/releases/download/v0.1.3/libprom-dev-0.1.3-Linux.deb && \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,11 +130,6 @@ install(FILES
             postinstall.txt
         DESTINATION doc/turnserver
             COMPONENT Runtime)
-install(FILES examples/etc/turnserver.conf
-    DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}
-        COMPONENT Runtime
-    RENAME turnserver.conf.default
-    )
 install(DIRECTORY
         examples
     DESTINATION share

--- a/Makefile.in
+++ b/Makefile.in
@@ -3,47 +3,25 @@ LIBEVENT_INCLUDE = -I${PREFIX}/include/ -I/usr/local/include/
 
 INCFLAGS = -Isrc -Isrc/apps/common -Isrc/server -Isrc/client -Isrc/client++ ${LIBEVENT_INCLUDE} 
 
-CFLAGS += ${INCFLAGS}
+CFLAGS += ${INCFLAGS} ${DBCFLAGS}
+CPPFLAGS += ${INCFLAGS} ${DBCFLAGS}
 
 MAKE_DEPS = Makefile
 
-LIBCLIENTTURN_HEADERS = src/ns_turn_defs.h src/client++/TurnMsgLib.h src/client/ns_turn_ioaddr.h src/client/ns_turn_msg.h src/client/ns_turn_msg_defs.h src/client/ns_turn_msg_defs_experimental.h src/client/ns_turn_msg_addr.h
-LIBCLIENTTURN_MODS = src/client/ns_turn_ioaddr.c src/client/ns_turn_msg_addr.c src/client/ns_turn_msg.c 
-LIBCLIENTTURN_DEPS = ${LIBCLIENTTURN_HEADERS} ${MAKE_DEPS} 
-LIBCLIENTTURN_OBJS = build/obj/ns_turn_ioaddr.o build/obj/ns_turn_msg_addr.o build/obj/ns_turn_msg.o 
+BUILD_DIR = build
+LIB_DIR = ${BUILD_DIR}/lib
+BIN_DIR = ${BUILD_DIR}/bin
 
-SERVERTURN_HEADERS = src/server/ns_turn_allocation.h src/server/ns_turn_ioalib.h src/server/ns_turn_khash.h src/server/ns_turn_maps_rtcp.h src/server/ns_turn_maps.h src/server/ns_turn_server.h src/server/ns_turn_session.h 
-SERVERTURN_DEPS = ${LIBCLIENTTURN_HEADERS} ${SERVERTURN_HEADERS} ${MAKE_DEPS} 
-SERVERTURN_MODS = ${LIBCLIENTTURN_MODS} src/server/ns_turn_allocation.c src/server/ns_turn_maps_rtcp.c src/server/ns_turn_maps.c src/server/ns_turn_server.c
+TURN_BUILD_RESULTS = ${BIN_DIR}/turnutils_uclient ${BIN_DIR}/turnutils_natdiscovery ${BIN_DIR}/turnutils_oauth ${BIN_DIR}/turnutils_stunclient ${BIN_DIR}/turnutils_rfc5769check ${BIN_DIR}/turnserver ${BIN_DIR}/turnutils_peer include/turn/ns_turn_defs.h sqlite_empty_db
 
-COMMON_HEADERS = src/apps/common/apputils.h src/apps/common/ns_turn_openssl.h src/apps/common/ns_turn_utils.h src/apps/common/stun_buffer.h
-COMMON_MODS = src/apps/common/apputils.c src/apps/common/ns_turn_utils.c src/apps/common/stun_buffer.c
-COMMON_DEPS = ${LIBCLIENTTURN_DEPS} ${COMMON_MODS} ${COMMON_HEADERS}
-
-IMPL_HEADERS = src/apps/relay/ns_ioalib_impl.h src/apps/relay/ns_sm.h src/apps/relay/turn_ports.h
-IMPL_MODS = src/apps/relay/ns_ioalib_engine_impl.c src/apps/relay/turn_ports.c src/apps/relay/http_server.c src/apps/relay/acme.c
-IMPL_DEPS = ${COMMON_DEPS} ${IMPL_HEADERS} ${IMPL_MODS}
-
-HIREDIS_HEADERS = src/apps/common/hiredis_libevent2.h
-HIREDIS_MODS = src/apps/common/hiredis_libevent2.c
-
-USERDB_HEADERS = src/apps/relay/dbdrivers/dbdriver.h src/apps/relay/dbdrivers/dbd_sqlite.h src/apps/relay/dbdrivers/dbd_pgsql.h src/apps/relay/dbdrivers/dbd_mysql.h src/apps/relay/dbdrivers/dbd_mongo.h src/apps/relay/dbdrivers/dbd_redis.h
-USERDB_MODS = src/apps/relay/dbdrivers/dbdriver.c src/apps/relay/dbdrivers/dbd_sqlite.c src/apps/relay/dbdrivers/dbd_pgsql.c src/apps/relay/dbdrivers/dbd_mysql.c src/apps/relay/dbdrivers/dbd_mongo.c src/apps/relay/dbdrivers/dbd_redis.c
-
-SERVERAPP_HEADERS = src/apps/relay/userdb.h src/apps/relay/tls_listener.h src/apps/relay/mainrelay.h src/apps/relay/turn_admin_server.h src/apps/relay/dtls_listener.h src/apps/relay/libtelnet.h src/apps/relay/prom_server.h ${HIREDIS_HEADERS} ${USERDB_HEADERS}
-SERVERAPP_MODS = src/apps/relay/mainrelay.c src/apps/relay/netengine.c src/apps/relay/libtelnet.c src/apps/relay/turn_admin_server.c src/apps/relay/userdb.c src/apps/relay/tls_listener.c src/apps/relay/dtls_listener.c src/apps/relay/prom_server.c ${HIREDIS_MODS} ${USERDB_MODS}
-SERVERAPP_DEPS = ${SERVERTURN_MODS} ${SERVERTURN_DEPS} ${SERVERAPP_MODS} ${SERVERAPP_HEADERS} ${COMMON_DEPS} ${IMPL_DEPS} lib/libturnclient.a
-
-TURN_BUILD_RESULTS = bin/turnutils_oauth bin/turnutils_natdiscovery bin/turnutils_stunclient bin/turnutils_rfc5769check bin/turnutils_uclient bin/turnserver bin/turnutils_peer lib/libturnclient.a include/turn/ns_turn_defs.h sqlite_empty_db
-
-.PHONY: all test check clean distclean sqlite_empty_db install deinstall uninstall reinstall
+.PHONY: all test check clean distclean install deinstall uninstall reinstall
 
 all:	${TURN_BUILD_RESULTS}
 
 test:	check
 
-check:	bin/turnutils_rfc5769check
-	bin/turnutils_rfc5769check
+check:	${BIN_DIR}/turnutils_rfc5769check
+	${BIN_DIR}/turnutils_rfc5769check
 
 format:
 	find . -iname "*.c" -o -iname "*.h" | xargs clang-format -i
@@ -58,62 +36,119 @@ include/turn/ns_turn_defs.h:	src/ns_turn_defs.h
 	cp -pf src/client++/*.h include/turn/client/
 	cp -pf src/ns_turn_defs.h include/turn/
 
-bin/turnutils_uclient:	${COMMON_DEPS} src/apps/uclient/session.h lib/libturnclient.a src/apps/uclient/mainuclient.c src/apps/uclient/uclient.c src/apps/uclient/uclient.h src/apps/uclient/startuclient.c src/apps/uclient/startuclient.h
-	${MKBUILDDIR} bin
-	${CC} ${CPPFLAGS} ${CFLAGS} src/apps/uclient/uclient.c src/apps/uclient/startuclient.c src/apps/uclient/mainuclient.c ${COMMON_MODS} -o $@ -Llib -lturnclient -Llib ${LDFLAGS}  
+# Build for C source
+$(BUILD_DIR)/%.c.o: %.c
+	${MKBUILDDIR} $(dir $@)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
-bin/turnutils_natdiscovery:	${COMMON_DEPS} lib/libturnclient.a src/apps/natdiscovery/natdiscovery.c
-	pwd
-	${MKBUILDDIR} bin
-	${CC} ${CPPFLAGS} ${CFLAGS} src/apps/natdiscovery/natdiscovery.c ${COMMON_MODS} -o $@ -Llib -lturnclient -Llib ${LDFLAGS}
+# Build for C++ source
+$(BUILD_DIR)/%.cpp.o: %.cpp
+	${MKBUILDDIR} $(dir $@)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
-bin/turnutils_oauth:	${COMMON_DEPS} lib/libturnclient.a src/apps/oauth/oauth.c
-	pwd
-	${MKBUILDDIR} bin
-	${CC} ${CPPFLAGS} ${CFLAGS} src/apps/oauth/oauth.c ${COMMON_MODS} -o $@ -Llib -lturnclient -Llib ${LDFLAGS}
+LOG4CPLUS_SOURCE := $(if ${HAS_LOG4CPLUS},src/apps/common/log4cplus.cpp,)
+COMMON_HEADERS = src/apps/common/apputils.h src/apps/common/ns_turn_openssl.h src/apps/common/ns_turn_utils.h src/apps/common/stun_buffer.h
+COMMON_SOURCE := src/apps/common/apputils.c src/apps/common/ns_turn_utils.c src/apps/common/stun_buffer.c ${LOG4CPLUS_SOURCE}
+COMMON_OBJS := $(COMMON_SOURCE:%=$(BUILD_DIR)/%.o)
 
-bin/turnutils_stunclient:	${COMMON_DEPS} lib/libturnclient.a src/apps/stunclient/stunclient.c 
-	pwd
-	${MKBUILDDIR} bin
-	${CC} ${CPPFLAGS} ${CFLAGS} src/apps/stunclient/stunclient.c ${COMMON_MODS} -o $@ -Llib -lturnclient -Llib ${LDFLAGS}   
+LIBCLIENTTURN_HEADERS = src/ns_turn_defs.h src/client++/TurnMsgLib.h src/client/ns_turn_ioaddr.h src/client/ns_turn_msg.h src/client/ns_turn_msg_defs.h src/client/ns_turn_msg_defs_experimental.h src/client/ns_turn_msg_addr.h
+LIBCLIENTTURN_SOURCE = src/client/ns_turn_ioaddr.c src/client/ns_turn_msg_addr.c src/client/ns_turn_msg.c 
+LIBCLIENTTURN_DEPS = ${LIBCLIENTTURN_HEADERS} ${MAKE_DEPS} 
+LIBCLIENTTURN_OBJS := $(LIBCLIENTTURN_SOURCE:%=$(BUILD_DIR)/%.o) ${COMMON_OBJS}
 
-bin/turnutils_rfc5769check:	${COMMON_DEPS} lib/libturnclient.a src/apps/rfc5769/rfc5769check.c 
-	pwd
-	${MKBUILDDIR} bin
-	${CC} ${CPPFLAGS} ${CFLAGS} src/apps/rfc5769/rfc5769check.c ${COMMON_MODS} -o $@ -Llib -lturnclient -Llib ${LDFLAGS} 
+SERVERTURN_HEADERS = src/server/ns_turn_allocation.h src/server/ns_turn_ioalib.h src/server/ns_turn_khash.h src/server/ns_turn_maps_rtcp.h src/server/ns_turn_maps.h src/server/ns_turn_server.h src/server/ns_turn_session.h 
+SERVERTURN_DEPS = ${LIB_DIR}/libturnclient.a
+SERVERTURN_SOURCE = src/server/ns_turn_allocation.c src/server/ns_turn_maps_rtcp.c src/server/ns_turn_maps.c src/server/ns_turn_server.c
+SERVERTURN_OBJS = $(SERVERTURN_SOURCE:%=$(BUILD_DIR)/%.o)
 
-bin/turnserver:	${SERVERAPP_DEPS}
-	${MKBUILDDIR} bin
-	${RMCMD} bin/turnadmin
-	${CC} ${CPPFLAGS} ${CFLAGS} ${DBCFLAGS} ${IMPL_MODS} -Ilib ${SERVERAPP_MODS} ${COMMON_MODS} ${SERVERTURN_MODS} -o $@ ${DBLIBS} ${LDFLAGS} 
-	cd bin; ln -s turnserver turnadmin  
-
-bin/turnutils_peer:	${COMMON_DEPS} ${LIBCLIENTTURN_MODS} ${LIBCLIENTTURN_DEPS} lib/libturnclient.a src/apps/peer/mainudpserver.c src/apps/peer/udpserver.h src/apps/peer/udpserver.c
-	${MKBUILDDIR} bin
-	${CC} ${CPPFLAGS} ${CFLAGS} src/apps/peer/mainudpserver.c src/apps/peer/udpserver.c ${COMMON_MODS} -o $@ -Llib -lturnclient -Llib ${LDFLAGS}  
-
-### Client Library:
-
-lib/libturnclient.a:	${LIBCLIENTTURN_OBJS} ${LIBCLIENTTURN_DEPS}
-	${MKBUILDDIR} lib
+### Libraries:
+${LIB_DIR}/libturnclient.a: ${LIBCLIENTTURN_OBJS} ${LIBCLIENTTURN_DEPS}
+	${MKBUILDDIR} ${LIB_DIR}
 	${ARCHIVERCMD} $@ ${LIBCLIENTTURN_OBJS}
 
-build/obj/ns_turn_ioaddr.o:	src/client/ns_turn_ioaddr.c ${LIBCLIENTTURN_DEPS}
-	${MKBUILDDIR} build/obj
-	${CC} ${CPPFLAGS} ${CFLAGS} -c src/client/ns_turn_ioaddr.c -o $@
+${LIB_DIR}/libturnserver.a: ${SERVERTURN_OBJS} ${SERVERTURN_DEPS}
+	${MKBUILDDIR} ${LIB_DIR}
+	${ARCHIVERCMD} $@ ${SERVERTURN_OBJS}
 
-build/obj/ns_turn_msg_addr.o:	src/client/ns_turn_msg_addr.c ${LIBCLIENTTURN_DEPS}
-	${MKBUILDDIR} build/obj
-	${CC} ${CPPFLAGS} ${CFLAGS} -c src/client/ns_turn_msg_addr.c -o $@
+### Applications
+# turnserver
+IMPL_HEADERS = src/apps/relay/ns_ioalib_impl.h src/apps/relay/ns_sm.h src/apps/relay/turn_ports.h
+IMPL_SOURCE = src/apps/relay/ns_ioalib_engine_impl.c src/apps/relay/turn_ports.c src/apps/relay/http_server.c src/apps/relay/acme.c
+IMPL_DEPS = ${IMPL_HEADERS} ${IMPL_SOURCE}
 
-build/obj/ns_turn_msg.o:	src/client/ns_turn_msg.c ${LIBCLIENTTURN_DEPS}
-	${MKBUILDDIR} build/obj
-	${CC} ${CPPFLAGS} ${CFLAGS} -c src/client/ns_turn_msg.c -o $@
+HIREDIS_HEADERS = src/apps/common/hiredis_libevent2.h
+HIREDIS_SOURCE = src/apps/common/hiredis_libevent2.c
+
+USERDB_HEADERS = src/apps/relay/dbdrivers/dbdriver.h src/apps/relay/dbdrivers/dbd_sqlite.h src/apps/relay/dbdrivers/dbd_pgsql.h src/apps/relay/dbdrivers/dbd_mysql.h src/apps/relay/dbdrivers/dbd_mongo.h src/apps/relay/dbdrivers/dbd_redis.h
+USERDB_SOURCE = src/apps/relay/dbdrivers/dbdriver.c src/apps/relay/dbdrivers/dbd_sqlite.c src/apps/relay/dbdrivers/dbd_pgsql.c src/apps/relay/dbdrivers/dbd_mysql.c src/apps/relay/dbdrivers/dbd_mongo.c src/apps/relay/dbdrivers/dbd_redis.c
+
+SERVERAPP_HEADERS = src/apps/relay/userdb.h src/apps/relay/tls_listener.h src/apps/relay/mainrelay.h src/apps/relay/turn_admin_server.h src/apps/relay/dtls_listener.h src/apps/relay/libtelnet.h src/apps/relay/prom_server.h ${HIREDIS_HEADERS} ${USERDB_HEADERS}
+SERVERAPP_SOURCE = src/apps/relay/mainrelay.c src/apps/relay/netengine.c src/apps/relay/libtelnet.c src/apps/relay/turn_admin_server.c src/apps/relay/userdb.c src/apps/relay/tls_listener.c src/apps/relay/dtls_listener.c src/apps/relay/prom_server.c ${HIREDIS_SOURCE} ${USERDB_SOURCE} ${IMPL_SOURCE}
+SERVERAPP_OBJ :=$(SERVERAPP_SOURCE:%=$(BUILD_DIR)/%.o)
+SERVERAPP_DEPS = ${LIB_DIR}/libturnserver.a ${LIB_DIR}/libturnclient.a
+${BIN_DIR}/turnserver: ${SERVERAPP_OBJ} ${SERVERAPP_DEPS}
+	${MKBUILDDIR} ${BIN_DIR}
+	${RMCMD} ${BIN_DIR}/turnadmin
+	$(CXX) $(SERVERAPP_OBJ) -o $@ ${SERVERAPP_DEPS} ${LDFLAGS} ${DBLIBS}
+	cd ${BIN_DIR} && ln -s turnserver turnadmin
+
+# turnutils_uclient
+turnutils_uclient_SRC = src/apps/uclient/uclient.c src/apps/uclient/startuclient.c src/apps/uclient/mainuclient.c
+turnutils_uclient_OBJ := $(turnutils_uclient_SRC:%=$(BUILD_DIR)/%.o)
+turnutils_uclient_DEPS := ${LIB_DIR}/libturnclient.a
+${BIN_DIR}/turnutils_uclient: ${turnutils_uclient_OBJ} ${turnutils_uclient_DEPS}
+	pwd
+	${MKBUILDDIR} ${BIN_DIR}
+	$(CXX) $(turnutils_uclient_OBJ) -o $@ ${turnutils_uclient_DEPS} ${LDFLAGS}
+
+# turnutils_natdiscovery
+turnutils_natdiscovery_SRC = src/apps/natdiscovery/natdiscovery.c
+turnutils_natdiscovery_OBJ := $(turnutils_natdiscovery_SRC:%=$(BUILD_DIR)/%.o)
+turnutils_natdiscovery_DEPS := ${LIB_DIR}/libturnclient.a
+${BIN_DIR}/turnutils_natdiscovery: ${turnutils_natdiscovery_OBJ} ${turnutils_natdiscovery_DEPS}
+	pwd
+	${MKBUILDDIR} ${BIN_DIR}
+	$(CXX) $(turnutils_natdiscovery_OBJ) -o $@ ${turnutils_uclient_DEPS} ${LDFLAGS}
+
+# turnutils_oauth
+turnutils_oauth_SRC = src/apps/oauth/oauth.c
+turnutils_oauth_OBJ := $(turnutils_oauth_SRC:%=$(BUILD_DIR)/%.o)
+turnutils_oauth_DEPS := ${LIB_DIR}/libturnclient.a
+${BIN_DIR}/turnutils_oauth:	${turnutils_oauth_OBJ} ${turnutils_oauth_DEPS}
+	pwd
+	${MKBUILDDIR} ${BIN_DIR}
+	$(CXX) $(turnutils_oauth_OBJ) -o $@ ${turnutils_oauth_DEPS} ${LDFLAGS}
+
+# turnutils_stunclient
+turnutils_stunclient_SRC = src/apps/stunclient/stunclient.c
+turnutils_stunclient_OBJ := $(turnutils_stunclient_SRC:%=$(BUILD_DIR)/%.o)
+turnutils_stunclient_DEPS := ${LIB_DIR}/libturnclient.a
+${BIN_DIR}/turnutils_stunclient: ${turnutils_stunclient_OBJ} ${turnutils_stunclient_DEPS}
+	pwd
+	${MKBUILDDIR} ${BIN_DIR}
+	$(CXX) $(turnutils_oauth_OBJ) -o $@ ${turnutils_oauth_DEPS} ${LDFLAGS}
+
+# turnutils_rfc5769check
+turnutils_rfc5769check_SRC = src/apps/rfc5769/rfc5769check.c
+turnutils_rfc5769check_OBJ := $(turnutils_rfc5769check_SRC:%=$(BUILD_DIR)/%.o)
+turnutils_rfc5769check_DEPS := ${LIB_DIR}/libturnclient.a
+${BIN_DIR}/turnutils_rfc5769check:	${turnutils_rfc5769check_OBJ} ${turnutils_rfc5769check_DEPS}
+	pwd
+	${MKBUILDDIR} ${BIN_DIR}
+	$(CXX) $(turnutils_rfc5769check_OBJ) -o $@ ${turnutils_oauth_DEPS} ${LDFLAGS}
+
+# turnutils_peer
+turnutils_peer_SRC = src/apps/peer/mainudpserver.c src/apps/peer/udpserver.c 
+turnutils_peer_OBJ := $(turnutils_peer_SRC:%=$(BUILD_DIR)/%.o)
+turnutils_peer_DEPS := ${LIB_DIR}/libturnclient.a
+${BIN_DIR}/turnutils_peer:	${turnutils_peer_OBJ} ${turnutils_peer_DEPS}
+	${MKBUILDDIR} ${BIN_DIR}
+	$(CXX) $(turnutils_peer_OBJ) -o $@ ${turnutils_peer_DEPS} ${LDFLAGS}
 
 ### Clean all:
 
 clean:	
-	${RMCMD} bin build lib obj *bak *~ */*~ */*/*~ */*/*/*~ *core */*core */*/*core include tmp sqlite
+	${RMCMD} ${BIN_DIR} build lib obj *bak *~ */*~ */*/*~ */*/*/*~ *core */*core */*/*core include tmp sqlite
 
 distclean:	clean
 	${RMCMD} Makefile
@@ -139,13 +174,13 @@ install:	all ${MAKE_DEPS}
 	${MKDIR} ${DESTDIR}${DOCSDIR}
 	${MKDIR} ${DESTDIR}${SCHEMADIR}
 	${MKDIR} ${DESTDIR}${TURNINCLUDEDIR}
-	${INSTALL_PROGRAM} bin/turnserver ${DESTDIR}${BINDIR}
-	${INSTALL_PROGRAM} bin/turnadmin ${DESTDIR}${BINDIR}
-	${INSTALL_PROGRAM} bin/turnutils_uclient ${DESTDIR}${BINDIR}
-	${INSTALL_PROGRAM} bin/turnutils_peer ${DESTDIR}${BINDIR}
-	${INSTALL_PROGRAM} bin/turnutils_stunclient ${DESTDIR}${BINDIR}
-	${INSTALL_PROGRAM} bin/turnutils_oauth ${DESTDIR}${BINDIR}
-	${INSTALL_PROGRAM} bin/turnutils_natdiscovery ${DESTDIR}${BINDIR}
+	${INSTALL_PROGRAM} ${BIN_DIR}/turnserver ${DESTDIR}${BINDIR}
+	${INSTALL_PROGRAM} ${BIN_DIR}/turnadmin ${DESTDIR}${BINDIR}
+	${INSTALL_PROGRAM} ${BIN_DIR}/turnutils_uclient ${DESTDIR}${BINDIR}
+	${INSTALL_PROGRAM} ${BIN_DIR}/turnutils_peer ${DESTDIR}${BINDIR}
+	${INSTALL_PROGRAM} ${BIN_DIR}/turnutils_stunclient ${DESTDIR}${BINDIR}
+	${INSTALL_PROGRAM} ${BIN_DIR}/turnutils_oauth ${DESTDIR}${BINDIR}
+	${INSTALL_PROGRAM} ${BIN_DIR}/turnutils_natdiscovery ${DESTDIR}${BINDIR}
 	${INSTALL_MAN} man/man1/turnserver.1 ${DESTDIR}${MANPREFIX}/man/man1/
 	${INSTALL_MAN} man/man1/turnadmin.1 ${DESTDIR}${MANPREFIX}/man/man1/
 	${INSTALL_MAN} man/man1/turnutils.1 ${DESTDIR}${MANPREFIX}/man/man1/
@@ -155,7 +190,8 @@ install:	all ${MAKE_DEPS}
 	${INSTALL_MAN} man/man1/turnutils_natdiscovery.1 ${DESTDIR}${MANPREFIX}/man/man1/
 	${INSTALL_MAN} man/man1/turnutils_peer.1 ${DESTDIR}${MANPREFIX}/man/man1/
 	${INSTALL_MAN} man/man1/coturn.1 ${DESTDIR}${MANPREFIX}/man/man1/
-	${INSTALL_STATIC_LIB} lib/libturnclient.a ${DESTDIR}${LIBDIR}
+	${INSTALL_STATIC_LIB} ${LIB_DIR}/libturnclient.a ${DESTDIR}${LIBDIR}
+	${INSTALL_STATIC_LIB} ${LIB_DIR}/libturnserver.a ${DESTDIR}${LIBDIR}
 	${INSTALL_DATA} LICENSE ${DESTDIR}${DOCSDIR}
 	${INSTALL_DATA} README.turnserver ${DESTDIR}${DOCSDIR}
 	${INSTALL_DATA} README.turnadmin ${DESTDIR}${DOCSDIR}
@@ -175,6 +211,7 @@ install:	all ${MAKE_DEPS}
 	${INSTALL_DATA} turndb/schema.stats.redis ${DESTDIR}${SCHEMADIR}
 	if [ -f sqlite/turndb ] ; then ${INSTALL_DATA} sqlite/turndb ${DESTDIR}${TURNDBDIR}/turndb; fi
 	${INSTALL_DATA} examples/etc/turnserver.conf ${DESTDIR}${CONFDIR}/turnserver.conf.default
+	${INSTALL_DATA} examples/etc/log.conf ${DESTDIR}${CONFDIR}/turnserver_log.conf
 	${INSTALL_DIR} examples/etc ${DESTDIR}${EXAMPLESDIR}
 	${INSTALL_DIR} examples/scripts ${DESTDIR}${EXAMPLESDIR}
 	${RMCMD} ${DESTDIR}${EXAMPLESDIR}/scripts/rfc5769.sh
@@ -204,8 +241,10 @@ deinstall:	${MAKE_DEPS}
 	${RMCMD} ${DESTDIR}${MANPREFIX}/man/man1/turnutils_peer.1
 	${RMCMD} ${DESTDIR}${MANPREFIX}/man/man1/coturn.1
 	${RMCMD} ${DESTDIR}${LIBDIR}/libturnclient.a
+	${RMCMD} ${DESTDIR}${LIBDIR}/libturnserver.a 
 	${RMCMD} ${DESTDIR}${EXAMPLESDIR}
 	${RMCMD} ${DESTDIR}${CONFDIR}/turnserver.conf.default
+	${RMCMD} ${DESTDIR}${CONFDIR}/turnserver_log.conf
 	${RMCMD} ${DESTDIR}${TURNINCLUDEDIR}
 
 uninstall:	deinstall

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Optional
 - [Hiredis](https://github.com/redis/hiredis) (user database, monitoring)
 - SQLite (user database)
 - PostgreSQL (user database)
+- [log4cplus](https://github.com/log4cplus/log4cplus) (log library)
 
 ### Building
 ```shell

--- a/configure
+++ b/configure
@@ -61,6 +61,7 @@ test_mysql_config() {
 testpkg_common() {
     testpkg "$@" || return $?
     OSCFLAGS="${OSCFLAGS} ${PKG_CFLAGS}"
+    OSCPPFLAGS += "${PKG_CFLAGS}"
     OSLIBS="${OSLIBS} ${PKG_LIBS}"
 }
 
@@ -838,6 +839,21 @@ else
 fi
 
 ###########################
+# Test log4cplus
+###########################
+
+if [ -z "${HAS_LOG4CPLUS}" ] ; then
+    if testpkg_common log4cplus; then
+        ${ECHO_CMD} "log4cplus library found."
+        OSCFLAGS="${OSCFLAGS} -DHAS_LOG4CPLUS"
+        OSCPPFLAGS="${OSCPPFLAGS} -DHAS_LOG4CPLUS"
+        MAKEFILE_VAR="${MAKEFILE_VAR}\nHAS_LOG4CPLUS=1"
+    else
+        ${ECHO_CMD} "log4cplus library not found. Building without log4cplus support."
+    fi
+fi
+
+###########################
 # Test Prometheus
 ###########################
 
@@ -1039,6 +1055,9 @@ if ! [ -z "${TURN_ACCEPT_RPATH}" ] ; then
 fi
 
 ${ECHO_CMD} PREFIX="${PREFIX}" LOCALSTATEDIR="${LOCALSTATEDIR}" OSLIBS="${OSLIBS}" DBLIBS="${DBLIBS}" OSCFLAGS="${OSCFLAGS}" DBCFLAGS="${DBCFLAGS}" $@
+${ECHO_CMD} "#########################"
+${ECHO_CMD} MAKEFILE_VAR:"${MAKEFILE_VAR}"
+${ECHO_CMD} "#########################"
 
 ###############################
 # Make make:
@@ -1052,7 +1071,7 @@ ${ECHO_CMD} "CC = ${CC}" >> Makefile
 ${ECHO_CMD} "LDFLAGS += ${OSLIBS}" >> Makefile
 ${ECHO_CMD} "DBLIBS += ${DBLIBS}" >> Makefile
 ${ECHO_CMD} "CFLAGS += ${OSCFLAGS}" >> Makefile
-${ECHO_CMD} "CPPFLAGS = ${CPPFLAGS}" >> Makefile
+${ECHO_CMD} "CPPFLAGS += ${OSCPPFLAGS}" >> Makefile
 ${ECHO_CMD} "DBCFLAGS += ${DBCFLAGS} ${TURN_NO_PQ} ${TURN_NO_MYSQL} ${TURN_NO_SQLITE} ${TURN_NO_MONGO} ${TURN_NO_HIREDIS} ${TURN_NO_SYSTEMD}" >> Makefile
 ${ECHO_CMD} "#" >> Makefile
 ${ECHO_CMD} "PORTNAME = ${PORTNAME}" >> Makefile
@@ -1097,6 +1116,8 @@ ${ECHO_CMD} "RMCMD = ${RMCMD}" >> Makefile
 ${ECHO_CMD} "MORECMD = ${MORECMD}" >> Makefile
 ${ECHO_CMD} "LDCONFIG=${LDCONFIG}" >> Makefile
 ${ECHO_CMD} "################################" >> Makefile
+${ECHO_CMD} "#" >> Makefile
+${ECHO_CMD} "${MAKEFILE_VAR}" >> Makefile
 ${ECHO_CMD} "" >> Makefile
 cat Makefile.in >> Makefile
 

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -188,6 +188,7 @@ RUN apt-get update \
             libhiredis0.14 \
             libmongoc-1.0-0 \
             libmicrohttpd12 \
+            liblog4cplus-dev \
  # Install `dig` tool for `detect-external-ip.sh`.
  && apt-get install -y --no-install-recommends --no-install-suggests \
             dnsutils \

--- a/docs/Log.md
+++ b/docs/Log.md
@@ -1,0 +1,352 @@
+# Log
+
+This project includes the following two types of log implementations:
+
+- Use a mature logging library. current use [log4cplus](https://github.com/log4cplus/log4cplus)
+- The project is implemented on its own [Discarded]
+
+See: [Discussions](https://github.com/coturn/coturn/issues/1344)
+
+## Setup log4cplus
+
+- System distribution
+  - Ubuntu
+
+        sudo apt install liblog4cplus-dev 
+
+- Install from source code
+  - Download [source code](https://github.com/log4cplus/log4cplus)
+
+        git clone https://github.com/log4cplus/log4cplus.git
+  
+  - Compile. See: https://github.com/log4cplus/log4cplus
+  
+        cd log4cplus
+        mkdir build
+        cd build
+        cmake ..
+        cmake --build . --traget install
+
+## Usage
+
+### Interface
+
+- TURN_LOG_CATEGORY(category, level, ...)
+- TURN_LOG_FUNC(level, ...) : Discarded, please use TURN_LOG_CATEGORY
+
+### Log4cplus configure file
+
+- Appender
+
+|Appender                    |Description         |
+|:--------------------------:|:------------------:|
+|ConsoleAppender             |Ouput to console    |
+|SysLogAppender              |Appends log events to a file. |
+|NTEventLogAppender          |Appends log events to NT EventLog. Only windows|
+|FileAppender                |Ouput to file       |
+|RollingFileAppender         |Backup the log files when they reach a certain size|
+|DailyRollingFileAppender	 |The log file is rolled over at a user chosen frequency|
+|TimeBasedRollingFileAppender|The log file is rolled over at a user chosen frequency while also keeping in check a total maximum number of produced files. |
+|SocketAppender              |Output to a remote a log server.|
+|Log4jUdpAppender            |Sends log events as Log4j XML to a remote a log server. |
+|AsyncAppender               |                    |
+
+- Layout
+
+| Layout      | Description |
+|:-----------:|:-----------:|
+|SimpleLayout |Simple layout|
+|TTCCLayout   | |
+|PatternLayout|Pattern layout|
+
+  - [PatternLayout](https://log4cplus.github.io/log4cplus/docs/log4cplus-2.1.0/doxygen/classlog4cplus_1_1PatternLayout.html#details)
+
+
+The recognized conversion characters are
+
+<table>
+<tr>
+<td>Conversion Character</td>
+<td>Effect</td>
+</tr>
+<tr>
+<td align=center><b>b</b></td>
+<td>Used to output file name component of path name.
+E.g. <tt>main.cxx</tt> from path <tt>../../main.cxx</tt>.</td>
+</tr>
+<tr>
+<td align=center><b>c</b></td>
+
+<td>Used to output the logger of the logging event. The
+logger conversion specifier can be optionally followed by
+<em>precision specifier</em>, that is a decimal constant in
+brackets.
+If a precision specifier is given, then only the corresponding
+number of right most components of the logger name will be
+printed. By default the logger name is printed in full.
+For example, for the logger name "a.b.c" the pattern
+<b>%c{2}</b> will output "b.c".
+
+</td>
+</tr>
+
+<tr>
+<td align=center><b>d</b></td>
+
+<td>Used to output the date of the logging event in <b>UTC</b>.
+
+The date conversion specifier may be followed by a <em>date format
+specifier</em> enclosed between braces. For example, <b>%%d{%%H:%%M:%%s}</b>
+or <b>%%d{%%d&nbsp;%%b&nbsp;%%Y&nbsp;%%H:%%M:%%s}</b>.  If no date format
+specifier is given then <b>%%d{%%d&nbsp;%%m&nbsp;%%Y&nbsp;%%H:%%M:%%s}</b>
+is assumed.
+
+The Following format options are possible:
+<ul>
+<li>%%a -- Abbreviated weekday name</li>
+<li>%%A -- Full weekday name</li>
+<li>%%b -- Abbreviated month name</li>
+<li>%%B -- Full month name</li>
+<li>%%c -- Standard date and time string</li>
+<li>%%d -- Day of month as a decimal(1-31)</li>
+<li>%%H -- Hour(0-23)</li>
+<li>%%I -- Hour(1-12)</li>
+<li>%%j -- Day of year as a decimal(1-366)</li>
+<li>%%m -- Month as decimal(1-12)</li>
+<li>%%M -- Minute as decimal(0-59)</li>
+<li>%%p -- Locale's equivalent of AM or PM</li>
+<li>%%q -- milliseconds as decimal(0-999) -- <b>Log4CPLUS specific</b>
+<li>%%Q -- fractional milliseconds as decimal(0-999.999) -- <b>Log4CPLUS specific</b>
+<li>%%S -- Second as decimal(0-59)</li>
+<li>%%U -- Week of year, Sunday being first day(0-53)</li>
+<li>%%w -- Weekday as a decimal(0-6, Sunday being 0)</li>
+<li>%%W -- Week of year, Monday being first day(0-53)</li>
+<li>%%x -- Standard date string</li>
+<li>%%X -- Standard time string</li>
+<li>%%y -- Year in decimal without century(0-99)</li>
+<li>%%Y -- Year including century as decimal</li>
+<li>%%Z -- Time zone name</li>
+<li>%% -- The percent sign</li>
+</ul>
+
+Lookup the documentation for the <code>strftime()</code> function
+found in the <code>&lt;ctime&gt;</code> header for more information.
+</td>
+</tr>
+
+<tr>
+<td align=center><b>D</b></td>
+
+<td>Used to output the date of the logging event in <b>local</b> time.
+
+All of the above information applies.
+</td>
+</tr>
+
+<tr>
+<td align=center><b>E</b></td>
+
+<td>Used to output the value of a given environment variable.  The
+name of is supplied as an argument in brackets.  If the variable does
+exist then empty string will be used.
+
+For example, the pattern <b>%E{HOME}</b> will output the contents
+of the HOME environment variable.
+</td>
+</tr>
+
+<tr>
+<td align=center><b>F</b></td>
+
+<td>Used to output the file name where the logging request was
+issued.
+
+<b>NOTE</b> Unlike log4j, there is no performance penalty for
+calling this method.</td>
+</tr>
+
+<tr>
+<td align=center><b>h</b></td>
+
+<td>Used to output the hostname of this system (as returned
+by gethostname(2)).
+
+<b>NOTE</b> The hostname is only retrieved once at
+initialization.
+
+</td>
+</tr>
+
+<tr>
+<td align=center><b>H</b></td>
+
+<td>Used to output the fully-qualified domain name of this
+system (as returned by gethostbyname(2) for the hostname
+returned by gethostname(2)).
+
+<b>NOTE</b> The hostname is only retrieved once at
+initialization.
+
+</td>
+</tr>
+
+<tr>
+<td align=center><b>l</b></td>
+
+<td>Equivalent to using "%F:%L"
+
+<b>NOTE:</b> Unlike log4j, there is no performance penalty for
+calling this method.
+
+</td>
+</tr>
+
+<tr>
+<td align=center><b>L</b></td>
+
+<td>Used to output the line number from where the logging request
+was issued.
+
+<b>NOTE:</b> Unlike log4j, there is no performance penalty for
+calling this method.
+
+</tr>
+
+<tr>
+<td align=center><b>m</b></td>
+<td>Used to output the application supplied message associated with
+the logging event.</td>
+</tr>
+
+<tr>
+<td align=center><b>M</b></td>
+
+<td>Used to output function name using
+<code>__FUNCTION__</code> or similar macro.
+
+<b>NOTE</b> The <code>__FUNCTION__</code> macro is not
+standard but it is common extension provided by all compilers
+(as of 2010). In case it is missing or in case this feature
+is disabled using the
+<code>LOG4CPLUS_DISABLE_FUNCTION_MACRO</code> macro, %M
+expands to an empty string.</td>
+</tr>
+
+<tr>
+<td align=center><b>n</b></td>
+
+<td>Outputs the platform dependent line separator character or
+characters.
+</tr>
+
+<tr>
+<td align=center><b>p</b></td>
+<td>Used to output the LogLevel of the logging event.</td>
+</tr>
+
+<tr>
+<td align=center><b>r</b></td>
+<td>Used to output miliseconds since program start
+of the logging event.</td>
+</tr>
+
+<tr>
+<td align=center><b>t</b></td>
+
+<td>Used to output the thread ID of the thread that generated
+the logging event. (This is either `pthread_t` value returned
+by `pthread_self()` on POSIX platforms or thread ID returned
+by `GetCurrentThreadId()` on Windows.)</td>
+</tr>
+
+<tr>
+<td align=center><b>T</b></td>
+
+<td>Used to output alternative name of the thread that generated the
+logging event.</td>
+</tr>
+
+<tr>
+<td align=center><b>i</b></td>
+
+<td>Used to output the process ID of the process that generated the
+logging event.</td>
+</tr>
+
+<tr>
+<td align=center><b>x</b></td>
+
+<td>Used to output the NDC (nested diagnostic context) associated
+with the thread that generated the logging event.
+</td>
+</tr>
+
+<tr>
+<td align=center><b>X</b></td>
+
+<td>Used to output the MDC (mapped diagnostic context)
+associated with the thread that generated the logging
+event. It takes optional key parameter. Without the key
+paramter (%%X), it outputs the whole MDC map. With the key
+(%%X{key}), it outputs just the key's value.
+</td>
+</tr>
+
+<tr>
+<td align=center><b>"%%"</b></td>
+<td>The sequence "%%" outputs a single percent sign.
+</td>
+</tr>
+
+</table>
+
+### [Example](../examples/etc/log.conf)
+
+- Default. don't use configure file
+  
+```
+INFO - System cpu num is 4
+
+INFO - System enable num is 4
+
+WARN - Cannot find config file: turnserver.conf. Default and command-line settings will be used.
+
+INFO - Coturn Version Coturn-4.6.2 'Gorst'
+
+INFO - Max number of open files/sockets allowed for this process: 1048576
+
+INFO - Due to the open files/sockets limitation, max supported number of TURN Sessions possible is: 524000 (approximately)
+```
+
+- Pattern=%m
+  
+```
+System cpu num is 4
+System enable num is 4
+Cannot find config file: turnserver.conf. Default and command-line settings will be used.
+Coturn Version Coturn-4.6.2 'Gorst'
+Max number of open files/sockets allowed for this process: 1048576
+Due to the open files/sockets limitation, max supported number of TURN Sessions possible is: 524000 (approximately)
+```
+
+- Pattern=[%t] %-5p - %m
+  
+```
+[140497062541824] INFO  - System cpu num is 4
+[140497062541824] INFO  - System enable num is 4
+[140497062541824] WARN  - Cannot find config file: turnserver.conf. Default and command-line settings will be used.
+[140497062541824] INFO  - Coturn Version Coturn-4.6.2 'Gorst'
+[140497062541824] INFO  - Max number of open files/sockets allowed for this process: 1048576
+[140497062541824] INFO  - Due to the open files/sockets limitation, max supported number of TURN Sessions possible is: 524000 (approximately)
+```
+
+- Pattern=%D{%Y-%m-%d %H:%M:%S,%Q} %l [%t] %-5p %c - %m
+  
+```
+2023-12-19 16:47:27,453.057 src/apps/relay/mainrelay.c:2950 [139876171266560] INFO  root - System cpu num is 4
+2023-12-19 16:47:27,453.088 src/apps/relay/mainrelay.c:2951 [139876171266560] INFO  root - System enable num is 4
+2023-12-19 16:47:27,453.141 src/apps/relay/mainrelay.c:2446 [139876171266560] WARN  root - Cannot find config file: turnserver.conf. Default and command-line settings will be used.
+2023-12-19 16:47:27,453.223 src/apps/relay/mainrelay.c:2695 [139876171266560] INFO  root - Coturn Version Coturn-4.6.2 'Gorst'
+2023-12-19 16:47:27,453.228 src/apps/relay/mainrelay.c:2696 [139876171266560] INFO  root - Max number of open files/sockets allowed for this process: 1048576
+2023-12-19 16:47:27,453.232 src/apps/relay/mainrelay.c:2704 [139876171266560] INFO  root - Due to the open files/sockets limitation, max supported number of TURN Sessions possible is: 524000 (approximately)
+```

--- a/examples/etc/log.conf
+++ b/examples/etc/log.conf
@@ -1,0 +1,18 @@
+logpath=log
+
+log4cplus.appender.console=log4cplus::ConsoleAppender
+log4cplus.appender.console.Append=true
+# Layout. See: https://github.com/log4cplus/log4cplus/blob/master/include/log4cplus/layout.h
+log4cplus.appender.console.layout=log4cplus::PatternLayout
+log4cplus.appender.console.layout.ConversionPattern=[%t] %-5p - %m
+#log4cplus.appender.console.layout.ConversionPattern=%D{%Y-%m-%d %H:%M:%S,%Q} %l [%t] %-5p %c - %m
+
+log4cplus.appender.file=log4cplus::DailyRollingFileAppender
+log4cplus.appender.file.File=../log/turnserver.log
+log4cplus.appender.file.Schedule=HOURLY
+log4cplus.appender.file.Append=true
+# Layout. See: https://github.com/log4cplus/log4cplus/blob/master/include/log4cplus/layout.h
+log4cplus.appender.file.layout=log4cplus::PatternLayout
+log4cplus.appender.file.layout.ConversionPattern=%D{%Y-%m-%d %H:%M:%S,%Q} [%t] %-5p %c - %m
+
+log4cplus.rootLogger=ALL, console, file

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -506,6 +506,9 @@
 #
 #dh-file=<DH-PEM-file-name>
 
+# log configure file
+#log-conf-file=/etc/turnserver/log.conf
+
 # Flag to prevent stdout log messages.
 # By default, all log messages go to both stdout and to
 # the configured log file. With this option everything will

--- a/examples/run_tests.sh
+++ b/examples/run_tests.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 echo 'Running turnserver'
-../bin/turnserver --use-auth-secret  --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --no-cli --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > /dev/null &
+../build/bin/turnserver --use-auth-secret  --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --no-cli --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > /dev/null &
 echo 'Running peer client'
-../bin/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > /dev/null &
+../build/bin/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > /dev/null &
 
 sleep 2
 
 echo 'Running turn client TCP'
-../bin/turnutils_uclient -t -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+../build/bin/turnutils_uclient -t -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else
@@ -17,7 +17,7 @@ else
 fi
 
 echo 'Running turn client TLS'
-../bin/turnutils_uclient -t -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+../build/bin/turnutils_uclient -t -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else
@@ -26,7 +26,7 @@ else
 fi
 
 echo 'Running turn client UDP'
-../bin/turnutils_uclient -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+../build/bin/turnutils_uclient -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else
@@ -35,7 +35,7 @@ else
 fi
 
 echo 'Running turn client DTLS'
-../bin/turnutils_uclient -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+../build/bin/turnutils_uclient -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -337,6 +337,10 @@ Do not allow TCP relay endpoints defined in RFC 6062,
 use only UDP relay endpoints as defined in RFC 5766.
 .TP
 .B
+\fB\-\-log-conf-file\fP
+Set the full path name of the log configure file.
+.TP
+.B
 \fB\-\-no\-stdout\-log\fP
 Flag to prevent stdout log messages.
 By default, all log messages are going to both stdout and to

--- a/src/apps/common/CMakeLists.txt
+++ b/src/apps/common/CMakeLists.txt
@@ -50,6 +50,18 @@ else()
     endif()
 endif()
 
+find_package(log4cplus)
+if(log4cplus_FOUND)
+    list(APPEND COMMON_LIBS log4cplus::log4cplus)
+    list(APPEND COMMON_DEFINED HAS_LOG4CPLUS)
+    list(APPEND SOURCE_FILES log4cplus.cpp)
+    install(FILES ${CMAKE_SOURCE_DIR}/examples/etc/log.conf
+        DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}
+            COMPONENT Runtime
+        RENAME turnserver_log.conf
+    )
+endif()
+
 find_package(hiredis)
 if(hiredis_FOUND)
     list(APPEND SOURCE_FILES hiredis_libevent2.c)

--- a/src/apps/common/log4cplus.cpp
+++ b/src/apps/common/log4cplus.cpp
@@ -1,0 +1,69 @@
+#include "ns_turn_utils.h"
+#include <log4cplus/clogger.h>
+#include <log4cplus/helpers/snprintf.h>
+#include <log4cplus/logger.h>
+
+using namespace log4cplus;
+using namespace log4cplus::helpers;
+
+void *turn_log_init() {
+  int ret = -1;
+  void *log = log4cplus_initialize();
+  const char *file = "../etc/turnserver_log.conf";
+  FILE *pf = fopen(file, "a");
+  if (pf) {
+    fclose(pf);
+    ret = log4cplus_file_configure(file);
+  }
+  if (ret)
+    log4cplus_basic_reconfigure(1);
+  return log;
+}
+
+void turn_log_clean(void *log) { log4cplus_deinitialize(log); }
+
+int turn_log_set_conf_file(const char *file) { return log4cplus_file_reconfigure(file); }
+
+LogLevel turn_level_to_loglevel(TURN_LOG_LEVEL level) {
+  switch ((int)level) {
+  case TURN_LOG_LEVEL_DEBUG:
+    return DEBUG_LOG_LEVEL;
+  case TURN_LOG_LEVEL_INFO:
+    return INFO_LOG_LEVEL;
+  case TURN_LOG_LEVEL_WARNING:
+    return WARN_LOG_LEVEL;
+  case TURN_LOG_LEVEL_ERROR:
+    return ERROR_LOG_LEVEL;
+  }
+  return DEBUG_LOG_LEVEL;
+}
+
+void turn_log_func_default(const char *file, int line, const char *f, char *category, TURN_LOG_LEVEL level,
+                           const char *msgfmt, ...) {
+  int retval = -1;
+
+  try {
+    Logger logger = category ? Logger::getInstance(category) : Logger::getRoot();
+    LogLevel ll = turn_level_to_loglevel(level);
+
+    if (logger.isEnabledFor(ll)) {
+      const tchar *msg = nullptr;
+      snprintf_buf buf;
+      std::va_list ap;
+
+      do {
+        va_start(ap, msgfmt);
+        retval = buf.print_va_list(msg, msgfmt, ap);
+        va_end(ap);
+      } while (retval == -1);
+
+      logger.forcedLog(ll, msg, file, line, f);
+    }
+
+  } catch (std::exception const &e) {
+    // Fall through.
+    printf("logger.forcedLog exception: %s", e.what());
+  }
+
+  return;
+}

--- a/src/apps/common/ns_turn_utils.h
+++ b/src/apps/common/ns_turn_utils.h
@@ -31,8 +31,11 @@
 #ifndef __TURN_ULIB__
 #define __TURN_ULIB__
 
+#define TURN_LOG_CATEGORY(category, level, ...)                                                                        \
+  turn_log_func_default(__FILE__, __LINE__, __FUNCTION__, category, level, __VA_ARGS__)
 #if !defined(TURN_LOG_FUNC)
-#define TURN_LOG_FUNC(level, ...) turn_log_func_default(__FILE__, __LINE__, level, __VA_ARGS__)
+// The log interfac is obsolete. use TURN_LOG_CATEGORY
+#define TURN_LOG_FUNC(level, ...) TURN_LOG_CATEGORY(NULL, level, __VA_ARGS__)
 #endif
 
 #if defined(WINDOWS)
@@ -52,7 +55,6 @@ extern "C" {
 typedef enum {
   TURN_LOG_LEVEL_DEBUG = 0,
   TURN_LOG_LEVEL_INFO,
-  TURN_LOG_LEVEL_CONTROL,
   TURN_LOG_LEVEL_WARNING,
   TURN_LOG_LEVEL_ERROR
 } TURN_LOG_LEVEL;
@@ -71,9 +73,13 @@ void set_syslog_facility(char *val);
 
 void set_turn_log_timestamp_format(char *new_format);
 
-void turn_log_func_default(char *file, int line, TURN_LOG_LEVEL level, const char *format, ...)
+/*!
+ * \note User don't use it. please use TURN_LOG_CATEGORY
+ */
+void turn_log_func_default(const char *file, int line, const char *f, char *category, TURN_LOG_LEVEL level,
+                           const char *format, ...)
 #ifdef __GNUC__
-    __attribute__((format(printf, 4, 5)))
+    __attribute__((format(printf, 6, 7)))
 #endif
     ;
 
@@ -83,6 +89,10 @@ void addr_debug_print(int verbose, const ioa_addr *addr, const char *s);
 extern volatile int _log_time_value_set;
 extern volatile turn_time_t _log_time_value;
 extern int use_new_log_timestamp_format;
+
+void *turn_log_init();
+void turn_log_clean(void *log);
+int turn_log_set_conf_file(const char *file);
 
 void rtpprintf(const char *format, ...);
 void reset_rtpprintf(void);
@@ -96,8 +106,10 @@ int is_secure_string(const uint8_t *string, int sanitizesql);
 
 ///////////////////////////////////////////////////////
 
+#ifndef __cplusplus
 #if !defined(min)
 #define min(a, b) ((a) <= (b) ? (a) : (b))
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/src/apps/natdiscovery/natdiscovery.c
+++ b/src/apps/natdiscovery/natdiscovery.c
@@ -632,6 +632,7 @@ int main(int argc, char **argv) {
   int first = 1;
   ioa_addr other_addr, reflexive_addr, tmp_addr, remote_addr, local_addr, local2_addr;
 
+  void *log = turn_log_init();
   if (socket_init())
     return -1;
 
@@ -813,6 +814,8 @@ int main(int argc, char **argv) {
   }
   socket_closesocket(udp_fd);
   socket_closesocket(udp_fd2);
+
+  turn_log_clean(log);
 
   return 0;
 }

--- a/src/apps/oauth/oauth.c
+++ b/src/apps/oauth/oauth.c
@@ -195,6 +195,7 @@ const char Usage[] =
 //////////////////////////////////////////////////
 
 int main(int argc, char **argv) {
+  void *log = turn_log_init();
 
   oauth_key key;
 
@@ -469,5 +470,6 @@ int main(int argc, char **argv) {
     }
   }
 
+  turn_log_clean(log);
   return 0;
 }

--- a/src/apps/peer/mainudpserver.c
+++ b/src/apps/peer/mainudpserver.c
@@ -61,6 +61,8 @@ int main(int argc, char **argv) {
   int c;
   char ifname[1025] = "\0";
 
+  void *log = turn_log_init();
+
   if (socket_init())
     return -1;
 
@@ -101,5 +103,6 @@ int main(int argc, char **argv) {
   run_udp_server(server);
   clean_udp_server(server);
 
+  turn_log_clean(log);
   return 0;
 }

--- a/src/apps/relay/CMakeLists.txt
+++ b/src/apps/relay/CMakeLists.txt
@@ -165,3 +165,9 @@ else()
             COMPONENT Runtime
 		)
 endif()
+
+install(FILES ${CMAKE_SOURCE_DIR}/examples/etc/turnserver.conf
+    DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}
+        COMPONENT Runtime
+    RENAME turnserver.conf.default
+    )

--- a/src/apps/rfc5769/rfc5769check.c
+++ b/src/apps/rfc5769/rfc5769check.c
@@ -197,6 +197,8 @@ static SHATYPE shatype = SHATYPE_SHA1;
 int main(int argc, const char **argv) {
   int res = -1;
 
+  void *log = turn_log_init();
+
   UNUSED_ARG(argc);
   UNUSED_ARG(argv);
 
@@ -560,6 +562,8 @@ int main(int argc, const char **argv) {
     if (check_oauth() < 0)
       exit(-1);
   }
+
+  turn_log_clean(log);
 
   return 0;
 }

--- a/src/apps/stunclient/stunclient.c
+++ b/src/apps/stunclient/stunclient.c
@@ -417,6 +417,8 @@ int main(int argc, char **argv) {
   int c = 0;
   int forceRfc5780 = 0;
 
+  void *log = turn_log_init();
+
   if (socket_init())
     return -1;
 
@@ -468,5 +470,6 @@ int main(int argc, char **argv) {
 
   socket_closesocket(udp_fd);
 
+  turn_log_clean(log);
   return 0;
 }

--- a/src/apps/uclient/mainuclient.c
+++ b/src/apps/uclient/mainuclient.c
@@ -170,6 +170,8 @@ int main(int argc, char **argv) {
   char rest_api_separator = ':';
   int use_null_cipher = 0;
 
+  void *log = turn_log_init();
+
 #if defined(WINDOWS)
 
   WORD wVersionRequested;
@@ -579,5 +581,6 @@ int main(int argc, char **argv) {
 
   start_mclient(argv[optind], port, client_ifname, local_addr, messagenumber, mclient);
 
+  turn_log_clean(log);
   return 0;
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,10 +11,10 @@
       "features": [ "openssl", "thread" ]
     },
     "openssl",
+    "log4cplus",
     "sqlite3",
     "libpq",
     "hiredis",
     "mongo-c-driver"
   ]
-
 }


### PR DESCRIPTION
log4cplus:
- Pros: 
  - Mature and stable logging system
  - It can be configured to be compatible with previous log output formats
  - Can output to syslog, log4 server etc.
- Cons: Not a pure C library

If you want to stick with C, After this PR(https://github.com/log4cplus/log4cplus/pull/607) is accepted by log4cplus, the .cpp will no longer appear in the source code.