### PR TITLE
Address clang-tidy warnings in db files

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_mongo.c
+++ b/src/apps/relay/dbdrivers/dbd_mongo.c
@@ -225,11 +225,8 @@ static int mongo_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
           char kval[sizeof(hmackey_t) + sizeof(hmackey_t) + 1];
           memcpy(kval, value, sz);
           kval[sz] = 0;
-          if (convert_string_key_to_binary(kval, key, sz / 2) < 0) {
-            TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key: %s, user %s\n", kval, usname);
-          } else {
-            ret = 0;
-          }
+          convert_string_key_to_binary(kval, key, sz / 2);
+          ret = 0;
         }
       }
     }

--- a/src/apps/relay/dbdrivers/dbd_mysql.c
+++ b/src/apps/relay/dbdrivers/dbd_mysql.c
@@ -403,11 +403,8 @@ static int mysql_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
               char kval[sizeof(hmackey_t) + sizeof(hmackey_t) + 1];
               memcpy(kval, row[0], sz);
               kval[sz] = 0;
-              if (convert_string_key_to_binary(kval, key, sz / 2) < 0) {
-                TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key: %s, user %s\n", kval, usname);
-              } else {
-                ret = 0;
-              }
+              convert_string_key_to_binary(kval, key, sz / 2);
+              ret = 0;
             }
           }
         }

--- a/src/apps/relay/dbdrivers/dbd_pgsql.c
+++ b/src/apps/relay/dbdrivers/dbd_pgsql.c
@@ -145,9 +145,8 @@ static int pgsql_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
         size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
         if (((size_t)len < sz * 2) || (strlen(kval) < sz * 2)) {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format: %s, user %s\n", kval, usname);
-        } else if (convert_string_key_to_binary(kval, key, sz) < 0) {
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key: %s, user %s\n", kval, usname);
         } else {
+          convert_string_key_to_binary(kval, key, sz);
           ret = 0;
         }
       } else {

--- a/src/apps/relay/dbdrivers/dbd_redis.c
+++ b/src/apps/relay/dbdrivers/dbd_redis.c
@@ -472,9 +472,8 @@ static int redis_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
         size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
         if (strlen(rget->str) < sz * 2) {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format: %s, user %s\n", rget->str, usname);
-        } else if (convert_string_key_to_binary(rget->str, key, sz) < 0) {
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key: %s, user %s\n", rget->str, usname);
         } else {
+          convert_string_key_to_binary(rget->str, key, sz);
           ret = 0;
         }
       }

--- a/src/apps/relay/dbdrivers/dbd_sqlite.c
+++ b/src/apps/relay/dbdrivers/dbd_sqlite.c
@@ -121,7 +121,6 @@ static void sqlite_unlock(int write) {
 //////////////////////////////////////////////////
 
 static void sqlite_init_multithreaded(void) {
-
 #if defined(SQLITE_CONFIG_MULTITHREAD)
   if (sqlite3_threadsafe() > 0) {
     int retCode = sqlite3_config(SQLITE_CONFIG_MULTITHREAD);
@@ -136,11 +135,8 @@ static void sqlite_init_multithreaded(void) {
     sqlite3_initialize();
   } else {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Your SQLite database is not compiled to be threadsafe.\n");
-    return;
   }
 #endif
-
-  return;
 }
 
 static int donot_print_connection_success = 0;
@@ -195,15 +191,12 @@ static void init_sqlite_database(sqlite3 *sqliteconnection) {
       "CREATE TABLE admin_user (name varchar(32), realm varchar(127), password varchar(127), primary key (name))",
       NULL};
 
-  int i = 0;
-  while (statements[i]) {
+  for (int i = 0; statements[i] != NULL; ++i) {
     sqlite3_stmt *statement = NULL;
-    int rc = 0;
-    if ((rc = sqlite3_prepare(sqliteconnection, statements[i], -1, &statement, 0)) == SQLITE_OK) {
+    if (sqlite3_prepare(sqliteconnection, statements[i], -1, &statement, 0) == SQLITE_OK) {
       sqlite3_step(statement);
     }
     sqlite3_finalize(statement);
-    ++i;
   }
 }
 
@@ -213,35 +206,37 @@ static sqlite3 *get_sqlite_connection(void) {
   persistent_users_db_t *pud = get_persistent_users_db();
 
   sqlite3 *sqliteconnection = (sqlite3 *)pthread_getspecific(connection_key);
-  if (!sqliteconnection) {
+  if (sqliteconnection != NULL) {
+    return sqliteconnection;
+  }
 
-    fix_user_directory(pud->userdb);
-    (void)pthread_once(&sqlite_init_once, sqlite_init_multithreaded);
-    int rc = sqlite3_open(pud->userdb, &sqliteconnection);
-    if (!sqliteconnection || (rc != SQLITE_OK)) {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(
-          TURN_LOG_LEVEL_ERROR,
-          "Cannot open SQLite DB connection: <%s>, runtime error:\n  %s\n  (If your intention is to use an SQLite "
-          "database for the TURN server, then\n  check and fix, if necessary, the effective permissions of the TURN "
-          "server\n  process and of the DB directory and then re-start the TURN server)\n",
-          pud->userdb_sanitized, errmsg);
-      if (sqliteconnection) {
-        sqlite3_close(sqliteconnection);
-        sqliteconnection = NULL;
-      }
-      turn_params.default_users_db.userdb_type = TURN_USERDB_TYPE_UNKNOWN;
-    } else {
-      init_sqlite_database(sqliteconnection);
-      if (!donot_print_connection_success) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "SQLite DB connection success: %s\n", pud->userdb_sanitized);
-        donot_print_connection_success = 1;
-      }
+  fix_user_directory(pud->userdb);
+  (void)pthread_once(&sqlite_init_once, sqlite_init_multithreaded);
+  int const rc = sqlite3_open(pud->userdb, &sqliteconnection);
+  if ((sqliteconnection == NULL) || (rc != SQLITE_OK)) {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(
+        TURN_LOG_LEVEL_ERROR,
+        "Cannot open SQLite DB connection: <%s>, runtime error:\n  %s\n  (If your intention is to use an SQLite "
+        "database for the TURN server, then\n  check and fix, if necessary, the effective permissions of the TURN "
+        "server\n  process and of the DB directory and then re-start the TURN server)\n",
+        pud->userdb_sanitized, errmsg);
+    if (sqliteconnection != NULL) {
+      sqlite3_close(sqliteconnection);
+      sqliteconnection = NULL;
     }
-    if (sqliteconnection) {
-      (void)pthread_setspecific(connection_key, sqliteconnection);
+    turn_params.default_users_db.userdb_type = TURN_USERDB_TYPE_UNKNOWN;
+  } else {
+    init_sqlite_database(sqliteconnection);
+    if (!donot_print_connection_success) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "SQLite DB connection success: %s\n", pud->userdb_sanitized);
+      donot_print_connection_success = 1;
     }
   }
+  if (sqliteconnection) {
+    (void)pthread_setspecific(connection_key, sqliteconnection);
+  }
+
   return sqliteconnection;
 }
 
@@ -249,32 +244,27 @@ static sqlite3 *get_sqlite_connection(void) {
 
 static int sqlite_get_auth_secrets(secrets_list_t *sl, uint8_t *realm) {
   int ret = -1;
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    char statement[TURN_LONG_STRING_SIZE];
-    sqlite3_stmt *st = NULL;
-    int rc = 0;
-    snprintf(statement, sizeof(statement) - 1, "select value from turn_secret where realm='%s'", realm);
 
-    sqlite_lock(0);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
+  }
 
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement) - 1, "select value from turn_secret where realm='%s'", realm);
 
-      int ctotal = sqlite3_column_count(st);
-      ret = 0;
+  sqlite_lock(0);
 
-      while (ctotal > 0) {
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
 
-        int res = sqlite3_step(st);
-        if (res == SQLITE_ROW) {
+    ret = 0;
+    if (sqlite3_column_count(st) > 0) {
 
-          int type = sqlite3_column_type(st, 0);
-          if (type != SQLITE_NULL) {
-            add_to_secrets_list(sl, (const char *)sqlite3_column_text(st, 0));
-          }
+      for (int stepResult = sqlite3_step(st); stepResult != SQLITE_DONE; stepResult = sqlite3_step(st)) {
 
-        } else if (res == SQLITE_DONE) {
-          break;
+        if ((stepResult == SQLITE_ROW) && (sqlite3_column_type(st, 0) != SQLITE_NULL)) {
+          add_to_secrets_list(sl, (const char *)sqlite3_column_text(st, 0));
         } else {
           const char *errmsg = sqlite3_errmsg(sqliteconnection);
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
@@ -282,688 +272,717 @@ static int sqlite_get_auth_secrets(secrets_list_t *sl, uint8_t *realm) {
           break;
         }
       }
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
     }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(0);
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
   }
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
+
   return ret;
 }
 
 static int sqlite_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
   int ret = -1;
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    char statement[TURN_LONG_STRING_SIZE];
-    sqlite3_stmt *st = NULL;
-    int rc = 0;
-    /* direct user input eliminated - there is no SQL injection problem (since version 4.4.5.3) */
-    snprintf(statement, sizeof(statement), "select hmackey from turnusers_lt where name='%s' and realm='%s'", usname,
-             realm);
 
-    sqlite_lock(0);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      int res = sqlite3_step(st);
-      if (res == SQLITE_ROW) {
-        char *kval = strdup((const char *)sqlite3_column_text(st, 0));
-        size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
-        if (convert_string_key_to_binary(kval, key, sz) < 0) {
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key: %s, user %s\n", kval, usname);
-        } else {
-          ret = 0;
-        }
-        free(kval);
-      }
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-
-    sqlite3_finalize(st);
-
-    sqlite_unlock(0);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  /* direct user input eliminated - there is no SQL injection problem (since version 4.4.5.3) */
+  snprintf(statement, sizeof(statement), "select hmackey from turnusers_lt where name='%s' and realm='%s'", usname,
+           realm);
+
+  sqlite_lock(0);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+
+    // TODO: Error if more than one result.
+    if (sqlite3_step(st) == SQLITE_ROW) {
+      char const *const kval = (const char *)sqlite3_column_text(st, 0);
+      size_t const sz = get_hmackey_size(SHATYPE_DEFAULT);
+      convert_string_key_to_binary(kval, key, sz);
+      ret = 0;
+    }
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
+
   return ret;
 }
 
 static int sqlite_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key) {
-
   int ret = -1;
+
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
+  }
 
   char statement[TURN_LONG_STRING_SIZE];
   sqlite3_stmt *st = NULL;
