### PR TITLE
changed variables in stunclient.c to bool (C11)

### DIFF
--- a/src/apps/natdiscovery/natdiscovery.c
+++ b/src/apps/natdiscovery/natdiscovery.c
@@ -28,6 +28,7 @@
  * SUCH DAMAGE.
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -76,8 +77,8 @@ static int init_socket(int *socketfd, ioa_addr *local_addr, int local_port, ioa_
   return ret;
 }
 
-static int stunclient_send(int sockfd, ioa_addr *local_addr, int *local_port, ioa_addr *remote_addr, int change_ip,
-                           int change_port, int padding, int response_port) {
+static int stunclient_send(int sockfd, ioa_addr *local_addr, int *local_port, ioa_addr *remote_addr, bool change_ip,
+                           bool change_port, int padding, int response_port) {
   int ret = 0;
 
   turn::StunMsgRequest req(STUN_METHOD_BINDING);
@@ -157,7 +158,7 @@ static int stunclient_send(int sockfd, ioa_addr *local_addr, int *local_port, io
 }
 
 static int stunclient_receive(int sockfd, ioa_addr *local_addr, ioa_addr *reflexive_addr, ioa_addr *other_addr,
-                              int *rfc5780) {
+                              bool *rfc5780) {
   int ret = 0;
 
   {
@@ -208,7 +209,7 @@ static int stunclient_receive(int sockfd, ioa_addr *local_addr, ioa_addr *reflex
 
               turn::StunAttrIterator iter1(res, STUN_ATTRIBUTE_OTHER_ADDRESS);
               if (!iter1.eof()) {
-                *rfc5780 = 1;
+                *rfc5780 = true;
                 printf("\n========================================\n");
                 printf("RFC 5780 response %d\n", ++counter);
                 turn::StunAttrIterator iter2(res, STUN_ATTRIBUTE_MAPPED_ADDRESS);
@@ -270,7 +271,7 @@ static int stunclient_receive(int sockfd, ioa_addr *local_addr, ioa_addr *reflex
 }
 
 static int run_stunclient(ioa_addr *local_addr, ioa_addr *remote_addr, ioa_addr *reflexive_addr, ioa_addr *other_addr,
-                          int *local_port, int *rfc5780, int change_ip, int change_port, int padding) {
+                          int *local_port, bool *rfc5780, bool change_ip, bool change_port, int padding) {
   int ret = 0;
 
   ret = init_socket(&udp_fd, local_addr, *local_port, remote_addr);
@@ -282,8 +283,8 @@ static int run_stunclient(ioa_addr *local_addr, ioa_addr *remote_addr, ioa_addr 
 }
 
 static int run_stunclient_hairpinning(ioa_addr *local_addr, ioa_addr *remote_addr, ioa_addr *reflexive_addr,
-                                      ioa_addr *other_addr, int *local_port, int *rfc5780, int change_ip,
-                                      int change_port, int padding) {
+                                      ioa_addr *other_addr, int *local_port, bool *rfc5780, bool change_ip,
+                                      bool change_port, int padding) {
   int ret = 0;
 
   init_socket(&udp_fd, local_addr, *local_port, remote_addr);
@@ -309,8 +310,8 @@ static int run_stunclient_hairpinning(ioa_addr *local_addr, ioa_addr *remote_add
 }
 
 static int run_stunclient_lifetime(int timer, ioa_addr *local_addr, ioa_addr *remote_addr, ioa_addr *reflexive_addr,
-                                   ioa_addr *other_addr, int *local_port, int *rfc5780, int change_ip, int change_port,
-                                   int padding) {
+                                   ioa_addr *other_addr, int *local_port, bool *rfc5780, bool change_ip,
+                                   bool change_port, int padding) {
   int ret = 0;
   int response_port;
 
@@ -357,7 +358,7 @@ static int init_socket(int *socketfd, ioa_addr *local_addr, int local_port, ioa_
 }
 
 static int stunclient_send(stun_buffer *buf, int sockfd, ioa_addr *local_addr, int *local_port, ioa_addr *remote_addr,
-                           int change_ip, int change_port, int padding, int response_port) {
+                           bool change_ip, bool change_port, int padding, int response_port) {
   int ret = 0;
 
   stun_prepare_binding_request(buf);
@@ -397,7 +398,7 @@ static int stunclient_send(stun_buffer *buf, int sockfd, ioa_addr *local_addr, i
 }
 
 static int stunclient_receive(stun_buffer *buf, int sockfd, ioa_addr *local_addr, ioa_addr *reflexive_addr,
-                              ioa_addr *other_addr, int *rfc5780) {
+                              ioa_addr *other_addr, bool *rfc5780) {
   int ret = 0;
 
   {
@@ -439,7 +440,7 @@ static int stunclient_receive(stun_buffer *buf, int sockfd, ioa_addr *local_addr
 
               stun_attr_ref sar = stun_attr_get_first_by_type_str(buf->buf, buf->len, STUN_ATTRIBUTE_OTHER_ADDRESS);
               if (sar) {
-                *rfc5780 = 1;
+                *rfc5780 = true;
                 printf("\n========================================\n");
                 printf("RFC 5780 response %d\n", ++counter);
                 ioa_addr mapped_addr;
@@ -501,7 +502,7 @@ static int stunclient_receive(stun_buffer *buf, int sockfd, ioa_addr *local_addr
 }
 
 static int run_stunclient(ioa_addr *local_addr, ioa_addr *remote_addr, ioa_addr *reflexive_addr, ioa_addr *other_addr,
-                          int *local_port, int *rfc5780, int change_ip, int change_port, int padding) {
+                          int *local_port, bool *rfc5780, bool change_ip, bool change_port, int padding) {
   int ret = 0;
   stun_buffer buf;
 
@@ -516,8 +517,8 @@ static int run_stunclient(ioa_addr *local_addr, ioa_addr *remote_addr, ioa_addr 
 }
 
 static int run_stunclient_hairpinning(ioa_addr *local_addr, ioa_addr *remote_addr, ioa_addr *reflexive_addr,
-                                      ioa_addr *other_addr, int *local_port, int *rfc5780, int change_ip,
-                                      int change_port, int padding) {
+                                      ioa_addr *other_addr, int *local_port, bool *rfc5780, bool change_ip,
+                                      bool change_port, int padding) {
   int ret = 0;
   stun_buffer buf;
   stun_buffer buf2;
@@ -546,8 +547,8 @@ static int run_stunclient_hairpinning(ioa_addr *local_addr, ioa_addr *remote_add
 }
 
 static int run_stunclient_lifetime(int timer, ioa_addr *local_addr, ioa_addr *remote_addr, ioa_addr *reflexive_addr,
-                                   ioa_addr *other_addr, int *local_port, int *rfc5780, int change_ip, int change_port,
-                                   int padding) {
+                                   ioa_addr *other_addr, int *local_port, bool *rfc5780, bool change_ip,
+                                   bool change_port, int padding) {
   int ret = 0;
   stun_buffer buf;
   stun_buffer buf2;
@@ -599,7 +600,7 @@ static char Usage[] = "Usage: natdiscovery [options] address\n"
 
 //////////////////////////////////////////////////
 
-static void init(int first, ioa_addr *local_addr, ioa_addr *remote_addr, int *local_port, int port, int *rfc5780,
+static void init(int first, ioa_addr *local_addr, ioa_addr *remote_addr, int *local_port, int port, bool *rfc5780,
                  char *local_addr_string, char *remote_param) {
   addr_set_any(local_addr);
 
@@ -611,7 +612,7 @@ static void init(int first, ioa_addr *local_addr, ioa_addr *remote_addr, int *lo
   if (!first) {
     *local_port = -1;
   }
-  *rfc5780 = 0;
+  *rfc5780 = false;
 
   if (make_ioa_addr((const uint8_t *)remote_param, port, remote_addr) < 0) {
     err(-1, NULL);
@@ -637,7 +638,7 @@ int main(int argc, char **argv) {
   int padding = 0;
   int hairpinning = 0;
   int local_port = -1;
-  int rfc5780;
+  bool rfc5780;
   int first = 1;
   ioa_addr other_addr, reflexive_addr, tmp_addr, remote_addr, local_addr, local2_addr;
 

--- a/src/apps/stunclient/stunclient.c
+++ b/src/apps/stunclient/stunclient.c
@@ -28,6 +28,7 @@
  * SUCH DAMAGE.
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -57,8 +58,8 @@ static int counter = 0;
 
 #ifdef __cplusplus
 
-static int run_stunclient(const char *rip, int rport, int *port, int *rfc5780, int response_port, int change_ip,
-                          int change_port, int padding) {
+static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, int response_port, bool change_ip,
+                          bool change_port, int padding) {
 
   ioa_addr remote_addr;
   int new_udp_fd = -1;
@@ -258,8 +259,8 @@ static int run_stunclient(const char *rip, int rport, int *port, int *rfc5780, i
 
 #else
 
-static int run_stunclient(const char *rip, int rport, int *port, int *rfc5780, int response_port, int change_ip,
-                          int change_port, int padding) {
+static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, int response_port, bool change_ip,
+                          bool change_port, int padding) {
 
   ioa_addr remote_addr;
   int new_udp_fd = -1;
@@ -429,7 +430,7 @@ int main(int argc, char **argv) {
   int port = DEFAULT_STUN_PORT;
   char local_addr[256] = "\0";
   int c = 0;
-  int forceRfc5780 = 0;
+  bool forceRfc5780 = false;
 
   if (socket_init()) {
     return -1;
@@ -472,7 +473,7 @@ int main(int argc, char **argv) {
   }
 
   int local_port = -1;
-  int rfc5780 = 0;
+  bool rfc5780 = false;
 
   run_stunclient(argv[optind], port, &local_port, &rfc5780, -1, 0, 0, 0);
 


### PR DESCRIPTION
# changed variables that appeared in `stunclient.c` and their uses to `bool` to follow C11 idioms
## approach was as follows:
- if a variable of type `int` was only being used as a boolean, replace it with bool as defined in `<stdbool.h>`
- replace its declaration and assignment with true/false, depending on prior assignment as 0/1

changes were only made when i was certain the variables were not being used as an int, so i may have missed some

---

## variables changed in `stunclient.c`
- `rfc5780`
- `change_ip`
- `change_port`

their usages were changed only where they appeared in the apps directory, and then everywhere that generated a warning after make

- `stunclient.c` itself
- `natdiscovery.c`