### PR TITLE
Update lukka/run-vcpkg@11

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,6 +1,6 @@
 name: msvc
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   compile:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -39,7 +39,7 @@ jobs:
       SOURCE_DIR:  ${{github.workspace}}\.cache\source
       TOOLS_DIR:   ${{github.workspace}}\.cache\tools
       INSTALL_DIR: ${{github.workspace}}\.cache\install_msvc_${{matrix.triplet}}_${{matrix.BUILD_TYPE}}
-      VCPKGGITCOMMITID: acc3bcf76b84ae5041c86ab55fe138ae7b8255c7
+      VCPKGGITCOMMITID: 4c1df40a3c5c5e18de299a99e9accb03c2a82e1e
       VCPKG_PLATFORM_TOOLSET: ${{matrix.VCPKG_PLATFORM_TOOLSET}}
       CMAKE_GENERATOR_PLATFORM: ${{matrix.CMAKE_GENERATOR_PLATFORM}}
 
@@ -58,24 +58,13 @@ jobs:
         cmake -E make_directory ${{env.TOOLS_DIR}}
         cmake -E make_directory ${{env.INSTALL_DIR}}
 
-    - name: Cache installed
-      uses: actions/cache@v3
-      id: cache-installed
-      with:
-        path: |
-          ${{env.INSTALL_DIR}}
-        key: coturn-cache-installed-${{matrix.os}}-vc${{matrix.VCPKG_PLATFORM_TOOLSET}}-${{matrix.triplet}}-${{matrix.BUILD_TYPE}}
-
     - name: run-vcpkg
-      uses: lukka/run-vcpkg@v10
+      uses: lukka/run-vcpkg@v11
       with:
         # If not using a submodule for vcpkg sources, this specifies which commit
         # id must be checkout from a Git repo. It must not set if using a submodule
         # for vcpkg.
         vcpkgGitCommitId: '${{ env.VCPKGGITCOMMITID }}'
-        # Since the cache must be invalidated when content of the vcpkg.json file changes, let's
-        # compute its hash and append this to the computed cache's key.
-        appendedCacheKey: coturn-msvc-${{matrix.os}}-vc${{matrix.VCPKG_PLATFORM_TOOLSET}}-${{matrix.triplet}}-${{matrix.BUILD_TYPE}}-${{env.VCPKGGITCOMMITID}}
 
     - name: build coturn
       run: |

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,6 +1,6 @@
 name: msvc
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   compile:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -39,7 +39,7 @@ jobs:
       SOURCE_DIR:  ${{github.workspace}}\.cache\source
       TOOLS_DIR:   ${{github.workspace}}\.cache\tools
       INSTALL_DIR: ${{github.workspace}}\.cache\install_msvc_${{matrix.triplet}}_${{matrix.BUILD_TYPE}}
-      VCPKGGITCOMMITID: 4c1df40a3c5c5e18de299a99e9accb03c2a82e1e
+      VCPKGGITCOMMITID: 53bef8994c541b6561884a8395ea35715ece75db
       VCPKG_PLATFORM_TOOLSET: ${{matrix.VCPKG_PLATFORM_TOOLSET}}
       CMAKE_GENERATOR_PLATFORM: ${{matrix.CMAKE_GENERATOR_PLATFORM}}
 


### PR DESCRIPTION
- update lukka/run-vcpkg@11
- vcpkg 2023-11-16 Release (new version was required anyway but taking somewhat newer but not latest)
- lukka/run-vcpkg@11 documentation states cache is not needed so deleted anything related to caching

Test plan: edited yaml file to run msvc job on PR and confirmed that it passes successfully