### PR TITLE
Only set MHD_USE_DUAL_STACK if IPv6 is available

### DIFF
--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -65,6 +65,8 @@ void prom_set_finished_traffic(const char *realm, const char *user, unsigned lon
 void prom_inc_allocation(SOCKET_TYPE type);
 void prom_dec_allocation(SOCKET_TYPE type);
 
+int is_ipv6_enabled(void);
+
 void prom_inc_stun_binding_request(void);
 void prom_inc_stun_binding_response(void);
 void prom_inc_stun_binding_error(void);


### PR DESCRIPTION
If IPv6 is not enabled during runtime, prometheus server fails to start with `EAFNOSUPPORT` because `MHD_USE_DUAL_STACK` is set unconditionally.

This PR fixes it. As a bonus, it also checks if libmicrohttpd is compiled with IPv6 support.