-  int rc = 0;
 
   /* direct user input eliminated - there is no SQL injection problem (since version 4.4.5.3) */
   snprintf(statement, sizeof(statement),
            "select ikm_key,timestamp,lifetime,as_rs_alg,realm from oauth_key where kid='%s'", (const char *)kid);
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
+  sqlite_lock(0);
 
-    sqlite_lock(0);
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
 
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-
-      int res = sqlite3_step(st);
-      if (res == SQLITE_ROW) {
-
-        STRCPY(key->ikm_key, sqlite3_column_text(st, 0));
-        key->timestamp = (uint64_t)strtoll((const char *)sqlite3_column_text(st, 1), NULL, 10);
-        key->lifetime = (uint32_t)strtol((const char *)sqlite3_column_text(st, 2), NULL, 10);
-        STRCPY(key->as_rs_alg, sqlite3_column_text(st, 3));
-        STRCPY(key->realm, sqlite3_column_text(st, 4));
-        STRCPY(key->kid, kid);
-        ret = 0;
-      }
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+    // TODO: Error if more than one result.
+    if (sqlite3_step(st) == SQLITE_ROW) {
+      STRCPY(key->ikm_key, sqlite3_column_text(st, 0));
+      key->timestamp = (uint64_t)strtoll((const char *)sqlite3_column_text(st, 1), NULL, 10);
+      key->lifetime = (uint32_t)strtol((const char *)sqlite3_column_text(st, 2), NULL, 10);
+      STRCPY(key->as_rs_alg, sqlite3_column_text(st, 3));
+      STRCPY(key->realm, sqlite3_column_text(st, 4));
+      STRCPY(key->kid, kid);
+      ret = 0;
     }
-
-    sqlite3_finalize(st);
-
-    sqlite_unlock(0);
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
   }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
 
   return ret;
 }
 
 static int sqlite_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, secrets_list_t *tss, secrets_list_t *lts,
                                   secrets_list_t *realms) {
+  int ret = -1;
+
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
+  }
 
   oauth_key_data_raw key_;
   oauth_key_data_raw *key = &key_;
 
   donot_print_connection_success = 1;
 
-  int ret = -1;
-
   char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
   snprintf(statement, sizeof(statement),
            "select ikm_key,timestamp,lifetime,as_rs_alg,realm,kid from oauth_key order by kid");
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
+  sqlite_lock(0);
 
