### PR TITLE
Fix memory leak in netengine.c

### DIFF
--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -352,7 +352,7 @@ void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params) {
   }
   else
   {
-    if (args) free(args);
+    if (args) { free(args); }
   }
 }
 

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -350,6 +350,10 @@ void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params) {
     params->tls_ctx_update_ev = ev;
     TURN_MUTEX_UNLOCK(&turn_params.tls_mutex);
   }
+  else
+  {
+    if (args) free(args);
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -349,10 +349,10 @@ void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params) {
     args->next = params->tls_ctx_update_ev;
     params->tls_ctx_update_ev = ev;
     TURN_MUTEX_UNLOCK(&turn_params.tls_mutex);
-  }
-  else
-  {
-    if (args) { free(args); }
+  } else {
+    if (args) {
+      free(args);
+    }
   }
 }
 


### PR DESCRIPTION
This is in response to issue #1366
The clang static analyzer basically claims that there is a memory leak happening in `set_ssl_ctx` for the variable `args`. The leak is  triggered when the base event `base` is NULL and the condition within `set_ssl_ctx` is not triggered. Therefore as a patch I am adding an else condition to free it. (It cannot be freed after the event is created by `event_new` because `args` can be invoked as argument for callback function later on)

Please let me know if this patch is helpful :)