### PR TITLE
Simplify macOS detection macros

### DIFF
--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -38,7 +38,7 @@
 
 #include <pthread.h>
 
-#if defined(__unix__) || defined(unix) || defined(__APPLE__) || defined(__DARWIN__) || defined(__MACH__)
+#if defined(__unix__) || defined(unix) || defined(__APPLE__)
 #include <syslog.h>
 #endif
 

--- a/src/apps/relay/dbdrivers/dbd_sqlite.c
+++ b/src/apps/relay/dbdrivers/dbd_sqlite.c
@@ -36,7 +36,7 @@
 
 #include <sqlite3.h>
 
-#if defined(__unix__) || defined(unix) || defined(__APPLE__) || defined(__DARWIN__) || defined(__MACH__)
+#if defined(__unix__) || defined(unix) || defined(__APPLE__)
 #include <pwd.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -149,7 +149,7 @@ static void fix_user_directory(char *dir0) {
   char *dir = dir0;
   while (*dir == ' ')
     ++dir;
-#if defined(__unix__) || defined(unix) || defined(__APPLE__) || defined(__DARWIN__) || defined(__MACH__)
+#if defined(__unix__) || defined(unix) || defined(__APPLE__)
   if (*dir == '~') {
     char *home = getenv("HOME");
     if (!home) {

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -49,7 +49,7 @@
 
 #include <getopt.h>
 
-#if defined(__unix__) || defined(unix) || defined(__APPLE__) || defined(__DARWIN__) || defined(__MACH__)
+#if defined(__unix__) || defined(unix) || defined(__APPLE__)
 #include <ifaddrs.h>
 #include <libgen.h>
 #include <sys/resource.h>

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -42,7 +42,7 @@
 #include <sys/param.h>
 #endif
 
-#if defined(__APPLE__) || defined(__DARWIN__) || defined(__MACH__)
+#if defined(__APPLE__)
 #define __APPLE_USE_RFC_3542
 #endif
 


### PR DESCRIPTION
As mentioned in multiple source, `__APPLE__` is enough to detect macOS (or iOS but since we do not target it then we ignore it). 

https://github.com/cpredef/predef/blob/master/OperatingSystems.md#macos

Tested by building on macOS - no difference observed