-    sqlite_lock(0);
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
 
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
+    ret = 0;
+    for (int stepResult = sqlite3_step(st); stepResult != SQLITE_DONE; stepResult = sqlite3_step(st)) {
 
-      ret = 0;
-      while (1) {
-        int res = sqlite3_step(st);
-        if (res == SQLITE_ROW) {
+      if (stepResult == SQLITE_ROW) {
 
-          STRCPY(key->ikm_key, sqlite3_column_text(st, 0));
-          key->timestamp = (uint64_t)strtoll((const char *)sqlite3_column_text(st, 1), NULL, 10);
-          key->lifetime = (uint32_t)strtol((const char *)sqlite3_column_text(st, 2), NULL, 10);
-          STRCPY(key->as_rs_alg, sqlite3_column_text(st, 3));
-          STRCPY(key->realm, sqlite3_column_text(st, 4));
-          STRCPY(key->kid, sqlite3_column_text(st, 5));
+        STRCPY(key->ikm_key, sqlite3_column_text(st, 0));
+        key->timestamp = (uint64_t)strtoll((const char *)sqlite3_column_text(st, 1), NULL, 10);
+        key->lifetime = (uint32_t)strtol((const char *)sqlite3_column_text(st, 2), NULL, 10);
+        STRCPY(key->as_rs_alg, sqlite3_column_text(st, 3));
+        STRCPY(key->realm, sqlite3_column_text(st, 4));
+        STRCPY(key->kid, sqlite3_column_text(st, 5));
 
-          if (kids) {
-            add_to_secrets_list(kids, key->kid);
-            add_to_secrets_list(teas, key->as_rs_alg);
-            add_to_secrets_list(realms, key->realm);
-            {
-              char ts[256];
-              snprintf(ts, sizeof(ts) - 1, "%llu", (unsigned long long)key->timestamp);
-              add_to_secrets_list(tss, ts);
-            }
-            {
-              char lt[256];
-              snprintf(lt, sizeof(lt) - 1, "%lu", (unsigned long)key->lifetime);
-              add_to_secrets_list(lts, lt);
-            }
-          } else {
-            printf("  kid=%s, ikm_key=%s, timestamp=%llu, lifetime=%lu, as_rs_alg=%s\n", key->kid, key->ikm_key,
-                   (unsigned long long)key->timestamp, (unsigned long)key->lifetime, key->as_rs_alg);
+        if (kids) {
+          add_to_secrets_list(kids, key->kid);
+          add_to_secrets_list(teas, key->as_rs_alg);
+          add_to_secrets_list(realms, key->realm);
+          {
+            char ts[256];
+            snprintf(ts, sizeof(ts) - 1, "%llu", (unsigned long long)key->timestamp);
+            add_to_secrets_list(tss, ts);
           }
-
-        } else if (res == SQLITE_DONE) {
-          break;
+          {
+            char lt[256];
+            snprintf(lt, sizeof(lt) - 1, "%lu", (unsigned long)key->lifetime);
+            add_to_secrets_list(lts, lt);
+          }
         } else {
-          const char *errmsg = sqlite3_errmsg(sqliteconnection);
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-          ret = -1;
-          break;
+          printf("  kid=%s, ikm_key=%s, timestamp=%llu, lifetime=%lu, as_rs_alg=%s\n", key->kid, key->ikm_key,
+                 (unsigned long long)key->timestamp, (unsigned long)key->lifetime, key->as_rs_alg);
         }
+
+      } else {
+        const char *errmsg = sqlite3_errmsg(sqliteconnection);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+        ret = -1;
+        break;
       }
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
     }
-
-    sqlite3_finalize(st);
-
-    sqlite_unlock(0);
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
   }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
 
   return ret;
 }
 
 static int sqlite_set_user_key(uint8_t *usname, uint8_t *realm, const char *key) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
 
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-
-    sqlite_lock(1);
-
-    snprintf(statement, sizeof(statement),
-             "insert or replace into turnusers_lt (realm,name,hmackey) values('%s','%s','%s')", realm, usname, key);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement),
+           "insert or replace into turnusers_lt (realm,name,hmackey) values('%s','%s','%s')", realm, usname, key);
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check the result...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_set_oauth_key(oauth_key_data_raw *key) {
-
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
 
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    snprintf(statement, sizeof(statement),
-             "insert or replace into oauth_key (kid,ikm_key,timestamp,lifetime,as_rs_alg,realm) "
-             "values('%s','%s',%llu,%lu,'%s','%s')",
-             key->kid, key->ikm_key, (unsigned long long)key->timestamp, (unsigned long)key->lifetime, key->as_rs_alg,
-             key->realm);
-
-    sqlite_lock(1);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error updating SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement),
+           "insert or replace into oauth_key (kid,ikm_key,timestamp,lifetime,as_rs_alg,realm) "
+           "values('%s','%s',%llu,%lu,'%s','%s')",
+           key->kid, key->ikm_key, (unsigned long long)key->timestamp, (unsigned long)key->lifetime, key->as_rs_alg,
+           key->realm);
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check the result...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error updating SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_del_user(uint8_t *usname, uint8_t *realm) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
 
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    snprintf(statement, sizeof(statement), "delete from turnusers_lt where name='%s' and realm='%s'", usname, realm);
-
-    sqlite_lock(1);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement), "delete from turnusers_lt where name='%s' and realm='%s'", usname, realm);
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check the result...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_del_oauth_key(const uint8_t *kid) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
 
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-
-    snprintf(statement, sizeof(statement), "delete from oauth_key where kid = '%s'", (const char *)kid);
-
-    sqlite_lock(1);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement), "delete from oauth_key where kid = '%s'", (const char *)kid);
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check the result...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_t *realms) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
-
-  uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
-    realm = realm0;
-  }
 
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    if (realm[0]) {
-      snprintf(statement, sizeof(statement), "select name,realm from turnusers_lt where realm='%s' order by name",
-               realm);
-    } else {
-      snprintf(statement, sizeof(statement), "select name,realm from turnusers_lt order by realm,name");
-    }
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
+  }
 
-    sqlite_lock(0);
+  char statement[TURN_LONG_STRING_SIZE];
+  if ((realm != NULL) && (realm[0] != '\0')) {
+    snprintf(statement, sizeof(statement), "select name,realm from turnusers_lt where realm='%s' order by name", realm);
+  } else {
+    snprintf(statement, sizeof(statement), "select name,realm from turnusers_lt order by realm,name");
+  }
 
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
+  sqlite_lock(0);
 
