### PR TITLE
updated types to bool in _turn_params_ to reflect C11

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -94,7 +94,7 @@ turn_params_t turn_params = {
     false, /*no_tlsv1*/
     false, /*no_tlsv1_1*/
     false, /*no_tlsv1_2*/
-       /*no_tls*/
+           /*no_tls*/
 #if !TLS_SUPPORTED
     true,
 #else
@@ -111,10 +111,10 @@ turn_params_t turn_params = {
     {0, NULL}, /*tls_mutex*/
 
     //////////////// Common params ////////////////////
-    TURN_VERBOSE_NONE, 	   /* verbose */
-    false,                 /* turn_daemon */
-    false,                 /* no_software_attribute */
-    false,                 /* web_admin_listen_on_workers */
+    TURN_VERBOSE_NONE, /* verbose */
+    false,             /* turn_daemon */
+    false,             /* no_software_attribute */
+    false,             /* web_admin_listen_on_workers */
 
     false, /* do_not_use_config_file */
 
@@ -128,7 +128,7 @@ turn_params_t turn_params = {
     0,                     /* alt_listener_port */
     0,                     /* alt_tls_listener_port */
     0,                     /* tcp_proxy_port */
-    true,                     /* rfc5780 */
+    true,                  /* rfc5780 */
 
     false, /* no_udp */
     false, /* no_tcp */
@@ -140,7 +140,7 @@ turn_params_t turn_params = {
     "", /*listener_ifname*/
 
     {"", ""},                                                                 /*redis_statsdb*/
-    false,                                                                        /*use_redis_statsdb*/
+    false,                                                                    /*use_redis_statsdb*/
     {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, NULL, NULL, NULL}, /*listener*/
     {NULL, 0},                                                                /*ip_whitelist*/
     {NULL, 0},                                                                /*ip_blacklist*/
@@ -184,9 +184,9 @@ turn_params_t turn_params = {
     false, /*stop_turn_server*/
 
     /////////////// MISC PARAMS ////////////////
-    false,                                  /* stun_only */
-    false,                                  /* no_stun */
-    false,                                  /* secure_stun */
+    false,                              /* stun_only */
+    false,                              /* no_stun */
+    false,                              /* secure_stun */
     0,                                  /* server_relay */
     0,                                  /* fingerprint */
     ':',                                /* rest_api_separator */

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -91,32 +91,32 @@ turn_params_t turn_params = {
     "",                     /*tls_password*/
     "",                     /*dh_file*/
 
-    0, /*no_tlsv1*/
-    0, /*no_tlsv1_1*/
-    0, /*no_tlsv1_2*/
+    false, /*no_tlsv1*/
+    false, /*no_tlsv1_1*/
+    false, /*no_tlsv1_2*/
        /*no_tls*/
 #if !TLS_SUPPORTED
-    1,
+    true,
 #else
-    0,
+    false,
 #endif
 /*no_dtls*/
 #if !DTLS_SUPPORTED
-    1,
+    true,
 #else
-    0,
+    false,
 #endif
 
     NULL,      /*tls_ctx_update_ev*/
     {0, NULL}, /*tls_mutex*/
 
     //////////////// Common params ////////////////////
-    TURN_VERBOSE_NONE, /* verbose */
-    0,                 /* turn_daemon */
-    false,             /* software_attribute */
-    0,                 /* web_admin_listen_on_workers */
+    TURN_VERBOSE_NONE, 	   /* verbose */
+    false,                 /* turn_daemon */
+    false,                 /* no_software_attribute */
+    false,                 /* web_admin_listen_on_workers */
 
-    0, /* do_not_use_config_file */
+    false, /* do_not_use_config_file */
 
     "/var/run/turnserver.pid", /* pidfile */
     "",                        /* acme_redirect */
@@ -128,19 +128,19 @@ turn_params_t turn_params = {
     0,                     /* alt_listener_port */
     0,                     /* alt_tls_listener_port */
     0,                     /* tcp_proxy_port */
-    1,                     /* rfc5780 */
+    true,                     /* rfc5780 */
 
-    0, /* no_udp */
-    0, /* no_tcp */
-    0, /* tcp_use_proxy */
+    false, /* no_udp */
+    false, /* no_tcp */
+    false, /* tcp_use_proxy */
 
-    0, /* no_tcp_relay */
-    0, /* no_udp_relay */
+    false, /* no_tcp_relay */
+    false, /* no_udp_relay */
 
     "", /*listener_ifname*/
 
     {"", ""},                                                                 /*redis_statsdb*/
-    0,                                                                        /*use_redis_statsdb*/
+    false,                                                                        /*use_redis_statsdb*/
     {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, NULL, NULL, NULL}, /*listener*/
     {NULL, 0},                                                                /*ip_whitelist*/
     {NULL, 0},                                                                /*ip_blacklist*/
@@ -152,10 +152,10 @@ turn_params_t turn_params = {
     LOW_DEFAULT_PORTS_BOUNDARY,  /*min_port*/
     HIGH_DEFAULT_PORTS_BOUNDARY, /*max_port*/
 
-    0, /*check_origin*/
+    false, /*check_origin*/
 
-    0, /*no_multicast_peers*/
-    0, /*allow_loopback_peers*/
+    false, /*no_multicast_peers*/
+    false, /*allow_loopback_peers*/
 
     "",   /*relay_ifname*/
     0,    /*relays_number*/
@@ -184,9 +184,9 @@ turn_params_t turn_params = {
     false, /*stop_turn_server*/
 
     /////////////// MISC PARAMS ////////////////
-    0,                                  /* stun_only */
-    0,                                  /* no_stun */
-    0,                                  /* secure_stun */
+    false,                                  /* stun_only */
+    false,                                  /* no_stun */
+    false,                                  /* secure_stun */
     0,                                  /* server_relay */
     0,                                  /* fingerprint */
     ':',                                /* rest_api_separator */
@@ -194,19 +194,19 @@ turn_params_t turn_params = {
     STUN_DEFAULT_MAX_ALLOCATE_LIFETIME, /* max_allocate_lifetime */
     STUN_DEFAULT_CHANNEL_LIFETIME,      /* channel_lifetime */
     STUN_DEFAULT_PERMISSION_LIFETIME,   /* permission_lifetime */
-    0,                                  /* mobility */
+    false,                              /* mobility */
     TURN_CREDENTIALS_NONE,              /* ct */
-    0,                                  /* use_auth_secret_with_timestamp */
+    false,                              /* use_auth_secret_with_timestamp */
     0,                                  /* max_bps */
     0,                                  /* bps_capacity */
     0,                                  /* bps_capacity_allocated */
     0,                                  /* total_quota */
     0,                                  /* user_quota */
-    0,                                  /* prometheus disabled by default */
+    false,                              /* prometheus disabled by default */
     DEFAULT_PROM_SERVER_PORT,           /* prometheus port */
     "",                                 /* prometheus address */
     "/metrics",                         /* prometheus path */
-    0, /* prometheus username labelling disabled by default when prometheus is enabled */
+    false, /* prometheus username labelling disabled by default when prometheus is enabled */
 
     ///////////// Users DB //////////////
     {(TURN_USERDB_TYPE)0, {"\0", "\0"}, {0, NULL, {NULL, 0}}},
@@ -218,14 +218,14 @@ turn_params_t turn_params = {
     "",                                     /* secret_key_file */
     "",                                     /* secret_key */
     ALLOCATION_DEFAULT_ADDRESS_FAMILY_IPV4, /* allocation_default_address_family */
-    0,                                      /* no_auth_pings */
-    0,                                      /* no_dynamic_ip_list */
-    0,                                      /* no_dynamic_realms */
+    false,                                  /* no_auth_pings */
+    false,                                  /* no_dynamic_ip_list */
+    false,                                  /* no_dynamic_realms */
 
-    0, /* log_binding */
-    0, /* no_stun_backward_compatibility */
-    0, /* response_origin_only_with_rfc5780 */
-    0  /* respond_http_unsupported */
+    false, /* log_binding */
+    false, /* no_stun_backward_compatibility */
+    false, /* response_origin_only_with_rfc5780 */
+    false  /* respond_http_unsupported */
 };
 
 //////////////// OpenSSL Init //////////////////////

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <stdbool.h>
 
 #include <locale.h>
 
@@ -193,11 +194,11 @@ typedef struct _turn_params_ {
   char tls_password[513];
   char dh_file[1025];
 
-  int no_tlsv1;
-  int no_tlsv1_1;
-  int no_tlsv1_2;
-  int no_tls;
-  int no_dtls;
+  bool no_tlsv1;
+  bool no_tlsv1_1;
+  bool no_tlsv1_2;
+  bool no_tls;
+  bool no_dtls;
 
   struct event *tls_ctx_update_ev;
   TURN_MUTEX_DECLARE(tls_mutex)
@@ -205,11 +206,11 @@ typedef struct _turn_params_ {
   //////////////// Common params ////////////////////
 
   int verbose;
-  int turn_daemon;
+  bool turn_daemon;
   bool software_attribute;
-  int web_admin_listen_on_workers;
+  bool web_admin_listen_on_workers;
 
-  int do_not_use_config_file;
+  bool do_not_use_config_file;
 
   char pidfile[1025];
   char acme_redirect[1025];
@@ -221,19 +222,19 @@ typedef struct _turn_params_ {
   int alt_listener_port;
   int alt_tls_listener_port;
   int tcp_proxy_port;
-  int rfc5780;
+  bool rfc5780;
 
-  int no_udp;
-  int no_tcp;
-  int tcp_use_proxy;
+  bool no_udp;
+  bool no_tcp;
+  bool tcp_use_proxy;
 
-  vint no_tcp_relay;
-  vint no_udp_relay;
+  bool no_tcp_relay;
+  bool no_udp_relay;
 
   char listener_ifname[1025];
 
   redis_stats_db_t redis_statsdb;
-  int use_redis_statsdb;
+  bool use_redis_statsdb;
 
   struct listener_server listener;
 
@@ -248,10 +249,10 @@ typedef struct _turn_params_ {
   uint16_t min_port;
   uint16_t max_port;
 
-  vint check_origin;
+  bool check_origin;
 
-  vint no_multicast_peers;
-  vint allow_loopback_peers;
+  bool no_multicast_peers;
+  bool allow_loopback_peers;
 
   char relay_ifname[1025];
   size_t relays_number;
@@ -284,13 +285,14 @@ typedef struct _turn_params_ {
 
   /////////////// stop/drain server ////////////////
   bool drain_turn_server;
+  /////////////// stop server ////////////////
   bool stop_turn_server;
 
   ////////////// MISC PARAMS ////////////////
 
-  vint stun_only;
-  vint no_stun;
-  vint secure_stun;
+  bool stun_only;
+  bool no_stun;
+  bool secure_stun;
   int server_relay;
   int fingerprint;
   char rest_api_separator;
@@ -298,19 +300,19 @@ typedef struct _turn_params_ {
   vint max_allocate_lifetime;
   vint channel_lifetime;
   vint permission_lifetime;
-  vint mobility;
+  bool mobility;
   turn_credential_type ct;
-  int use_auth_secret_with_timestamp;
+  bool use_auth_secret_with_timestamp;
   band_limit_t max_bps;
   band_limit_t bps_capacity;
   band_limit_t bps_capacity_allocated;
   vint total_quota;
   vint user_quota;
-  int prometheus;
+  bool prometheus;
   int prometheus_port;
   char prometheus_address[INET6_ADDRSTRLEN];
   char prometheus_path[1025];
-  int prometheus_username_labels;
+  bool prometheus_username_labels;
 
   /////// Users DB ///////////
 
@@ -324,14 +326,14 @@ typedef struct _turn_params_ {
   char secret_key_file[1025];
   unsigned char secret_key[1025];
   ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family;
-  int no_auth_pings;
-  int no_dynamic_ip_list;
-  int no_dynamic_realms;
+  bool no_auth_pings;
+  bool no_dynamic_ip_list;
+  bool no_dynamic_realms;
 
-  vint log_binding;
-  vint no_stun_backward_compatibility;
-  vint response_origin_only_with_rfc5780;
-  vint respond_http_unsupported;
+  bool log_binding;
+  bool no_stun_backward_compatibility;
+  bool response_origin_only_with_rfc5780;
+  bool respond_http_unsupported;
 } turn_params_t;
 
 extern turn_params_t turn_params;

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -37,7 +37,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <stdbool.h>
 
 #include <locale.h>
 

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -189,19 +189,20 @@ static const telnet_telopt_t cli_telopts[] = {
 
 struct toggleable_command {
   const char *cmd;
-  vintp data;
+  bool *data;
 };
 
-struct toggleable_command tcmds[] = {{"stale-nonce", &turn_params.stale_nonce},
-                                     {"stun-only", &turn_params.stun_only},
-                                     {"no-stun", &turn_params.no_stun},
-                                     {"secure-stun", &turn_params.secure_stun},
-                                     {"no-udp-relay", &turn_params.no_udp_relay},
-                                     {"no-tcp-relay", &turn_params.no_tcp_relay},
-                                     {"no-multicast-peers", &turn_params.no_multicast_peers},
-                                     {"allow-loopback-peers", &turn_params.allow_loopback_peers},
-                                     {"mobility", &turn_params.mobility},
-                                     {NULL, NULL}};
+struct toggleable_command tcmds[] = {
+    //{"stale-nonce", &turn_params.stale_nonce}, // TODO re-enable this option by separating from rest of bools
+    {"stun-only", &turn_params.stun_only},
+    {"no-stun", &turn_params.no_stun},
+    {"secure-stun", &turn_params.secure_stun},
+    {"no-udp-relay", &turn_params.no_udp_relay},
+    {"no-tcp-relay", &turn_params.no_tcp_relay},
+    {"no-multicast-peers", &turn_params.no_multicast_peers},
+    {"allow-loopback-peers", &turn_params.allow_loopback_peers},
+    {"mobility", &turn_params.mobility},
+    {NULL, NULL}};
 
 ///////////////////////////////
 

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4888,19 +4888,19 @@ static void client_input_handler(ioa_socket_handle s, int event_type, ioa_net_da
 void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, ioa_engine_handle e,
                       turn_credential_type ct, int fingerprint, dont_fragment_option_t dont_fragment,
                       get_user_key_cb userkeycb, check_new_allocation_quota_cb chquotacb,
-                      release_allocation_quota_cb raqcb, ioa_addr *external_ip, vintp check_origin, vintp no_tcp_relay,
-                      vintp no_udp_relay, vintp stale_nonce, vintp max_allocate_lifetime, vintp channel_lifetime,
-                      vintp permission_lifetime, vintp stun_only, vintp no_stun, bool software_attribute,
-                      vintp web_admin_listen_on_workers, turn_server_addrs_list_t *alternate_servers_list,
+                      release_allocation_quota_cb raqcb, ioa_addr *external_ip, bool *check_origin, bool *no_tcp_relay,
+                      bool *no_udp_relay, vintp stale_nonce, vintp max_allocate_lifetime, vintp channel_lifetime,
+                      vintp permission_lifetime, bool *stun_only, bool *no_stun, bool software_attribute,
+                      bool *web_admin_listen_on_workers, turn_server_addrs_list_t *alternate_servers_list,
                       turn_server_addrs_list_t *tls_alternate_servers_list, turn_server_addrs_list_t *aux_servers_list,
-                      int self_udp_balance, vintp no_multicast_peers, vintp allow_loopback_peers,
+                      int self_udp_balance, bool *no_multicast_peers, bool *allow_loopback_peers,
                       ip_range_list_t *ip_whitelist, ip_range_list_t *ip_blacklist,
-                      send_socket_to_relay_cb send_socket_to_relay, vintp secure_stun, vintp mobility, int server_relay,
+                      send_socket_to_relay_cb send_socket_to_relay, bool *secure_stun, bool *mobility, int server_relay,
                       send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
                       allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
                       const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family,
-                      vintp log_binding, vintp no_stun_backward_compatibility, vintp response_origin_only_with_rfc5780,
-                      vintp respond_http_unsupported) {
+                      bool *log_binding, bool *no_stun_backward_compatibility, bool *response_origin_only_with_rfc5780,
+                      bool *respond_http_unsupported) {
 
   if (!server) {
     return;

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -127,16 +127,16 @@ struct _turn_turnserver {
   int verbose;
   int fingerprint;
   int rfc5780;
-  vintp check_origin;
+  bool *check_origin;
   vintp stale_nonce;
   vintp max_allocate_lifetime;
   vintp channel_lifetime;
   vintp permission_lifetime;
-  vintp stun_only;
-  vintp no_stun;
+  bool *stun_only;
+  bool *no_stun;
   bool software_attribute;
-  vintp web_admin_listen_on_workers;
-  vintp secure_stun;
+  bool *web_admin_listen_on_workers;
+  bool *secure_stun;
   turn_credential_type ct;
   get_alt_addr_cb alt_addr_cb;
   send_message_cb sm_cb;
@@ -147,14 +147,14 @@ struct _turn_turnserver {
   release_allocation_quota_cb raqcb;
   int external_ip_set;
   ioa_addr external_ip;
-  vintp allow_loopback_peers;
-  vintp no_multicast_peers;
+  bool *allow_loopback_peers;
+  bool *no_multicast_peers;
   send_turn_session_info_cb send_turn_session_info;
   send_https_socket_cb send_https_socket;
 
   /* RFC 6062 ==>> */
-  vintp no_udp_relay;
-  vintp no_tcp_relay;
+  bool *no_udp_relay;
+  bool *no_tcp_relay;
   ur_map *tcp_relay_connections;
   send_socket_to_relay_cb send_socket_to_relay;
   /* <<== RFC 6062 */
@@ -172,7 +172,7 @@ struct _turn_turnserver {
   ip_range_list_t *ip_blacklist;
 
   /* Mobility */
-  vintp mobility;
+  bool *mobility;
   ur_map *mobile_connections_map;
 
   /* Server relay */
@@ -192,17 +192,17 @@ struct _turn_turnserver {
   ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family;
 
   /* Log Binding Requrest */
-  vintp log_binding;
+  bool *log_binding;
 
   /* Disable handling old STUN Binding Requests and disable MAPPED-ADDRESS attribute in response */
-  vintp no_stun_backward_compatibility;
+  bool *no_stun_backward_compatibility;
 
   /* Only send RESPONSE-ORIGIN attribute in response if RFC5780 is enabled */
-  vintp response_origin_only_with_rfc5780;
+  bool *response_origin_only_with_rfc5780;
 
   /* Return an HTTP 400 response to HTTP connections made to ports not
      otherwise handling HTTP. */
-  vintp respond_http_unsupported;
+  bool *respond_http_unsupported;
 
   /* Set to true on SIGUSR1 */
   bool is_draining;
@@ -216,16 +216,16 @@ void init_turn_server(
     turn_turnserver *server, turnserver_id id, int verbose, ioa_engine_handle e, turn_credential_type ct,
     int fingerprint, dont_fragment_option_t dont_fragment, get_user_key_cb userkeycb,
     check_new_allocation_quota_cb chquotacb, release_allocation_quota_cb raqcb, ioa_addr *external_addr,
-    vintp check_origin, vintp no_tcp_relay, vintp no_udp_relay, vintp stale_nonce, vintp max_allocate_lifetime,
-    vintp channel_lifetime, vintp permission_lifetime, vintp stun_only, vintp no_stun, bool software_attribute,
-    vintp web_admin_listen_on_workers, turn_server_addrs_list_t *alternate_servers_list,
+    bool *check_origin, bool *no_tcp_relay, bool *no_udp_relay, vintp stale_nonce, vintp max_allocate_lifetime,
+    vintp channel_lifetime, vintp permission_lifetime, bool *stun_only, bool *no_stun, bool software_attribute,
+    bool *web_admin_listen_on_workers, turn_server_addrs_list_t *alternate_servers_list,
     turn_server_addrs_list_t *tls_alternate_servers_list, turn_server_addrs_list_t *aux_servers_list,
-    int self_udp_balance, vintp no_multicast_peers, vintp allow_loopback_peers, ip_range_list_t *ip_whitelist,
-    ip_range_list_t *ip_blacklist, send_socket_to_relay_cb send_socket_to_relay, vintp secure_stun, vintp mobility,
+    int self_udp_balance, bool *no_multicast_peers, bool *allow_loopback_peers, ip_range_list_t *ip_whitelist,
+    ip_range_list_t *ip_blacklist, send_socket_to_relay_cb send_socket_to_relay, bool *secure_stun, bool *mobility,
     int server_relay, send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
     allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name, const char *acme_redirect,
-    ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family, vintp log_binding,
-    vintp no_stun_backward_compatibility, vintp response_origin_only_with_rfc5780, vintp respond_http_unsupported);
+    ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family, bool *log_binding,
+    bool *no_stun_backward_compatibility, bool *response_origin_only_with_rfc5780, bool *respond_http_unsupported);
 
 ioa_engine_handle turn_server_get_engine(turn_turnserver *s);
 


### PR DESCRIPTION
approach was as follows, for the `_turn_params_` struct:
- if a variable of type `int` or `vint` was only being used as a boolean, replace it with bool as defined in `<stdbool.h>`
- replace its declaration with true/false, depending on prior assignment as 0/1

changes were only made when i was certain the variables were not being used as an `int`, so i may have missed some

no changes were made to other sections of the code as int-to-bool assignment is allowed in C, only code within the structs were changed, but that can be changed with a later commit

---

from a documentation perspective, it's not clear as to what purpose or benefit the vint alias has. the definition in `ns_turn_defs.h` simply reads

```c
typedef int vint;
typedef vint *vintp;
```
with no comments, and it seems most (but not all) `vint`s are being used as interim booleans through the code. this may just be from lack of knowledge of the codebase, but it doesn't seem useful in any way, so it would be helpful if someone with more expertise could clarify
