### PR TITLE
Run all of the CI except for Docker builds on any change

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,8 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ 'master' ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ 'master' ]
+    types: [ opened, reopened, synchronize ]
   schedule:
     - cron: '6 13 * * 4'
 


### PR DESCRIPTION
I'm having trouble testing changes in my own fork because many of the CI workflows are only set to build on a pull request.

Better to just build on any commit.

I've left the docker builds as they are.