-      ret = 0;
-      while (1) {
-        int res = sqlite3_step(st);
-        if (res == SQLITE_ROW) {
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
 
-          const char *kval = (const char *)sqlite3_column_text(st, 0);
-          const char *rval = (const char *)sqlite3_column_text(st, 1);
+    // TODO: Validate column count...
+    ret = 0;
+    for (int stepResult = sqlite3_step(st); stepResult != SQLITE_DONE; stepResult = sqlite3_step(st)) {
 
-          if (users) {
-            add_to_secrets_list(users, kval);
-            if (realms) {
-              if (rval && *rval) {
-                add_to_secrets_list(realms, rval);
-              } else {
-                add_to_secrets_list(realms, (char *)realm);
-              }
+      if (stepResult == SQLITE_ROW) {
+
+        const char *kval = (const char *)sqlite3_column_text(st, 0);
+        const char *rval = (const char *)sqlite3_column_text(st, 1);
+
+        if (users) {
+          add_to_secrets_list(users, kval);
+
+          if (realms) {
+            if (rval && *rval) {
+              add_to_secrets_list(realms, rval);
+            } else {
+              add_to_secrets_list(realms, (char *)realm);
             }
-          } else {
-            printf("%s[%s]\n", kval, rval);
           }
 
-        } else if (res == SQLITE_DONE) {
-          break;
         } else {
-          const char *errmsg = sqlite3_errmsg(sqliteconnection);
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-          ret = -1;
-          break;
+          printf("%s[%s]\n", kval, rval);
         }
-      }
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
 
-    sqlite_unlock(0);
+      } else {
+        const char *errmsg = sqlite3_errmsg(sqliteconnection);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+        ret = -1;
+        break;
+      }
+    }
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
   }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
+
   return ret;
 }
 
 static int sqlite_list_secrets(uint8_t *realm, secrets_list_t *secrets, secrets_list_t *realms) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
 
-  uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
-    realm = realm0;
+  donot_print_connection_success = 1;
+
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
 
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
-
-  if (realm[0]) {
+  char statement[TURN_LONG_STRING_SIZE];
+  if ((realm != NULL) && (realm[0] != '\0')) {
     snprintf(statement, sizeof(statement), "select value,realm from turn_secret where realm='%s' order by value",
              realm);
   } else {
     snprintf(statement, sizeof(statement), "select value,realm from turn_secret order by realm,value");
   }
 
-  donot_print_connection_success = 1;
+  sqlite_lock(0);
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
 
-    sqlite_lock(0);
+    // TODO: Validate column count...
+    ret = 0;
+    for (int stepResult = sqlite3_step(st); stepResult != SQLITE_DONE; stepResult = sqlite3_step(st)) {
 
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
+      if (stepResult == SQLITE_ROW) {
 
-      int res = 0;
-      while (1) {
-        res = sqlite3_step(st);
-        if (res == SQLITE_ROW) {
-          ret = 0;
-          const char *kval = (const char *)sqlite3_column_text(st, 0);
-          if (kval) {
-            const char *rval = (const char *)sqlite3_column_text(st, 1);
-            if (secrets) {
-              add_to_secrets_list(secrets, kval);
-              if (realms) {
-                if (rval && *rval) {
-                  add_to_secrets_list(realms, rval);
-                } else {
-                  add_to_secrets_list(realms, (char *)realm);
-                }
-              }
+        const char *kval = (const char *)sqlite3_column_text(st, 0);
+        const char *rval = (const char *)sqlite3_column_text(st, 1);
+
+        if (secrets) {
+          add_to_secrets_list(secrets, kval);
+
+          if (realms) {
+            if (rval && *rval) {
+              add_to_secrets_list(realms, rval);
             } else {
-              printf("%s[%s]\n", kval, rval);
+              add_to_secrets_list(realms, (char *)realm);
             }
           }
-        } else if (res == SQLITE_DONE) {
-          break;
+
         } else {
-          const char *errmsg = sqlite3_errmsg(sqliteconnection);
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-          ret = -1;
-          break;
+          printf("%s[%s]\n", kval, rval);
         }
+      } else {
+        const char *errmsg = sqlite3_errmsg(sqliteconnection);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+        ret = -1;
+        break;
       }
     }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(0);
   }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
+
   return ret;
 }
 
 static int sqlite_del_secret(uint8_t *secret, uint8_t *realm) {
   int ret = -1;
+
   donot_print_connection_success = 1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    if (!secret || (secret[0] == 0)) {
-      snprintf(statement, sizeof(statement), "delete from turn_secret where realm='%s'", realm);
-    } else {
-      snprintf(statement, sizeof(statement), "delete from turn_secret where value='%s' and realm='%s'", secret, realm);
-    }
-
-    sqlite_lock(1);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+
+  if (!secret || (secret[0] == 0)) {
+    snprintf(statement, sizeof(statement), "delete from turn_secret where realm='%s'", realm);
+  } else {
+    snprintf(statement, sizeof(statement), "delete from turn_secret where value='%s' and realm='%s'", secret, realm);
+  }
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check results...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_set_secret(uint8_t *secret, uint8_t *realm) {
   int ret = -1;
+
   donot_print_connection_success = 1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-
-    snprintf(statement, sizeof(statement), "insert or replace into turn_secret (realm,value) values('%s','%s')", realm,
-             secret);
-
-    sqlite_lock(1);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement), "insert or replace into turn_secret (realm,value) values('%s','%s')", realm,
+           secret);
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check results...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_add_origin(uint8_t *origin, uint8_t *realm) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
+
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    snprintf(statement, sizeof(statement),
-             "insert or replace into turn_origin_to_realm (origin,realm) values('%s','%s')", origin, realm);
-
-    sqlite_lock(1);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement), "insert or replace into turn_origin_to_realm (origin,realm) values('%s','%s')",
+           origin, realm);
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check results...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_del_origin(uint8_t *origin) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
+
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    snprintf(statement, sizeof(statement), "delete from turn_origin_to_realm where origin='%s'", origin);
-
-    sqlite_lock(1);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement), "delete from turn_origin_to_realm where origin='%s'", origin);
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check results...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_list_t *realms) {
   int ret = -1;
 
-  uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
-    realm = realm0;
-  }
-
   donot_print_connection_success = 1;
 
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
-
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    char statement[TURN_LONG_STRING_SIZE];
-    if (realm && realm[0]) {
-      snprintf(statement, sizeof(statement),
-               "select origin,realm from turn_origin_to_realm where realm='%s' order by origin", realm);
-    } else {
-      snprintf(statement, sizeof(statement), "select origin,realm from turn_origin_to_realm order by realm,origin");
-    }
-
-    sqlite_lock(0);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-
-      ret = 0;
-      while (1) {
-        int res = sqlite3_step(st);
-        if (res == SQLITE_ROW) {
-
-          const char *kval = (const char *)sqlite3_column_text(st, 0);
-          const char *rval = (const char *)sqlite3_column_text(st, 1);
-
-          if (origins) {
-            add_to_secrets_list(origins, kval);
-            if (realms) {
-              if (rval && *rval) {
-                add_to_secrets_list(realms, rval);
-              } else {
-                add_to_secrets_list(realms, (char *)realm);
-              }
-            }
-          } else {
-            printf("%s ==>> %s\n", kval, rval);
-          }
-        } else if (res == SQLITE_DONE) {
-          break;
-        } else {
-          const char *errmsg = sqlite3_errmsg(sqliteconnection);
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-          ret = -1;
-          break;
-        }
-      }
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(0);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  if (realm && realm[0]) {
+    snprintf(statement, sizeof(statement),
+             "select origin,realm from turn_origin_to_realm where realm='%s' order by origin", realm);
+  } else {
+    snprintf(statement, sizeof(statement), "select origin,realm from turn_origin_to_realm order by realm,origin");
+  }
+
+  sqlite_lock(0);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+
+    // TODO: Validate column count...
+    ret = 0;
+    for (int stepResult = sqlite3_step(st); stepResult != SQLITE_DONE; stepResult = sqlite3_step(st)) {
+
+      if (stepResult == SQLITE_ROW) {
+
+        const char *kval = (const char *)sqlite3_column_text(st, 0);
+        const char *rval = (const char *)sqlite3_column_text(st, 1);
+
+        if (origins) {
+          add_to_secrets_list(origins, kval);
+
+          if (realms) {
+            if (rval && *rval) {
+              add_to_secrets_list(realms, rval);
+            } else {
+              add_to_secrets_list(realms, (char *)realm);
+            }
+          }
+
+        } else {
+          printf("%s ==>> %s\n", kval, rval);
+        }
+      } else {
+        const char *errmsg = sqlite3_errmsg(sqliteconnection);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+        ret = -1;
+        break;
+      }
+    }
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
+
   return ret;
 }
 
 static int sqlite_set_realm_option_one(uint8_t *realm, unsigned long value, const char *opt) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
