### PR TITLE
refactored uclient.* to use bool to reflect C11

### DIFF
--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -105,6 +105,7 @@ static void __turn_getMSTime(void) {
 }
 
 ////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////
 
 static int refresh_channel(app_ur_session *elem, uint16_t method, uint32_t lt);
 
@@ -216,7 +217,7 @@ int send_buffer(app_ur_conn_info *clnet_info, stun_buffer *message, int data_con
 
   if (ssl) {
 
-    int message_sent = 0;
+    bool message_sent = 0;
     while (!message_sent) {
 
       if (SSL_get_shutdown(ssl)) {
@@ -611,7 +612,7 @@ recv_again:
   return rc;
 }
 
-static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info *atc) {
+static int client_read(app_ur_session *elem, bool is_tcp_data, app_tcp_conn_info *atc) {
 
   if (!elem)
     return -1;
@@ -902,7 +903,7 @@ static int client_write(app_ur_session *elem) {
   return 0;
 }
 
-void client_input_handler(evutil_socket_t fd, short what, void *arg) {
+void client_input_handler(evutil_socket_t fd, bool what, void *arg) {
 
   if (!(what & EV_READ) || !arg)
     return;
@@ -1582,7 +1583,6 @@ int add_integrity(app_ur_conn_info *clnet_info, stun_buffer *message) {
       // self-test:
       {
         password_t pwd;
-        if (stun_check_message_integrity_by_key_str(get_turn_credentials_type(), message->buf, (size_t)(message->len),
                                                     clnet_info->key, pwd, shatype) < 1) {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, " Self-test of integrity does not comple correctly !\n");
           return -1;
@@ -1644,3 +1644,4 @@ SOCKET_TYPE get_socket_type(void) {
   }
 }
 ///////////////////////////////////////////
+/*

--- a/src/apps/uclient/uclient.h
+++ b/src/apps/uclient/uclient.h
@@ -37,6 +37,8 @@
 
 #include "ns_turn_openssl.h"
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,46 +49,46 @@ extern "C" {
 #define STARTING_TCP_RELAY_TIME (30)
 
 extern int clmessage_length;
-extern int do_not_use_channel;
-extern int clnet_verbose;
-extern int use_tcp;
-extern int use_sctp;
-extern int use_secure;
+extern bool do_not_use_channel;
+extern bool clnet_verbose;
+extern bool use_tcp;
+extern bool use_sctp;
+extern bool use_secure;
 extern char cert_file[1025];
 extern char pkey_file[1025];
-extern int hang_on;
-extern int c2c;
+extern bool hang_on;
+extern bool c2c;
 extern ioa_addr peer_addr;
-extern int no_rtcp;
+extern bool no_rtcp;
 extern int default_address_family;
-extern int dont_fragment;
+extern bool dont_fragment;
 extern uint8_t g_uname[STUN_MAX_USERNAME_SIZE + 1];
 extern password_t g_upwd;
 extern char g_auth_secret[1025];
-extern int g_use_auth_secret_with_timestamp;
-extern int use_fingerprints;
+extern bool g_use_auth_secret_with_timestamp;
+extern bool use_fingerprints;
 extern SSL_CTX *root_tls_ctx[32];
 extern int root_tls_ctx_num;
 extern int RTP_PACKET_INTERVAL;
 extern uint8_t relay_transport;
 extern unsigned char client_ifname[1025];
 extern struct event_base *client_event_base;
-extern int passive_tcp;
-extern int mandatory_channel_padding;
-extern int negative_test;
-extern int negative_protocol_test;
-extern int dos;
-extern int random_disconnect;
+extern bool passive_tcp;
+extern bool mandatory_channel_padding;
+extern bool negative_test;
+extern bool negative_protocol_test;
+extern bool dos;
+extern bool random_disconnect;
 extern SHATYPE shatype;
-extern int mobility;
-extern int no_permissions;
-extern int extra_requests;
+extern bool mobility;
+extern bool no_permissions;
+extern bool extra_requests;
 extern band_limit_t bps;
-extern int dual_allocation;
+extern bool dual_allocation;
 
 extern char origin[STUN_MAX_ORIGIN_SIZE + 1];
 
-extern int oauth;
+extern bool oauth;
 extern oauth_key okey_array[3];
 
 #define UCLIENT_SESSION_LIFETIME (777)


### PR DESCRIPTION
similar in nature to my changes in #1406 

approach was as follows:

- if a variable of type `int` was only being used as a boolean, replace it with bool as defined in `<stdbool.h>`
- replace its declaration with true/false, depending on prior assignment as 0/1

changes were only made when i was certain the variables were not being used as an `int`, so i may have missed some

no changes were made to other sections of the code as int-to-bool assignment is allowed in C, only code within the structs were changed, but that can be changed with a later commit