### PR TITLE
Remove unimplemented test folder reference from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,11 +100,6 @@ ADD_CUSTOM_TARGET(uninstall
 
 add_subdirectory(src)
 
-OPTION(BUILD_TEST "Build test" OFF)
-if(BUILD_TEST)
-    add_subdirectory(test)
-endif(BUILD_TEST)
-
 CONFIGURE_FILE(
     "${CMAKE_SOURCE_DIR}/cmake/coturnConfig.cmake.in"
     "${CMAKE_BINARY_DIR}/coturnConfig.cmake"


### PR DESCRIPTION
BUILD_TEST is not implemented in CMakeLists.txt
Removing to prefent confusion
Fixes #1367