+
+  if (value <= 0) {
+    return ret;
+  }
+
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    if (value > 0) {
-      snprintf(statement, sizeof(statement),
-               "insert or replace into turn_realm_option (realm,opt,value) values('%s','%s','%lu')", realm, opt,
-               (unsigned long)value);
-
-      sqlite_lock(1);
-
-      if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-        sqlite3_step(st);
-        ret = 0;
-      } else {
-        const char *errmsg = sqlite3_errmsg(sqliteconnection);
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-      }
-      sqlite3_finalize(st);
-
-      sqlite_unlock(1);
-    }
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement),
+           "insert or replace into turn_realm_option (realm,opt,value) values('%s','%s','%lu')", realm, opt, value);
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check results...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_list_realm_options(uint8_t *realm) {
   int ret = -1;
+
   donot_print_connection_success = 1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    if (realm && realm[0]) {
-      snprintf(statement, sizeof(statement),
-               "select realm,opt,value from turn_realm_option where realm='%s' order by realm,opt", realm);
-    } else {
-      snprintf(statement, sizeof(statement), "select realm,opt,value from turn_realm_option order by realm,opt");
-    }
-
-    sqlite_lock(0);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-
-      ret = 0;
-
-      while (1) {
-        int res = sqlite3_step(st);
-        if (res == SQLITE_ROW) {
-
-          const char *rval = (const char *)sqlite3_column_text(st, 0);
-          const char *oval = (const char *)sqlite3_column_text(st, 1);
-          const char *vval = (const char *)sqlite3_column_text(st, 2);
-
-          printf("%s[%s]=%s\n", oval, rval, vval);
-
-        } else if (res == SQLITE_DONE) {
-          break;
-        } else {
-          const char *errmsg = sqlite3_errmsg(sqliteconnection);
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-          ret = -1;
-          break;
-        }
-      }
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(0);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  if (realm && realm[0]) {
+    snprintf(statement, sizeof(statement),
+             "select realm,opt,value from turn_realm_option where realm='%s' order by realm,opt", realm);
+  } else {
+    snprintf(statement, sizeof(statement), "select realm,opt,value from turn_realm_option order by realm,opt");
+  }
+
+  sqlite_lock(0);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+
+    // TODO: Validate column count...
+    ret = 0;
+    for (int stepResult = sqlite3_step(st); stepResult != SQLITE_DONE; stepResult = sqlite3_step(st)) {
+
+      if (stepResult == SQLITE_ROW) {
+
+        const char *rval = (const char *)sqlite3_column_text(st, 0);
+        const char *oval = (const char *)sqlite3_column_text(st, 1);
+        const char *vval = (const char *)sqlite3_column_text(st, 2);
+
+        printf("%s[%s]=%s\n", oval, rval, vval);
+
+      } else {
+        const char *errmsg = sqlite3_errmsg(sqliteconnection);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+        ret = -1;
+        break;
+      }
+    }
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
+
   return ret;
 }
 
