### PR TITLE
Fix memory leak on http_server.c

### DIFF
--- a/src/apps/relay/http_server.c
+++ b/src/apps/relay/http_server.c
@@ -172,7 +172,7 @@ static struct http_request *parse_http_request_1(struct http_request *ret, char 
           if (evhttp_parse_query_str(query, kv) < 0) {
             free(ret);
             ret = NULL;
-            if (kv) free(kv); //kv no longer assigned on this path
+            if (kv) { free(kv); } //kv no longer assigned on this path
           } else {
             ret->headers = (struct http_headers *)calloc(sizeof(struct http_headers), 1);
             ret->headers->uri_headers = kv;

--- a/src/apps/relay/http_server.c
+++ b/src/apps/relay/http_server.c
@@ -173,7 +173,7 @@ static struct http_request *parse_http_request_1(struct http_request *ret, char 
             free(ret);
             ret = NULL;
             if (kv) {
-              //kv no longer assigned on this path
+              // kv no longer assigned on this path
               free(kv);
             }
           } else {

--- a/src/apps/relay/http_server.c
+++ b/src/apps/relay/http_server.c
@@ -172,7 +172,10 @@ static struct http_request *parse_http_request_1(struct http_request *ret, char 
           if (evhttp_parse_query_str(query, kv) < 0) {
             free(ret);
             ret = NULL;
-            if (kv) { free(kv); } //kv no longer assigned on this path
+            if (kv) {
+              //kv no longer assigned on this path
+              free(kv);
+            }
           } else {
             ret->headers = (struct http_headers *)calloc(sizeof(struct http_headers), 1);
             ret->headers->uri_headers = kv;

--- a/src/apps/relay/http_server.c
+++ b/src/apps/relay/http_server.c
@@ -172,6 +172,7 @@ static struct http_request *parse_http_request_1(struct http_request *ret, char 
           if (evhttp_parse_query_str(query, kv) < 0) {
             free(ret);
             ret = NULL;
+            if (kv) free(kv); //kv no longer assigned on this path
           } else {
             ret->headers = (struct http_headers *)calloc(sizeof(struct http_headers), 1);
             ret->headers->uri_headers = kv;


### PR DESCRIPTION
This is in response to issue #1365.
The clang static analyzer basically claims that there is a memory leak happening in `parse_http_request_1` for the variable `kv`. The leak is triggered when evhttp_parse_query_str fails and is unable to obtain key value pairs for a given URI. In this case ret is freed, however kv is still not freed and thereafter not used. Therefore as a patch I am freeing kv right after ret is freed.

Please let me know if this patch is helpful :)