@@ -972,34 +991,200 @@ static void sqlite_auth_ping(void *rch) { UNUSED_ARG(rch); }
 static int sqlite_get_ip_list(const char *kind, ip_range_list_t *list) {
   int ret = -1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
+  donot_print_connection_success = 1;
+
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
+  }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement), "select ip_range,realm from %s_peer_ip", kind);
+
+  sqlite_lock(0);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+
+    // TODO: Validate column count...
+    ret = 0;
+    for (int stepResult = sqlite3_step(st); stepResult != SQLITE_DONE; stepResult = sqlite3_step(st)) {
+
+      if (stepResult == SQLITE_ROW) {
+
+        const char *kval = (const char *)sqlite3_column_text(st, 0);
+        const char *rval = (const char *)sqlite3_column_text(st, 1);
+
+        add_ip_list_range(kval, rval, list);
+
+      } else {
+        const char *errmsg = sqlite3_errmsg(sqliteconnection);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+        ret = -1;
+        break;
+      }
+    }
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
+
+  return ret;
+}
+
+static int sqlite_set_permission_ip(const char *kind, uint8_t *realm, const char *ip, int del) {
+  int ret = -1;
+
+  donot_print_connection_success = 1;
+
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
+  }
+
+  uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
+  if (!realm) {
+    realm = realm0;
+  }
+
+  sqlite_lock(1);
+
+  char statement[TURN_LONG_STRING_SIZE];
+  if (del) {
+    snprintf(statement, sizeof(statement), "delete from %s_peer_ip where realm = '%s'  and ip_range = '%s'", kind,
+             (char *)realm, ip);
+  } else {
+    snprintf(statement, sizeof(statement), "insert or replace into %s_peer_ip (realm,ip_range) values('%s','%s')", kind,
+             (char *)realm, ip);
+  }
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check result...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error updating SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
+  return ret;
+}
+
+static void sqlite_reread_realms(secrets_list_t *realms_list) {
+  donot_print_connection_success = 1;
+
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return;
+  }
+
+  {
     char statement[TURN_LONG_STRING_SIZE];
-    sqlite3_stmt *st = NULL;
-    int rc = 0;
-    snprintf(statement, sizeof(statement), "select ip_range,realm from %s_peer_ip", kind);
+    snprintf(statement, sizeof(statement), "select origin,realm from turn_origin_to_realm");
 
     sqlite_lock(0);
 
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
 
-      ret = 0;
+      ur_string_map *o_to_realm_new = ur_string_map_create(free);
 
-      while (1) {
-        int res = sqlite3_step(st);
-        if (res == SQLITE_ROW) {
+      // TODO: Validate column count...
+      for (int stepResult = sqlite3_step(st); stepResult != SQLITE_DONE; stepResult = sqlite3_step(st)) {
 
-          const char *kval = (const char *)sqlite3_column_text(st, 0);
-          const char *rval = (const char *)sqlite3_column_text(st, 1);
+        if (stepResult == SQLITE_ROW) {
 
-          add_ip_list_range(kval, rval, list);
+          // TODO: Why does oval need to be strdup? It seems used read-only, non-owning?
+          char *oval = strdup((const char *)sqlite3_column_text(st, 0));
+          char *rval = strdup((const char *)sqlite3_column_text(st, 1));
 
-        } else if (res == SQLITE_DONE) {
-          break;
+          get_realm(rval);
+          ur_string_map_value_type value = rval;
+          ur_string_map_put(o_to_realm_new, (ur_string_map_key_type)oval, value);
+
+          free(oval);
+
         } else {
           const char *errmsg = sqlite3_errmsg(sqliteconnection);
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-          ret = -1;
+          break;
+        }
+      }
+
+      update_o_to_realm(o_to_realm_new);
+
+    } else {
+      const char *errmsg = sqlite3_errmsg(sqliteconnection);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+    }
+
+    sqlite3_finalize(st);
+
+    sqlite_unlock(0);
+  }
+
+  {
+    lock_realms();
+    size_t const rlsz = realms_list->sz;
+    unlock_realms();
+
+    for (size_t i = 0; i < rlsz; ++i) {
+      char *realm = realms_list->secrets[i];
+
+      realm_params_t *rp = get_realm(realm);
+
+      lock_realms();
+      rp->options.perf_options.max_bps = turn_params.max_bps;
+      rp->options.perf_options.total_quota = turn_params.total_quota;
+      rp->options.perf_options.user_quota = turn_params.user_quota;
+      unlock_realms();
+    }
+  }
+
+  {
+    sqlite_lock(0);
+
+    char statement[TURN_LONG_STRING_SIZE];
+    snprintf(statement, sizeof(statement), "select realm,opt,value from turn_realm_option");
+
+    sqlite3_stmt *st = NULL;
+    if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+
+      // TODO: Validate column count...
+      for (int stepResult = sqlite3_step(st); stepResult != SQLITE_DONE; stepResult = sqlite3_step(st)) {
+
+        if (stepResult == SQLITE_ROW) {
+
+          // TODO: Why does rval need strdup? seems read-only non-owning.
+          char *rval = strdup((const char *)sqlite3_column_text(st, 0));
+          const char *oval = (const char *)sqlite3_column_text(st, 1);
+          const char *vval = (const char *)sqlite3_column_text(st, 2);
+
+          realm_params_t *rp = get_realm(rval);
+          if (strcmp(oval, "max-bps") == 0) {
+            rp->options.perf_options.max_bps = (band_limit_t)strtoul(vval, NULL, 10);
+          } else if (strcmp(oval, "total-quota") == 0) {
+            rp->options.perf_options.total_quota = (vint)atoi(vval);
+          } else if (strcmp(oval, "user-quota") == 0) {
+            rp->options.perf_options.user_quota = (vint)atoi(vval);
+          } else {
+            TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown realm option: %s\n", oval);
+          }
+
+          free(rval);
+
+        } else {
+          const char *errmsg = sqlite3_errmsg(sqliteconnection);
+          TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
           break;
         }
       }
@@ -1007,174 +1192,10 @@ static int sqlite_get_ip_list(const char *kind, ip_range_list_t *list) {
       const char *errmsg = sqlite3_errmsg(sqliteconnection);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
     }
+
     sqlite3_finalize(st);
 
     sqlite_unlock(0);
-  }
-  return ret;
-}
-
-static int sqlite_set_permission_ip(const char *kind, uint8_t *realm, const char *ip, int del) {
-  int ret = -1;
-
-  uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
-    realm = realm0;
-  }
-
-  char statement[TURN_LONG_STRING_SIZE];
-
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
-
-  donot_print_connection_success = 1;
-
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-
-    sqlite_lock(1);
-
-    if (del) {
-      snprintf(statement, sizeof(statement), "delete from %s_peer_ip where realm = '%s'  and ip_range = '%s'", kind,
-               (char *)realm, ip);
-    } else {
-      snprintf(statement, sizeof(statement), "insert or replace into %s_peer_ip (realm,ip_range) values('%s','%s')",
-               kind, (char *)realm, ip);
-    }
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error updating SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
-  }
-  return ret;
-}
-
-static void sqlite_reread_realms(secrets_list_t *realms_list) {
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    char statement[TURN_LONG_STRING_SIZE];
-    sqlite3_stmt *st = NULL;
-    int rc = 0;
-    {
-      snprintf(statement, sizeof(statement), "select origin,realm from turn_origin_to_realm");
-
-      sqlite_lock(0);
-
-      if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-
-        ur_string_map *o_to_realm_new = ur_string_map_create(free);
-
-        while (1) {
-          int res = sqlite3_step(st);
-          if (res == SQLITE_ROW) {
-
-            char *oval = strdup((const char *)sqlite3_column_text(st, 0));
-            char *rval = strdup((const char *)sqlite3_column_text(st, 1));
-
-            get_realm(rval);
-            ur_string_map_value_type value = rval;
-            ur_string_map_put(o_to_realm_new, (ur_string_map_key_type)oval, value);
-
-            free(oval);
-
-          } else if (res == SQLITE_DONE) {
-            break;
-          } else {
-            const char *errmsg = sqlite3_errmsg(sqliteconnection);
-            TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-            break;
-          }
-        }
-
-        update_o_to_realm(o_to_realm_new);
-
-      } else {
-        const char *errmsg = sqlite3_errmsg(sqliteconnection);
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-      }
-      sqlite3_finalize(st);
-
-      sqlite_unlock(0);
-    }
-
-    {
-      {
-        size_t i = 0;
-        size_t rlsz = 0;
-
-        lock_realms();
-        rlsz = realms_list->sz;
-        unlock_realms();
-
-        for (i = 0; i < rlsz; ++i) {
-
-          char *realm = realms_list->secrets[i];
-
-          realm_params_t *rp = get_realm(realm);
-
-          lock_realms();
-          rp->options.perf_options.max_bps = turn_params.max_bps;
-          unlock_realms();
-
-          lock_realms();
-          rp->options.perf_options.total_quota = turn_params.total_quota;
-          unlock_realms();
-
-          lock_realms();
-          rp->options.perf_options.user_quota = turn_params.user_quota;
-          unlock_realms();
-        }
-      }
-
-      sqlite_lock(0);
-
-      snprintf(statement, sizeof(statement), "select realm,opt,value from turn_realm_option");
-      if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-
-        while (1) {
-          int res = sqlite3_step(st);
-          if (res == SQLITE_ROW) {
-
-            char *rval = strdup((const char *)sqlite3_column_text(st, 0));
-            const char *oval = (const char *)sqlite3_column_text(st, 1);
-            const char *vval = (const char *)sqlite3_column_text(st, 2);
-
-            realm_params_t *rp = get_realm(rval);
-            if (!strcmp(oval, "max-bps")) {
-              rp->options.perf_options.max_bps = (band_limit_t)strtoul(vval, NULL, 10);
-            } else if (!strcmp(oval, "total-quota")) {
-              rp->options.perf_options.total_quota = (vint)atoi(vval);
-            } else if (!strcmp(oval, "user-quota")) {
-              rp->options.perf_options.user_quota = (vint)atoi(vval);
-            } else {
-              TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown realm option: %s\n", oval);
-            }
-
-            free(rval);
-
-          } else if (res == SQLITE_DONE) {
-            break;
-          } else {
-            const char *errmsg = sqlite3_errmsg(sqliteconnection);
-            TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-            break;
-          }
-        }
-      } else {
-        const char *errmsg = sqlite3_errmsg(sqliteconnection);
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-      }
-      sqlite3_finalize(st);
-
-      sqlite_unlock(0);
-    }
   }
 }
 
@@ -1183,160 +1204,181 @@ static void sqlite_reread_realms(secrets_list_t *realms_list) {
 static int sqlite_get_admin_user(const uint8_t *usname, uint8_t *realm, password_t pwd) {
   int ret = -1;
 
+  if ((realm == NULL) || (usname == NULL)) {
+    return ret;
+  }
+
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
+  }
+
   realm[0] = 0;
   pwd[0] = 0;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    char statement[TURN_LONG_STRING_SIZE];
-    sqlite3_stmt *st = NULL;
-    int rc = 0;
-    snprintf(statement, sizeof(statement), "select realm,password from admin_user where name='%s'", usname);
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement), "select realm,password from admin_user where name='%s'", usname);
 
-    sqlite_lock(0);
+  sqlite_lock(0);
 
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      int res = sqlite3_step(st);
-      if (res == SQLITE_ROW) {
-        const char *kval = (const char *)sqlite3_column_text(st, 0);
-        if (kval) {
-          strncpy((char *)realm, kval, STUN_MAX_REALM_SIZE);
-        }
-        kval = (const char *)sqlite3_column_text(st, 1);
-        if (kval) {
-          strncpy((char *)pwd, kval, STUN_MAX_PWD_SIZE);
-        }
-        ret = 0;
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Validate column count...
+    // TODO: Error if more than one result.
+    if (sqlite3_step(st) == SQLITE_ROW) {
+
+      const char *kval = (const char *)sqlite3_column_text(st, 0);
+      const char *rval = (const char *)sqlite3_column_text(st, 1);
+
+      if (kval) {
+        strncpy((char *)realm, kval, STUN_MAX_REALM_SIZE);
       }
+      if (rval) {
+        strncpy((char *)pwd, rval, STUN_MAX_PWD_SIZE);
+      }
+
+      ret = 0;
     } else {
       const char *errmsg = sqlite3_errmsg(sqliteconnection);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
     }
-
-    sqlite3_finalize(st);
-
-    sqlite_unlock(0);
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
   }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
+
   return ret;
 }
 
 static int sqlite_set_admin_user(const uint8_t *usname, const uint8_t *realm, const password_t pwd) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
 
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-
-    sqlite_lock(1);
-
-    snprintf(statement, sizeof(statement),
-             "insert or replace into admin_user (realm,name,password) values('%s','%s','%s')", realm, usname, pwd);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement),
+           "insert or replace into admin_user (realm,name,password) values('%s','%s','%s')", realm, usname, pwd);
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check result...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_del_admin_user(const uint8_t *usname) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
 
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    snprintf(statement, sizeof(statement), "delete from admin_user where name='%s'", usname);
-
-    sqlite_lock(1);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-      sqlite3_step(st);
-      ret = 0;
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(1);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement), "delete from admin_user where name='%s'", usname);
+
+  sqlite_lock(1);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+    // TODO: Check result...
+    sqlite3_step(st);
+    ret = 0;
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(1);
+
   return ret;
 }
 
 static int sqlite_list_admin_users(int no_print) {
   int ret = -1;
-  char statement[TURN_LONG_STRING_SIZE];
-  sqlite3_stmt *st = NULL;
-  int rc = 0;
 
   donot_print_connection_success = 1;
 
-  sqlite3 *sqliteconnection = get_sqlite_connection();
-  if (sqliteconnection) {
-    snprintf(statement, sizeof(statement), "select name,realm from admin_user order by realm,name");
-
-    sqlite_lock(0);
-
-    if ((rc = sqlite3_prepare(sqliteconnection, statement, -1, &st, 0)) == SQLITE_OK) {
-
-      ret = 0;
-      while (1) {
-        int res = sqlite3_step(st);
-        if (res == SQLITE_ROW) {
-
-          const char *kval = (const char *)sqlite3_column_text(st, 0);
-          const char *rval = (const char *)sqlite3_column_text(st, 1);
-
-          if (!no_print) {
-            if (rval && *rval) {
-              printf("%s[%s]\n", kval, rval);
-            } else {
-              printf("%s\n", kval);
-            }
-          }
-
-          ++ret;
-
-        } else if (res == SQLITE_DONE) {
-          break;
-        } else {
-          const char *errmsg = sqlite3_errmsg(sqliteconnection);
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-          ret = -1;
-          break;
-        }
-      }
-    } else {
-      const char *errmsg = sqlite3_errmsg(sqliteconnection);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
-    }
-    sqlite3_finalize(st);
-
-    sqlite_unlock(0);
+  sqlite3 *const sqliteconnection = get_sqlite_connection();
+  if (sqliteconnection == NULL) {
+    return ret;
   }
+
+  char statement[TURN_LONG_STRING_SIZE];
+  snprintf(statement, sizeof(statement), "select name,realm from admin_user order by realm,name");
+
+  sqlite_lock(0);
+
+  sqlite3_stmt *st = NULL;
+  if (sqlite3_prepare(sqliteconnection, statement, -1, &st, 0) == SQLITE_OK) {
+
+    ret = 0;
+    // TODO: Validate column count...
+    for (int stepResult = sqlite3_step(st); stepResult != SQLITE_DONE; stepResult = sqlite3_step(st)) {
+
+      if (stepResult == SQLITE_ROW) {
+
+        const char *kval = (const char *)sqlite3_column_text(st, 0);
+        const char *rval = (const char *)sqlite3_column_text(st, 1);
+
+        if (!no_print) {
+          if (rval && *rval) {
+            printf("%s[%s]\n", kval, rval);
+          } else {
+            printf("%s\n", kval);
+          }
+        }
+
+        ++ret; // TODO: Why increment this? No other function does.
+
+      } else {
+        const char *errmsg = sqlite3_errmsg(sqliteconnection);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+        ret = -1;
+        break;
+      }
+    }
+  } else {
+    const char *errmsg = sqlite3_errmsg(sqliteconnection);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving SQLite DB information: %s\n", errmsg);
+  }
+
+  sqlite3_finalize(st);
+
+  sqlite_unlock(0);
+
   return ret;
 }
 
 static void sqlite_disconnect(void) {
-  sqlite3 *sqliteconnection = (sqlite3 *)pthread_getspecific(connection_key);
+  sqlite3 *const sqliteconnection = (sqlite3 *)pthread_getspecific(connection_key);
   if (sqliteconnection) {
     sqlite3_close(sqliteconnection);
-    sqliteconnection = NULL;
   }
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "SQLite connection was closed.\n");
 }
@@ -1358,8 +1400,8 @@ const turn_dbdriver_t *get_sqlite_dbdriver(void) { return &driver; }
 
 //////////////////////////////////////////////////
 
-#else
+#else // defined(TURN_NO_SQLITE)
 
 const turn_dbdriver_t *get_sqlite_dbdriver(void) { return NULL; }
 
-#endif
+#endif // !defined(TURN_NO_SQLITE)

--- a/src/apps/relay/dbdrivers/dbdriver.c
+++ b/src/apps/relay/dbdrivers/dbdriver.c
@@ -45,7 +45,7 @@ static void make_connection_key(void) { (void)pthread_key_create(&connection_key
 pthread_key_t connection_key;
 pthread_once_t connection_key_once = PTHREAD_ONCE_INIT;
 
-int convert_string_key_to_binary(char *keysource, hmackey_t key, size_t sz) {
+void convert_string_key_to_binary(char const *keysource, hmackey_t key, size_t sz) {
   char is[3];
   size_t i;
   unsigned int v;
@@ -56,7 +56,6 @@ int convert_string_key_to_binary(char *keysource, hmackey_t key, size_t sz) {
     sscanf(is, "%02x", &v);
     key[i] = (unsigned char)v;
   }
-  return 0;
 }
 
 persistent_users_db_t *get_persistent_users_db(void) { return &(turn_params.default_users_db.persistent_users_db); }

--- a/src/apps/relay/dbdrivers/dbdriver.h
+++ b/src/apps/relay/dbdrivers/dbdriver.h
@@ -79,7 +79,7 @@ typedef struct _turn_dbdriver_t {
 
 /////////// USER DB CHECK //////////////////
 
-int convert_string_key_to_binary(char *keysource, hmackey_t key, size_t sz);
+void convert_string_key_to_binary(char const *keysource, hmackey_t key, size_t sz);
 persistent_users_db_t *get_persistent_users_db(void);
 const turn_dbdriver_t *get_dbdriver(void);
 char *sanitize_userdb_string(char *udb);

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -774,8 +774,8 @@ int add_static_user_account(char *user) {
     return -1;
   }
 
-  // key argument (the usname variable) is deep-copied, so ownership isn't transfered, and we still need to free usname later..
-  // value argument (the key variable) has ownership transfered into this function
+  // key argument (the usname variable) is deep-copied, so ownership isn't transfered, and we still need to free usname
+  // later.. value argument (the key variable) has ownership transfered into this function
   ur_string_map_put(turn_params.default_users_db.ram_db.static_accounts, (ur_string_map_key_type)usname,
                     (ur_string_map_value_type)*key);
   ur_string_map_unlock(turn_params.default_users_db.ram_db.static_accounts);

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -759,12 +759,7 @@ int add_static_user_account(char *user) {
     if (strlen(keysource) < sz * 2) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format: %s\n", s);
     }
-    if (convert_string_key_to_binary(keysource, *key, sz) < 0) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key: %s\n", s);
-      free(usname);
-      free(key);
-      return -1;
-    }
+    convert_string_key_to_binary(keysource, *key, sz);
   } else {
     // this is only for default realm
     stun_produce_integrity_key_str((uint8_t *)usname, (uint8_t *)get_realm(NULL)->options.name, (uint8_t *)s, *key,

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -184,6 +184,7 @@ typedef uint32_t turn_time_t;
 #error WRONG BYTE_ORDER SETTING
 #endif
 
+// NOLINTBEGIN(clang-diagnostic-string-compare)
 #define STRCPY(dst, src)                                                                                               \
   do {                                                                                                                 \
     if ((const char *)(dst) != (const char *)(src)) {                                                                  \
@@ -196,6 +197,7 @@ typedef uint32_t turn_time_t;
       }                                                                                                                \
     }                                                                                                                  \
   } while (0)
+// NOLINTEND(clang-diagnostic-string-compare)
 
 //////////////// Bufferevents /////////////////////
 


### PR DESCRIPTION
The general approach here was:

- Always declare variables as close to where they are defined as possible.
- Check for pre-conditions of functions before doing work (e.g. ensure we can connect to the DB before doing a bunch of string formatting)
- Keep the scope of mutexes as reasonably small as practical.
- Use idiomatic C11, such as for-loops over the thing being iterated, not while() loops over constants, or variables that aren't modified.
- Prefer if(fail){return} function-body after over `if(not fail){ function-body inside if} return;

Clang-tidy returns a clean bill of health, but while going through this file i noticed a lot of things that raise questions.

Lack of checking column counts. Lack of handling the possibility of multiple return values. Questionably handling of strings. Complete lack of checking function inputs for invalid values (e.g. nullptr).

I'm not going to fix those, my organization doesn't USE the DB drivers, so i have little interest in re-working the logic beyond addressing clang-tidy warnings for my own sanity, but i did add TODO comments for someone else to look at in the future.



Additional note: While the changes look very invasive.... they aren't.

I don't think there is a way to get github to ignore whitespace in the filediff, but if someone were to compare the commit locally, they'll see that almost all of the changes are just adjusting indentation.