### PR TITLE
Change .clang-format to apply linebreaks before open-braces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,25 +24,25 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: true
+BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterCaseLabel:  false
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  AfterExternBlock: false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
+  AfterCaseLabel:        true
+  AfterClass:            true
+  AfterControlStatement: true
+  AfterEnum:             true
+  AfterFunction:         true
+  AfterNamespace:        true
+  AfterObjCDeclaration:  true
+  AfterStruct:           true
+  AfterUnion:            true
+  AfterExternBlock:      true
+  BeforeCatch:           true
+  BeforeElse:            true
+  IndentBraces:          false
+  SplitEmptyFunction:    true
+  SplitEmptyRecord:      true
+  SplitEmptyNamespace:   true
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
 BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
@@ -80,10 +80,11 @@ IncludeCategories:
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
 IndentCaseLabels: false
-IndentGotoLabels: true
+IndentGotoLabels: false
 IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+IndentExternBlock: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true

--- a/fuzzing/FuzzStun.c
+++ b/fuzzing/FuzzStun.c
@@ -11,10 +11,11 @@ static SHATYPE shatype = SHATYPE_SHA1;
 #define kMinInputLength 10
 #define kMaxInputLength 5120
 
-extern int LLVMFuzzerTestOneInput(const uint8_t *Data,
-                                  size_t Size) { // rfc5769check
+extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{ // rfc5769check
 
-  if (Size < kMinInputLength || Size > kMaxInputLength) {
+  if (Size < kMinInputLength || Size > kMaxInputLength)
+  {
     return 1;
   }
 

--- a/fuzzing/FuzzStunClient.c
+++ b/fuzzing/FuzzStunClient.c
@@ -9,10 +9,11 @@
 #define kMinInputLength 10
 #define kMaxInputLength 5120
 
-extern int LLVMFuzzerTestOneInput(const uint8_t *Data,
-                                  size_t Size) { // stunclient.c
+extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
+{ // stunclient.c
 
-  if (Size < kMinInputLength || Size > kMaxInputLength) {
+  if (Size < kMinInputLength || Size > kMaxInputLength)
+  {
     return 1;
   }
 
@@ -21,10 +22,14 @@ extern int LLVMFuzzerTestOneInput(const uint8_t *Data,
   buf.len = Size;
   memcpy(buf.buf, Data, buf.len);
 
-  if (stun_is_command_message(&buf)) {
-    if (stun_is_response(&buf)) {
-      if (stun_is_success_response(&buf)) {
-        if (stun_is_binding_response(&buf)) {
+  if (stun_is_command_message(&buf))
+  {
+    if (stun_is_response(&buf))
+    {
+      if (stun_is_success_response(&buf))
+      {
+        if (stun_is_binding_response(&buf))
+        {
           return 0;
         }
       }

--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -80,12 +80,14 @@ int IS_TURN_SERVER = 0;
 
 /*********************** Sockets *********************************/
 
-int socket_set_nonblocking(evutil_socket_t fd) {
+int socket_set_nonblocking(evutil_socket_t fd)
+{
 #if defined(WINDOWS)
   unsigned long nonblocking = 1;
   ioctlsocket(fd, FIONBIO, (unsigned long *)&nonblocking);
 #else
-  if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1) {
+  if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1)
+  {
     perror("O_NONBLOCK");
     return -1;
   }
@@ -93,8 +95,10 @@ int socket_set_nonblocking(evutil_socket_t fd) {
   return 0;
 }
 
-void read_spare_buffer(evutil_socket_t fd) {
-  if (fd >= 0) {
+void read_spare_buffer(evutil_socket_t fd)
+{
+  if (fd >= 0)
+  {
     static char buffer[65536];
 #if defined(WINDOWS)
     // TODO: add set no-block? by Kang Lin <kl222@126.com>
@@ -105,33 +109,44 @@ void read_spare_buffer(evutil_socket_t fd) {
   }
 }
 
-int set_sock_buf_size(evutil_socket_t fd, int sz0) {
+int set_sock_buf_size(evutil_socket_t fd, int sz0)
+{
   int sz;
 
   sz = sz0;
-  while (sz > 0) {
-    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, (const void *)&sz, (socklen_t)sizeof(sz)) < 0) {
+  while (sz > 0)
+  {
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, (const void *)&sz, (socklen_t)sizeof(sz)) < 0)
+    {
       sz = sz / 2;
-    } else {
+    }
+    else
+    {
       break;
     }
   }
 
-  if (sz < 1) {
+  if (sz < 1)
+  {
     perror("Cannot set socket rcv size");
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Cannot set rcv sock size %d on fd %d\n", sz0, fd);
   }
 
   sz = sz0;
-  while (sz > 0) {
-    if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (const void *)&sz, (socklen_t)sizeof(sz)) < 0) {
+  while (sz > 0)
+  {
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDBUF, (const void *)&sz, (socklen_t)sizeof(sz)) < 0)
+    {
       sz = sz / 2;
-    } else {
+    }
+    else
+    {
       break;
     }
   }
 
-  if (sz < 1) {
+  if (sz < 1)
+  {
     perror("Cannot set socket snd size");
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Cannot set snd sock size %d on fd %d\n", sz0, fd);
   }
@@ -139,7 +154,8 @@ int set_sock_buf_size(evutil_socket_t fd, int sz0) {
   return 0;
 }
 
-int socket_init(void) {
+int socket_init(void)
+{
 #if defined(WINDOWS)
   {
     WORD wVersionRequested;
@@ -150,7 +166,8 @@ int socket_init(void) {
     wVersionRequested = MAKEWORD(2, 2);
 
     e = WSAStartup(wVersionRequested, &wsaData);
-    if (e != 0) {
+    if (e != 0)
+    {
       /* Tell the user that we could not find a usable */
       /* Winsock DLL.                                  */
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "WSAStartup failed with error: %d\n", e);
@@ -161,7 +178,8 @@ int socket_init(void) {
   return 0;
 }
 
-int socket_tcp_set_keepalive(evutil_socket_t fd, SOCKET_TYPE st) {
+int socket_tcp_set_keepalive(evutil_socket_t fd, SOCKET_TYPE st)
+{
   UNUSED_ARG(st);
 
 #ifdef SO_KEEPALIVE
@@ -184,12 +202,16 @@ int socket_tcp_set_keepalive(evutil_socket_t fd, SOCKET_TYPE st) {
   return 0;
 }
 
-int socket_set_reusable(evutil_socket_t fd, int flag, SOCKET_TYPE st) {
+int socket_set_reusable(evutil_socket_t fd, int flag, SOCKET_TYPE st)
+{
   UNUSED_ARG(st);
 
-  if (fd < 0) {
+  if (fd < 0)
+  {
     return -1;
-  } else {
+  }
+  else
+  {
 
 #if defined(WINDOWS)
     int use_reuseaddr = IS_TURN_SERVER;
@@ -198,10 +220,12 @@ int socket_set_reusable(evutil_socket_t fd, int flag, SOCKET_TYPE st) {
 #endif
 
 #if defined(SO_REUSEADDR)
-    if (use_reuseaddr) {
+    if (use_reuseaddr)
+    {
       int on = flag;
       int ret = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (const void *)&on, (socklen_t)sizeof(on));
-      if (ret < 0) {
+      if (ret < 0)
+      {
         perror("SO_REUSEADDR");
       }
     }
@@ -209,11 +233,14 @@ int socket_set_reusable(evutil_socket_t fd, int flag, SOCKET_TYPE st) {
 
 #if !defined(TURN_NO_SCTP)
 #if defined(SCTP_REUSE_PORT)
-    if (use_reuseaddr) {
-      if (is_sctp_socket(st)) {
+    if (use_reuseaddr)
+    {
+      if (is_sctp_socket(st))
+      {
         int on = flag;
         int ret = setsockopt(fd, IPPROTO_SCTP, SCTP_REUSE_PORT, (const void *)&on, (socklen_t)sizeof(on));
-        if (ret < 0) {
+        if (ret < 0)
+        {
           perror("SCTP_REUSE_PORT");
         }
       }
@@ -222,7 +249,8 @@ int socket_set_reusable(evutil_socket_t fd, int flag, SOCKET_TYPE st) {
 #endif
 
 #if defined(SO_REUSEPORT)
-    if (use_reuseaddr) {
+    if (use_reuseaddr)
+    {
       int on = flag;
       setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, (const void *)&on, (socklen_t)sizeof(on));
     }
@@ -232,9 +260,11 @@ int socket_set_reusable(evutil_socket_t fd, int flag, SOCKET_TYPE st) {
   }
 }
 
-int sock_bind_to_device(evutil_socket_t fd, const unsigned char *ifname) {
+int sock_bind_to_device(evutil_socket_t fd, const unsigned char *ifname)
+{
 
-  if (fd >= 0 && ifname && ifname[0]) {
+  if (fd >= 0 && ifname && ifname[0])
+  {
 
 #if defined(SO_BINDTODEVICE)
 
@@ -243,10 +273,14 @@ int sock_bind_to_device(evutil_socket_t fd, const unsigned char *ifname) {
 
     strncpy(ifr.ifr_name, (const char *)ifname, sizeof(ifr.ifr_name));
 
-    if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, (const void *)&ifr, sizeof(ifr)) < 0) {
-      if (socket_eperm()) {
+    if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, (const void *)&ifr, sizeof(ifr)) < 0)
+    {
+      if (socket_eperm())
+      {
         perror("You must obtain superuser privileges to bind a socket to device");
-      } else {
+      }
+      else
+      {
         perror("Cannot bind socket to device");
       }
 
@@ -261,26 +295,38 @@ int sock_bind_to_device(evutil_socket_t fd, const unsigned char *ifname) {
   return 0;
 }
 
-int addr_connect(evutil_socket_t fd, const ioa_addr *addr, int *out_errno) {
-  if (!addr || fd < 0) {
+int addr_connect(evutil_socket_t fd, const ioa_addr *addr, int *out_errno)
+{
+  if (!addr || fd < 0)
+  {
     return -1;
-  } else {
+  }
+  else
+  {
     int err = 0;
-    do {
-      if (addr->ss.sa_family == AF_INET) {
+    do
+    {
+      if (addr->ss.sa_family == AF_INET)
+      {
         err = connect(fd, (const struct sockaddr *)addr, sizeof(struct sockaddr_in));
-      } else if (addr->ss.sa_family == AF_INET6) {
+      }
+      else if (addr->ss.sa_family == AF_INET6)
+      {
         err = connect(fd, (const struct sockaddr *)addr, sizeof(struct sockaddr_in6));
-      } else {
+      }
+      else
+      {
         return -1;
       }
     } while (err < 0 && socket_eintr());
 
-    if (out_errno) {
+    if (out_errno)
+    {
       *out_errno = socket_errno();
     }
 
-    if (err < 0 && !socket_einprogress()) {
+    if (err < 0 && !socket_einprogress())
+    {
       perror("Connect");
     }
 
@@ -288,32 +334,44 @@ int addr_connect(evutil_socket_t fd, const ioa_addr *addr, int *out_errno) {
   }
 }
 
-int addr_bind(evutil_socket_t fd, const ioa_addr *addr, int reusable, int debug, SOCKET_TYPE st) {
-  if (!addr || fd < 0) {
+int addr_bind(evutil_socket_t fd, const ioa_addr *addr, int reusable, int debug, SOCKET_TYPE st)
+{
+  if (!addr || fd < 0)
+  {
 
     return -1;
-
-  } else {
+  }
+  else
+  {
 
     int ret = -1;
 
     socket_set_reusable(fd, reusable, st);
 
-    if (addr->ss.sa_family == AF_INET) {
-      do {
+    if (addr->ss.sa_family == AF_INET)
+    {
+      do
+      {
         ret = bind(fd, (const struct sockaddr *)addr, sizeof(struct sockaddr_in));
       } while (ret < 0 && socket_eintr());
-    } else if (addr->ss.sa_family == AF_INET6) {
+    }
+    else if (addr->ss.sa_family == AF_INET6)
+    {
       const int off = 0;
       setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (const void *)&off, sizeof(off));
-      do {
+      do
+      {
         ret = bind(fd, (const struct sockaddr *)addr, sizeof(struct sockaddr_in6));
       } while (ret < 0 && socket_eintr());
-    } else {
+    }
+    else
+    {
       return -1;
     }
-    if (ret < 0) {
-      if (debug) {
+    if (ret < 0)
+    {
+      if (debug)
+      {
         int err = socket_errno();
         perror("bind");
         char str[129];
@@ -325,19 +383,25 @@ int addr_bind(evutil_socket_t fd, const ioa_addr *addr, int reusable, int debug,
   }
 }
 
-int addr_get_from_sock(evutil_socket_t fd, ioa_addr *addr) {
+int addr_get_from_sock(evutil_socket_t fd, ioa_addr *addr)
+{
 
-  if (fd < 0 || !addr) {
+  if (fd < 0 || !addr)
+  {
     return -1;
-  } else {
+  }
+  else
+  {
 
     ioa_addr a;
     a.ss.sa_family = AF_INET6;
     socklen_t socklen = get_ioa_addr_len(&a);
-    if (getsockname(fd, (struct sockaddr *)&a, &socklen) < 0) {
+    if (getsockname(fd, (struct sockaddr *)&a, &socklen) < 0)
+    {
       a.ss.sa_family = AF_INET;
       socklen = get_ioa_addr_len(&a);
-      if (getsockname(fd, (struct sockaddr *)&a, &socklen) < 0) {
+      if (getsockname(fd, (struct sockaddr *)&a, &socklen) < 0)
+      {
         return -1;
       }
     }
@@ -348,31 +412,39 @@ int addr_get_from_sock(evutil_socket_t fd, ioa_addr *addr) {
   }
 }
 
-int get_raw_socket_ttl(evutil_socket_t fd, int family) {
+int get_raw_socket_ttl(evutil_socket_t fd, int family)
+{
   int ttl = 0;
 
-  if (family == AF_INET6) {
+  if (family == AF_INET6)
+  {
 #if !defined(IPV6_UNICAST_HOPS)
     UNUSED_ARG(fd);
-    do {
+    do
+    {
       return TTL_IGNORE;
     } while (0);
 #else
     socklen_t slen = (socklen_t)sizeof(ttl);
-    if (getsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (void *)&ttl, &slen) < 0) {
+    if (getsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (void *)&ttl, &slen) < 0)
+    {
       perror("get HOPLIMIT on socket");
       return TTL_IGNORE;
     }
 #endif
-  } else {
+  }
+  else
+  {
 #if !defined(IP_TTL)
     UNUSED_ARG(fd);
-    do {
+    do
+    {
       return TTL_IGNORE;
     } while (0);
 #else
     socklen_t slen = (socklen_t)sizeof(ttl);
-    if (getsockopt(fd, IPPROTO_IP, IP_TTL, (void *)&ttl, &slen) < 0) {
+    if (getsockopt(fd, IPPROTO_IP, IP_TTL, (void *)&ttl, &slen) < 0)
+    {
       perror("get TTL on socket");
       return TTL_IGNORE;
     }
@@ -384,31 +456,39 @@ int get_raw_socket_ttl(evutil_socket_t fd, int family) {
   return ttl;
 }
 
-int get_raw_socket_tos(evutil_socket_t fd, int family) {
+int get_raw_socket_tos(evutil_socket_t fd, int family)
+{
   int tos = 0;
 
-  if (family == AF_INET6) {
+  if (family == AF_INET6)
+  {
 #if !defined(IPV6_TCLASS)
     UNUSED_ARG(fd);
-    do {
+    do
+    {
       return TOS_IGNORE;
     } while (0);
 #else
     socklen_t slen = (socklen_t)sizeof(tos);
-    if (getsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, (void *)&tos, &slen) < 0) {
+    if (getsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, (void *)&tos, &slen) < 0)
+    {
       perror("get TCLASS on socket");
       return -1;
     }
 #endif
-  } else {
+  }
+  else
+  {
 #if !defined(IP_TOS)
     UNUSED_ARG(fd);
-    do {
+    do
+    {
       return TOS_IGNORE;
     } while (0);
 #else
     socklen_t slen = (socklen_t)sizeof(tos);
-    if (getsockopt(fd, IPPROTO_IP, IP_TOS, (void *)&tos, &slen) < 0) {
+    if (getsockopt(fd, IPPROTO_IP, IP_TOS, (void *)&tos, &slen) < 0)
+    {
       perror("get TOS on socket");
       return -1;
     }
@@ -420,26 +500,32 @@ int get_raw_socket_tos(evutil_socket_t fd, int family) {
   return tos;
 }
 
-int set_raw_socket_ttl(evutil_socket_t fd, int family, int ttl) {
+int set_raw_socket_ttl(evutil_socket_t fd, int family, int ttl)
+{
 
-  if (family == AF_INET6) {
+  if (family == AF_INET6)
+  {
 #if !defined(IPV6_UNICAST_HOPS)
     UNUSED_ARG(fd);
     UNUSED_ARG(ttl);
 #else
     CORRECT_RAW_TTL(ttl);
-    if (setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (const void *)&ttl, sizeof(ttl)) < 0) {
+    if (setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (const void *)&ttl, sizeof(ttl)) < 0)
+    {
       perror("set HOPLIMIT on socket");
       return -1;
     }
 #endif
-  } else {
+  }
+  else
+  {
 #if !defined(IP_TTL)
     UNUSED_ARG(fd);
     UNUSED_ARG(ttl);
 #else
     CORRECT_RAW_TTL(ttl);
-    if (setsockopt(fd, IPPROTO_IP, IP_TTL, (const void *)&ttl, sizeof(ttl)) < 0) {
+    if (setsockopt(fd, IPPROTO_IP, IP_TTL, (const void *)&ttl, sizeof(ttl)) < 0)
+    {
       perror("set TTL on socket");
       return -1;
     }
@@ -449,25 +535,31 @@ int set_raw_socket_ttl(evutil_socket_t fd, int family, int ttl) {
   return 0;
 }
 
-int set_raw_socket_tos(evutil_socket_t fd, int family, int tos) {
+int set_raw_socket_tos(evutil_socket_t fd, int family, int tos)
+{
 
-  if (family == AF_INET6) {
+  if (family == AF_INET6)
+  {
 #if !defined(IPV6_TCLASS)
     UNUSED_ARG(fd);
     UNUSED_ARG(tos);
 #else
     CORRECT_RAW_TOS(tos);
-    if (setsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, (const void *)&tos, sizeof(tos)) < 0) {
+    if (setsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, (const void *)&tos, sizeof(tos)) < 0)
+    {
       perror("set TCLASS on socket");
       return -1;
     }
 #endif
-  } else {
+  }
+  else
+  {
 #if !defined(IP_TOS)
     UNUSED_ARG(fd);
     UNUSED_ARG(tos);
 #else
-    if (setsockopt(fd, IPPROTO_IP, IP_TOS, (const void *)&tos, sizeof(tos)) < 0) {
+    if (setsockopt(fd, IPPROTO_IP, IP_TOS, (const void *)&tos, sizeof(tos)) < 0)
+    {
       perror("set TOS on socket");
       return -1;
     }
@@ -477,8 +569,10 @@ int set_raw_socket_tos(evutil_socket_t fd, int family, int tos) {
   return 0;
 }
 
-int is_stream_socket(int st) {
-  switch (st) {
+int is_stream_socket(int st)
+{
+  switch (st)
+  {
   case TCP_SOCKET:
   case TCP_SOCKET_PROXY:
   case TLS_SOCKET:
@@ -492,8 +586,10 @@ int is_stream_socket(int st) {
   return 0;
 }
 
-int is_tcp_socket(int st) {
-  switch (st) {
+int is_tcp_socket(int st)
+{
+  switch (st)
+  {
   case TCP_SOCKET:
   case TLS_SOCKET:
   case TENTATIVE_TCP_SOCKET:
@@ -503,8 +599,10 @@ int is_tcp_socket(int st) {
   return 0;
 }
 
-int is_sctp_socket(int st) {
-  switch (st) {
+int is_sctp_socket(int st)
+{
+  switch (st)
+  {
   case SCTP_SOCKET:
   case TLS_SCTP_SOCKET:
   case TENTATIVE_SCTP_SOCKET:
@@ -514,8 +612,10 @@ int is_sctp_socket(int st) {
   return 0;
 }
 
-const char *socket_type_name(SOCKET_TYPE st) {
-  switch (st) {
+const char *socket_type_name(SOCKET_TYPE st)
+{
+  switch (st)
+  {
   case TCP_SOCKET:
     return "TCP";
   case SCTP_SOCKET:
@@ -539,7 +639,8 @@ const char *socket_type_name(SOCKET_TYPE st) {
 
 /////////////////// MTU /////////////////////////////////////////
 
-int set_socket_df(evutil_socket_t fd, int family, int value) {
+int set_socket_df(evutil_socket_t fd, int family, int value)
+{
 
   int ret = 0;
 
@@ -547,16 +648,20 @@ int set_socket_df(evutil_socket_t fd, int family, int value) {
   {
     const int val = value;
     /* kernel sets DF bit on outgoing IP packets */
-    if (family == AF_INET) {
+    if (family == AF_INET)
+    {
       ret = setsockopt(fd, IPPROTO_IP, IP_DONTFRAG, (const void *)&val, sizeof(val));
-    } else {
+    }
+    else
+    {
 #if defined(IPV6_DONTFRAG) && defined(IPPROTO_IPV6)
       ret = setsockopt(fd, IPPROTO_IPV6, IPV6_DONTFRAG, (const void *)&val, sizeof(val));
 #else
 #error CANNOT SET IPV6 SOCKET DF FLAG (1)
 #endif
     }
-    if (ret < 0) {
+    if (ret < 0)
+    {
       int err = socket_errno();
       perror("set socket df:");
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: set sockopt failed: fd=%d, err=%d, family=%d\n", __FUNCTION__, fd, err,
@@ -566,16 +671,21 @@ int set_socket_df(evutil_socket_t fd, int family, int value) {
 #elif defined(IPPROTO_IP) && defined(IP_MTU_DISCOVER) && defined(IP_PMTUDISC_DO) && defined(IP_PMTUDISC_DONT) // LINUX
   {
     /* kernel sets DF bit on outgoing IP packets */
-    if (family == AF_INET) {
+    if (family == AF_INET)
+    {
       int val = IP_PMTUDISC_DO;
-      if (!value) {
+      if (!value)
+      {
         val = IP_PMTUDISC_DONT;
       }
       ret = setsockopt(fd, IPPROTO_IP, IP_MTU_DISCOVER, (const void *)&val, sizeof(val));
-    } else {
+    }
+    else
+    {
 #if defined(IPPROTO_IPV6) && defined(IPV6_MTU_DISCOVER) && defined(IPV6_PMTUDISC_DO) && defined(IPV6_PMTUDISC_DONT)
       int val = IPV6_PMTUDISC_DO;
-      if (!value) {
+      if (!value)
+      {
         val = IPV6_PMTUDISC_DONT;
       }
       ret = setsockopt(fd, IPPROTO_IPV6, IPV6_MTU_DISCOVER, (const void *)&val, sizeof(val));
@@ -583,7 +693,8 @@ int set_socket_df(evutil_socket_t fd, int family, int value) {
 #error CANNOT SET IPV6 SOCKET DF FLAG (2)
 #endif
     }
-    if (ret < 0) {
+    if (ret < 0)
+    {
       perror("set DF");
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: set sockopt failed\n", __FUNCTION__);
     }
@@ -598,10 +709,12 @@ int set_socket_df(evutil_socket_t fd, int family, int value) {
   return ret;
 }
 
-static int get_mtu_from_ssl(SSL *ssl) {
+static int get_mtu_from_ssl(SSL *ssl)
+{
   int ret = SOSO_MTU;
 #if DTLS_SUPPORTED
-  if (ssl) {
+  if (ssl)
+  {
     ret = BIO_ctrl(SSL_get_wbio(ssl), BIO_CTRL_DGRAM_QUERY_MTU, 0, NULL);
   }
 #else
@@ -610,8 +723,10 @@ static int get_mtu_from_ssl(SSL *ssl) {
   return ret;
 }
 
-static void set_query_mtu(SSL *ssl) {
-  if (ssl) {
+static void set_query_mtu(SSL *ssl)
+{
+  if (ssl)
+  {
 #if defined(SSL_OP_NO_QUERY_MTU)
     SSL_set_options(ssl, SSL_OP_NO_QUERY_MTU);
 #else
@@ -620,35 +735,46 @@ static void set_query_mtu(SSL *ssl) {
   }
 }
 
-int decrease_mtu(SSL *ssl, int mtu, int verbose) {
+int decrease_mtu(SSL *ssl, int mtu, int verbose)
+{
 
-  if (!ssl) {
+  if (!ssl)
+  {
     return mtu;
   }
 
   int new_mtu = get_mtu_from_ssl(ssl);
 
-  if (new_mtu < 1) {
+  if (new_mtu < 1)
+  {
     new_mtu = mtu;
   }
 
-  if (new_mtu > MAX_MTU) {
+  if (new_mtu > MAX_MTU)
+  {
     mtu = MAX_MTU;
   }
-  if (new_mtu > 0 && new_mtu < MIN_MTU) {
+  if (new_mtu > 0 && new_mtu < MIN_MTU)
+  {
     mtu = MIN_MTU;
-  } else if (new_mtu < mtu) {
+  }
+  else if (new_mtu < mtu)
+  {
     mtu = new_mtu;
-  } else {
+  }
+  else
+  {
     mtu -= MTU_STEP;
   }
 
-  if (mtu < MIN_MTU) {
+  if (mtu < MIN_MTU)
+  {
     mtu = MIN_MTU;
   }
 
   set_query_mtu(ssl);
-  if (verbose) {
+  if (verbose)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "1. mtu to use: %d\n", mtu);
   }
 
@@ -660,24 +786,32 @@ int decrease_mtu(SSL *ssl, int mtu, int verbose) {
   return mtu;
 }
 
-int set_mtu_df(SSL *ssl, evutil_socket_t fd, int family, int mtu, int df_value, int verbose) {
+int set_mtu_df(SSL *ssl, evutil_socket_t fd, int family, int mtu, int df_value, int verbose)
+{
 
-  if (!ssl || fd < 0) {
+  if (!ssl || fd < 0)
+  {
     return 0;
   }
 
   int ret = set_socket_df(fd, family, df_value);
 
-  if (!mtu) {
+  if (!mtu)
+  {
     mtu = SOSO_MTU;
-  } else if (mtu < MIN_MTU) {
+  }
+  else if (mtu < MIN_MTU)
+  {
     mtu = MIN_MTU;
-  } else if (mtu > MAX_MTU) {
+  }
+  else if (mtu > MAX_MTU)
+  {
     mtu = MAX_MTU;
   }
 
   set_query_mtu(ssl);
-  if (verbose) {
+  if (verbose)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "3. mtu to use: %d\n", mtu);
   }
 
@@ -689,14 +823,16 @@ int set_mtu_df(SSL *ssl, evutil_socket_t fd, int family, int mtu, int df_value, 
 
 #endif
 
-  if (verbose) {
+  if (verbose)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "4. new mtu: %d\n", get_mtu_from_ssl(ssl));
   }
 
   return ret;
 }
 
-int get_socket_mtu(evutil_socket_t fd, int family, int verbose) {
+int get_socket_mtu(evutil_socket_t fd, int family, int verbose)
+{
 
   int ret = 0;
 
@@ -707,9 +843,12 @@ int get_socket_mtu(evutil_socket_t fd, int family, int verbose) {
 #if defined(IP_MTU)
   int val = 0;
   socklen_t slen = sizeof(val);
-  if (family == AF_INET) {
+  if (family == AF_INET)
+  {
     ret = getsockopt(fd, IPPROTO_IP, IP_MTU, (void *)&val, &slen);
-  } else {
+  }
+  else
+  {
 #if defined(IPPROTO_IPV6) && defined(IPV6_MTU)
     ret = getsockopt(fd, IPPROTO_IPV6, IPV6_MTU, (void *)&val, &slen);
 #endif
@@ -719,7 +858,8 @@ int get_socket_mtu(evutil_socket_t fd, int family, int verbose) {
   ret = val;
 #endif
 
-  if (verbose) {
+  if (verbose)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: final=%d\n", __FUNCTION__, ret);
   }
 
@@ -728,47 +868,56 @@ int get_socket_mtu(evutil_socket_t fd, int family, int verbose) {
 
 //////////////////// socket error handle ////////////////////
 
-int handle_socket_error(void) {
-  if (socket_eintr()) {
+int handle_socket_error(void)
+{
+  if (socket_eintr())
+  {
     /* Interrupted system call.
      * Just ignore.
      */
     return 1;
   }
-  if (socket_enobufs()) {
+  if (socket_enobufs())
+  {
     /* Interrupted system call.
      * Just ignore.
      */
     return 1;
   }
-  if (socket_ewouldblock() || socket_eagain()) {
+  if (socket_ewouldblock() || socket_eagain())
+  {
     return 1;
   }
-  if (socket_ebadf()) {
+  if (socket_ebadf())
+  {
     /* Invalid socket.
      * Must close connection.
      */
     return 0;
   }
-  if (socket_ehostdown()) {
+  if (socket_ehostdown())
+  {
     /* Host is down.
      * Just ignore, might be an attacker
      * sending fake ICMP messages.
      */
     return 1;
   }
-  if (socket_econnreset() || socket_econnrefused()) {
+  if (socket_econnreset() || socket_econnrefused())
+  {
     /* Connection reset by peer. */
     return 0;
   }
-  if (socket_enomem()) {
+  if (socket_enomem())
+  {
     /* Out of memory.
      * Must close connection.
      */
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Out of memory!\n");
     return 0;
   }
-  if (socket_eacces()) {
+  if (socket_eacces())
+  {
     /* Permission denied.
      * Just ignore, we might be blocked
      * by some firewall policy. Try again
@@ -784,8 +933,10 @@ int handle_socket_error(void) {
 
 //////////////////// Misc utils //////////////////////////////
 
-char *skip_blanks(char *s) {
-  while (*s == ' ' || *s == '\t' || *s == '\n') {
+char *skip_blanks(char *s)
+{
+  while (*s == ' ' || *s == '\t' || *s == '\n')
+  {
     ++s;
   }
 
@@ -794,7 +945,8 @@ char *skip_blanks(char *s) {
 
 #if defined(_MSC_VER)
 
-LARGE_INTEGER getFILETIMEoffset() {
+LARGE_INTEGER getFILETIMEoffset()
+{
   SYSTEMTIME s;
   FILETIME f;
   LARGE_INTEGER t;
@@ -813,7 +965,8 @@ LARGE_INTEGER getFILETIMEoffset() {
   return (t);
 }
 
-int clock_gettime(int X, struct timeval *tv) {
+int clock_gettime(int X, struct timeval *tv)
+{
   LARGE_INTEGER t;
   FILETIME f;
   double microseconds;
@@ -822,21 +975,28 @@ int clock_gettime(int X, struct timeval *tv) {
   static int initialized = 0;
   static BOOL usePerformanceCounter = FALSE;
 
-  if (!initialized) {
+  if (!initialized)
+  {
     LARGE_INTEGER performanceFrequency;
     initialized = 1;
     usePerformanceCounter = QueryPerformanceFrequency(&performanceFrequency);
-    if (usePerformanceCounter) {
+    if (usePerformanceCounter)
+    {
       QueryPerformanceCounter(&offset);
       frequencyToMicroseconds = (double)performanceFrequency.QuadPart / 1000000.;
-    } else {
+    }
+    else
+    {
       offset = getFILETIMEoffset();
       frequencyToMicroseconds = 10.;
     }
   }
-  if (usePerformanceCounter) {
+  if (usePerformanceCounter)
+  {
     QueryPerformanceCounter(&t);
-  } else {
+  }
+  else
+  {
     GetSystemTimeAsFileTime(&f);
     t.QuadPart = f.dwHighDateTime;
     t.QuadPart <<= 32;
@@ -851,7 +1011,8 @@ int clock_gettime(int X, struct timeval *tv) {
   return 0;
 }
 
-int gettimeofday(struct timeval *tp, void *tzp) {
+int gettimeofday(struct timeval *tp, void *tzp)
+{
   time_t clock;
   struct tm tm;
   SYSTEMTIME wtm;
@@ -871,20 +1032,25 @@ int gettimeofday(struct timeval *tp, void *tzp) {
   return (0);
 }
 
-char *dirname(char *path) {
+char *dirname(char *path)
+{
   char drive[_MAX_DRIVE];
   char dir[_MAX_DIR];
 
   errno_t err = _splitpath_s(path, drive, _MAX_DRIVE, dir, _MAX_DIR, NULL, 0, NULL, 0);
-  if (err) {
+  if (err)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "split path fail: %d", err);
     return NULL;
   }
 
   int n = strlen(drive) + strlen(dir);
-  if (n > 0) {
+  if (n > 0)
+  {
     path[n] = 0;
-  } else {
+  }
+  else
+  {
     return NULL;
   }
   return path;
@@ -902,12 +1068,15 @@ char *dirname(char *path) {
  * \param pnOutSize: size of output char buffer
  * \return
  */
-static char *_WTA(__in wchar_t *pszInBuf, __in int nInSize, __out char **pszOutBuf, __out int *pnOutSize) {
-  if (!pszInBuf || !pszOutBuf || !pnOutSize || nInSize <= 0) {
+static char *_WTA(__in wchar_t *pszInBuf, __in int nInSize, __out char **pszOutBuf, __out int *pnOutSize)
+{
+  if (!pszInBuf || !pszOutBuf || !pnOutSize || nInSize <= 0)
+  {
     return NULL;
   }
   *pnOutSize = WideCharToMultiByte((UINT)0, (DWORD)0, pszInBuf, nInSize, NULL, 0, NULL, NULL);
-  if (*pnOutSize == 0) {
+  if (*pnOutSize == 0)
+  {
     return NULL;
   }
   // add 1 for explicit nul-terminator at end.
@@ -915,85 +1084,112 @@ static char *_WTA(__in wchar_t *pszInBuf, __in int nInSize, __out char **pszOutB
   // and we have to add space to the allocation ourselves.
   (*pnOutSize)++;
   *pszOutBuf = malloc(*pnOutSize * sizeof(char));
-  if (WideCharToMultiByte((UINT)0, (DWORD)0, pszInBuf, nInSize, *pszOutBuf, *pnOutSize, NULL, NULL) == 0) {
+  if (WideCharToMultiByte((UINT)0, (DWORD)0, pszInBuf, nInSize, *pszOutBuf, *pnOutSize, NULL, NULL) == 0)
+  {
     free(*pszOutBuf);
     return NULL;
-  } else {
+  }
+  else
+  {
     (*pszOutBuf)[*pnOutSize - 1] = '\0';
     return *pszOutBuf;
   }
 }
 
-int getdomainname(char *name, size_t len) {
+int getdomainname(char *name, size_t len)
+{
   DSROLE_PRIMARY_DOMAIN_INFO_BASIC *info;
   DWORD dw;
 
   dw = DsRoleGetPrimaryDomainInformation(NULL, DsRolePrimaryDomainInfoBasic, (PBYTE *)&info);
-  if (dw != ERROR_SUCCESS) {
+  if (dw != ERROR_SUCCESS)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "DsRoleGetPrimaryDomainInformation: %u\n", dw);
     return -1;
   }
 
-  do {
-    if (info->DomainForestName) {
+  do
+  {
+    if (info->DomainForestName)
+    {
       char *pszOut = NULL;
       int nOutSize = 0;
-      if (_WTA(info->DomainForestName, wcslen(info->DomainForestName), &pszOut, &nOutSize)) {
+      if (_WTA(info->DomainForestName, wcslen(info->DomainForestName), &pszOut, &nOutSize))
+      {
         int n = nOutSize - 1;
-        if (nOutSize > len - 1) {
+        if (nOutSize > len - 1)
+        {
           n = len - 1;
         }
         strncpy(name, pszOut, n);
         name[n] = 0;
         TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "DomainForestName: %s\n", pszOut);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "wchar convert to char fail");
       }
 
       free(pszOut);
       break;
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "DomainForestName is NULL\n");
     }
 
-    if (info->DomainNameDns) {
+    if (info->DomainNameDns)
+    {
       char *pszOut = NULL;
       int nOutSize = 0;
-      if (_WTA(info->DomainNameDns, wcslen(info->DomainNameDns), &pszOut, &nOutSize)) {
+      if (_WTA(info->DomainNameDns, wcslen(info->DomainNameDns), &pszOut, &nOutSize))
+      {
         int n = nOutSize - 1;
-        if (nOutSize > len - 1) {
+        if (nOutSize > len - 1)
+        {
           n = len - 1;
         }
         strncpy(name, pszOut, n);
         name[n] = 0;
         TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "DomainNameDns: %s\n", pszOut);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "wchar convert to char fail");
       }
 
       free(pszOut);
       break;
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "DomainNameDns is NULL\n");
     }
 
-    if (info->DomainNameFlat) {
+    if (info->DomainNameFlat)
+    {
       char *pszOut = NULL;
       int nOutSize = 0;
-      if (_WTA(info->DomainNameFlat, wcslen(info->DomainNameFlat), &pszOut, &nOutSize)) {
+      if (_WTA(info->DomainNameFlat, wcslen(info->DomainNameFlat), &pszOut, &nOutSize))
+      {
         int n = nOutSize - 1;
-        if (nOutSize > len - 1) {
+        if (nOutSize > len - 1)
+        {
           n = len - 1;
         }
         strncpy(name, pszOut, n);
         name[n] = 0;
         TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "DomainNameFlat: %s\n", pszOut);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "wchar convert to char fail");
       }
 
       free(pszOut);
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "DomainNameFlat is NULL\n");
       return -2;
     }
@@ -1040,12 +1236,14 @@ static const char *config_file_search_dirs[] = {"./",
                                                 NULL};
 static char *c_execdir = NULL;
 
-void set_execdir(void) {
+void set_execdir(void)
+{
   /* On some systems, this may give us the execution path */
   char *_var = NULL;
 #if defined(_MSC_VER)
   char szPath[MAX_PATH];
-  if (!GetModuleFileNameA(NULL, szPath, MAX_PATH)) {
+  if (!GetModuleFileNameA(NULL, szPath, MAX_PATH))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "GetModuleFileName failed(%d)\n", GetLastError());
     return;
   }
@@ -1053,18 +1251,24 @@ void set_execdir(void) {
 #elif defined(__unix__)
   _var = getenv("_");
 #endif
-  if (_var && *_var) {
+  if (_var && *_var)
+  {
     _var = strdup(_var);
     char *edir = _var;
-    if (edir[0] != '.') {
+    if (edir[0] != '.')
+    {
       edir = strstr(edir, "/");
     }
-    if (edir && *edir) {
+    if (edir && *edir)
+    {
       edir = dirname(edir);
-    } else {
+    }
+    else
+    {
       edir = dirname(_var);
     }
-    if (c_execdir) {
+    if (c_execdir)
+    {
       free(c_execdir);
     }
     c_execdir = strdup(edir);
@@ -1072,55 +1276,75 @@ void set_execdir(void) {
   }
 }
 
-void print_abs_file_name(const char *msg1, const char *msg2, const char *fn) {
+void print_abs_file_name(const char *msg1, const char *msg2, const char *fn)
+{
   char absfn[1025];
   absfn[0] = 0;
 
-  if (fn) {
-    while (fn[0] && fn[0] == ' ') {
+  if (fn)
+  {
+    while (fn[0] && fn[0] == ' ')
+    {
       ++fn;
     }
-    if (fn[0]) {
-      if (fn[0] == '/') {
+    if (fn[0])
+    {
+      if (fn[0] == '/')
+      {
         STRCPY(absfn, fn);
-      } else {
-        if (fn[0] == '.' && fn[1] && fn[1] == '/') {
+      }
+      else
+      {
+        if (fn[0] == '.' && fn[1] && fn[1] == '/')
+        {
           fn += 2;
         }
-        if (!getcwd(absfn, sizeof(absfn) - 1)) {
+        if (!getcwd(absfn, sizeof(absfn) - 1))
+        {
           absfn[0] = 0;
         }
         size_t blen = strlen(absfn);
-        if (blen < sizeof(absfn) - 1) {
+        if (blen < sizeof(absfn) - 1)
+        {
           strncpy(absfn + blen, "/", sizeof(absfn) - blen);
           strncpy(absfn + blen + 1, fn, sizeof(absfn) - blen - 1);
-        } else {
+        }
+        else
+        {
           STRCPY(absfn, fn);
         }
         absfn[sizeof(absfn) - 1] = 0;
       }
     }
   }
-  if (absfn[0]) {
+  if (absfn[0])
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s%s file found: %s\n", msg1, msg2, absfn);
   }
 }
 
-char *find_config_file(const char *config_file) {
+char *find_config_file(const char *config_file)
+{
   char *full_path_to_config_file = NULL;
 
-  if (config_file && config_file[0]) {
-    if ((config_file[0] == '/') || (config_file[0] == '~')) {
+  if (config_file && config_file[0])
+  {
+    if ((config_file[0] == '/') || (config_file[0] == '~'))
+    {
       FILE *f = fopen(config_file, "r");
-      if (f) {
+      if (f)
+      {
         fclose(f);
         full_path_to_config_file = strdup(config_file);
       }
-    } else {
+    }
+    else
+    {
       int i = 0;
       size_t cflen = strlen(config_file);
 
-      while (config_file_search_dirs[i]) {
+      while (config_file_search_dirs[i])
+      {
         size_t dirlen = strlen(config_file_search_dirs[i]);
         size_t fnsz = sizeof(char) * (dirlen + cflen + 10);
         char *fn = (char *)malloc(fnsz + 1);
@@ -1128,33 +1352,40 @@ char *find_config_file(const char *config_file) {
         strncpy(fn + dirlen, config_file, fnsz - dirlen);
         fn[fnsz] = 0;
         FILE *f = fopen(fn, "r");
-        if (f) {
+        if (f)
+        {
           fclose(f);
           full_path_to_config_file = fn;
           break;
         }
         free(fn);
-        if (config_file_search_dirs[i][0] != '/' && config_file_search_dirs[i][0] != '.' && c_execdir && c_execdir[0]) {
+        if (config_file_search_dirs[i][0] != '/' && config_file_search_dirs[i][0] != '.' && c_execdir && c_execdir[0])
+        {
           size_t celen = strlen(c_execdir);
           fnsz = sizeof(char) * (dirlen + cflen + celen + 10);
           fn = (char *)malloc(fnsz + 1);
           strncpy(fn, c_execdir, fnsz);
           size_t fnlen = strlen(fn);
-          if (fnlen < fnsz) {
+          if (fnlen < fnsz)
+          {
             strncpy(fn + fnlen, "/", fnsz - fnlen);
             fnlen = strlen(fn);
-            if (fnlen < fnsz) {
+            if (fnlen < fnsz)
+            {
               strncpy(fn + fnlen, config_file_search_dirs[i], fnsz - fnlen);
               fnlen = strlen(fn);
-              if (fnlen < fnsz) {
+              if (fnlen < fnsz)
+              {
                 strncpy(fn + fnlen, config_file, fnsz - fnlen);
               }
             }
           }
           fn[fnsz] = 0;
-          if (strstr(fn, "//") != fn) {
+          if (strstr(fn, "//") != fn)
+          {
             f = fopen(fn, "r");
-            if (f) {
+            if (f)
+            {
               fclose(f);
               full_path_to_config_file = fn;
               break;
@@ -1166,8 +1397,10 @@ char *find_config_file(const char *config_file) {
       }
     }
 
-    if (!full_path_to_config_file) {
-      if (strstr(config_file, "etc/") == config_file) {
+    if (!full_path_to_config_file)
+    {
+      if (strstr(config_file, "etc/") == config_file)
+      {
         return find_config_file(config_file + 4);
       }
     }
@@ -1178,16 +1411,19 @@ char *find_config_file(const char *config_file) {
 
 /////////////////// SYS SETTINGS ///////////////////////
 
-void ignore_sigpipe(void) {
+void ignore_sigpipe(void)
+{
 #if defined(__linux__) || defined(__APPLE__)
   /* Ignore SIGPIPE from TCP sockets */
-  if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+  if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)
+  {
     perror("Cannot set SIGPIPE handler");
   }
 #endif
 }
 
-static uint64_t turn_getRandTime(void) {
+static uint64_t turn_getRandTime(void)
+{
   struct timespec tp = {0, 0};
 #if defined(CLOCK_REALTIME)
   clock_gettime(CLOCK_REALTIME, &tp);
@@ -1200,7 +1436,8 @@ static uint64_t turn_getRandTime(void) {
   return current_mstime;
 }
 
-void turn_srandom(void) {
+void turn_srandom(void)
+{
 #if defined(WINDOWS)
   srand((unsigned int)(turn_getRandTime() + (unsigned int)((long)(&turn_getRandTime))));
 #else
@@ -1208,7 +1445,8 @@ void turn_srandom(void) {
 #endif
 }
 
-long turn_random(void) {
+long turn_random(void)
+{
 #if defined(WINDOWS)
   return rand();
 #else
@@ -1216,7 +1454,8 @@ long turn_random(void) {
 #endif
 }
 
-unsigned long set_system_parameters(int max_resources) {
+unsigned long set_system_parameters(int max_resources)
+{
   turn_srandom();
 
   setlocale(LC_ALL, "C");
@@ -1225,7 +1464,8 @@ unsigned long set_system_parameters(int max_resources) {
 
   ignore_sigpipe();
 
-  if (max_resources) {
+  if (max_resources)
+  {
 #if defined(WINDOWS)
     int num = 0;
     // TODO: get max socket? by KangLin <kl222@126.com>
@@ -1235,11 +1475,15 @@ unsigned long set_system_parameters(int max_resources) {
 #elif defined(__linux__) || defined(__APPLE__)
 
     struct rlimit rlim;
-    if (getrlimit(RLIMIT_NOFILE, &rlim) < 0) {
+    if (getrlimit(RLIMIT_NOFILE, &rlim) < 0)
+    {
       perror("Cannot get system limit");
-    } else {
+    }
+    else
+    {
       rlim.rlim_cur = rlim.rlim_max;
-      while ((setrlimit(RLIMIT_NOFILE, &rlim) < 0) && (rlim.rlim_cur > 0)) {
+      while ((setrlimit(RLIMIT_NOFILE, &rlim) < 0) && (rlim.rlim_cur > 0))
+      {
         rlim.rlim_cur = rlim.rlim_cur >> 1;
       }
       return (unsigned long)rlim.rlim_cur;
@@ -1251,7 +1495,8 @@ unsigned long set_system_parameters(int max_resources) {
   return 0;
 }
 
-unsigned long get_system_number_of_cpus(void) {
+unsigned long get_system_number_of_cpus(void)
+{
 #if defined(WINDOWS)
   SYSTEM_INFO sysInfo;
   GetSystemInfo(&sysInfo);
@@ -1269,7 +1514,8 @@ unsigned long get_system_number_of_cpus(void) {
 #endif
 }
 
-unsigned long get_system_active_number_of_cpus(void) {
+unsigned long get_system_active_number_of_cpus(void)
+{
 #if defined(WINDOWS)
   SYSTEM_INFO sysInfo;
   GetSystemInfo(&sysInfo);
@@ -1296,16 +1542,19 @@ static const char encoding_table[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I
                                       'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
 static const char *decoding_table = NULL;
 
-char *base64_encode(const unsigned char *data, size_t input_length, size_t *output_length) {
+char *base64_encode(const unsigned char *data, size_t input_length, size_t *output_length)
+{
 
   *output_length = 4 * ((input_length + 2) / 3);
 
   char *encoded_data = (char *)malloc(*output_length + 1);
-  if (encoded_data == NULL) {
+  if (encoded_data == NULL)
+  {
     return NULL;
   }
 
-  for (size_t i = 0, j = 0; i < input_length;) {
+  for (size_t i = 0, j = 0; i < input_length;)
+  {
 
     uint32_t octet_a = i < input_length ? data[i++] : 0;
     uint32_t octet_b = i < input_length ? data[i++] : 0;
@@ -1319,7 +1568,8 @@ char *base64_encode(const unsigned char *data, size_t input_length, size_t *outp
     encoded_data[j++] = encoding_table[(triple >> 0 * 6) & 0x3F];
   }
 
-  for (size_t i = 0; i < mod_table[input_length % 3]; i++) {
+  for (size_t i = 0; i < mod_table[input_length % 3]; i++)
+  {
     encoded_data[*output_length - 1 - i] = '=';
   }
 
@@ -1328,42 +1578,51 @@ char *base64_encode(const unsigned char *data, size_t input_length, size_t *outp
   return encoded_data;
 }
 
-void build_base64_decoding_table(void) {
+void build_base64_decoding_table(void)
+{
 
   char *table = (char *)calloc(256, sizeof(char));
 
-  for (size_t i = 0; i < 64; i++) {
+  for (size_t i = 0; i < 64; i++)
+  {
     table[(unsigned char)encoding_table[i]] = i;
   }
   decoding_table = table;
 }
 
-unsigned char *base64_decode(const char *data, size_t input_length, size_t *output_length) {
+unsigned char *base64_decode(const char *data, size_t input_length, size_t *output_length)
+{
 
-  if (decoding_table == NULL) {
+  if (decoding_table == NULL)
+  {
     build_base64_decoding_table();
   }
 
-  if (input_length % 4 != 0) {
+  if (input_length % 4 != 0)
+  {
     return NULL;
   }
 
   *output_length = input_length / 4 * 3;
-  if (data[input_length - 1] == '=') {
+  if (data[input_length - 1] == '=')
+  {
     (*output_length)--;
   }
-  if (data[input_length - 2] == '=') {
+  if (data[input_length - 2] == '=')
+  {
     (*output_length)--;
   }
 
   unsigned char *decoded_data = (unsigned char *)malloc(*output_length);
-  if (decoded_data == NULL) {
+  if (decoded_data == NULL)
+  {
     return NULL;
   }
 
   int i;
   size_t j;
-  for (i = 0, j = 0; i < (int)input_length;) {
+  for (i = 0, j = 0; i < (int)input_length;)
+  {
 
     uint32_t sextet_a = data[i] == '=' ? 0 & i++ : decoding_table[(int)data[i++]];
     uint32_t sextet_b = data[i] == '=' ? 0 & i++ : decoding_table[(int)data[i++]];
@@ -1372,13 +1631,16 @@ unsigned char *base64_decode(const char *data, size_t input_length, size_t *outp
 
     uint32_t triple = (sextet_a << 3 * 6) + (sextet_b << 2 * 6) + (sextet_c << 1 * 6) + (sextet_d << 0 * 6);
 
-    if (j < *output_length) {
+    if (j < *output_length)
+    {
       decoded_data[j++] = (triple >> 2 * 8) & 0xFF;
     }
-    if (j < *output_length) {
+    if (j < *output_length)
+    {
       decoded_data[j++] = (triple >> 1 * 8) & 0xFF;
     }
-    if (j < *output_length) {
+    if (j < *output_length)
+    {
       decoded_data[j++] = (triple >> 0 * 8) & 0xFF;
     }
   }
@@ -1388,11 +1650,15 @@ unsigned char *base64_decode(const char *data, size_t input_length, size_t *outp
 
 ////////////////// SSL /////////////////////
 
-const char *turn_get_ssl_method(SSL *ssl, const char *mdefault) {
+const char *turn_get_ssl_method(SSL *ssl, const char *mdefault)
+{
   const char *ret = "unknown";
-  if (!ssl) {
+  if (!ssl)
+  {
     ret = mdefault;
-  } else {
+  }
+  else
+  {
     ret = SSL_get_version(ssl);
   }
 
@@ -1401,7 +1667,8 @@ const char *turn_get_ssl_method(SSL *ssl, const char *mdefault) {
 
 //////////// EVENT BASE ///////////////
 
-struct event_base *turn_event_base_new(void) {
+struct event_base *turn_event_base_new(void)
+{
   struct event_config *cfg = event_config_new();
 
   event_config_set_flag(cfg, EVENT_BASE_FLAG_EPOLL_USE_CHANGELIST);
@@ -1411,8 +1678,10 @@ struct event_base *turn_event_base_new(void) {
 
 /////////// OAUTH /////////////////
 
-void convert_oauth_key_data_raw(const oauth_key_data_raw *raw, oauth_key_data *oakd) {
-  if (raw && oakd) {
+void convert_oauth_key_data_raw(const oauth_key_data_raw *raw, oauth_key_data *oakd)
+{
+  if (raw && oakd)
+  {
 
     memset(oakd, 0, sizeof(oauth_key_data));
 
@@ -1422,10 +1691,12 @@ void convert_oauth_key_data_raw(const oauth_key_data_raw *raw, oauth_key_data *o
     memcpy(oakd->as_rs_alg, raw->as_rs_alg, sizeof(oakd->as_rs_alg));
     memcpy(oakd->kid, raw->kid, sizeof(oakd->kid));
 
-    if (raw->ikm_key[0]) {
+    if (raw->ikm_key[0])
+    {
       size_t ikm_key_size = 0;
       char *ikm_key = (char *)base64_decode(raw->ikm_key, strlen(raw->ikm_key), &ikm_key_size);
-      if (ikm_key) {
+      if (ikm_key)
+      {
         memcpy(oakd->ikm_key, ikm_key, ikm_key_size);
         oakd->ikm_key_size = ikm_key_size;
         free(ikm_key);

--- a/src/apps/common/apputils.h
+++ b/src/apps/common/apputils.h
@@ -41,7 +41,8 @@
 #include "ns_turn_msg_defs.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////// Common defines ///////////////////////////
@@ -89,7 +90,8 @@ typedef enum _TURN_TLS_TYPE TURN_TLS_TYPE;
 
 ////////////////////////////////////////////
 
-struct _oauth_key_data_raw {
+struct _oauth_key_data_raw
+{
   char kid[OAUTH_KID_SIZE + 1];
   char ikm_key[OAUTH_KEY_SIZE + 1];
   uint64_t timestamp;
@@ -103,7 +105,8 @@ typedef struct _oauth_key_data_raw oauth_key_data_raw;
 //////////////////////////////////////////
 
 #define EVENT_DEL(ev)                                                                                                  \
-  if (ev) {                                                                                                            \
+  if (ev)                                                                                                              \
+  {                                                                                                                    \
     event_del(ev);                                                                                                     \
     event_free(ev);                                                                                                    \
     ev = NULL;                                                                                                         \
@@ -144,12 +147,14 @@ int addr_get_from_sock(evutil_socket_t fd, ioa_addr *addr);
 int handle_socket_error(void);
 
 #define CORRECT_RAW_TTL(ttl)                                                                                           \
-  do {                                                                                                                 \
+  do                                                                                                                   \
+  {                                                                                                                    \
     if (ttl < 0 || ttl > 255)                                                                                          \
       ttl = TTL_DEFAULT;                                                                                               \
   } while (0)
 #define CORRECT_RAW_TOS(tos)                                                                                           \
-  do {                                                                                                                 \
+  do                                                                                                                   \
+  {                                                                                                                    \
     if (tos < 0 || tos > 255)                                                                                          \
       tos = TOS_DEFAULT;                                                                                               \
   } while (0)

--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -67,12 +67,15 @@ static volatile turn_time_t log_start_time = 0;
 volatile int _log_time_value_set = 0;
 volatile turn_time_t _log_time_value = 0;
 
-static inline turn_time_t log_time(void) {
-  if (!log_start_time) {
+static inline turn_time_t log_time(void)
+{
+  if (!log_start_time)
+  {
     log_start_time = turn_time();
   }
 
-  if (_log_time_value_set) {
+  if (_log_time_value_set)
+  {
     return (_log_time_value - log_start_time);
   }
 
@@ -83,58 +86,81 @@ static inline turn_time_t log_time(void) {
 
 #define MAGIC_CODE (0xEFCD1983)
 
-int turn_mutex_lock(const turn_mutex *mutex) {
-  if (mutex && mutex->mutex && (mutex->data == MAGIC_CODE)) {
+int turn_mutex_lock(const turn_mutex *mutex)
+{
+  if (mutex && mutex->mutex && (mutex->data == MAGIC_CODE))
+  {
     int ret = 0;
     ret = pthread_mutex_lock((pthread_mutex_t *)mutex->mutex);
-    if (ret < 0) {
+    if (ret < 0)
+    {
       perror("Mutex lock");
     }
     return ret;
-  } else {
+  }
+  else
+  {
     printf("Uninitialized mutex\n");
     return -1;
   }
 }
 
-int turn_mutex_unlock(const turn_mutex *mutex) {
-  if (mutex && mutex->mutex && (mutex->data == MAGIC_CODE)) {
+int turn_mutex_unlock(const turn_mutex *mutex)
+{
+  if (mutex && mutex->mutex && (mutex->data == MAGIC_CODE))
+  {
     int ret = 0;
     ret = pthread_mutex_unlock((pthread_mutex_t *)mutex->mutex);
-    if (ret < 0) {
+    if (ret < 0)
+    {
       perror("Mutex unlock");
     }
     return ret;
-  } else {
+  }
+  else
+  {
     printf("Uninitialized mutex\n");
     return -1;
   }
 }
 
-int turn_mutex_init(turn_mutex *mutex) {
-  if (mutex) {
+int turn_mutex_init(turn_mutex *mutex)
+{
+  if (mutex)
+  {
     mutex->data = MAGIC_CODE;
     mutex->mutex = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
     pthread_mutex_init((pthread_mutex_t *)mutex->mutex, NULL);
     return 0;
-  } else {
+  }
+  else
+  {
     return -1;
   }
 }
 
-int turn_mutex_init_recursive(turn_mutex *mutex) {
+int turn_mutex_init_recursive(turn_mutex *mutex)
+{
   int ret = -1;
-  if (mutex) {
+  if (mutex)
+  {
     pthread_mutexattr_t attr;
-    if (pthread_mutexattr_init(&attr) < 0) {
+    if (pthread_mutexattr_init(&attr) < 0)
+    {
       perror("Cannot init mutex attr");
-    } else {
-      if (pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) < 0) {
+    }
+    else
+    {
+      if (pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE) < 0)
+      {
         perror("Cannot set type on mutex attr");
-      } else {
+      }
+      else
+      {
         mutex->data = MAGIC_CODE;
         mutex->mutex = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
-        if ((ret = pthread_mutex_init((pthread_mutex_t *)mutex->mutex, &attr)) < 0) {
+        if ((ret = pthread_mutex_init((pthread_mutex_t *)mutex->mutex, &attr)) < 0)
+        {
           perror("Cannot init mutex");
           mutex->data = 0;
           free(mutex->mutex);
@@ -147,15 +173,19 @@ int turn_mutex_init_recursive(turn_mutex *mutex) {
   return ret;
 }
 
-int turn_mutex_destroy(turn_mutex *mutex) {
-  if (mutex && mutex->mutex && mutex->data == MAGIC_CODE) {
+int turn_mutex_destroy(turn_mutex *mutex)
+{
+  if (mutex && mutex->mutex && mutex->data == MAGIC_CODE)
+  {
     int ret = 0;
     ret = pthread_mutex_destroy((pthread_mutex_t *)(mutex->mutex));
     free(mutex->mutex);
     mutex->mutex = NULL;
     mutex->data = 0;
     return ret;
-  } else {
+  }
+  else
+  {
     return 0;
   }
 }
@@ -176,23 +206,29 @@ static const int int_fac[] = {LOG_AUTH,   LOG_CRON,   LOG_DAEMON, LOG_KERN,     
 
 static int syslog_facility = 0;
 
-static int str_to_syslog_facility(char *s) {
+static int str_to_syslog_facility(char *s)
+{
   int i;
-  for (i = 0; str_fac[i]; i++) {
-    if (!strcasecmp(s, str_fac[i])) {
+  for (i = 0; str_fac[i]; i++)
+  {
+    if (!strcasecmp(s, str_fac[i]))
+    {
       return int_fac[i];
     }
   }
   return -1;
 }
 #endif
-void set_syslog_facility(char *val) {
-  if (val == NULL) {
+void set_syslog_facility(char *val)
+{
+  if (val == NULL)
+  {
     return;
   }
 #if defined(__unix__) || defined(unix) || defined(__APPLE__)
   int tmp = str_to_syslog_facility(val);
-  if (tmp == -1) {
+  if (tmp == -1)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "WARNING: invalid syslog-facility value (%s); ignored.\n", val);
     return;
   }
@@ -211,31 +247,46 @@ void set_no_stdout_log(int val) { no_stdout_log = val; }
 #define MAX_LOG_TIMESTAMP_FORMAT_LEN 48
 static char turn_log_timestamp_format[MAX_LOG_TIMESTAMP_FORMAT_LEN] = "%FT%T%z";
 
-void set_turn_log_timestamp_format(char *new_format) {
+void set_turn_log_timestamp_format(char *new_format)
+{
   strncpy(turn_log_timestamp_format, new_format, MAX_LOG_TIMESTAMP_FORMAT_LEN - 1);
 }
 
 int use_new_log_timestamp_format = 0;
 
-void addr_debug_print(int verbose, const ioa_addr *addr, const char *s) {
-  if (verbose) {
-    if (!addr) {
+void addr_debug_print(int verbose, const ioa_addr *addr, const char *s)
+{
+  if (verbose)
+  {
+    if (!addr)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: EMPTY\n", s);
-    } else {
+    }
+    else
+    {
       char addrbuf[INET6_ADDRSTRLEN];
-      if (!s) {
+      if (!s)
+      {
         s = "";
       }
-      if (addr->ss.sa_family == AF_INET) {
+      if (addr->ss.sa_family == AF_INET)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "IPv4. %s: %s:%d\n", s,
                       inet_ntop(AF_INET, &addr->s4.sin_addr, addrbuf, INET6_ADDRSTRLEN), nswap16(addr->s4.sin_port));
-      } else if (addr->ss.sa_family == AF_INET6) {
+      }
+      else if (addr->ss.sa_family == AF_INET6)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "IPv6. %s: %s:%d\n", s,
                       inet_ntop(AF_INET6, &addr->s6.sin6_addr, addrbuf, INET6_ADDRSTRLEN), nswap16(addr->s6.sin6_port));
-      } else {
-        if (addr_any_no_port(addr)) {
+      }
+      else
+      {
+        if (addr_any_no_port(addr))
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "IP. %s: 0.0.0.0:%d\n", s, nswap16(addr->s4.sin_port));
-        } else {
+        }
+        else
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: wrong IP address family: %d\n", s, (int)(addr->ss.sa_family));
         }
       }
@@ -257,8 +308,10 @@ static volatile int to_reset_log_file = 0;
 static turn_mutex log_mutex;
 static int log_mutex_inited = 0;
 
-static void log_lock(void) {
-  if (!log_mutex_inited) {
+static void log_lock(void)
+{
+  if (!log_mutex_inited)
+  {
     log_mutex_inited = 1;
     turn_mutex_init_recursive(&log_mutex);
   }
@@ -267,7 +320,8 @@ static void log_lock(void) {
 
 static void log_unlock(void) { turn_mutex_unlock(&log_mutex); }
 
-static void get_date(char *s, size_t sz) {
+static void get_date(char *s, size_t sz)
+{
   time_t curtm;
   struct tm *tm_info;
 
@@ -277,10 +331,13 @@ static void get_date(char *s, size_t sz) {
   strftime(s, sz, "%F", tm_info);
 }
 
-void set_logfile(const char *fn) {
-  if (fn) {
+void set_logfile(const char *fn)
+{
+  if (fn)
+  {
     log_lock();
-    if (strcmp(fn, log_fn_base)) {
+    if (strcmp(fn, log_fn_base))
+    {
       reset_rtpprintf();
       STRCPY(log_fn_base, fn);
     }
@@ -290,10 +347,13 @@ void set_logfile(const char *fn) {
 
 void set_log_file_line(int set) { _log_file_line_set = set; }
 
-void reset_rtpprintf(void) {
+void reset_rtpprintf(void)
+{
   log_lock();
-  if (_rtpfile) {
-    if (_rtpfile != stdout) {
+  if (_rtpfile)
+  {
+    if (_rtpfile != stdout)
+    {
       fclose(_rtpfile);
     }
     _rtpfile = NULL;
@@ -303,8 +363,10 @@ void reset_rtpprintf(void) {
 
 #define set_log_file_name(base, f) set_log_file_name_func(base, f, sizeof(f))
 
-static void set_log_file_name_func(char *base, char *f, size_t fsz) {
-  if (simple_log) {
+static void set_log_file_name_func(char *base, char *f, size_t fsz)
+{
+  if (simple_log)
+  {
     strncpy(f, base, fsz);
     return;
   }
@@ -320,8 +382,10 @@ static void set_log_file_name_func(char *base, char *f, size_t fsz) {
 
   --len;
 
-  while (len >= 0) {
-    if ((base1[len] == ' ') || (base1[len] == '\t')) {
+  while (len >= 0)
+  {
+    if ((base1[len] == ' ') || (base1[len] == '\t'))
+    {
       base1[len] = '_';
     }
     --len;
@@ -329,14 +393,19 @@ static void set_log_file_name_func(char *base, char *f, size_t fsz) {
 
   len = (int)strlen(base1);
 
-  while (len >= 0) {
-    if (base1[len] == '/') {
+  while (len >= 0)
+  {
+    if (base1[len] == '/')
+    {
       break;
-    } else if (base1[len] == '.') {
+    }
+    else if (base1[len] == '.')
+    {
       free(tail);
       tail = strdup(base1 + len);
       base1[len] = 0;
-      if (strlen(tail) < 2) {
+      if (strlen(tail) < 2)
+      {
         free(tail);
         tail = strdup(".log");
       }
@@ -346,9 +415,12 @@ static void set_log_file_name_func(char *base, char *f, size_t fsz) {
   }
 
   len = (int)strlen(base1);
-  if (len > 0 && (base1[len - 1] != '/') && (base1[len - 1] != '-') && (base1[len - 1] != '_')) {
+  if (len > 0 && (base1[len - 1] != '/') && (base1[len - 1] != '-') && (base1[len - 1] != '_'))
+  {
     snprintf(f, FILE_STR_LEN, "%s_%s%s", base1, logdate, tail);
-  } else {
+  }
+  else
+  {
     snprintf(f, FILE_STR_LEN, "%s%s%s", base1, logdate, tail);
   }
 
@@ -356,105 +428,145 @@ static void set_log_file_name_func(char *base, char *f, size_t fsz) {
   free(tail);
 }
 
-static void sighup_callback_handler(int signum) {
+static void sighup_callback_handler(int signum)
+{
 #if defined(__unix__) || defined(unix) || defined(__APPLE__)
-  if (signum == SIGHUP) {
+  if (signum == SIGHUP)
+  {
     to_reset_log_file = 1;
   }
 #endif
 }
 
-static void set_rtpfile(void) {
-  if (to_reset_log_file) {
+static void set_rtpfile(void)
+{
+  if (to_reset_log_file)
+  {
     printf("%s: resetting the log file\n", __FUNCTION__);
     reset_rtpprintf();
     to_reset_log_file = 0;
   }
 
-  if (to_syslog) {
+  if (to_syslog)
+  {
     return;
-  } else if (!_rtpfile) {
+  }
+  else if (!_rtpfile)
+  {
 
 #if defined(__unix__) || defined(unix) || defined(__APPLE__)
     signal(SIGHUP, sighup_callback_handler);
 #endif
 
-    if (log_fn_base[0]) {
-      if (!strcmp(log_fn_base, "syslog")) {
+    if (log_fn_base[0])
+    {
+      if (!strcmp(log_fn_base, "syslog"))
+      {
         _rtpfile = stdout;
         to_syslog = 1;
-      } else if (!strcmp(log_fn_base, "stdout") || !strcmp(log_fn_base, "-")) {
+      }
+      else if (!strcmp(log_fn_base, "stdout") || !strcmp(log_fn_base, "-"))
+      {
         _rtpfile = stdout;
         no_stdout_log = 1;
-      } else {
+      }
+      else
+      {
         set_log_file_name(log_fn_base, log_fn);
         _rtpfile = fopen(log_fn, "a");
-        if (_rtpfile) {
+        if (_rtpfile)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "log file opened: %s\n", log_fn);
         }
       }
-      if (!_rtpfile) {
+      if (!_rtpfile)
+      {
         fprintf(stderr, "ERROR: Cannot open log file for writing: %s\n", log_fn);
-      } else {
+      }
+      else
+      {
         return;
       }
     }
   }
 
-  if (!_rtpfile) {
+  if (!_rtpfile)
+  {
 
     char logbase[FILE_STR_LEN];
     char logtail[FILE_STR_LEN];
     char logf[FILE_STR_LEN];
 
-    if (simple_log) {
+    if (simple_log)
+    {
       snprintf(logtail, FILE_STR_LEN, "turn.log");
-    } else {
+    }
+    else
+    {
       snprintf(logtail, FILE_STR_LEN, "turn_%d_", (int)getpid());
     }
 
-    if (snprintf(logbase, FILE_STR_LEN, "/var/log/turnserver/%s", logtail) < 0) {
+    if (snprintf(logbase, FILE_STR_LEN, "/var/log/turnserver/%s", logtail) < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "String truncation occured.\n");
     }
 
     set_log_file_name(logbase, logf);
 
     _rtpfile = fopen(logf, "a");
-    if (_rtpfile) {
+    if (_rtpfile)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "log file opened: %s\n", logf);
-    } else {
-      if (snprintf(logbase, FILE_STR_LEN, "/var/log/%s", logtail) < 0) {
+    }
+    else
+    {
+      if (snprintf(logbase, FILE_STR_LEN, "/var/log/%s", logtail) < 0)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "String truncation occured.\n");
       }
 
       set_log_file_name(logbase, logf);
       _rtpfile = fopen(logf, "a");
-      if (_rtpfile) {
+      if (_rtpfile)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "log file opened: %s\n", logf);
-      } else {
-        if (snprintf(logbase, FILE_STR_LEN, "/var/tmp/%s", logtail) < 0) {
+      }
+      else
+      {
+        if (snprintf(logbase, FILE_STR_LEN, "/var/tmp/%s", logtail) < 0)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "String truncation occured.\n");
         }
 
         set_log_file_name(logbase, logf);
         _rtpfile = fopen(logf, "a");
-        if (_rtpfile) {
+        if (_rtpfile)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "log file opened: %s\n", logf);
-        } else {
-          if (snprintf(logbase, FILE_STR_LEN, "/tmp/%s", logtail) < 0) {
+        }
+        else
+        {
+          if (snprintf(logbase, FILE_STR_LEN, "/tmp/%s", logtail) < 0)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "String truncation occured.\n");
           }
           set_log_file_name(logbase, logf);
           _rtpfile = fopen(logf, "a");
-          if (_rtpfile) {
+          if (_rtpfile)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "log file opened: %s\n", logf);
-          } else {
+          }
+          else
+          {
             snprintf(logbase, FILE_STR_LEN, "%s", logtail);
             set_log_file_name(logbase, logf);
             _rtpfile = fopen(logf, "a");
-            if (_rtpfile) {
+            if (_rtpfile)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "log file opened: %s\n", logf);
-            } else {
+            }
+            else
+            {
               _rtpfile = stdout;
               return;
             }
@@ -475,40 +587,51 @@ void set_simple_log(int val) { simple_log = val; }
 #define Q(x) #x
 #define QUOTE(x) Q(x)
 
-void rollover_logfile(void) {
-  if (to_syslog || !(log_fn[0])) {
+void rollover_logfile(void)
+{
+  if (to_syslog || !(log_fn[0]))
+  {
     return;
   }
 
   {
     FILE *f = fopen(log_fn, "r");
-    if (!f) {
+    if (!f)
+    {
       fprintf(stderr, "log file is damaged\n");
       reset_rtpprintf();
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "log file reopened: %s\n", log_fn);
       return;
-    } else {
+    }
+    else
+    {
       fclose(f);
     }
   }
 
-  if (simple_log) {
+  if (simple_log)
+  {
     return;
   }
 
   log_lock();
-  if (_rtpfile && log_fn[0] && (_rtpfile != stdout)) {
+  if (_rtpfile && log_fn[0] && (_rtpfile != stdout))
+  {
     char logf[FILE_STR_LEN];
 
     set_log_file_name(log_fn_base, logf);
-    if (strcmp(log_fn, logf)) {
+    if (strcmp(log_fn, logf))
+    {
       fclose(_rtpfile);
       log_fn[0] = 0;
       _rtpfile = fopen(logf, "w");
-      if (_rtpfile) {
+      if (_rtpfile)
+      {
         STRCPY(log_fn, logf);
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "log file opened: %s\n", log_fn);
-      } else {
+      }
+      else
+      {
         _rtpfile = stdout;
       }
     }
@@ -516,9 +639,11 @@ void rollover_logfile(void) {
   log_unlock();
 }
 
-static int get_syslog_level(TURN_LOG_LEVEL level) {
+static int get_syslog_level(TURN_LOG_LEVEL level)
+{
 #if defined(__unix__) || defined(unix) || defined(__APPLE__)
-  switch (level) {
+  switch (level)
+  {
   case TURN_LOG_LEVEL_CONTROL:
     return LOG_NOTICE;
   case TURN_LOG_LEVEL_WARNING:
@@ -533,7 +658,8 @@ static int get_syslog_level(TURN_LOG_LEVEL level) {
 }
 
 #if defined(WINDOWS)
-void err(int eval, const char *format, ...) {
+void err(int eval, const char *format, ...)
+{
   va_list args;
   va_start(args, format);
   TURN_LOG_FUNC(eval, format, args);
@@ -542,7 +668,8 @@ void err(int eval, const char *format, ...) {
 #endif
 
 void turn_log_func_default(const char *const file, const int line, const TURN_LOG_LEVEL level, const char *const format,
-                           ...) {
+                           ...)
+{
   va_list args;
   va_start(args, format);
 #if defined(TURN_LOG_FUNC_IMPL)
@@ -552,10 +679,13 @@ void turn_log_func_default(const char *const file, const int line, const TURN_LO
 #define MAX_RTPPRINTF_BUFFER_SIZE (1024)
   char s[MAX_RTPPRINTF_BUFFER_SIZE + 1];
   size_t so_far = 0;
-  if (use_new_log_timestamp_format) {
+  if (use_new_log_timestamp_format)
+  {
     time_t now = time(NULL);
     so_far += strftime(s, sizeof(s), turn_log_timestamp_format, localtime(&now));
-  } else {
+  }
+  else
+  {
     so_far += snprintf(s, sizeof(s), "%lu: ", (unsigned long)log_time());
   }
 
@@ -563,11 +693,13 @@ void turn_log_func_default(const char *const file, const int line, const TURN_LO
   so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "(%lu): ", (unsigned long)gettid());
 #endif
 
-  if (_log_file_line_set) {
+  if (_log_file_line_set)
+  {
     so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "%s(%d):", file, line);
   }
 
-  switch (level) {
+  switch (level)
+  {
   case TURN_LOG_LEVEL_DEBUG:
     so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "DEBUG: ");
     break;
@@ -586,14 +718,17 @@ void turn_log_func_default(const char *const file, const int line, const TURN_LO
   }
   so_far += vsnprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), format, args);
 
-  if (so_far > MAX_RTPPRINTF_BUFFER_SIZE + 1) {
+  if (so_far > MAX_RTPPRINTF_BUFFER_SIZE + 1)
+  {
     so_far = MAX_RTPPRINTF_BUFFER_SIZE + 1;
   }
-  if (!no_stdout_log) {
+  if (!no_stdout_log)
+  {
     fwrite(s, so_far, 1, stdout);
   }
   /* write to syslog or to log file */
-  if (to_syslog) {
+  if (to_syslog)
+  {
 
 #if defined(WINDOWS)
     // TODO: add event tracing: https://docs.microsoft.com/en-us/windows/win32/etw/about-event-tracing
@@ -602,13 +737,17 @@ void turn_log_func_default(const char *const file, const int line, const TURN_LO
 #else
     syslog(syslog_facility | get_syslog_level(level), "%s", s);
 #endif
-
-  } else {
+  }
+  else
+  {
     log_lock();
     set_rtpfile();
-    if (fprintf(_rtpfile, "%s", s) < 0) {
+    if (fprintf(_rtpfile, "%s", s) < 0)
+    {
       reset_rtpprintf();
-    } else if (fflush(_rtpfile) < 0) {
+    }
+    else if (fflush(_rtpfile) < 0)
+    {
       reset_rtpprintf();
     }
     log_unlock();
@@ -619,64 +758,83 @@ void turn_log_func_default(const char *const file, const int line, const TURN_LO
 
 ///////////// ORIGIN ///////////////////
 
-int get_default_protocol_port(const char *scheme, size_t slen) {
-  if (scheme && (slen > 0)) {
-    switch (slen) {
+int get_default_protocol_port(const char *scheme, size_t slen)
+{
+  if (scheme && (slen > 0))
+  {
+    switch (slen)
+    {
     case 3:
-      if (!memcmp("ftp", scheme, 3)) {
+      if (!memcmp("ftp", scheme, 3))
+      {
         return 21;
       }
-      if (!memcmp("svn", scheme, 3)) {
+      if (!memcmp("svn", scheme, 3))
+      {
         return 3690;
       }
-      if (!memcmp("ssh", scheme, 3)) {
+      if (!memcmp("ssh", scheme, 3))
+      {
         return 22;
       }
-      if (!memcmp("sip", scheme, 3)) {
+      if (!memcmp("sip", scheme, 3))
+      {
         return 5060;
       }
       break;
     case 4:
-      if (!memcmp("http", scheme, 4)) {
+      if (!memcmp("http", scheme, 4))
+      {
         return 80;
       }
-      if (!memcmp("ldap", scheme, 4)) {
+      if (!memcmp("ldap", scheme, 4))
+      {
         return 389;
       }
-      if (!memcmp("sips", scheme, 4)) {
+      if (!memcmp("sips", scheme, 4))
+      {
         return 5061;
       }
-      if (!memcmp("turn", scheme, 4)) {
+      if (!memcmp("turn", scheme, 4))
+      {
         return 3478;
       }
-      if (!memcmp("stun", scheme, 4)) {
+      if (!memcmp("stun", scheme, 4))
+      {
         return 3478;
       }
       break;
     case 5:
-      if (!memcmp("https", scheme, 5)) {
+      if (!memcmp("https", scheme, 5))
+      {
         return 443;
       }
-      if (!memcmp("ldaps", scheme, 5)) {
+      if (!memcmp("ldaps", scheme, 5))
+      {
         return 636;
       }
-      if (!memcmp("turns", scheme, 5)) {
+      if (!memcmp("turns", scheme, 5))
+      {
         return 5349;
       }
-      if (!memcmp("stuns", scheme, 5)) {
+      if (!memcmp("stuns", scheme, 5))
+      {
         return 5349;
       }
       break;
     case 6:
-      if (!memcmp("telnet", scheme, 6)) {
+      if (!memcmp("telnet", scheme, 6))
+      {
         return 23;
       }
-      if (!memcmp("radius", scheme, 6)) {
+      if (!memcmp("radius", scheme, 6))
+      {
         return 1645;
       }
       break;
     case 7:
-      if (!memcmp("svn+ssh", scheme, 7)) {
+      if (!memcmp("svn+ssh", scheme, 7))
+      {
         return 22;
       }
       break;
@@ -687,44 +845,56 @@ int get_default_protocol_port(const char *scheme, size_t slen) {
   return 0;
 }
 
-int get_canonic_origin(const char *o, char *co, int sz) {
+int get_canonic_origin(const char *o, char *co, int sz)
+{
   int ret = -1;
 
-  if (o && o[0] && co) {
+  if (o && o[0] && co)
+  {
     co[0] = 0;
     struct evhttp_uri *uri = evhttp_uri_parse(o);
-    if (uri) {
+    if (uri)
+    {
       const char *scheme = evhttp_uri_get_scheme(uri);
-      if (scheme && scheme[0]) {
+      if (scheme && scheme[0])
+      {
         size_t schlen = strlen(scheme);
-        if ((schlen < (size_t)sz) && (schlen < STUN_MAX_ORIGIN_SIZE)) {
+        if ((schlen < (size_t)sz) && (schlen < STUN_MAX_ORIGIN_SIZE))
+        {
           const char *host = evhttp_uri_get_host(uri);
-          if (host && host[0]) {
+          if (host && host[0])
+          {
             char otmp[STUN_MAX_ORIGIN_SIZE + STUN_MAX_ORIGIN_SIZE];
             memcpy(otmp, scheme, schlen);
             otmp[schlen] = 0;
 
             {
               unsigned char *s = (unsigned char *)otmp;
-              while (*s) {
+              while (*s)
+              {
                 *s = (unsigned char)tolower((int)*s);
                 ++s;
               }
             }
 
             int port = evhttp_uri_get_port(uri);
-            if (port < 1) {
+            if (port < 1)
+            {
               port = get_default_protocol_port(otmp, schlen);
             }
-            if (port > 0) {
+            if (port > 0)
+            {
               snprintf(otmp + schlen, sizeof(otmp) - schlen - 1, "://%s:%d", host, port);
-            } else {
+            }
+            else
+            {
               snprintf(otmp + schlen, sizeof(otmp) - schlen - 1, "://%s", host);
             }
 
             {
               unsigned char *s = (unsigned char *)otmp + schlen + 3;
-              while (*s) {
+              while (*s)
+              {
                 *s = (unsigned char)tolower((int)*s);
                 ++s;
               }
@@ -739,7 +909,8 @@ int get_canonic_origin(const char *o, char *co, int sz) {
       evhttp_uri_free(uri);
     }
 
-    if (ret < 0) {
+    if (ret < 0)
+    {
       strncpy(co, o, sz);
       co[sz] = 0;
     }
@@ -750,22 +921,30 @@ int get_canonic_origin(const char *o, char *co, int sz) {
 
 //////////////////////////////////////////////////////////////////
 
-int is_secure_string(const uint8_t *string, int sanitizesql) {
+int is_secure_string(const uint8_t *string, int sanitizesql)
+{
   int ret = 0;
-  if (string) {
+  if (string)
+  {
     unsigned char *s0 = (unsigned char *)strdup((const char *)string);
     unsigned char *s = s0;
-    while (*s) {
+    while (*s)
+    {
       *s = (unsigned char)tolower((int)*s);
       ++s;
     }
     s = s0;
     if (strstr((char *)s, " ") || strstr((char *)s, "\t") || strstr((char *)s, "'") || strstr((char *)s, "\"") ||
-        strstr((char *)s, "\n") || strstr((char *)s, "\r") || strstr((char *)s, "\\")) {
+        strstr((char *)s, "\n") || strstr((char *)s, "\r") || strstr((char *)s, "\\"))
+    {
       ;
-    } else if (sanitizesql && strstr((char *)s, "union") && strstr((char *)s, "select")) {
+    }
+    else if (sanitizesql && strstr((char *)s, "union") && strstr((char *)s, "select"))
+    {
       ;
-    } else {
+    }
+    else
+    {
       ret = 1;
     }
     free(s);

--- a/src/apps/common/ns_turn_utils.h
+++ b/src/apps/common/ns_turn_utils.h
@@ -49,12 +49,14 @@ void err(int eval, const char *format, ...);
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////////////////// LOG //////////////////////////
 
-typedef enum {
+typedef enum
+{
   TURN_LOG_LEVEL_DEBUG = 0,
   TURN_LOG_LEVEL_INFO,
   TURN_LOG_LEVEL_CONTROL,

--- a/src/apps/common/stun_buffer.c
+++ b/src/apps/common/stun_buffer.c
@@ -34,8 +34,10 @@
 
 ////////////////////// BUFFERS ///////////////////////////
 
-int stun_init_buffer(stun_buffer *buf) {
-  if (!buf) {
+int stun_init_buffer(stun_buffer *buf)
+{
+  if (!buf)
+  {
     return -1;
   }
   memset(buf->buf, 0, sizeof(buf->buf));
@@ -45,8 +47,10 @@ int stun_init_buffer(stun_buffer *buf) {
   return 0;
 }
 
-int stun_get_size(const stun_buffer *buf) {
-  if (!buf) {
+int stun_get_size(const stun_buffer *buf)
+{
+  if (!buf)
+  {
     return 0;
   }
   return sizeof(buf->buf);
@@ -54,47 +58,60 @@ int stun_get_size(const stun_buffer *buf) {
 
 ////////////////////////////////////////////////////////////
 
-void stun_tid_from_message(const stun_buffer *buf, stun_tid *id) {
+void stun_tid_from_message(const stun_buffer *buf, stun_tid *id)
+{
   stun_tid_from_message_str(buf->buf, (size_t)(buf->len), id);
 }
 
-void stun_tid_generate_in_message(stun_buffer *buf, stun_tid *id) {
-  if (buf) {
+void stun_tid_generate_in_message(stun_buffer *buf, stun_tid *id)
+{
+  if (buf)
+  {
     stun_tid_generate_in_message_str(buf->buf, id);
   }
 }
 
 ////////////////////////////////////////////////////////
 
-static inline bool is_channel_msg(const stun_buffer *buf) {
-  if (buf && buf->len > 0) {
+static inline bool is_channel_msg(const stun_buffer *buf)
+{
+  if (buf && buf->len > 0)
+  {
     return is_channel_msg_str(buf->buf, (size_t)(buf->len));
   }
   return false;
 }
 
-bool stun_is_command_message(const stun_buffer *buf) {
-  if (!buf || buf->len <= 0) {
+bool stun_is_command_message(const stun_buffer *buf)
+{
+  if (!buf || buf->len <= 0)
+  {
     return false;
-  } else {
+  }
+  else
+  {
     return stun_is_command_message_str(buf->buf, (size_t)(buf->len));
   }
 }
 
 bool stun_is_request(const stun_buffer *buf) { return stun_is_request_str(buf->buf, (size_t)buf->len); }
 
-bool stun_is_success_response(const stun_buffer *buf) {
+bool stun_is_success_response(const stun_buffer *buf)
+{
   return stun_is_success_response_str(buf->buf, (size_t)(buf->len));
 }
 
-bool stun_is_error_response(const stun_buffer *buf, int *err_code, uint8_t *err_msg, size_t err_msg_size) {
+bool stun_is_error_response(const stun_buffer *buf, int *err_code, uint8_t *err_msg, size_t err_msg_size)
+{
   return stun_is_error_response_str(buf->buf, (size_t)(buf->len), err_code, err_msg, err_msg_size);
 }
 
 bool stun_is_response(const stun_buffer *buf) { return stun_is_response_str(buf->buf, (size_t)(buf->len)); }
 
-bool stun_is_indication(const stun_buffer *buf) {
-  if (is_channel_msg(buf)) {
+bool stun_is_indication(const stun_buffer *buf)
+{
+  if (is_channel_msg(buf))
+  {
     return false;
   }
   return IS_STUN_INDICATION(stun_get_msg_type(buf));
@@ -102,8 +119,10 @@ bool stun_is_indication(const stun_buffer *buf) {
 
 uint16_t stun_get_method(const stun_buffer *buf) { return stun_get_method_str(buf->buf, (size_t)(buf->len)); }
 
-uint16_t stun_get_msg_type(const stun_buffer *buf) {
-  if (!buf) {
+uint16_t stun_get_msg_type(const stun_buffer *buf)
+{
+  if (!buf)
+  {
     return (uint16_t)-1;
   }
   return stun_get_msg_type_str(buf->buf, (size_t)buf->len);
@@ -111,7 +130,8 @@ uint16_t stun_get_msg_type(const stun_buffer *buf) {
 
 ////////////////////////////////////////////////////////////
 
-static void stun_init_command(uint16_t message_type, stun_buffer *buf) {
+static void stun_init_command(uint16_t message_type, stun_buffer *buf)
+{
   buf->len = stun_get_size(buf);
   stun_init_command_str(message_type, buf->buf, &(buf->len));
 }
@@ -120,36 +140,43 @@ void stun_init_request(uint16_t method, stun_buffer *buf) { stun_init_command(st
 
 void stun_init_indication(uint16_t method, stun_buffer *buf) { stun_init_command(stun_make_indication(method), buf); }
 
-void stun_init_success_response(uint16_t method, stun_buffer *buf, stun_tid *id) {
+void stun_init_success_response(uint16_t method, stun_buffer *buf, stun_tid *id)
+{
   buf->len = stun_get_size(buf);
   stun_init_success_response_str(method, buf->buf, &(buf->len), id);
 }
 
 void stun_init_error_response(uint16_t method, stun_buffer *buf, uint16_t error_code, const uint8_t *reason,
-                              stun_tid *id) {
+                              stun_tid *id)
+{
   buf->len = stun_get_size(buf);
   stun_init_error_response_str(method, buf->buf, &(buf->len), error_code, reason, id);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
-int stun_get_command_message_len(const stun_buffer *buf) {
+int stun_get_command_message_len(const stun_buffer *buf)
+{
   return stun_get_command_message_len_str(buf->buf, buf->len);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 
-bool stun_init_channel_message(uint16_t chnumber, stun_buffer *buf, int length, bool do_padding) {
+bool stun_init_channel_message(uint16_t chnumber, stun_buffer *buf, int length, bool do_padding)
+{
   return stun_init_channel_message_str(chnumber, buf->buf, &(buf->len), length, do_padding);
 }
 
-bool stun_is_channel_message(stun_buffer *buf, uint16_t *chnumber, bool is_padding_mandatory) {
-  if (!buf) {
+bool stun_is_channel_message(stun_buffer *buf, uint16_t *chnumber, bool is_padding_mandatory)
+{
+  if (!buf)
+  {
     return false;
   }
   size_t blen = buf->len;
   bool ret = stun_is_channel_message_str(buf->buf, &blen, chnumber, is_padding_mandatory);
-  if (ret) {
+  if (ret)
+  {
     buf->len = blen;
   }
   return ret;
@@ -158,14 +185,16 @@ bool stun_is_channel_message(stun_buffer *buf, uint16_t *chnumber, bool is_paddi
 ///////////////////////////////////////////////////////////////////////////////
 
 bool stun_set_allocate_request(stun_buffer *buf, uint32_t lifetime, bool af4, bool af6, uint8_t transport, bool mobile,
-                               const char *rt, int ep) {
+                               const char *rt, int ep)
+{
   return stun_set_allocate_request_str(buf->buf, &(buf->len), lifetime, af4, af6, transport, mobile, rt, ep);
 }
 
 bool stun_set_allocate_response(stun_buffer *buf, stun_tid *tid, const ioa_addr *relayed_addr1,
                                 const ioa_addr *relayed_addr2, const ioa_addr *reflexive_addr, uint32_t lifetime,
                                 uint32_t max_lifetime, int error_code, const uint8_t *reason,
-                                uint64_t reservation_token, char *mobile_id) {
+                                uint64_t reservation_token, char *mobile_id)
+{
 
   return stun_set_allocate_response_str(buf->buf, &(buf->len), tid, relayed_addr1, relayed_addr2, reflexive_addr,
                                         lifetime, max_lifetime, error_code, reason, reservation_token, mobile_id);
@@ -173,12 +202,14 @@ bool stun_set_allocate_response(stun_buffer *buf, stun_tid *tid, const ioa_addr 
 
 ///////////////////////////////////////////////////////////////////////////////
 
-uint16_t stun_set_channel_bind_request(stun_buffer *buf, const ioa_addr *peer_addr, uint16_t channel_number) {
+uint16_t stun_set_channel_bind_request(stun_buffer *buf, const ioa_addr *peer_addr, uint16_t channel_number)
+{
 
   return stun_set_channel_bind_request_str(buf->buf, &(buf->len), peer_addr, channel_number);
 }
 
-void stun_set_channel_bind_response(stun_buffer *buf, stun_tid *tid, int error_code, const uint8_t *reason) {
+void stun_set_channel_bind_response(stun_buffer *buf, stun_tid *tid, int error_code, const uint8_t *reason)
+{
   stun_set_channel_bind_response_str(buf->buf, &(buf->len), tid, error_code, reason);
 }
 
@@ -186,42 +217,52 @@ void stun_set_channel_bind_response(stun_buffer *buf, stun_tid *tid, int error_c
 
 stun_attr_ref stun_attr_get_first(const stun_buffer *buf) { return stun_attr_get_first_str(buf->buf, buf->len); }
 
-stun_attr_ref stun_attr_get_next(const stun_buffer *buf, stun_attr_ref prev) {
+stun_attr_ref stun_attr_get_next(const stun_buffer *buf, stun_attr_ref prev)
+{
   return stun_attr_get_next_str(buf->buf, buf->len, prev);
 }
 
-bool stun_attr_add(stun_buffer *buf, uint16_t attr, const char *avalue, int alen) {
+bool stun_attr_add(stun_buffer *buf, uint16_t attr, const char *avalue, int alen)
+{
   return stun_attr_add_str(buf->buf, &(buf->len), attr, (const uint8_t *)avalue, alen);
 }
 
-bool stun_attr_add_channel_number(stun_buffer *buf, uint16_t chnumber) {
+bool stun_attr_add_channel_number(stun_buffer *buf, uint16_t chnumber)
+{
   return stun_attr_add_channel_number_str(buf->buf, &(buf->len), chnumber);
 }
 
-bool stun_attr_add_addr(stun_buffer *buf, uint16_t attr_type, const ioa_addr *ca) {
+bool stun_attr_add_addr(stun_buffer *buf, uint16_t attr_type, const ioa_addr *ca)
+{
   return stun_attr_add_addr_str(buf->buf, &(buf->len), attr_type, ca);
 }
 
-bool stun_attr_get_addr(const stun_buffer *buf, stun_attr_ref attr, ioa_addr *ca, const ioa_addr *default_addr) {
+bool stun_attr_get_addr(const stun_buffer *buf, stun_attr_ref attr, ioa_addr *ca, const ioa_addr *default_addr)
+{
   return stun_attr_get_addr_str(buf->buf, buf->len, attr, ca, default_addr);
 }
 
-bool stun_attr_get_first_addr(const stun_buffer *buf, uint16_t attr_type, ioa_addr *ca, const ioa_addr *default_addr) {
+bool stun_attr_get_first_addr(const stun_buffer *buf, uint16_t attr_type, ioa_addr *ca, const ioa_addr *default_addr)
+{
   return stun_attr_get_first_addr_str(buf->buf, buf->len, attr_type, ca, default_addr);
 }
 
-bool stun_attr_add_even_port(stun_buffer *buf, uint8_t value) {
-  if (value) {
+bool stun_attr_add_even_port(stun_buffer *buf, uint8_t value)
+{
+  if (value)
+  {
     value = 0x80;
   }
   return stun_attr_add(buf, STUN_ATTRIBUTE_EVEN_PORT, (const char *)&value, 1);
 }
 
-uint16_t stun_attr_get_first_channel_number(const stun_buffer *buf) {
+uint16_t stun_attr_get_first_channel_number(const stun_buffer *buf)
+{
   return stun_attr_get_first_channel_number_str(buf->buf, buf->len);
 }
 
-stun_attr_ref stun_attr_get_first_by_type(const stun_buffer *buf, uint16_t attr_type) {
+stun_attr_ref stun_attr_get_first_by_type(const stun_buffer *buf, uint16_t attr_type)
+{
   return stun_attr_get_first_by_type_str(buf->buf, buf->len, attr_type);
 }
 
@@ -230,7 +271,8 @@ stun_attr_ref stun_attr_get_first_by_type(const stun_buffer *buf, uint16_t attr_
 void stun_set_binding_request(stun_buffer *buf) { stun_set_binding_request_str(buf->buf, (size_t *)(&(buf->len))); }
 
 bool stun_set_binding_response(stun_buffer *buf, stun_tid *tid, const ioa_addr *reflexive_addr, int error_code,
-                               const uint8_t *reason) {
+                               const uint8_t *reason)
+{
   return stun_set_binding_response_str(buf->buf, &(buf->len), tid, reflexive_addr, error_code, reason, 0, false, true);
 }
 

--- a/src/apps/common/stun_buffer.h
+++ b/src/apps/common/stun_buffer.h
@@ -37,12 +37,14 @@
 #include "ns_turn_msg_defs.h" // for STUN_CHANNEL_HEADER_LENGTH
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ///////////////////////////////////////////////////////////////
 
-typedef struct _stun_buffer {
+typedef struct _stun_buffer
+{
   uint8_t channel[STUN_CHANNEL_HEADER_LENGTH];
   uint8_t buf[STUN_BUFFER_SIZE];
   size_t len;

--- a/src/apps/common/win/getopt.c
+++ b/src/apps/common/win/getopt.c
@@ -111,15 +111,18 @@ static const char noarg[] = "option doesn't take an argument -- %.*s";
 static const char illoptchar[] = "unknown option -- %c";
 static const char illoptstring[] = "unknown option -- %s";
 
-static void _vwarnx(const char *fmt, va_list ap) {
+static void _vwarnx(const char *fmt, va_list ap)
+{
   (void)fprintf(stderr, "%s: ", __progname);
-  if (fmt != NULL) {
+  if (fmt != NULL)
+  {
     (void)vfprintf(stderr, fmt, ap);
   }
   (void)fprintf(stderr, "\n");
 }
 
-static void warnx(const char *fmt, ...) {
+static void warnx(const char *fmt, ...)
+{
   va_list ap;
   va_start(ap, fmt);
   _vwarnx(fmt, ap);
@@ -129,11 +132,13 @@ static void warnx(const char *fmt, ...) {
 /*
  * Compute the greatest common divisor of a and b.
  */
-static int gcd(int a, int b) {
+static int gcd(int a, int b)
+{
   int c;
 
   c = a % b;
-  while (c != 0) {
+  while (c != 0)
+  {
     a = b;
     b = c;
     c = a % b;
@@ -147,7 +152,8 @@ static int gcd(int a, int b) {
  * from nonopt_end to opt_end (keeping the same order of arguments
  * in each block).
  */
-static void permute_args(int panonopt_start, int panonopt_end, int opt_end, char *const *nargv) {
+static void permute_args(int panonopt_start, int panonopt_end, int opt_end, char *const *nargv)
+{
   int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
   char *swap;
 
@@ -159,13 +165,18 @@ static void permute_args(int panonopt_start, int panonopt_end, int opt_end, char
   ncycle = gcd(nnonopts, nopts);
   cyclelen = (opt_end - panonopt_start) / ncycle;
 
-  for (i = 0; i < ncycle; i++) {
+  for (i = 0; i < ncycle; i++)
+  {
     cstart = panonopt_end + i;
     pos = cstart;
-    for (j = 0; j < cyclelen; j++) {
-      if (pos >= panonopt_end) {
+    for (j = 0; j < cyclelen; j++)
+    {
+      if (pos >= panonopt_end)
+      {
         pos -= nnonopts;
-      } else {
+      }
+      else
+      {
         pos += nopts;
       }
       swap = nargv[pos];
@@ -183,7 +194,8 @@ static void permute_args(int panonopt_start, int panonopt_end, int opt_end, char
  * Returns -1 if short_too is set and the option does not match long_options.
  */
 static int parse_long_options(char *const *nargv, const char *options, const struct option *long_options, int *idx,
-                              int short_too) {
+                              int short_too)
+{
   char *current_argv, *has_equal;
   size_t current_argv_len;
   int i, ambiguous, match;
@@ -198,21 +210,27 @@ static int parse_long_options(char *const *nargv, const char *options, const str
 
   optind++;
 
-  if ((has_equal = strchr(current_argv, '=')) != NULL) {
+  if ((has_equal = strchr(current_argv, '=')) != NULL)
+  {
     /* argument found (--option=arg) */
     current_argv_len = has_equal - current_argv;
     has_equal++;
-  } else {
+  }
+  else
+  {
     current_argv_len = strlen(current_argv);
   }
 
-  for (i = 0; long_options[i].name; i++) {
+  for (i = 0; long_options[i].name; i++)
+  {
     /* find matching long option */
-    if (strncmp(current_argv, long_options[i].name, current_argv_len)) {
+    if (strncmp(current_argv, long_options[i].name, current_argv_len))
+    {
       continue;
     }
 
-    if (strlen(long_options[i].name) == current_argv_len) {
+    if (strlen(long_options[i].name) == current_argv_len)
+    {
       /* exact match */
       match = i;
       ambiguous = 0;
@@ -222,86 +240,115 @@ static int parse_long_options(char *const *nargv, const char *options, const str
      * If this is a known short option, don't allow
      * a partial match of a single character.
      */
-    if (short_too && current_argv_len == 1) {
+    if (short_too && current_argv_len == 1)
+    {
       continue;
     }
 
-    if (match == -1) { /* partial match */
+    if (match == -1)
+    { /* partial match */
       match = i;
-    } else if (!IDENTICAL_INTERPRETATION(i, match)) {
+    }
+    else if (!IDENTICAL_INTERPRETATION(i, match))
+    {
       ambiguous = 1;
     }
   }
-  if (ambiguous) {
+  if (ambiguous)
+  {
     /* ambiguous abbreviation */
-    if (PRINT_ERROR) {
+    if (PRINT_ERROR)
+    {
       warnx(ambig, (int)current_argv_len, current_argv);
     }
     optopt = 0;
     return (BADCH);
   }
-  if (match != -1) { /* option found */
-    if (long_options[match].has_arg == no_argument && has_equal) {
-      if (PRINT_ERROR) {
+  if (match != -1)
+  { /* option found */
+    if (long_options[match].has_arg == no_argument && has_equal)
+    {
+      if (PRINT_ERROR)
+      {
         warnx(noarg, (int)current_argv_len, current_argv);
       }
       /*
        * XXX: GNU sets optopt to val regardless of flag
        */
-      if (long_options[match].flag == NULL) {
+      if (long_options[match].flag == NULL)
+      {
         optopt = long_options[match].val;
-      } else {
+      }
+      else
+      {
         optopt = 0;
       }
       return (BADARG);
     }
-    if (long_options[match].has_arg == required_argument || long_options[match].has_arg == optional_argument) {
-      if (has_equal) {
+    if (long_options[match].has_arg == required_argument || long_options[match].has_arg == optional_argument)
+    {
+      if (has_equal)
+      {
         optarg = has_equal;
-      } else if (long_options[match].has_arg == required_argument) {
+      }
+      else if (long_options[match].has_arg == required_argument)
+      {
         /*
          * optional argument doesn't use next nargv
          */
         optarg = nargv[optind++];
       }
     }
-    if ((long_options[match].has_arg == required_argument) && (optarg == NULL)) {
+    if ((long_options[match].has_arg == required_argument) && (optarg == NULL))
+    {
       /*
        * Missing argument; leading ':' indicates no error
        * should be generated.
        */
-      if (PRINT_ERROR) {
+      if (PRINT_ERROR)
+      {
         warnx(recargstring, current_argv);
       }
       /*
        * XXX: GNU sets optopt to val regardless of flag
        */
-      if (long_options[match].flag == NULL) {
+      if (long_options[match].flag == NULL)
+      {
         optopt = long_options[match].val;
-      } else {
+      }
+      else
+      {
         optopt = 0;
       }
       --optind;
       return (BADARG);
     }
-  } else { /* unknown option */
-    if (short_too) {
+  }
+  else
+  { /* unknown option */
+    if (short_too)
+    {
       --optind;
       return (-1);
     }
-    if (PRINT_ERROR) {
+    if (PRINT_ERROR)
+    {
       warnx(illoptstring, current_argv);
     }
     optopt = 0;
     return (BADCH);
   }
-  if (idx) {
+  if (idx)
+  {
     *idx = match;
   }
-  if (long_options[match].flag) {
+  if (long_options[match].flag)
+  {
     *long_options[match].flag = long_options[match].val;
     return (0);
-  } else {
+  }
+  else
+  {
     return (long_options[match].val);
   }
 #undef IDENTICAL_INTERPRETATION
@@ -312,12 +359,14 @@ static int parse_long_options(char *const *nargv, const char *options, const str
  *	Parse argc/argv argument vector.  Called by user level routines.
  */
 static int getopt_internal(int nargc, char *const *nargv, const char *options, const struct option *long_options,
-                           int *idx, int flags) {
+                           int *idx, int flags)
+{
   const char *oli; /* option letter list index */
   int optchar, short_too;
   static int posixly_correct = -1;
 
-  if (options == NULL) {
+  if (options == NULL)
+  {
     return (-1);
   }
 
@@ -325,7 +374,8 @@ static int getopt_internal(int nargc, char *const *nargv, const char *options, c
    * XXX Some GNU programs (like cvs) set optind to 0 instead of
    * XXX using optreset.  Work around this braindamage.
    */
-  if (optind == 0) {
+  if (optind == 0)
+  {
     optind = optreset = 1;
   }
 
@@ -336,32 +386,43 @@ static int getopt_internal(int nargc, char *const *nargv, const char *options, c
    * CV, 2009-12-14: Check POSIXLY_CORRECT anew if optind == 0 or
    *                 optreset != 0 for GNU compatibility.
    */
-  if (posixly_correct == -1 || optreset != 0) {
+  if (posixly_correct == -1 || optreset != 0)
+  {
     posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
   }
-  if (*options == '-') {
+  if (*options == '-')
+  {
     flags |= FLAG_ALLARGS;
-  } else if (posixly_correct || *options == '+') {
+  }
+  else if (posixly_correct || *options == '+')
+  {
     flags &= ~FLAG_PERMUTE;
   }
-  if (*options == '+' || *options == '-') {
+  if (*options == '+' || *options == '-')
+  {
     options++;
   }
 
   optarg = NULL;
-  if (optreset) {
+  if (optreset)
+  {
     nonopt_start = nonopt_end = -1;
   }
 start:
-  if (optreset || !*place) { /* update scanning pointer */
+  if (optreset || !*place)
+  { /* update scanning pointer */
     optreset = 0;
-    if (optind >= nargc) { /* end of argument vector */
+    if (optind >= nargc)
+    { /* end of argument vector */
       place = EMSG;
-      if (nonopt_end != -1) {
+      if (nonopt_end != -1)
+      {
         /* do permutation, if we have to */
         permute_args(nonopt_start, nonopt_end, optind, nargv);
         optind -= nonopt_end - nonopt_start;
-      } else if (nonopt_start != -1) {
+      }
+      else if (nonopt_start != -1)
+      {
         /*
          * If we skipped non-options, set optind
          * to the first of them.
@@ -371,9 +432,11 @@ start:
       nonopt_start = nonopt_end = -1;
       return (-1);
     }
-    if (*(place = nargv[optind]) != '-' || (place[1] == '\0' && strchr(options, '-') == NULL)) {
+    if (*(place = nargv[optind]) != '-' || (place[1] == '\0' && strchr(options, '-') == NULL))
+    {
       place = EMSG; /* found non-option */
-      if (flags & FLAG_ALLARGS) {
+      if (flags & FLAG_ALLARGS)
+      {
         /*
          * GNU extension:
          * return non-option as argument to option 1
@@ -381,7 +444,8 @@ start:
         optarg = nargv[optind++];
         return (INORDER);
       }
-      if (!(flags & FLAG_PERMUTE)) {
+      if (!(flags & FLAG_PERMUTE))
+      {
         /*
          * If no permutation wanted, stop parsing
          * at first non-option.
@@ -389,9 +453,12 @@ start:
         return (-1);
       }
       /* do permutation */
-      if (nonopt_start == -1) {
+      if (nonopt_start == -1)
+      {
         nonopt_start = optind;
-      } else if (nonopt_end != -1) {
+      }
+      else if (nonopt_end != -1)
+      {
         permute_args(nonopt_start, nonopt_end, optind, nargv);
         nonopt_start = optind - (nonopt_end - nonopt_start);
         nonopt_end = -1;
@@ -400,21 +467,24 @@ start:
       /* process next argument */
       goto start;
     }
-    if (nonopt_start != -1 && nonopt_end == -1) {
+    if (nonopt_start != -1 && nonopt_end == -1)
+    {
       nonopt_end = optind;
     }
 
     /*
      * If we have "-" do nothing, if "--" we are done.
      */
-    if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
+    if (place[1] != '\0' && *++place == '-' && place[1] == '\0')
+    {
       optind++;
       place = EMSG;
       /*
        * We found an option (--), so if we skipped
        * non-options, we have to permute.
        */
-      if (nonopt_end != -1) {
+      if (nonopt_end != -1)
+      {
         permute_args(nonopt_start, nonopt_end, optind, nargv);
         optind -= nonopt_end - nonopt_start;
       }
@@ -429,75 +499,102 @@ start:
    *  2) the arg is not just "-"
    *  3) either the arg starts with -- we are getopt_long_only()
    */
-  if (long_options != NULL && place != nargv[optind] && (*place == '-' || (flags & FLAG_LONGONLY))) {
+  if (long_options != NULL && place != nargv[optind] && (*place == '-' || (flags & FLAG_LONGONLY)))
+  {
     short_too = 0;
-    if (*place == '-') {
+    if (*place == '-')
+    {
       place++; /* --foo long option */
-    } else if (*place != ':' && strchr(options, *place) != NULL) {
+    }
+    else if (*place != ':' && strchr(options, *place) != NULL)
+    {
       short_too = 1; /* could be short option too */
     }
 
     optchar = parse_long_options(nargv, options, long_options, idx, short_too);
-    if (optchar != -1) {
+    if (optchar != -1)
+    {
       place = EMSG;
       return (optchar);
     }
   }
 
   if ((optchar = (int)*place++) == (int)':' || (optchar == (int)'-' && *place != '\0') ||
-      (oli = strchr(options, optchar)) == NULL) {
+      (oli = strchr(options, optchar)) == NULL)
+  {
     /*
      * If the user specified "-" and  '-' isn't listed in
      * options, return -1 (non-option) as per POSIX.
      * Otherwise, it is an unknown option character (or ':').
      */
-    if (optchar == (int)'-' && *place == '\0') {
+    if (optchar == (int)'-' && *place == '\0')
+    {
       return (-1);
     }
-    if (!*place) {
+    if (!*place)
+    {
       ++optind;
     }
-    if (PRINT_ERROR) {
+    if (PRINT_ERROR)
+    {
       warnx(illoptchar, optchar);
     }
     optopt = optchar;
     return (BADCH);
   }
-  if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+  if (long_options != NULL && optchar == 'W' && oli[1] == ';')
+  {
     /* -W long-option */
-    if (*place) /* no space */ {
+    if (*place) /* no space */
+    {
       /* NOTHING */;
-    } else if (++optind >= nargc) { /* no arg */
+    }
+    else if (++optind >= nargc)
+    { /* no arg */
       place = EMSG;
-      if (PRINT_ERROR) {
+      if (PRINT_ERROR)
+      {
         warnx(recargchar, optchar);
       }
       optopt = optchar;
       return (BADARG);
-    } else { /* white space */
+    }
+    else
+    { /* white space */
       place = nargv[optind];
     }
     optchar = parse_long_options(nargv, options, long_options, idx, 0);
     place = EMSG;
     return (optchar);
   }
-  if (*++oli != ':') { /* doesn't take argument */
-    if (!*place) {
+  if (*++oli != ':')
+  { /* doesn't take argument */
+    if (!*place)
+    {
       ++optind;
     }
-  } else { /* takes (optional) argument */
+  }
+  else
+  { /* takes (optional) argument */
     optarg = NULL;
-    if (*place) { /* no white space */
+    if (*place)
+    { /* no white space */
       optarg = place;
-    } else if (oli[1] != ':') { /* arg not optional */
-      if (++optind >= nargc) {  /* no arg */
+    }
+    else if (oli[1] != ':')
+    { /* arg not optional */
+      if (++optind >= nargc)
+      { /* no arg */
         place = EMSG;
-        if (PRINT_ERROR) {
+        if (PRINT_ERROR)
+        {
           warnx(recargchar, optchar);
         }
         optopt = optchar;
         return (BADARG);
-      } else {
+      }
+      else
+      {
         optarg = nargv[optind];
       }
     }
@@ -515,7 +612,8 @@ start:
  *
  * [eventually this will replace the BSD getopt]
  */
-int getopt(int nargc, char *const *nargv, const char *options) {
+int getopt(int nargc, char *const *nargv, const char *options)
+{
 
   /*
    * We don't pass FLAG_PERMUTE to getopt_internal() since
@@ -533,7 +631,8 @@ int getopt(int nargc, char *const *nargv, const char *options) {
  * getopt_long --
  *	Parse argc/argv argument vector.
  */
-int getopt_long(int nargc, char *const *nargv, const char *options, const struct option *long_options, int *idx) {
+int getopt_long(int nargc, char *const *nargv, const char *options, const struct option *long_options, int *idx)
+{
 
   return (getopt_internal(nargc, nargv, options, long_options, idx, FLAG_PERMUTE));
 }
@@ -542,7 +641,8 @@ int getopt_long(int nargc, char *const *nargv, const char *options, const struct
  * getopt_long_only --
  *	Parse argc/argv argument vector.
  */
-int getopt_long_only(int nargc, char *const *nargv, const char *options, const struct option *long_options, int *idx) {
+int getopt_long_only(int nargc, char *const *nargv, const char *options, const struct option *long_options, int *idx)
+{
 
   return (getopt_internal(nargc, nargv, options, long_options, idx, FLAG_PERMUTE | FLAG_LONGONLY));
 }

--- a/src/apps/common/win/getopt.h
+++ b/src/apps/common/win/getopt.h
@@ -26,7 +26,8 @@
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 WINGETOPT_API extern int optind; /* index of first non-option in argv      */
@@ -66,7 +67,8 @@ extern int optreset;
 #define __GETOPT_LONG_H__
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 struct option /* specification for a long form option...	*/

--- a/src/apps/oauth/oauth.c
+++ b/src/apps/oauth/oauth.c
@@ -61,7 +61,8 @@
 #define OAUTH_HMAC_ALG_SIZE 20
 
 static int setup_ikm_key(const char *kid, const char *ikm_key, const turn_time_t key_timestamp,
-                         const turn_time_t key_lifetime, const char *as_rs_alg, oauth_key *key) {
+                         const turn_time_t key_lifetime, const char *as_rs_alg, oauth_key *key)
+{
 
   memset(key, 0, sizeof(*key));
 
@@ -84,7 +85,8 @@ static int setup_ikm_key(const char *kid, const char *ikm_key, const turn_time_t
   char err_msg[1025] = "\0";
   size_t err_msg_size = sizeof(err_msg) - 1;
 
-  if (!convert_oauth_key_data(&okd, key, err_msg, err_msg_size)) {
+  if (!convert_oauth_key_data(&okd, key, err_msg, err_msg_size))
+  {
     fprintf(stderr, "%s\n", err_msg);
     return -1;
   }
@@ -94,7 +96,8 @@ static int setup_ikm_key(const char *kid, const char *ikm_key, const turn_time_t
 
 static int encode_token(const char *server_name, const char *gcm_nonce, const char *mac_key,
                         const uint64_t token_timestamp, const uint32_t token_lifetime, const oauth_key key,
-                        char *base64encoded_etoken) {
+                        char *base64encoded_etoken)
+{
 
   oauth_token ot;
   memset(&ot, 0, sizeof(ot));
@@ -109,11 +112,13 @@ static int encode_token(const char *server_name, const char *gcm_nonce, const ch
   memset(&etoken, 0, sizeof(etoken));
 
   // TODO: avoid this hack
-  if (!*gcm_nonce) {
+  if (!*gcm_nonce)
+  {
     gcm_nonce = NULL;
   }
 
-  if (!encode_oauth_token((const uint8_t *)server_name, &etoken, &key, &ot, (const uint8_t *)gcm_nonce)) {
+  if (!encode_oauth_token((const uint8_t *)server_name, &etoken, &key, &ot, (const uint8_t *)gcm_nonce))
+  {
     fprintf(stderr, "%s: cannot encode oauth token\n", __FUNCTION__);
     return -1;
   }
@@ -127,7 +132,8 @@ static int encode_token(const char *server_name, const char *gcm_nonce, const ch
 }
 
 static int validate_decode_token(const char *server_name, const oauth_key key, const char *base64encoded_etoken,
-                                 oauth_token *dot) {
+                                 oauth_token *dot)
+{
 
   memset(dot, 0, sizeof(*dot));
 
@@ -139,15 +145,19 @@ static int validate_decode_token(const char *server_name, const oauth_key key, c
   memcpy(etoken.token, tmp, etoken.size);
   free(tmp);
 
-  if (!decode_oauth_token((const uint8_t *)server_name, &etoken, &key, dot)) {
+  if (!decode_oauth_token((const uint8_t *)server_name, &etoken, &key, dot))
+  {
     fprintf(stderr, "%s: cannot decode oauth token\n", __FUNCTION__);
     return -1;
-  } else {
+  }
+  else
+  {
     return 0;
   };
 }
 
-static void print_token_body(oauth_token *dot) {
+static void print_token_body(oauth_token *dot)
+{
   printf("\n");
   printf("Token non-encrpyted body:\n");
   printf("{\n");
@@ -199,7 +209,8 @@ const char Usage[] =
 
 //////////////////////////////////////////////////
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 
   oauth_key key;
 
@@ -266,8 +277,10 @@ int main(int argc, char **argv) {
   set_no_stdout_log(1);
   set_system_parameters(0);
 
-  while ((c = getopt_long(argc, argv, "hvedi:j:k:l:m:n:o:p:q:r:t:u:", long_options, &option_index)) != -1) {
-    switch (c) {
+  while ((c = getopt_long(argc, argv, "hvedi:j:k:l:m:n:o:p:q:r:t:u:", long_options, &option_index)) != -1)
+  {
+    switch (c)
+    {
     case 'h':
       fprintf(stderr, "%s\n", Usage);
       exit(1);
@@ -283,27 +296,36 @@ int main(int argc, char **argv) {
       break;
     case 'i':
       // server-name
-      if (strlen(optarg) <= OAUTH_SERVER_NAME_SIZE) {
+      if (strlen(optarg) <= OAUTH_SERVER_NAME_SIZE)
+      {
         STRCPY(server_name, optarg);
-      } else {
+      }
+      else
+      {
         fprintf(stderr, "Server-name must not exceed %d!\n", OAUTH_LTK_ID_SIZE);
         exit(1);
       }
       break;
     case 'j':
       // auth-key-id
-      if (strlen(optarg) <= OAUTH_LTK_ID_SIZE) {
+      if (strlen(optarg) <= OAUTH_LTK_ID_SIZE)
+      {
         STRCPY(kid, optarg);
-      } else {
+      }
+      else
+      {
         fprintf(stderr, "Key ID must not exceed %d!\n", OAUTH_LTK_ID_SIZE);
         exit(1);
       }
       break;
     case 'k':
       // auth-key
-      if (strlen(optarg) <= OAUTH_LTK_BASE64ENCODED_SIZE) {
+      if (strlen(optarg) <= OAUTH_LTK_BASE64ENCODED_SIZE)
+      {
         STRCPY(base64encoded_ltk, optarg);
-      } else {
+      }
+      else
+      {
         fprintf(stderr, "Key must not exceed %d!\n", OAUTH_LTK_BASE64ENCODED_SIZE);
         exit(1);
       }
@@ -318,9 +340,12 @@ int main(int argc, char **argv) {
       break;
     case 'n':
       // auth-key-as-rs-alg
-      if (strlen(optarg) <= OAUTH_AS_RS_ALG_SIZE) {
+      if (strlen(optarg) <= OAUTH_AS_RS_ALG_SIZE)
+      {
         STRCPY(as_rs_alg, optarg);
-      } else {
+      }
+      else
+      {
         fprintf(stderr, "AS-RS Alg must not exceed %d!\n", OAUTH_AS_RS_ALG_SIZE);
         exit(1);
       }
@@ -328,7 +353,8 @@ int main(int argc, char **argv) {
     case 'o':
       // token-nonce
       nonce_val = (char *)base64_decode(optarg, strlen(optarg), &nonce_size);
-      if (nonce_size > OAUTH_GCM_NONCE_SIZE) {
+      if (nonce_size > OAUTH_GCM_NONCE_SIZE)
+      {
         nonce_size = OAUTH_GCM_NONCE_SIZE;
       }
       strncpy(gcm_nonce, nonce_val, nonce_size);
@@ -337,7 +363,8 @@ int main(int argc, char **argv) {
     case 'p':
       // token-mac-key
       mac_key_val = (char *)base64_decode(optarg, strlen(optarg), &mac_key_size);
-      if (mac_key_size > OAUTH_MAC_KEY_SIZE) {
+      if (mac_key_size > OAUTH_MAC_KEY_SIZE)
+      {
         mac_key_size = OAUTH_MAC_KEY_SIZE;
       }
       strncpy(mac_key, mac_key_val, mac_key_size);
@@ -352,18 +379,24 @@ int main(int argc, char **argv) {
       token_lifetime = atoi(optarg);
       break;
     case 't':
-      if (strlen(optarg) <= OAUTH_TOKEN_SIZE) {
+      if (strlen(optarg) <= OAUTH_TOKEN_SIZE)
+      {
         STRCPY(base64encoded_etoken, optarg);
-      } else {
+      }
+      else
+      {
         fprintf(stderr, "base64 encoded encrypted token must not exceed %d!\n", OAUTH_TOKEN_SIZE);
         exit(1);
       }
       break;
     case 'u':
       // hmac-alg
-      if (strlen(optarg) <= OAUTH_HMAC_ALG_SIZE) {
+      if (strlen(optarg) <= OAUTH_HMAC_ALG_SIZE)
+      {
         STRCPY(hmac_alg, optarg);
-      } else {
+      }
+      else
+      {
         fprintf(stderr, "STUN client HMAC Alg must not exceed %d!\n", OAUTH_HMAC_ALG_SIZE);
         exit(1);
       }
@@ -375,76 +408,98 @@ int main(int argc, char **argv) {
     }
   }
 
-  for (i = optind; i < argc; i++) {
+  for (i = optind; i < argc; i++)
+  {
     printf("Non-option argument %s\n", argv[i]);
   }
 
-  if (optind > argc) {
+  if (optind > argc)
+  {
     fprintf(stderr, "%s\n", Usage);
     exit(-1);
   }
 
-  if (!(encrypt_flag || decrypt_flag)) {
+  if (!(encrypt_flag || decrypt_flag))
+  {
     fprintf(stderr, "Use either encrypt or decrypt.\nPlease use -h or --help for the detailed help\n");
     exit(-1);
   }
 
   // check if we have required params
   // TODO: more compact warnning handling
-  if (encrypt_flag || decrypt_flag) {
-    if (strlen(server_name) == 0) {
+  if (encrypt_flag || decrypt_flag)
+  {
+    if (strlen(server_name) == 0)
+    {
       fprintf(stderr, "For encode/decode  --server-name/-i is mandatory \n");
       exit(-1);
     }
 
-    if (strlen(kid) == 0) {
+    if (strlen(kid) == 0)
+    {
       fprintf(stderr, "For encode/decode  --auth-key-id/-j is mandatory \n");
       exit(-1);
     }
-    if (strlen(base64encoded_ltk) == 0) {
+    if (strlen(base64encoded_ltk) == 0)
+    {
       fprintf(stderr, "For encode/decode  --auth-key/-k is mandatory \n");
       exit(-1);
     }
-    if (key_timestamp == 0) {
+    if (key_timestamp == 0)
+    {
       fprintf(stderr, "For encode/decode  --auth-key-timestamp/-l is mandatory \n");
       exit(-1);
     }
-    if (key_lifetime == 0) {
+    if (key_lifetime == 0)
+    {
       fprintf(stderr, "For encode/decode  --auth-key-lifetime/-m is mandatory \n");
       exit(-1);
     }
 
-    if (encrypt_flag && strlen(mac_key) == 0) {
+    if (encrypt_flag && strlen(mac_key) == 0)
+    {
       fprintf(stderr, "For encode --token-mac-key/-p is mandatory \n");
       exit(-1);
     }
 
-    if (!encrypt_flag && decrypt_flag && strlen(base64encoded_etoken) == 0) {
+    if (!encrypt_flag && decrypt_flag && strlen(base64encoded_etoken) == 0)
+    {
       fprintf(stderr, "For decode --token/-t is mandatory \n");
       exit(-1);
     }
 
     // Expiry warnings
-    if ((unsigned long long)key_timestamp << 16 > token_timestamp + ((unsigned long long)token_lifetime << 16)) {
+    if ((unsigned long long)key_timestamp << 16 > token_timestamp + ((unsigned long long)token_lifetime << 16))
+    {
       fprintf(stderr, "\nWARNING: Token expiry is earlear then Auth key life time start timestamp!!\n\n");
-    } else {
-      if ((unsigned long long)key_timestamp << 16 > token_timestamp) {
+    }
+    else
+    {
+      if ((unsigned long long)key_timestamp << 16 > token_timestamp)
+      {
         fprintf(stderr, "\nWARNING: Token life time start timestamp is earlier then Auth key start timestamp!!\n\n");
       }
     }
-    if ((unsigned long long)(key_timestamp + key_lifetime) << 16 < token_timestamp) {
+    if ((unsigned long long)(key_timestamp + key_lifetime) << 16 < token_timestamp)
+    {
       fprintf(stderr, "\nWARNING: Auth key will expire before token lifetime start timestamp!!\n\n");
-    } else {
+    }
+    else
+    {
       if ((unsigned long long)(key_timestamp + key_lifetime) << 16 <
-          token_timestamp + ((unsigned long long)token_lifetime << 16)) {
+          token_timestamp + ((unsigned long long)token_lifetime << 16))
+      {
         fprintf(stderr, "\nWARNING: Auth key will expire before token expiry!!\n\n");
       }
     }
 
-    if (setup_ikm_key(kid, base64encoded_ltk, key_timestamp, key_lifetime, as_rs_alg, &key) == 0) {
-      if (encrypt_flag) {
+    if (setup_ikm_key(kid, base64encoded_ltk, key_timestamp, key_lifetime, as_rs_alg, &key) == 0)
+    {
+      if (encrypt_flag)
+      {
         if (encode_token(server_name, gcm_nonce, mac_key, token_timestamp, token_lifetime, key, base64encoded_etoken) ==
-            0) {
+            0)
+        {
           printf("{\n");
           printf("    \"access_token\":\"%s\",\n", base64encoded_etoken);
           printf("    \"token_type\":\"pop\",\n");
@@ -453,24 +508,33 @@ int main(int argc, char **argv) {
           printf("    \"key\":\"%s\",\n", mac_key);
           printf("    \"alg\":\"%s\"\n", hmac_alg);
           printf("}\n");
-        } else {
+        }
+        else
+        {
           fprintf(stderr, "Error during token encode\n");
           exit(-1);
         }
       }
-      if (decrypt_flag) {
+      if (decrypt_flag)
+      {
         oauth_token dot;
-        if (validate_decode_token(server_name, key, base64encoded_etoken, &dot) == 0) {
+        if (validate_decode_token(server_name, key, base64encoded_etoken, &dot) == 0)
+        {
           printf("-=Valid token!=-\n");
-          if (verbose_flag) {
+          if (verbose_flag)
+          {
             print_token_body(&dot);
           }
-        } else {
+        }
+        else
+        {
           fprintf(stderr, "Error during token validation and decoding\n");
           exit(-1);
         }
       }
-    } else {
+    }
+    else
+    {
       fprintf(stderr, "Error during key setup\n");
       exit(-1);
     }

--- a/src/apps/peer/mainudpserver.c
+++ b/src/apps/peer/mainudpserver.c
@@ -53,7 +53,8 @@ static char Usage[] = "Usage: server [options]\n"
 
 //////////////////////////////////////////////////
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
   int port = PEER_DEFAULT_PORT;
   char **local_addr_list = NULL;
   size_t las = 0;
@@ -61,7 +62,8 @@ int main(int argc, char **argv) {
   int c;
   char ifname[1025] = "\0";
 
-  if (socket_init()) {
+  if (socket_init())
+  {
     return -1;
   }
 
@@ -71,8 +73,10 @@ int main(int argc, char **argv) {
   set_no_stdout_log(1);
   set_system_parameters(0);
 
-  while ((c = getopt(argc, argv, "d:p:L:v")) != -1) {
-    switch (c) {
+  while ((c = getopt(argc, argv, "d:p:L:v")) != -1)
+  {
+    switch (c)
+    {
     case 'd':
       STRCPY(ifname, optarg);
       break;
@@ -92,7 +96,8 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (las < 1) {
+  if (las < 1)
+  {
     local_addr_list = (char **)realloc(local_addr_list, ++las * sizeof(char *));
     local_addr_list[las - 1] = strdup("0.0.0.0");
     local_addr_list = (char **)realloc(local_addr_list, ++las * sizeof(char *));

--- a/src/apps/peer/udpserver.h
+++ b/src/apps/peer/udpserver.h
@@ -40,7 +40,8 @@
 #include <stddef.h> // for size_t
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////////////////////////
@@ -50,7 +51,8 @@ typedef struct server_info server_type;
 
 ///////////////////////////////////////////////////////
 
-struct server_info {
+struct server_info
+{
   char ifname[1025];
   struct event_base *event_base;
   int verbose;

--- a/src/apps/relay/acme.c
+++ b/src/apps/relay/acme.c
@@ -15,35 +15,43 @@
 #define GET_ACME_PREFIX "GET /.well-known/acme-challenge/"
 #define GET_ACME_PREFIX_LEN 32
 
-static int is_acme_req(char *req, size_t len) {
+static int is_acme_req(char *req, size_t len)
+{
   static const char *A = "                                             -  0123456789       ABCDEFGHIJKLMNOPQRSTUVWXYZ  "
                          "  _ abcdefghijklmnopqrstuvwxyz     ";
   int c, i, k;
 
   // Check first request line. Should be like: GET path HTTP/1.x
-  if (strncmp(req, GET_ACME_PREFIX, GET_ACME_PREFIX_LEN)) {
+  if (strncmp(req, GET_ACME_PREFIX, GET_ACME_PREFIX_LEN))
+  {
     return -1;
   }
   // Usually (for LE) the "method path" is 32 + 43 = 55 chars. But other
   // implementations may choose longer pathes. We define PATHMAX = 127 chars
   // to be prepared for "DoS" attacks (STUN msg size max. is ~ 64K).
   len -= 21; // min size of trailing headers
-  if (len > 131) {
+  if (len > 131)
+  {
     len = 131;
   }
-  for (i = GET_ACME_PREFIX_LEN; i < (int)len; i++) {
+  for (i = GET_ACME_PREFIX_LEN; i < (int)len; i++)
+  {
     // find the end of the path
-    if (req[i] != ' ') {
+    if (req[i] != ' ')
+    {
       continue;
     }
     // consider path < 10 chars invalid. Also we wanna see a "trailer".
-    if (i < (GET_ACME_PREFIX_LEN + 10) || strncmp(req + i, " HTTP/1.", 8)) {
+    if (i < (GET_ACME_PREFIX_LEN + 10) || strncmp(req + i, " HTTP/1.", 8))
+    {
       return -2;
     }
     // finally check for allowed chars
-    for (k = GET_ACME_PREFIX_LEN; k < i; k++) {
+    for (k = GET_ACME_PREFIX_LEN; k < i; k++)
+    {
       c = req[k];
-      if ((c > 127) || (A[c] == ' ')) {
+      if ((c > 127) || (A[c] == ' '))
+      {
         return -3;
       }
     }
@@ -53,17 +61,20 @@ static int is_acme_req(char *req, size_t len) {
   return -4; // end of path not found
 }
 
-int try_acme_redirect(char *req, size_t len, const char *url, ioa_socket_handle s) {
+int try_acme_redirect(char *req, size_t len, const char *url, ioa_socket_handle s)
+{
   static const char *HTML = "<html><head><title>301 Moved Permanently</title></head>\
 		<body><h1>301 Moved Permanently</h1></body></html>";
   char http_response[1024];
   size_t plen, rlen;
 
-  if (url == NULL || url[0] == '\0' || req == NULL || s == 0) {
+  if (url == NULL || url[0] == '\0' || req == NULL || s == 0)
+  {
     return 1;
   }
   if (len < (GET_ACME_PREFIX_LEN + 32) || len > (512 - GET_ACME_PREFIX_LEN) ||
-      (plen = is_acme_req(req, len)) < (GET_ACME_PREFIX_LEN + 1)) {
+      (plen = is_acme_req(req, len)) < (GET_ACME_PREFIX_LEN + 1))
+  {
     return 2;
   }
 
@@ -87,9 +98,12 @@ int try_acme_redirect(char *req, size_t len, const char *url, ioa_socket_handle 
   ioa_network_buffer_set_size(nbh_acme, rlen);
   send_data_from_ioa_socket_nbh(s, NULL, nbh_acme, TTL_IGNORE, TOS_IGNORE, NULL);
 #else
-  if (write(s->fd, http_response, rlen) == -1) {
+  if (write(s->fd, http_response, rlen) == -1)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "Sending redirect to '%s%s' failed", url, req + GET_ACME_PREFIX_LEN);
-  } else if (((turn_turnserver *)s->session->server)->verbose) {
+  }
+  else if (((turn_turnserver *)s->session->server)->verbose)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "ACME redirected to %s%s\n", url, req + GET_ACME_PREFIX_LEN);
   }
 #endif

--- a/src/apps/relay/acme.h
+++ b/src/apps/relay/acme.h
@@ -39,7 +39,8 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ///////////// ACME /////////////////////

--- a/src/apps/relay/dbdrivers/dbd_mongo.h
+++ b/src/apps/relay/dbdrivers/dbd_mongo.h
@@ -35,7 +35,8 @@
 #include "dbdriver.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 const turn_dbdriver_t *get_mongo_dbdriver(void);

--- a/src/apps/relay/dbdrivers/dbd_mysql.c
+++ b/src/apps/relay/dbdrivers/dbd_mysql.c
@@ -39,7 +39,8 @@
 
 static int donot_print_connection_success = 0;
 
-struct _Myconninfo {
+struct _Myconninfo
+{
   char *host;
   char *dbname;
   char *user;
@@ -58,33 +59,44 @@ struct _Myconninfo {
 
 typedef struct _Myconninfo Myconninfo;
 
-static void MyconninfoFree(Myconninfo *co) {
-  if (co) {
-    if (co->host) {
+static void MyconninfoFree(Myconninfo *co)
+{
+  if (co)
+  {
+    if (co->host)
+    {
       free(co->host);
     }
-    if (co->dbname) {
+    if (co->dbname)
+    {
       free(co->dbname);
     }
-    if (co->user) {
+    if (co->user)
+    {
       free(co->user);
     }
-    if (co->password) {
+    if (co->password)
+    {
       free(co->password);
     }
-    if (co->key) {
+    if (co->key)
+    {
       free(co->key);
     }
-    if (co->ca) {
+    if (co->ca)
+    {
       free(co->ca);
     }
-    if (co->cert) {
+    if (co->cert)
+    {
       free(co->cert);
     }
-    if (co->capath) {
+    if (co->capath)
+    {
       free(co->capath);
     }
-    if (co->cipher) {
+    if (co->cipher)
+    {
       free(co->cipher);
     }
     memset(co, 0, sizeof(Myconninfo));
@@ -92,7 +104,8 @@ static void MyconninfoFree(Myconninfo *co) {
   }
 }
 
-char *decryptPassword(char *in, const unsigned char *mykey) {
+char *decryptPassword(char *in, const unsigned char *mykey)
+{
 
   char *out;
   unsigned char iv[8] = {0}; // changed
@@ -115,100 +128,171 @@ char *decryptPassword(char *in, const unsigned char *mykey) {
   return out;
 }
 
-static Myconninfo *MyconninfoParse(char *userdb, char **errmsg) {
+static Myconninfo *MyconninfoParse(char *userdb, char **errmsg)
+{
   Myconninfo *co = (Myconninfo *)calloc(1, sizeof(Myconninfo));
-  if (userdb) {
+  if (userdb)
+  {
     char *s0 = strdup(userdb);
     char *s = s0;
 
-    while (s && *s) {
+    while (s && *s)
+    {
 
-      while (*s && (*s == ' ')) {
+      while (*s && (*s == ' '))
+      {
         ++s;
       }
       char *snext = strstr(s, " ");
-      if (snext) {
+      if (snext)
+      {
         *snext = 0;
         ++snext;
       }
 
       char *seq = strstr(s, "=");
-      if (!seq) {
+      if (!seq)
+      {
         MyconninfoFree(co);
         co = NULL;
-        if (errmsg) {
+        if (errmsg)
+        {
           *errmsg = strdup(s);
         }
         break;
       }
 
       *seq = 0;
-      if (!strcmp(s, "host")) {
+      if (!strcmp(s, "host"))
+      {
         co->host = strdup(seq + 1);
-      } else if (!strcmp(s, "ip")) {
+      }
+      else if (!strcmp(s, "ip"))
+      {
         co->host = strdup(seq + 1);
-      } else if (!strcmp(s, "addr")) {
+      }
+      else if (!strcmp(s, "addr"))
+      {
         co->host = strdup(seq + 1);
-      } else if (!strcmp(s, "ipaddr")) {
+      }
+      else if (!strcmp(s, "ipaddr"))
+      {
         co->host = strdup(seq + 1);
-      } else if (!strcmp(s, "hostaddr")) {
+      }
+      else if (!strcmp(s, "hostaddr"))
+      {
         co->host = strdup(seq + 1);
-      } else if (!strcmp(s, "dbname")) {
+      }
+      else if (!strcmp(s, "dbname"))
+      {
         co->dbname = strdup(seq + 1);
-      } else if (!strcmp(s, "db")) {
+      }
+      else if (!strcmp(s, "db"))
+      {
         co->dbname = strdup(seq + 1);
-      } else if (!strcmp(s, "database")) {
+      }
+      else if (!strcmp(s, "database"))
+      {
         co->dbname = strdup(seq + 1);
-      } else if (!strcmp(s, "user")) {
+      }
+      else if (!strcmp(s, "user"))
+      {
         co->user = strdup(seq + 1);
-      } else if (!strcmp(s, "uname")) {
+      }
+      else if (!strcmp(s, "uname"))
+      {
         co->user = strdup(seq + 1);
-      } else if (!strcmp(s, "name")) {
+      }
+      else if (!strcmp(s, "name"))
+      {
         co->user = strdup(seq + 1);
-      } else if (!strcmp(s, "username")) {
+      }
+      else if (!strcmp(s, "username"))
+      {
         co->user = strdup(seq + 1);
-      } else if (!strcmp(s, "password")) {
+      }
+      else if (!strcmp(s, "password"))
+      {
         co->password = strdup(seq + 1);
-      } else if (!strcmp(s, "pwd")) {
+      }
+      else if (!strcmp(s, "pwd"))
+      {
         co->password = strdup(seq + 1);
-      } else if (!strcmp(s, "passwd")) {
+      }
+      else if (!strcmp(s, "passwd"))
+      {
         co->password = strdup(seq + 1);
-      } else if (!strcmp(s, "secret")) {
+      }
+      else if (!strcmp(s, "secret"))
+      {
         co->password = strdup(seq + 1);
-      } else if (!strcmp(s, "port")) {
+      }
+      else if (!strcmp(s, "port"))
+      {
         co->port = (unsigned int)atoi(seq + 1);
-      } else if (!strcmp(s, "p")) {
+      }
+      else if (!strcmp(s, "p"))
+      {
         co->port = (unsigned int)atoi(seq + 1);
-      } else if (!strcmp(s, "connect_timeout")) {
+      }
+      else if (!strcmp(s, "connect_timeout"))
+      {
         co->connect_timeout = (unsigned int)atoi(seq + 1);
-      } else if (!strcmp(s, "timeout")) {
+      }
+      else if (!strcmp(s, "timeout"))
+      {
         co->connect_timeout = (unsigned int)atoi(seq + 1);
-      } else if (!strcmp(s, "read_timeout")) {
+      }
+      else if (!strcmp(s, "read_timeout"))
+      {
         co->read_timeout = (unsigned int)atoi(seq + 1);
-      } else if (!strcmp(s, "key")) {
+      }
+      else if (!strcmp(s, "key"))
+      {
         co->key = strdup(seq + 1);
-      } else if (!strcmp(s, "ssl-key")) {
+      }
+      else if (!strcmp(s, "ssl-key"))
+      {
         co->key = strdup(seq + 1);
-      } else if (!strcmp(s, "ca")) {
+      }
+      else if (!strcmp(s, "ca"))
+      {
         co->ca = strdup(seq + 1);
-      } else if (!strcmp(s, "ssl-ca")) {
+      }
+      else if (!strcmp(s, "ssl-ca"))
+      {
         co->ca = strdup(seq + 1);
-      } else if (!strcmp(s, "capath")) {
+      }
+      else if (!strcmp(s, "capath"))
+      {
         co->capath = strdup(seq + 1);
-      } else if (!strcmp(s, "ssl-capath")) {
+      }
+      else if (!strcmp(s, "ssl-capath"))
+      {
         co->capath = strdup(seq + 1);
-      } else if (!strcmp(s, "cert")) {
+      }
+      else if (!strcmp(s, "cert"))
+      {
         co->cert = strdup(seq + 1);
-      } else if (!strcmp(s, "ssl-cert")) {
+      }
+      else if (!strcmp(s, "ssl-cert"))
+      {
         co->cert = strdup(seq + 1);
-      } else if (!strcmp(s, "cipher")) {
+      }
+      else if (!strcmp(s, "cipher"))
+      {
         co->cipher = strdup(seq + 1);
-      } else if (!strcmp(s, "ssl-cipher")) {
+      }
+      else if (!strcmp(s, "ssl-cipher"))
+      {
         co->cipher = strdup(seq + 1);
-      } else {
+      }
+      else
+      {
         MyconninfoFree(co);
         co = NULL;
-        if (errmsg) {
+        if (errmsg)
+        {
           *errmsg = strdup(s);
         }
         break;
@@ -220,17 +304,22 @@ static Myconninfo *MyconninfoParse(char *userdb, char **errmsg) {
     free(s0);
   }
 
-  if (co) {
-    if (!(co->dbname)) {
+  if (co)
+  {
+    if (!(co->dbname))
+    {
       co->dbname = strdup("0");
     }
-    if (!(co->host)) {
+    if (!(co->host))
+    {
       co->host = strdup("127.0.0.1");
     }
-    if (!(co->user)) {
+    if (!(co->user))
+    {
       co->user = strdup("");
     }
-    if (!(co->password)) {
+    if (!(co->password))
+    {
       co->password = strdup("");
     }
   }
@@ -238,77 +327,106 @@ static Myconninfo *MyconninfoParse(char *userdb, char **errmsg) {
   return co;
 }
 
-static MYSQL *get_mydb_connection(void) {
+static MYSQL *get_mydb_connection(void)
+{
 
   persistent_users_db_t *pud = get_persistent_users_db();
 
   MYSQL *mydbconnection = (MYSQL *)pthread_getspecific(connection_key);
 
-  if (mydbconnection) {
-    if (mysql_ping(mydbconnection)) {
+  if (mydbconnection)
+  {
+    if (mysql_ping(mydbconnection))
+    {
       mysql_close(mydbconnection);
       mydbconnection = NULL;
       (void)pthread_setspecific(connection_key, mydbconnection);
     }
   }
 
-  if (!mydbconnection) {
+  if (!mydbconnection)
+  {
     char *errmsg = NULL;
     Myconninfo *co = MyconninfoParse(pud->userdb, &errmsg);
-    if (!co) {
-      if (errmsg) {
+    if (!co)
+    {
+      if (errmsg)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
                       "Cannot open MySQL DB connection <%s>, connection string format error: %s\n",
                       pud->userdb_sanitized, errmsg);
         free(errmsg);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot open MySQL DB connection <%s>, connection string format error\n",
                       pud->userdb_sanitized);
       }
-    } else if (errmsg) {
+    }
+    else if (errmsg)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot open MySQL DB connection <%s>, connection string format error: %s\n",
                     pud->userdb_sanitized, errmsg);
       free(errmsg);
       MyconninfoFree(co);
-    } else if (!(co->dbname)) {
+    }
+    else if (!(co->dbname))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "MySQL Database name is not provided: <%s>\n", pud->userdb_sanitized);
       MyconninfoFree(co);
-    } else {
+    }
+    else
+    {
       mydbconnection = mysql_init(NULL);
-      if (!mydbconnection) {
+      if (!mydbconnection)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot initialize MySQL DB connection\n");
-      } else {
-        if (co->connect_timeout) {
+      }
+      else
+      {
+        if (co->connect_timeout)
+        {
           mysql_options(mydbconnection, MYSQL_OPT_CONNECT_TIMEOUT, &(co->connect_timeout));
         }
-        if (co->read_timeout) {
+        if (co->read_timeout)
+        {
           mysql_options(mydbconnection, MYSQL_OPT_READ_TIMEOUT, &(co->read_timeout));
         }
-        if (co->ca || co->capath || co->cert || co->cipher || co->key) {
+        if (co->ca || co->capath || co->cert || co->cipher || co->key)
+        {
           mysql_ssl_set(mydbconnection, co->key, co->cert, co->ca, co->capath, co->cipher);
         }
 
-        if (turn_params.secret_key_file[0]) {
+        if (turn_params.secret_key_file[0])
+        {
           co->password = decryptPassword(co->password, turn_params.secret_key);
         }
 
         MYSQL *conn = mysql_real_connect(mydbconnection, co->host, co->user, co->password, co->dbname, co->port, NULL,
                                          CLIENT_IGNORE_SIGPIPE);
-        if (!conn) {
+        if (!conn)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot open MySQL DB connection: <%s>, runtime error: %s\n",
                         pud->userdb_sanitized, mysql_error(mydbconnection));
           mysql_close(mydbconnection);
           mydbconnection = NULL;
-        } else if (mysql_select_db(mydbconnection, co->dbname)) {
+        }
+        else if (mysql_select_db(mydbconnection, co->dbname))
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot connect to MySQL DB: %s\n", co->dbname);
           mysql_close(mydbconnection);
           mydbconnection = NULL;
-        } else if (!donot_print_connection_success) {
+        }
+        else if (!donot_print_connection_success)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "MySQL DB connection success: %s\n", pud->userdb_sanitized);
-          if (turn_params.secret_key_file[0]) {
+          if (turn_params.secret_key_file[0])
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Encryption with AES is activated.\n");
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Connection is secure.\n");
-          } else {
+          }
+          else
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Connection is not secure.\n");
           }
           donot_print_connection_success = 1;
@@ -316,7 +434,8 @@ static MYSQL *get_mydb_connection(void) {
       }
       MyconninfoFree(co);
     }
-    if (mydbconnection) {
+    if (mydbconnection)
+    {
       (void)pthread_setspecific(connection_key, mydbconnection);
     }
   }
@@ -325,28 +444,42 @@ static MYSQL *get_mydb_connection(void) {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static int mysql_get_auth_secrets(secrets_list_t *sl, uint8_t *realm) {
+static int mysql_get_auth_secrets(secrets_list_t *sl, uint8_t *realm)
+{
   int ret = -1;
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     snprintf(statement, sizeof(statement) - 1, "select value from turn_secret where realm='%s'", realm);
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else if (mysql_field_count(myc) == 1) {
-        for (;;) {
+      }
+      else if (mysql_field_count(myc) == 1)
+      {
+        for (;;)
+        {
           MYSQL_ROW row = mysql_fetch_row(mres);
-          if (!row) {
+          if (!row)
+          {
             break;
-          } else {
-            if (row[0]) {
+          }
+          else
+          {
+            if (row[0])
+            {
               unsigned long *lengths = mysql_fetch_lengths(mres);
-              if (lengths) {
+              if (lengths)
+              {
                 size_t sz = lengths[0];
                 char auth_secret[TURN_LONG_STRING_SIZE];
                 memcpy(auth_secret, row[0], sz);
@@ -359,7 +492,8 @@ static int mysql_get_auth_secrets(secrets_list_t *sl, uint8_t *realm) {
         ret = 0;
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -367,33 +501,48 @@ static int mysql_get_auth_secrets(secrets_list_t *sl, uint8_t *realm) {
   return ret;
 }
 
-static int mysql_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
+static int mysql_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key)
+{
   int ret = -1;
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     /* direct user input eliminated - there is no SQL injection problem (since version 4.4.5.3) */
     snprintf(statement, sizeof(statement), "select hmackey from turnusers_lt where name='%s' and realm='%s'", usname,
              realm);
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else if (mysql_field_count(myc) != 1) {
+      }
+      else if (mysql_field_count(myc) != 1)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown error retrieving MySQL DB information: %s\n", statement);
-      } else {
+      }
+      else
+      {
         MYSQL_ROW row = mysql_fetch_row(mres);
-        if (row && row[0]) {
+        if (row && row[0])
+        {
           unsigned long *lengths = mysql_fetch_lengths(mres);
-          if (lengths) {
+          if (lengths)
+          {
             size_t sz = get_hmackey_size(SHATYPE_DEFAULT) * 2;
-            if (lengths[0] < sz) {
+            if (lengths[0] < sz)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format: string length=%d (must be %d): user %s\n",
                             (int)lengths[0], (int)sz, usname);
-            } else {
+            }
+            else
+            {
               char kval[sizeof(hmackey_t) + sizeof(hmackey_t) + 1];
               memcpy(kval, row[0], sz);
               kval[sz] = 0;
@@ -404,7 +553,8 @@ static int mysql_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
         }
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -412,7 +562,8 @@ static int mysql_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
   return ret;
 }
 
-static int mysql_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key) {
+static int mysql_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key)
+{
 
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
@@ -421,21 +572,32 @@ static int mysql_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key) {
            "select ikm_key,timestamp,lifetime,as_rs_alg,realm from oauth_key where kid='%s'", (const char *)kid);
 
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else if (mysql_field_count(myc) != 5) {
+      }
+      else if (mysql_field_count(myc) != 5)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown error retrieving MySQL DB information: %s\n", statement);
-      } else {
+      }
+      else
+      {
         MYSQL_ROW row = mysql_fetch_row(mres);
-        if (row && row[0]) {
+        if (row && row[0])
+        {
           unsigned long *lengths = mysql_fetch_lengths(mres);
-          if (lengths) {
+          if (lengths)
+          {
             STRCPY(key->kid, kid);
             memcpy(key->ikm_key, row[0], lengths[0]);
             key->ikm_key[lengths[0]] = 0;
@@ -461,7 +623,8 @@ static int mysql_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key) {
         }
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -470,7 +633,8 @@ static int mysql_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key) {
 }
 
 static int mysql_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, secrets_list_t *tss, secrets_list_t *lts,
-                                 secrets_list_t *realms) {
+                                 secrets_list_t *realms)
+{
 
   oauth_key_data_raw key_;
   oauth_key_data_raw *key = &key_;
@@ -480,21 +644,32 @@ static int mysql_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, sec
            "select ikm_key,timestamp,lifetime,as_rs_alg,realm,kid from oauth_key order by kid");
 
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else if (mysql_field_count(myc) != 6) {
+      }
+      else if (mysql_field_count(myc) != 6)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown error retrieving MySQL DB information: %s\n", statement);
-      } else {
+      }
+      else
+      {
         MYSQL_ROW row = mysql_fetch_row(mres);
-        while (row) {
+        while (row)
+        {
           unsigned long *lengths = mysql_fetch_lengths(mres);
-          if (lengths) {
+          if (lengths)
+          {
 
             memcpy(key->ikm_key, row[0], lengths[0]);
             key->ikm_key[lengths[0]] = 0;
@@ -518,7 +693,8 @@ static int mysql_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, sec
             memcpy(key->kid, row[5], lengths[5]);
             key->kid[lengths[5]] = 0;
 
-            if (kids) {
+            if (kids)
+            {
               add_to_secrets_list(kids, key->kid);
               add_to_secrets_list(teas, key->as_rs_alg);
               add_to_secrets_list(realms, key->realm);
@@ -532,7 +708,9 @@ static int mysql_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, sec
                 snprintf(lt, sizeof(lt) - 1, "%lu", (unsigned long)key->lifetime);
                 add_to_secrets_list(lts, lt);
               }
-            } else {
+            }
+            else
+            {
               printf("  kid=%s, ikm_key=%s, timestamp=%llu, lifetime=%lu, as_rs_alg=%s, realm=%s\n", key->kid,
                      key->ikm_key, (unsigned long long)key->timestamp, (unsigned long)key->lifetime, key->as_rs_alg,
                      key->realm);
@@ -542,7 +720,8 @@ static int mysql_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, sec
         }
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -551,23 +730,31 @@ static int mysql_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, sec
   return ret;
 }
 
-static int mysql_set_user_key(uint8_t *usname, uint8_t *realm, const char *key) {
+static int mysql_set_user_key(uint8_t *usname, uint8_t *realm, const char *key)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     snprintf(statement, sizeof(statement), "insert into turnusers_lt (realm,name,hmackey) values('%s','%s','%s')",
              realm, usname, key);
     int res = mysql_query(myc, statement);
-    if (!res) {
+    if (!res)
+    {
       ret = 0;
-    } else {
+    }
+    else
+    {
       snprintf(statement, sizeof(statement), "update turnusers_lt set hmackey='%s' where name='%s' and realm='%s'", key,
                usname, realm);
       res = mysql_query(myc, statement);
-      if (!res) {
+      if (!res)
+      {
         ret = 0;
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error inserting/updating user key information: %s\n", mysql_error(myc));
       }
     }
@@ -575,111 +762,155 @@ static int mysql_set_user_key(uint8_t *usname, uint8_t *realm, const char *key) 
   return ret;
 }
 
-static int mysql_set_oauth_key(oauth_key_data_raw *key) {
+static int mysql_set_oauth_key(oauth_key_data_raw *key)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     snprintf(
         statement, sizeof(statement),
         "insert into oauth_key (kid,ikm_key,timestamp,lifetime,as_rs_alg,realm) values('%s','%s',%llu,%lu,'%s','%s')",
         key->kid, key->ikm_key, (unsigned long long)key->timestamp, (unsigned long)key->lifetime, key->as_rs_alg,
         key->realm);
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       snprintf(
           statement, sizeof(statement),
           "update oauth_key set ikm_key='%s',timestamp=%lu,lifetime=%lu, as_rs_alg='%s', realm='%s' where kid='%s'",
           key->ikm_key, (unsigned long)key->timestamp, (unsigned long)key->lifetime, key->as_rs_alg, key->realm,
           key->kid);
       res = mysql_query(myc, statement);
-      if (res) {
+      if (res)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error inserting/updating oauth key information: %s\n", mysql_error(myc));
-      } else {
+      }
+      else
+      {
         ret = 0;
       }
-    } else {
+    }
+    else
+    {
       ret = 0;
     }
   }
   return ret;
 }
 
-static int mysql_del_user(uint8_t *usname, uint8_t *realm) {
+static int mysql_del_user(uint8_t *usname, uint8_t *realm)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     snprintf(statement, sizeof(statement), "delete from turnusers_lt where name='%s' and realm='%s'", usname, realm);
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error deleting user key information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       ret = 0;
     }
   }
   return ret;
 }
 
-static int mysql_del_oauth_key(const uint8_t *kid) {
+static int mysql_del_oauth_key(const uint8_t *kid)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     snprintf(statement, sizeof(statement), "delete from oauth_key where kid = '%s'", (const char *)kid);
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error deleting oauth key information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       ret = 0;
     }
   }
   return ret;
 }
 
-static int mysql_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_t *realms) {
+static int mysql_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_t *realms)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
 
   uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
+  if (!realm)
+  {
     realm = realm0;
   }
 
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
-    if (realm[0]) {
+  if (myc)
+  {
+    if (realm[0])
+    {
       snprintf(statement, sizeof(statement), "select name, realm from turnusers_lt where realm='%s' order by name",
                realm);
-    } else {
+    }
+    else
+    {
       snprintf(statement, sizeof(statement), "select name, realm from turnusers_lt order by realm,name");
     }
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else if (mysql_field_count(myc) != 2) {
+      }
+      else if (mysql_field_count(myc) != 2)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown error retrieving MySQL DB information: %s\n", statement);
-      } else {
-        for (;;) {
+      }
+      else
+      {
+        for (;;)
+        {
           MYSQL_ROW row = mysql_fetch_row(mres);
-          if (!row) {
+          if (!row)
+          {
             break;
-          } else {
-            if (row[0]) {
-              if (users) {
+          }
+          else
+          {
+            if (row[0])
+            {
+              if (users)
+              {
                 add_to_secrets_list(users, row[0]);
-                if (realms) {
-                  if (row[1]) {
+                if (realms)
+                {
+                  if (row[1])
+                  {
                     add_to_secrets_list(realms, row[1]);
-                  } else {
+                  }
+                  else
+                  {
                     add_to_secrets_list(realms, (char *)realm);
                   }
                 }
-              } else {
+              }
+              else
+              {
                 printf("%s[%s]\n", row[0], row[1]);
               }
             }
@@ -688,7 +919,8 @@ static int mysql_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_
         ret = 0;
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -696,54 +928,80 @@ static int mysql_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_
   return ret;
 }
 
-static int mysql_list_secrets(uint8_t *realm, secrets_list_t *secrets, secrets_list_t *realms) {
+static int mysql_list_secrets(uint8_t *realm, secrets_list_t *secrets, secrets_list_t *realms)
+{
   int ret = -1;
 
   uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
+  if (!realm)
+  {
     realm = realm0;
   }
 
   char statement[TURN_LONG_STRING_SIZE];
-  if (realm[0]) {
+  if (realm[0])
+  {
     snprintf(statement, sizeof(statement), "select value,realm from turn_secret where realm='%s' order by value",
              realm);
-  } else {
+  }
+  else
+  {
     snprintf(statement, sizeof(statement), "select value,realm from turn_secret order by realm,value");
   }
 
   donot_print_connection_success = 1;
 
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else if (mysql_field_count(myc) != 2) {
+      }
+      else if (mysql_field_count(myc) != 2)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown error retrieving MySQL DB information: %s\n", statement);
-      } else {
-        for (;;) {
+      }
+      else
+      {
+        for (;;)
+        {
           MYSQL_ROW row = mysql_fetch_row(mres);
-          if (!row) {
+          if (!row)
+          {
             break;
-          } else {
+          }
+          else
+          {
             const char *kval = row[0];
-            if (kval) {
+            if (kval)
+            {
               const char *rval = row[1];
-              if (secrets) {
+              if (secrets)
+              {
                 add_to_secrets_list(secrets, kval);
-                if (realms) {
-                  if (rval && *rval) {
+                if (realms)
+                {
+                  if (rval && *rval)
+                  {
                     add_to_secrets_list(realms, rval);
-                  } else {
+                  }
+                  else
+                  {
                     add_to_secrets_list(realms, (char *)realm);
                   }
                 }
-              } else {
+              }
+              else
+              {
                 printf("%s[%s]\n", kval, rval);
               }
             }
@@ -752,7 +1010,8 @@ static int mysql_list_secrets(uint8_t *realm, secrets_list_t *secrets, secrets_l
         ret = 0;
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -760,15 +1019,20 @@ static int mysql_list_secrets(uint8_t *realm, secrets_list_t *secrets, secrets_l
   return ret;
 }
 
-static int mysql_del_secret(uint8_t *secret, uint8_t *realm) {
+static int mysql_del_secret(uint8_t *secret, uint8_t *realm)
+{
   int ret = -1;
   donot_print_connection_success = 1;
   char statement[TURN_LONG_STRING_SIZE];
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
-    if (!secret || (secret[0] == 0)) {
+  if (myc)
+  {
+    if (!secret || (secret[0] == 0))
+    {
       snprintf(statement, sizeof(statement), "delete from turn_secret where realm='%s'", realm);
-    } else {
+    }
+    else
+    {
       snprintf(statement, sizeof(statement), "delete from turn_secret where value='%s' and realm='%s'", secret, realm);
     }
     mysql_query(myc, statement);
@@ -777,28 +1041,35 @@ static int mysql_del_secret(uint8_t *secret, uint8_t *realm) {
   return ret;
 }
 
-static int mysql_set_secret(uint8_t *secret, uint8_t *realm) {
+static int mysql_set_secret(uint8_t *secret, uint8_t *realm)
+{
   int ret = -1;
   donot_print_connection_success = 1;
   char statement[TURN_LONG_STRING_SIZE];
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     snprintf(statement, sizeof(statement), "insert into turn_secret (realm,value) values('%s','%s')", realm, secret);
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error inserting/updating secret key information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       ret = 0;
     }
   }
   return ret;
 }
 
-static int mysql_set_permission_ip(const char *kind, uint8_t *realm, const char *ip, int del) {
+static int mysql_set_permission_ip(const char *kind, uint8_t *realm, const char *ip, int del)
+{
   int ret = -1;
 
   uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
+  if (!realm)
+  {
     realm = realm0;
   }
 
@@ -807,104 +1078,147 @@ static int mysql_set_permission_ip(const char *kind, uint8_t *realm, const char 
   char statement[TURN_LONG_STRING_SIZE];
 
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
-    if (del) {
+  if (myc)
+  {
+    if (del)
+    {
       snprintf(statement, sizeof(statement), "delete from %s_peer_ip where realm = '%s'  and ip_range = '%s'", kind,
                (char *)realm, ip);
-    } else {
+    }
+    else
+    {
       snprintf(statement, sizeof(statement), "insert into %s_peer_ip (realm,ip_range) values('%s','%s')", kind,
                (char *)realm, ip);
     }
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error inserting permission ip information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       ret = 0;
     }
   }
   return ret;
 }
 
-static int mysql_add_origin(uint8_t *origin, uint8_t *realm) {
+static int mysql_add_origin(uint8_t *origin, uint8_t *realm)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     snprintf(statement, sizeof(statement), "insert into turn_origin_to_realm (origin,realm) values('%s','%s')", origin,
              realm);
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error inserting origin information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       ret = 0;
     }
   }
   return ret;
 }
 
-static int mysql_del_origin(uint8_t *origin) {
+static int mysql_del_origin(uint8_t *origin)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     snprintf(statement, sizeof(statement), "delete from turn_origin_to_realm where origin='%s'", origin);
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error deleting origin information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       ret = 0;
     }
   }
   return ret;
 }
 
-static int mysql_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_list_t *realms) {
+static int mysql_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_list_t *realms)
+{
   int ret = -1;
 
   uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
+  if (!realm)
+  {
     realm = realm0;
   }
 
   donot_print_connection_success = 1;
 
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
-    if (realm && realm[0]) {
+    if (realm && realm[0])
+    {
       snprintf(statement, sizeof(statement),
                "select origin,realm from turn_origin_to_realm where realm='%s' order by origin", realm);
-    } else {
+    }
+    else
+    {
       snprintf(statement, sizeof(statement), "select origin,realm from turn_origin_to_realm order by realm,origin");
     }
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else if (mysql_field_count(myc) != 2) {
+      }
+      else if (mysql_field_count(myc) != 2)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown error retrieving MySQL DB information: %s\n", statement);
-      } else {
-        for (;;) {
+      }
+      else
+      {
+        for (;;)
+        {
           MYSQL_ROW row = mysql_fetch_row(mres);
-          if (!row) {
+          if (!row)
+          {
             break;
-          } else {
-            if (row[0] && row[1]) {
+          }
+          else
+          {
+            if (row[0] && row[1])
+            {
               const char *kval = row[0];
               const char *rval = row[1];
-              if (origins) {
+              if (origins)
+              {
                 add_to_secrets_list(origins, kval);
-                if (realms) {
-                  if (rval && *rval) {
+                if (realms)
+                {
+                  if (rval && *rval)
+                  {
                     add_to_secrets_list(realms, rval);
-                  } else {
+                  }
+                  else
+                  {
                     add_to_secrets_list(realms, (char *)realm);
                   }
                 }
-              } else {
+              }
+              else
+              {
                 printf("%s ==>> %s\n", kval, rval);
               }
             }
@@ -913,7 +1227,8 @@ static int mysql_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_l
         ret = 0;
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -921,22 +1236,28 @@ static int mysql_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_l
   return ret;
 }
 
-static int mysql_set_realm_option_one(uint8_t *realm, unsigned long value, const char *opt) {
+static int mysql_set_realm_option_one(uint8_t *realm, unsigned long value, const char *opt)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     {
       snprintf(statement, sizeof(statement), "delete from turn_realm_option where realm='%s' and opt='%s'", realm, opt);
       mysql_query(myc, statement);
     }
-    if (value > 0) {
+    if (value > 0)
+    {
       snprintf(statement, sizeof(statement), "insert into turn_realm_option (realm,opt,value) values('%s','%s','%lu')",
                realm, opt, (unsigned long)value);
       int res = mysql_query(myc, statement);
-      if (res) {
+      if (res)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error inserting realm option information: %s\n", mysql_error(myc));
-      } else {
+      }
+      else
+      {
         ret = 0;
       }
     }
@@ -944,34 +1265,52 @@ static int mysql_set_realm_option_one(uint8_t *realm, unsigned long value, const
   return ret;
 }
 
-static int mysql_list_realm_options(uint8_t *realm) {
+static int mysql_list_realm_options(uint8_t *realm)
+{
   int ret = -1;
   donot_print_connection_success = 1;
   char statement[TURN_LONG_STRING_SIZE];
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
-    if (realm && realm[0]) {
+  if (myc)
+  {
+    if (realm && realm[0])
+    {
       snprintf(statement, sizeof(statement),
                "select realm,opt,value from turn_realm_option where realm='%s' order by realm,opt", realm);
-    } else {
+    }
+    else
+    {
       snprintf(statement, sizeof(statement), "select realm,opt,value from turn_realm_option order by realm,opt");
     }
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else if (mysql_field_count(myc) != 3) {
+      }
+      else if (mysql_field_count(myc) != 3)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown error retrieving MySQL DB information: %s\n", statement);
-      } else {
-        for (;;) {
+      }
+      else
+      {
+        for (;;)
+        {
           MYSQL_ROW row = mysql_fetch_row(mres);
-          if (!row) {
+          if (!row)
+          {
             break;
-          } else {
-            if (row[0] && row[1] && row[2]) {
+          }
+          else
+          {
+            if (row[0] && row[1] && row[2])
+            {
               printf("%s[%s]=%s\n", row[1], row[0], row[2]);
             }
           }
@@ -979,7 +1318,8 @@ static int mysql_list_realm_options(uint8_t *realm) {
         ret = 0;
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -987,37 +1327,49 @@ static int mysql_list_realm_options(uint8_t *realm) {
   return ret;
 }
 
-static void mysql_auth_ping(void *rch) {
+static void mysql_auth_ping(void *rch)
+{
   UNUSED_ARG(rch);
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     STRCPY(statement, "select value from turn_secret");
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else {
+      }
+      else
+      {
         mysql_free_result(mres);
       }
     }
   }
 }
 
-static int mysql_get_ip_list(const char *kind, ip_range_list_t *list) {
+static int mysql_get_ip_list(const char *kind, ip_range_list_t *list)
+{
   int ret = -1;
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     snprintf(statement, sizeof(statement), "select ip_range,realm from %s_peer_ip", kind);
     int res = mysql_query(myc, statement);
 
-    if (res) {
+    if (res)
+    {
       static int wrong_table_reported = 0;
-      if (!wrong_table_reported) {
+      if (!wrong_table_reported)
+      {
         wrong_table_reported = 1;
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
                       "Error retrieving MySQL DB information; probably, the tables 'allowed_peer_ip' and/or "
@@ -1027,17 +1379,25 @@ static int mysql_get_ip_list(const char *kind, ip_range_list_t *list) {
       res = mysql_query(myc, statement);
     }
 
-    if (res == 0) {
+    if (res == 0)
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (mres && mysql_field_count(myc) == 2) {
-        for (;;) {
+      if (mres && mysql_field_count(myc) == 2)
+      {
+        for (;;)
+        {
           MYSQL_ROW row = mysql_fetch_row(mres);
-          if (!row) {
+          if (!row)
+          {
             break;
-          } else {
-            if (row[0]) {
+          }
+          else
+          {
+            if (row[0])
+            {
               unsigned long *lengths = mysql_fetch_lengths(mres);
-              if (lengths) {
+              if (lengths)
+              {
                 size_t sz = lengths[0];
                 char kval[TURN_LONG_STRING_SIZE];
                 memcpy(kval, row[0], sz);
@@ -1054,7 +1414,8 @@ static int mysql_get_ip_list(const char *kind, ip_range_list_t *list) {
         ret = 0;
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -1062,27 +1423,37 @@ static int mysql_get_ip_list(const char *kind, ip_range_list_t *list) {
   return ret;
 }
 
-static void mysql_reread_realms(secrets_list_t *realms_list) {
+static void mysql_reread_realms(secrets_list_t *realms_list)
+{
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     {
       snprintf(statement, sizeof(statement), "select origin,realm from turn_origin_to_realm");
       int res = mysql_query(myc, statement);
-      if (res == 0) {
+      if (res == 0)
+      {
         MYSQL_RES *mres = mysql_store_result(myc);
-        if (mres && mysql_field_count(myc) == 2) {
+        if (mres && mysql_field_count(myc) == 2)
+        {
 
           ur_string_map *o_to_realm_new = ur_string_map_create(free);
 
-          for (;;) {
+          for (;;)
+          {
             MYSQL_ROW row = mysql_fetch_row(mres);
-            if (!row) {
+            if (!row)
+            {
               break;
-            } else {
-              if (row[0] && row[1]) {
+            }
+            else
+            {
+              if (row[0] && row[1])
+              {
                 unsigned long *lengths = mysql_fetch_lengths(mres);
-                if (lengths) {
+                if (lengths)
+                {
                   size_t sz = lengths[0];
                   char oval[513];
                   memcpy(oval, row[0], sz);
@@ -1099,7 +1470,8 @@ static void mysql_reread_realms(secrets_list_t *realms_list) {
           update_o_to_realm(o_to_realm_new);
         }
 
-        if (mres) {
+        if (mres)
+        {
           mysql_free_result(mres);
         }
       }
@@ -1112,7 +1484,8 @@ static void mysql_reread_realms(secrets_list_t *realms_list) {
       rlsz = realms_list->sz;
       unlock_realms();
 
-      for (i = 0; i < rlsz; ++i) {
+      for (i = 0; i < rlsz; ++i)
+      {
 
         char *realm = realms_list->secrets[i];
 
@@ -1134,18 +1507,26 @@ static void mysql_reread_realms(secrets_list_t *realms_list) {
 
     snprintf(statement, sizeof(statement), "select realm,opt,value from turn_realm_option");
     int res = mysql_query(myc, statement);
-    if (res == 0) {
+    if (res == 0)
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (mres && mysql_field_count(myc) == 3) {
+      if (mres && mysql_field_count(myc) == 3)
+      {
 
-        for (;;) {
+        for (;;)
+        {
           MYSQL_ROW row = mysql_fetch_row(mres);
-          if (!row) {
+          if (!row)
+          {
             break;
-          } else {
-            if (row[0] && row[1] && row[2]) {
+          }
+          else
+          {
+            if (row[0] && row[1] && row[2])
+            {
               unsigned long *lengths = mysql_fetch_lengths(mres);
-              if (lengths) {
+              if (lengths)
+              {
                 char rval[513];
                 size_t sz = lengths[0];
                 memcpy(rval, row[0], sz);
@@ -1159,13 +1540,20 @@ static void mysql_reread_realms(secrets_list_t *realms_list) {
                 memcpy(vval, row[2], sz);
                 vval[sz] = 0;
                 realm_params_t *rp = get_realm(rval);
-                if (!strcmp(oval, "max-bps")) {
+                if (!strcmp(oval, "max-bps"))
+                {
                   rp->options.perf_options.max_bps = (band_limit_t)strtoul(vval, NULL, 10);
-                } else if (!strcmp(oval, "total-quota")) {
+                }
+                else if (!strcmp(oval, "total-quota"))
+                {
                   rp->options.perf_options.total_quota = (vint)atoi(vval);
-                } else if (!strcmp(oval, "user-quota")) {
+                }
+                else if (!strcmp(oval, "user-quota"))
+                {
                   rp->options.perf_options.user_quota = (vint)atoi(vval);
-                } else {
+                }
+                else
+                {
                   TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown realm option: %s\n", oval);
                 }
               }
@@ -1174,7 +1562,8 @@ static void mysql_reread_realms(secrets_list_t *realms_list) {
         }
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -1183,35 +1572,47 @@ static void mysql_reread_realms(secrets_list_t *realms_list) {
 
 /////////////////////////////////////////////////////
 
-static int mysql_get_admin_user(const uint8_t *usname, uint8_t *realm, password_t pwd) {
+static int mysql_get_admin_user(const uint8_t *usname, uint8_t *realm, password_t pwd)
+{
   int ret = -1;
 
   realm[0] = 0;
   pwd[0] = 0;
 
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     snprintf(statement, sizeof(statement), "select realm,password from admin_user where name='%s'", usname);
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else if (mysql_field_count(myc) != 2) {
+      }
+      else if (mysql_field_count(myc) != 2)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown error retrieving MySQL DB information: %s\n", statement);
-      } else {
+      }
+      else
+      {
         MYSQL_ROW row = mysql_fetch_row(mres);
-        if (row && row[0]) {
+        if (row && row[0])
+        {
           strncpy((char *)realm, row[0], STUN_MAX_REALM_SIZE);
           strncpy((char *)pwd, row[1], STUN_MAX_PWD_SIZE);
           ret = 0;
         }
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -1219,24 +1620,32 @@ static int mysql_get_admin_user(const uint8_t *usname, uint8_t *realm, password_
   return ret;
 }
 
-static int mysql_set_admin_user(const uint8_t *usname, const uint8_t *realm, const password_t pwd) {
+static int mysql_set_admin_user(const uint8_t *usname, const uint8_t *realm, const password_t pwd)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
   donot_print_connection_success = 1;
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     snprintf(statement, sizeof(statement), "insert into admin_user (realm,name,password) values('%s','%s','%s')", realm,
              usname, pwd);
     int res = mysql_query(myc, statement);
-    if (!res) {
+    if (!res)
+    {
       ret = 0;
-    } else {
+    }
+    else
+    {
       snprintf(statement, sizeof(statement), "update admin_user set realm='%s',password='%s' where name='%s'", realm,
                pwd, usname);
       res = mysql_query(myc, statement);
-      if (!res) {
+      if (!res)
+      {
         ret = 0;
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error inserting/updating user key information: %s\n", mysql_error(myc));
       }
     }
@@ -1244,51 +1653,74 @@ static int mysql_set_admin_user(const uint8_t *usname, const uint8_t *realm, con
   return ret;
 }
 
-static int mysql_del_admin_user(const uint8_t *usname) {
+static int mysql_del_admin_user(const uint8_t *usname)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
   donot_print_connection_success = 1;
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     snprintf(statement, sizeof(statement), "delete from admin_user where name='%s'", usname);
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error deleting admin user information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       ret = 0;
     }
   }
   return ret;
 }
 
-static int mysql_list_admin_users(int no_print) {
+static int mysql_list_admin_users(int no_print)
+{
   int ret = -1;
   char statement[TURN_LONG_STRING_SIZE];
   donot_print_connection_success = 1;
   MYSQL *myc = get_mydb_connection();
-  if (myc) {
+  if (myc)
+  {
     snprintf(statement, sizeof(statement), "select name, realm from admin_user order by realm,name");
     int res = mysql_query(myc, statement);
-    if (res) {
+    if (res)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-    } else {
+    }
+    else
+    {
       MYSQL_RES *mres = mysql_store_result(myc);
-      if (!mres) {
+      if (!mres)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error retrieving MySQL DB information: %s\n", mysql_error(myc));
-      } else if (mysql_field_count(myc) != 2) {
+      }
+      else if (mysql_field_count(myc) != 2)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown error retrieving MySQL DB information: %s\n", statement);
-      } else {
+      }
+      else
+      {
         ret = 0;
-        for (;;) {
+        for (;;)
+        {
           MYSQL_ROW row = mysql_fetch_row(mres);
-          if (!row) {
+          if (!row)
+          {
             break;
-          } else {
+          }
+          else
+          {
             ++ret;
-            if (row[0] && !no_print) {
-              if (row[1] && row[1][0]) {
+            if (row[0] && !no_print)
+            {
+              if (row[1] && row[1][0])
+              {
                 printf("%s[%s]\n", row[0], row[1]);
-              } else {
+              }
+              else
+              {
                 printf("%s\n", row[0]);
               }
             }
@@ -1296,7 +1728,8 @@ static int mysql_list_admin_users(int no_print) {
         }
       }
 
-      if (mres) {
+      if (mres)
+      {
         mysql_free_result(mres);
       }
     }
@@ -1304,9 +1737,11 @@ static int mysql_list_admin_users(int no_print) {
   return ret;
 }
 
-static void mysql_disconnect(void) {
+static void mysql_disconnect(void)
+{
   MYSQL *mydbconnection = (MYSQL *)pthread_getspecific(connection_key);
-  if (mydbconnection) {
+  if (mydbconnection)
+  {
     mysql_close(mydbconnection);
     mydbconnection = NULL;
   }

--- a/src/apps/relay/dbdrivers/dbd_mysql.h
+++ b/src/apps/relay/dbdrivers/dbd_mysql.h
@@ -35,7 +35,8 @@
 #include "dbdriver.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 const turn_dbdriver_t *get_mysql_dbdriver(void);

--- a/src/apps/relay/dbdrivers/dbd_pgsql.h
+++ b/src/apps/relay/dbdrivers/dbd_pgsql.h
@@ -35,7 +35,8 @@
 #include "dbdriver.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 const turn_dbdriver_t *get_pgsql_dbdriver(void);

--- a/src/apps/relay/dbdrivers/dbd_redis.c
+++ b/src/apps/relay/dbdrivers/dbd_redis.c
@@ -40,13 +40,16 @@
 
 static int donot_print_connection_success = 0;
 
-static void turnFreeRedisReply(void *reply) {
-  if (reply) {
+static void turnFreeRedisReply(void *reply)
+{
+  if (reply)
+  {
     freeReplyObject(reply);
   }
 }
 
-struct _Ryconninfo {
+struct _Ryconninfo
+{
   char *host;
   char *dbname;
   char *user;
@@ -57,18 +60,24 @@ struct _Ryconninfo {
 
 typedef struct _Ryconninfo Ryconninfo;
 
-static void RyconninfoFree(Ryconninfo *co) {
-  if (co) {
-    if (co->host) {
+static void RyconninfoFree(Ryconninfo *co)
+{
+  if (co)
+  {
+    if (co->host)
+    {
       free(co->host);
     }
-    if (co->dbname) {
+    if (co->dbname)
+    {
       free(co->dbname);
     }
-    if (co->user) {
+    if (co->user)
+    {
       free(co->user);
     }
-    if (co->password) {
+    if (co->password)
+    {
       free(co->password);
     }
     memset(co, 0, sizeof(Ryconninfo));
@@ -76,78 +85,127 @@ static void RyconninfoFree(Ryconninfo *co) {
   }
 }
 
-static Ryconninfo *RyconninfoParse(const char *userdb, char **errmsg) {
+static Ryconninfo *RyconninfoParse(const char *userdb, char **errmsg)
+{
   Ryconninfo *co = (Ryconninfo *)calloc(1, sizeof(Ryconninfo));
-  if (userdb) {
+  if (userdb)
+  {
     char *s0 = strdup(userdb);
     char *s = s0;
 
-    while (s && *s) {
+    while (s && *s)
+    {
 
-      while (*s && (*s == ' ')) {
+      while (*s && (*s == ' '))
+      {
         ++s;
       }
       char *snext = strstr(s, " ");
-      if (snext) {
+      if (snext)
+      {
         *snext = 0;
         ++snext;
       }
 
       char *seq = strstr(s, "=");
-      if (!seq) {
+      if (!seq)
+      {
         RyconninfoFree(co);
         co = NULL;
-        if (errmsg) {
+        if (errmsg)
+        {
           *errmsg = strdup(s);
         }
         break;
       }
 
       *seq = 0;
-      if (!strcmp(s, "host")) {
+      if (!strcmp(s, "host"))
+      {
         co->host = strdup(seq + 1);
-      } else if (!strcmp(s, "ip")) {
+      }
+      else if (!strcmp(s, "ip"))
+      {
         co->host = strdup(seq + 1);
-      } else if (!strcmp(s, "addr")) {
+      }
+      else if (!strcmp(s, "addr"))
+      {
         co->host = strdup(seq + 1);
-      } else if (!strcmp(s, "ipaddr")) {
+      }
+      else if (!strcmp(s, "ipaddr"))
+      {
         co->host = strdup(seq + 1);
-      } else if (!strcmp(s, "hostaddr")) {
+      }
+      else if (!strcmp(s, "hostaddr"))
+      {
         co->host = strdup(seq + 1);
-      } else if (!strcmp(s, "dbname")) {
+      }
+      else if (!strcmp(s, "dbname"))
+      {
         co->dbname = strdup(seq + 1);
-      } else if (!strcmp(s, "db")) {
+      }
+      else if (!strcmp(s, "db"))
+      {
         co->dbname = strdup(seq + 1);
-      } else if (!strcmp(s, "database")) {
+      }
+      else if (!strcmp(s, "database"))
+      {
         co->dbname = strdup(seq + 1);
-      } else if (!strcmp(s, "user")) {
+      }
+      else if (!strcmp(s, "user"))
+      {
         co->user = strdup(seq + 1);
-      } else if (!strcmp(s, "uname")) {
+      }
+      else if (!strcmp(s, "uname"))
+      {
         co->user = strdup(seq + 1);
-      } else if (!strcmp(s, "name")) {
+      }
+      else if (!strcmp(s, "name"))
+      {
         co->user = strdup(seq + 1);
-      } else if (!strcmp(s, "username")) {
+      }
+      else if (!strcmp(s, "username"))
+      {
         co->user = strdup(seq + 1);
-      } else if (!strcmp(s, "password")) {
+      }
+      else if (!strcmp(s, "password"))
+      {
         co->password = strdup(seq + 1);
-      } else if (!strcmp(s, "pwd")) {
+      }
+      else if (!strcmp(s, "pwd"))
+      {
         co->password = strdup(seq + 1);
-      } else if (!strcmp(s, "passwd")) {
+      }
+      else if (!strcmp(s, "passwd"))
+      {
         co->password = strdup(seq + 1);
-      } else if (!strcmp(s, "secret")) {
+      }
+      else if (!strcmp(s, "secret"))
+      {
         co->password = strdup(seq + 1);
-      } else if (!strcmp(s, "port")) {
+      }
+      else if (!strcmp(s, "port"))
+      {
         co->port = (unsigned int)atoi(seq + 1);
-      } else if (!strcmp(s, "p")) {
+      }
+      else if (!strcmp(s, "p"))
+      {
         co->port = (unsigned int)atoi(seq + 1);
-      } else if (!strcmp(s, "connect_timeout")) {
+      }
+      else if (!strcmp(s, "connect_timeout"))
+      {
         co->connect_timeout = (unsigned int)atoi(seq + 1);
-      } else if (!strcmp(s, "timeout")) {
+      }
+      else if (!strcmp(s, "timeout"))
+      {
         co->connect_timeout = (unsigned int)atoi(seq + 1);
-      } else {
+      }
+      else
+      {
         RyconninfoFree(co);
         co = NULL;
-        if (errmsg) {
+        if (errmsg)
+        {
           *errmsg = strdup(s);
         }
         break;
@@ -159,11 +217,14 @@ static Ryconninfo *RyconninfoParse(const char *userdb, char **errmsg) {
     free(s0);
   }
 
-  if (co) {
-    if (!(co->dbname)) {
+  if (co)
+  {
+    if (!(co->dbname))
+    {
       co->dbname = strdup("0");
     }
-    if (!(co->host)) {
+    if (!(co->host))
+    {
       co->host = strdup("127.0.0.1");
     }
   }
@@ -172,92 +233,126 @@ static Ryconninfo *RyconninfoParse(const char *userdb, char **errmsg) {
 }
 
 redis_context_handle get_redis_async_connection(struct event_base *base, redis_stats_db_t *redis_stats_db,
-                                                int delete_keys) {
+                                                int delete_keys)
+{
 
   redis_context_handle ret = NULL;
 
   char *errmsg = NULL;
-  if (base && redis_stats_db->connection_string[0]) {
+  if (base && redis_stats_db->connection_string[0])
+  {
     Ryconninfo *co = RyconninfoParse(redis_stats_db->connection_string, &errmsg);
-    if (!co) {
-      if (errmsg) {
+    if (!co)
+    {
+      if (errmsg)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
                       "Cannot open Redis DB connection <%s>, connection string format error: %s\n",
                       redis_stats_db->connection_string_sanitized, errmsg);
         free(errmsg);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot open Redis DB connection <%s>, connection string format error\n",
                       redis_stats_db->connection_string_sanitized);
       }
-    } else if (errmsg) {
+    }
+    else if (errmsg)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot open Redis DB connection <%s>, connection string format error: %s\n",
                     redis_stats_db->connection_string_sanitized, errmsg);
       free(errmsg);
       RyconninfoFree(co);
-    } else {
+    }
+    else
+    {
 
-      if (delete_keys) {
+      if (delete_keys)
+      {
 
         redisContext *rc = NULL;
 
         char ip[256] = "\0";
         int port = DEFAULT_REDIS_PORT;
-        if (co->host) {
+        if (co->host)
+        {
           STRCPY(ip, co->host);
         }
-        if (!ip[0]) {
+        if (!ip[0])
+        {
           strncpy(ip, "127.0.0.1", sizeof(ip));
         }
 
-        if (co->port) {
+        if (co->port)
+        {
           port = (int)(co->port);
         }
 
-        if (co->connect_timeout) {
+        if (co->connect_timeout)
+        {
           struct timeval tv;
           tv.tv_usec = 0;
           tv.tv_sec = (time_t)(co->connect_timeout);
           rc = redisConnectWithTimeout(ip, port, tv);
-        } else {
+        }
+        else
+        {
           rc = redisConnect(ip, port);
         }
 
-        if (!rc) {
+        if (!rc)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot initialize Redis DB async connection\n");
-        } else {
-          if (co->password && strlen(co->password)) {
-            if (co->user && strlen(co->user)) {
+        }
+        else
+        {
+          if (co->password && strlen(co->password))
+          {
+            if (co->user && strlen(co->user))
+            {
               turnFreeRedisReply(redisCommand(rc, "AUTH %s %s", co->user, co->password));
-            } else {
+            }
+            else
+            {
               turnFreeRedisReply(redisCommand(rc, "AUTH %s", co->password));
             }
           }
-          if (co->dbname) {
+          if (co->dbname)
+          {
             turnFreeRedisReply(redisCommand(rc, "select %s", co->dbname));
           }
           {
             redisReply *reply = (redisReply *)redisCommand(rc, "keys turn/*/allocation/*/status");
-            if (reply) {
+            if (reply)
+            {
               secrets_list_t keys;
               size_t isz = 0;
               char s[513];
 
               init_secrets_list(&keys);
 
-              if (reply->type == REDIS_REPLY_ERROR) {
+              if (reply->type == REDIS_REPLY_ERROR)
+              {
                 TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-              } else if (reply->type != REDIS_REPLY_ARRAY) {
-                if (reply->type != REDIS_REPLY_NIL) {
+              }
+              else if (reply->type != REDIS_REPLY_ARRAY)
+              {
+                if (reply->type != REDIS_REPLY_NIL)
+                {
                   TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
                 }
-              } else {
+              }
+              else
+              {
                 size_t i;
-                for (i = 0; i < reply->elements; ++i) {
+                for (i = 0; i < reply->elements; ++i)
+                {
                   add_to_secrets_list(&keys, reply->element[i]->str);
                 }
               }
 
-              for (isz = 0; isz < keys.sz; ++isz) {
+              for (isz = 0; isz < keys.sz; ++isz)
+              {
 
                 snprintf(s, sizeof(s), "del %s", keys.secrets[isz]);
                 turnFreeRedisReply(redisCommand(rc, s));
@@ -274,9 +369,12 @@ redis_context_handle get_redis_async_connection(struct event_base *base, redis_s
 
       ret = redisLibeventAttach(base, co->host, co->port, co->user, co->password, atoi(co->dbname));
 
-      if (!ret) {
+      if (!ret)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot initialize Redis DB connection\n");
-      } else if (is_redis_asyncconn_good(ret) && !donot_print_connection_success) {
+      }
+      else if (is_redis_asyncconn_good(ret) && !donot_print_connection_success)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Redis DB async connection to be used: %s\n",
                       redis_stats_db->connection_string_sanitized);
         donot_print_connection_success = 1;
@@ -288,13 +386,16 @@ redis_context_handle get_redis_async_connection(struct event_base *base, redis_s
   return ret;
 }
 
-static redisContext *get_redis_connection(void) {
+static redisContext *get_redis_connection(void)
+{
   persistent_users_db_t *pud = get_persistent_users_db();
 
   redisContext *redisconnection = (redisContext *)pthread_getspecific(connection_key);
 
-  if (redisconnection) {
-    if (redisconnection->err) {
+  if (redisconnection)
+  {
+    if (redisconnection->err)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot connect to redis, err=%d, flags=0x%lx\n", __FUNCTION__,
                     (int)redisconnection->err, (unsigned long)redisconnection->flags);
       redisFree(redisconnection);
@@ -303,97 +404,131 @@ static redisContext *get_redis_connection(void) {
     }
   }
 
-  if (!redisconnection) {
+  if (!redisconnection)
+  {
 
     char *errmsg = NULL;
     Ryconninfo *co = RyconninfoParse(pud->userdb, &errmsg);
-    if (!co) {
-      if (errmsg) {
+    if (!co)
+    {
+      if (errmsg)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
                       "Cannot open Redis DB connection <%s>, connection string format error: %s\n", pud->userdb,
                       errmsg);
         free(errmsg);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot open Redis DB connection <%s>, connection string format error\n",
                       pud->userdb);
       }
-    } else if (errmsg) {
+    }
+    else if (errmsg)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot open Redis DB connection <%s>, connection string format error: %s\n",
                     pud->userdb, errmsg);
       free(errmsg);
       RyconninfoFree(co);
-    } else {
+    }
+    else
+    {
       char ip[256] = "\0";
       int port = DEFAULT_REDIS_PORT;
-      if (co->host) {
+      if (co->host)
+      {
         STRCPY(ip, co->host);
       }
-      if (!ip[0]) {
+      if (!ip[0])
+      {
         strncpy(ip, "127.0.0.1", sizeof(ip));
       }
 
-      if (co->port) {
+      if (co->port)
+      {
         port = (int)(co->port);
       }
 
-      if (co->connect_timeout) {
+      if (co->connect_timeout)
+      {
         struct timeval tv;
         tv.tv_usec = 0;
         tv.tv_sec = (time_t)(co->connect_timeout);
         redisconnection = redisConnectWithTimeout(ip, port, tv);
-      } else {
+      }
+      else
+      {
         redisconnection = redisConnect(ip, port);
       }
 
-      if (redisconnection && redisconnection->err) {
-        if (redisconnection->errstr[0]) {
+      if (redisconnection && redisconnection->err)
+      {
+        if (redisconnection->errstr[0])
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Redis: %s\n", redisconnection->errstr);
         }
         redisFree(redisconnection);
         redisconnection = NULL;
       }
 
-      if (redisconnection && co->password && co->password[0]) {
+      if (redisconnection && co->password && co->password[0])
+      {
         void *reply;
-        if (co->user && co->user[0]) {
+        if (co->user && co->user[0])
+        {
           reply = redisCommand(redisconnection, "AUTH %s %s", co->user, co->password);
-        } else {
+        }
+        else
+        {
           reply = redisCommand(redisconnection, "AUTH %s", co->password);
         }
-        if (!reply) {
-          if (redisconnection->err && redisconnection->errstr[0]) {
+        if (!reply)
+        {
+          if (redisconnection->err && redisconnection->errstr[0])
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Redis: %s\n", redisconnection->errstr);
           }
           redisFree(redisconnection);
           redisconnection = NULL;
-        } else {
+        }
+        else
+        {
           turnFreeRedisReply(reply);
         }
       }
 
-      if (redisconnection && co->dbname) {
+      if (redisconnection && co->dbname)
+      {
         void *reply = redisCommand(redisconnection, "select %s", co->dbname);
-        if (!reply) {
-          if (redisconnection->err && redisconnection->errstr[0]) {
+        if (!reply)
+        {
+          if (redisconnection->err && redisconnection->errstr[0])
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Redis: %s\n", redisconnection->errstr);
           }
           redisFree(redisconnection);
           redisconnection = NULL;
-        } else {
+        }
+        else
+        {
           turnFreeRedisReply(reply);
         }
       }
 
-      if (!redisconnection) {
+      if (!redisconnection)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot initialize Redis DB connection\n");
-      } else if (!donot_print_connection_success) {
+      }
+      else if (!donot_print_connection_success)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Redis DB sync connection success: %s\n", pud->userdb);
         donot_print_connection_success = 1;
       }
 
       RyconninfoFree(co);
     }
-    if (redisconnection) {
+    if (redisconnection)
+    {
       (void)pthread_setspecific(connection_key, redisconnection);
     }
   }
@@ -401,12 +536,14 @@ static redisContext *get_redis_connection(void) {
   return redisconnection;
 }
 
-static int set_redis_realm_opt(char *realm, const char *key, unsigned long *value) {
+static int set_redis_realm_opt(char *realm, const char *key, unsigned long *value)
+{
   int found = 0;
 
   redisContext *rc = get_redis_connection();
 
-  if (rc) {
+  if (rc)
+  {
     redisReply *rget = NULL;
 
     char s[1025];
@@ -414,14 +551,21 @@ static int set_redis_realm_opt(char *realm, const char *key, unsigned long *valu
     snprintf(s, sizeof(s), "get turn/realm/%s/%s", realm, key);
 
     rget = (redisReply *)redisCommand(rc, s);
-    if (rget) {
-      if (rget->type == REDIS_REPLY_ERROR) {
+    if (rget)
+    {
+      if (rget->type == REDIS_REPLY_ERROR)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", rget->str);
-      } else if (rget->type != REDIS_REPLY_STRING) {
-        if (rget->type != REDIS_REPLY_NIL) {
+      }
+      else if (rget->type != REDIS_REPLY_STRING)
+      {
+        if (rget->type != REDIS_REPLY_NIL)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", rget->type);
         }
-      } else {
+      }
+      else
+      {
         lock_realms();
         *value = (unsigned long)atol(rget->str);
         unlock_realms();
@@ -436,22 +580,32 @@ static int set_redis_realm_opt(char *realm, const char *key, unsigned long *valu
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static int redis_get_auth_secrets(secrets_list_t *sl, uint8_t *realm) {
+static int redis_get_auth_secrets(secrets_list_t *sl, uint8_t *realm)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     redisReply *reply = (redisReply *)redisCommand(rc, "smembers turn/realm/%s/secret", (char *)realm);
-    if (reply) {
+    if (reply)
+    {
 
-      if (reply->type == REDIS_REPLY_ERROR) {
+      if (reply->type == REDIS_REPLY_ERROR)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-      } else if (reply->type != REDIS_REPLY_ARRAY) {
-        if (reply->type != REDIS_REPLY_NIL) {
+      }
+      else if (reply->type != REDIS_REPLY_ARRAY)
+      {
+        if (reply->type != REDIS_REPLY_NIL)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
         }
-      } else {
+      }
+      else
+      {
         size_t i;
-        for (i = 0; i < reply->elements; ++i) {
+        for (i = 0; i < reply->elements; ++i)
+        {
           add_to_secrets_list(sl, reply->element[i]->str);
         }
       }
@@ -464,25 +618,37 @@ static int redis_get_auth_secrets(secrets_list_t *sl, uint8_t *realm) {
   return ret;
 }
 
-static int redis_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
+static int redis_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char s[TURN_LONG_STRING_SIZE];
     snprintf(s, sizeof(s), "get turn/realm/%s/user/%s/key", (char *)realm, usname);
     redisReply *rget = (redisReply *)redisCommand(rc, s);
-    if (rget) {
-      if (rget->type == REDIS_REPLY_ERROR) {
+    if (rget)
+    {
+      if (rget->type == REDIS_REPLY_ERROR)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", rget->str);
-      } else if (rget->type != REDIS_REPLY_STRING) {
-        if (rget->type != REDIS_REPLY_NIL) {
+      }
+      else if (rget->type != REDIS_REPLY_STRING)
+      {
+        if (rget->type != REDIS_REPLY_NIL)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", rget->type);
         }
-      } else {
+      }
+      else
+      {
         size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
-        if (strlen(rget->str) < sz * 2) {
+        if (strlen(rget->str) < sz * 2)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format: %s, user %s\n", rget->str, usname);
-        } else {
+        }
+        else
+        {
           convert_string_key_to_binary(rget->str, key, sz);
           ret = 0;
         }
@@ -493,37 +659,57 @@ static int redis_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
   return ret;
 }
 
-static int redis_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key) {
+static int redis_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char s[TURN_LONG_STRING_SIZE];
     memset(key, 0, sizeof(oauth_key_data_raw));
     STRCPY(key->kid, kid);
     snprintf(s, sizeof(s), "hgetall turn/oauth/kid/%s", (const char *)kid);
     redisReply *reply = (redisReply *)redisCommand(rc, s);
-    if (reply) {
-      if (reply->type == REDIS_REPLY_ERROR) {
+    if (reply)
+    {
+      if (reply->type == REDIS_REPLY_ERROR)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-      } else if (reply->type != REDIS_REPLY_ARRAY) {
-        if (reply->type != REDIS_REPLY_NIL) {
+      }
+      else if (reply->type != REDIS_REPLY_ARRAY)
+      {
+        if (reply->type != REDIS_REPLY_NIL)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
         }
-      } else if (reply->elements > 1) {
+      }
+      else if (reply->elements > 1)
+      {
         size_t i;
-        for (i = 0; i < (reply->elements) / 2; ++i) {
+        for (i = 0; i < (reply->elements) / 2; ++i)
+        {
           char *kw = reply->element[2 * i]->str;
           char *val = reply->element[2 * i + 1]->str;
-          if (kw) {
-            if (!strcmp(kw, "as_rs_alg")) {
+          if (kw)
+          {
+            if (!strcmp(kw, "as_rs_alg"))
+            {
               STRCPY(key->as_rs_alg, val);
-            } else if (!strcmp(kw, "realm")) {
+            }
+            else if (!strcmp(kw, "realm"))
+            {
               STRCPY(key->realm, val);
-            } else if (!strcmp(kw, "ikm_key")) {
+            }
+            else if (!strcmp(kw, "ikm_key"))
+            {
               STRCPY(key->ikm_key, val);
-            } else if (!strcmp(kw, "timestamp")) {
+            }
+            else if (!strcmp(kw, "timestamp"))
+            {
               key->timestamp = (uint64_t)strtoull(val, NULL, 10);
-            } else if (!strcmp(kw, "lifetime")) {
+            }
+            else if (!strcmp(kw, "lifetime"))
+            {
               key->lifetime = (uint32_t)strtoul(val, NULL, 10);
             }
           }
@@ -536,10 +722,12 @@ static int redis_get_oauth_key(const uint8_t *kid, oauth_key_data_raw *key) {
   return ret;
 }
 
-static int redis_set_user_key(uint8_t *usname, uint8_t *realm, const char *key) {
+static int redis_set_user_key(uint8_t *usname, uint8_t *realm, const char *key)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     snprintf(statement, sizeof(statement), "set turn/realm/%s/user/%s/key %s", (char *)realm, usname, key);
     turnFreeRedisReply(redisCommand(rc, statement));
@@ -549,10 +737,12 @@ static int redis_set_user_key(uint8_t *usname, uint8_t *realm, const char *key) 
   return ret;
 }
 
-static int redis_set_oauth_key(oauth_key_data_raw *key) {
+static int redis_set_oauth_key(oauth_key_data_raw *key)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     snprintf(statement, sizeof(statement),
              "hmset turn/oauth/kid/%s ikm_key %s as_rs_alg %s timestamp %llu lifetime %lu realm %s", key->kid,
@@ -565,10 +755,12 @@ static int redis_set_oauth_key(oauth_key_data_raw *key) {
   return ret;
 }
 
-static int redis_del_user(uint8_t *usname, uint8_t *realm) {
+static int redis_del_user(uint8_t *usname, uint8_t *realm)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     {
       snprintf(statement, sizeof(statement), "del turn/realm/%s/user/%s/key", (char *)realm, usname);
@@ -581,10 +773,12 @@ static int redis_del_user(uint8_t *usname, uint8_t *realm) {
   return ret;
 }
 
-static int redis_del_oauth_key(const uint8_t *kid) {
+static int redis_del_oauth_key(const uint8_t *kid)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     snprintf(statement, sizeof(statement), "del turn/oauth/kid/%s", (const char *)kid);
     turnFreeRedisReply(redisCommand(rc, statement));
@@ -594,16 +788,19 @@ static int redis_del_oauth_key(const uint8_t *kid) {
   return ret;
 }
 
-static int redis_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_t *realms) {
+static int redis_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_t *realms)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
 
   uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
+  if (!realm)
+  {
     realm = realm0;
   }
 
-  if (rc) {
+  if (rc)
+  {
     secrets_list_t keys;
     size_t isz = 0;
 
@@ -612,23 +809,34 @@ static int redis_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_
     redisReply *reply = NULL;
 
     {
-      if (realm && realm[0]) {
+      if (realm && realm[0])
+      {
         reply = (redisReply *)redisCommand(rc, "keys turn/realm/%s/user/*/key", (char *)realm);
-      } else {
+      }
+      else
+      {
         reply = (redisReply *)redisCommand(rc, "keys turn/realm/*/user/*/key");
       }
 
-      if (reply) {
+      if (reply)
+      {
 
-        if (reply->type == REDIS_REPLY_ERROR) {
+        if (reply->type == REDIS_REPLY_ERROR)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-        } else if (reply->type != REDIS_REPLY_ARRAY) {
-          if (reply->type != REDIS_REPLY_NIL) {
+        }
+        else if (reply->type != REDIS_REPLY_ARRAY)
+        {
+          if (reply->type != REDIS_REPLY_NIL)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
           }
-        } else {
+        }
+        else
+        {
           size_t i;
-          for (i = 0; i < reply->elements; ++i) {
+          for (i = 0; i < reply->elements; ++i)
+          {
             add_to_secrets_list(&keys, reply->element[i]->str);
           }
         }
@@ -639,16 +847,19 @@ static int redis_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_
     size_t rhsz = strlen("turn/realm/");
     size_t uhsz = strlen("user/");
 
-    for (isz = 0; isz < keys.sz; ++isz) {
+    for (isz = 0; isz < keys.sz; ++isz)
+    {
       char *s = keys.secrets[isz];
 
       char *sh = strstr(s, "turn/realm/");
-      if (sh != s) {
+      if (sh != s)
+      {
         continue;
       }
       sh += rhsz;
       char *st = strchr(sh, '/');
-      if (!st) {
+      if (!st)
+      {
         continue;
       }
       *st = 0;
@@ -656,23 +867,29 @@ static int redis_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_
       ++st;
 
       sh = strstr(st, "user/");
-      if (sh != st) {
+      if (sh != st)
+      {
         continue;
       }
       sh += uhsz;
       st = strchr(sh, '/');
-      if (!st) {
+      if (!st)
+      {
         continue;
       }
       *st = 0;
       char *su = sh;
 
-      if (users) {
+      if (users)
+      {
         add_to_secrets_list(users, su);
-        if (realms) {
+        if (realms)
+        {
           add_to_secrets_list(realms, sr);
         }
-      } else {
+      }
+      else
+      {
         printf("%s[%s]\n", su, sr);
       }
     }
@@ -684,29 +901,39 @@ static int redis_list_users(uint8_t *realm, secrets_list_t *users, secrets_list_
 }
 
 static int redis_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, secrets_list_t *tss, secrets_list_t *lts,
-                                 secrets_list_t *realms) {
+                                 secrets_list_t *realms)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
   secrets_list_t keys;
   size_t isz = 0;
   init_secrets_list(&keys);
 
-  if (rc) {
+  if (rc)
+  {
 
     redisReply *reply = NULL;
 
     reply = (redisReply *)redisCommand(rc, "keys turn/oauth/kid/*");
-    if (reply) {
+    if (reply)
+    {
 
-      if (reply->type == REDIS_REPLY_ERROR) {
+      if (reply->type == REDIS_REPLY_ERROR)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-      } else if (reply->type != REDIS_REPLY_ARRAY) {
-        if (reply->type != REDIS_REPLY_NIL) {
+      }
+      else if (reply->type != REDIS_REPLY_ARRAY)
+      {
+        if (reply->type != REDIS_REPLY_NIL)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
         }
-      } else {
+      }
+      else
+      {
         size_t i;
-        for (i = 0; i < reply->elements; ++i) {
+        for (i = 0; i < reply->elements; ++i)
+        {
           add_to_secrets_list(&keys, reply->element[i]->str);
         }
       }
@@ -714,13 +941,16 @@ static int redis_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, sec
     }
   }
 
-  for (isz = 0; isz < keys.sz; ++isz) {
+  for (isz = 0; isz < keys.sz; ++isz)
+  {
     char *s = keys.secrets[isz];
     s += strlen("turn/oauth/kid/");
     oauth_key_data_raw key_;
     oauth_key_data_raw *key = &key_;
-    if (redis_get_oauth_key((const uint8_t *)s, key) == 0) {
-      if (kids) {
+    if (redis_get_oauth_key((const uint8_t *)s, key) == 0)
+    {
+      if (kids)
+      {
         add_to_secrets_list(kids, key->kid);
         add_to_secrets_list(teas, key->as_rs_alg);
         add_to_secrets_list(realms, key->realm);
@@ -734,7 +964,9 @@ static int redis_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, sec
           snprintf(lt, sizeof(lt) - 1, "%lu", (unsigned long)key->lifetime);
           add_to_secrets_list(lts, lt);
         }
-      } else {
+      }
+      else
+      {
         printf("  kid=%s, ikm_key=%s, timestamp=%llu, lifetime=%lu, as_rs_alg=%s, realm=%s\n", key->kid, key->ikm_key,
                (unsigned long long)key->timestamp, (unsigned long)key->lifetime, key->as_rs_alg, key->realm);
       }
@@ -747,86 +979,120 @@ static int redis_list_oauth_keys(secrets_list_t *kids, secrets_list_t *teas, sec
   return ret;
 }
 
-static int redis_list_secrets(uint8_t *realm, secrets_list_t *secrets, secrets_list_t *realms) {
+static int redis_list_secrets(uint8_t *realm, secrets_list_t *secrets, secrets_list_t *realms)
+{
   int ret = -1;
 
   uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
+  if (!realm)
+  {
     realm = realm0;
   }
 
   donot_print_connection_success = 1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     redisReply *reply = NULL;
-    if (realm && realm[0]) {
+    if (realm && realm[0])
+    {
       reply = (redisReply *)redisCommand(rc, "keys turn/realm/%s/secret", (char *)realm);
-    } else {
+    }
+    else
+    {
       reply = (redisReply *)redisCommand(rc, "keys turn/realm/*/secret");
     }
-    if (reply) {
+    if (reply)
+    {
       secrets_list_t keys;
       size_t isz = 0;
       char s[257];
 
       init_secrets_list(&keys);
 
-      if (reply->type == REDIS_REPLY_ERROR) {
+      if (reply->type == REDIS_REPLY_ERROR)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-      } else if (reply->type != REDIS_REPLY_ARRAY) {
-        if (reply->type != REDIS_REPLY_NIL) {
+      }
+      else if (reply->type != REDIS_REPLY_ARRAY)
+      {
+        if (reply->type != REDIS_REPLY_NIL)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
         }
-      } else {
+      }
+      else
+      {
         size_t i;
-        for (i = 0; i < reply->elements; ++i) {
+        for (i = 0; i < reply->elements; ++i)
+        {
           add_to_secrets_list(&keys, reply->element[i]->str);
         }
       }
 
       size_t rhsz = strlen("turn/realm/");
 
-      for (isz = 0; isz < keys.sz; ++isz) {
+      for (isz = 0; isz < keys.sz; ++isz)
+      {
         snprintf(s, sizeof(s), "smembers %s", keys.secrets[isz]);
         redisReply *rget = (redisReply *)redisCommand(rc, s);
-        if (rget) {
-          if (rget->type == REDIS_REPLY_ERROR) {
+        if (rget)
+        {
+          if (rget->type == REDIS_REPLY_ERROR)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", rget->str);
-          } else if (rget->type == REDIS_REPLY_STRING) {
+          }
+          else if (rget->type == REDIS_REPLY_STRING)
+          {
             printf("%s\n", rget->str);
-          } else if (rget->type != REDIS_REPLY_ARRAY) {
-            if (rget->type != REDIS_REPLY_NIL) {
+          }
+          else if (rget->type != REDIS_REPLY_ARRAY)
+          {
+            if (rget->type != REDIS_REPLY_NIL)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", rget->type);
             }
-          } else {
+          }
+          else
+          {
 
             char *s = keys.secrets[isz];
 
             char *sh = strstr(s, "turn/realm/");
-            if (sh != s) {
+            if (sh != s)
+            {
               continue;
             }
             sh += rhsz;
             char *st = strchr(sh, '/');
-            if (!st) {
+            if (!st)
+            {
               continue;
             }
             *st = 0;
             const char *rval = sh;
 
             size_t i;
-            for (i = 0; i < rget->elements; ++i) {
+            for (i = 0; i < rget->elements; ++i)
+            {
               const char *kval = rget->element[i]->str;
-              if (secrets) {
+              if (secrets)
+              {
                 add_to_secrets_list(secrets, kval);
-                if (realms) {
-                  if (rval && *rval) {
+                if (realms)
+                {
+                  if (rval && *rval)
+                  {
                     add_to_secrets_list(realms, rval);
-                  } else {
+                  }
+                  else
+                  {
                     add_to_secrets_list(realms, (char *)realm);
                   }
                 }
-              } else {
+              }
+              else
+              {
                 printf("%s[%s]\n", kval, rval);
               }
             }
@@ -844,11 +1110,13 @@ static int redis_list_secrets(uint8_t *realm, secrets_list_t *secrets, secrets_l
   return ret;
 }
 
-static int redis_del_secret(uint8_t *secret, uint8_t *realm) {
+static int redis_del_secret(uint8_t *secret, uint8_t *realm)
+{
   int ret = -1;
   donot_print_connection_success = 1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     turnFreeRedisReply(redisCommand(rc, "srem turn/realm/%s/secret %s", (char *)realm, (char *)secret));
     turnFreeRedisReply(redisCommand(rc, "save"));
     ret = 0;
@@ -856,11 +1124,13 @@ static int redis_del_secret(uint8_t *secret, uint8_t *realm) {
   return ret;
 }
 
-static int redis_set_secret(uint8_t *secret, uint8_t *realm) {
+static int redis_set_secret(uint8_t *secret, uint8_t *realm)
+{
   int ret = -1;
   donot_print_connection_success = 1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char s[TURN_LONG_STRING_SIZE];
 
     redis_del_secret(secret, realm);
@@ -874,23 +1144,29 @@ static int redis_set_secret(uint8_t *secret, uint8_t *realm) {
   return ret;
 }
 
-static int redis_set_permission_ip(const char *kind, uint8_t *realm, const char *ip, int del) {
+static int redis_set_permission_ip(const char *kind, uint8_t *realm, const char *ip, int del)
+{
   int ret = -1;
 
   uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
+  if (!realm)
+  {
     realm = realm0;
   }
 
   donot_print_connection_success = 1;
 
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char s[TURN_LONG_STRING_SIZE];
 
-    if (del) {
+    if (del)
+    {
       snprintf(s, sizeof(s), "srem turn/realm/%s/%s-peer-ip %s", (char *)realm, kind, ip);
-    } else {
+    }
+    else
+    {
       snprintf(s, sizeof(s), "sadd turn/realm/%s/%s-peer-ip %s", (char *)realm, kind, ip);
     }
 
@@ -901,10 +1177,12 @@ static int redis_set_permission_ip(const char *kind, uint8_t *realm, const char 
   return ret;
 }
 
-static int redis_add_origin(uint8_t *origin, uint8_t *realm) {
+static int redis_add_origin(uint8_t *origin, uint8_t *realm)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char s[TURN_LONG_STRING_SIZE];
 
     snprintf(s, sizeof(s), "set turn/origin/%s %s", (char *)origin, (char *)realm);
@@ -916,10 +1194,12 @@ static int redis_add_origin(uint8_t *origin, uint8_t *realm) {
   return ret;
 }
 
-static int redis_del_origin(uint8_t *origin) {
+static int redis_del_origin(uint8_t *origin)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char s[TURN_LONG_STRING_SIZE];
 
     snprintf(s, sizeof(s), "del turn/origin/%s", (char *)origin);
@@ -931,18 +1211,21 @@ static int redis_del_origin(uint8_t *origin) {
   return ret;
 }
 
-static int redis_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_list_t *realms) {
+static int redis_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_list_t *realms)
+{
   int ret = -1;
 
   uint8_t realm0[STUN_MAX_REALM_SIZE + 1] = "\0";
-  if (!realm) {
+  if (!realm)
+  {
     realm = realm0;
   }
 
   donot_print_connection_success = 1;
 
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     secrets_list_t keys;
     size_t isz = 0;
 
@@ -952,18 +1235,26 @@ static int redis_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_l
 
     {
       reply = (redisReply *)redisCommand(rc, "keys turn/origin/*");
-      if (reply) {
+      if (reply)
+      {
 
-        if (reply->type == REDIS_REPLY_ERROR) {
+        if (reply->type == REDIS_REPLY_ERROR)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-        } else if (reply->type != REDIS_REPLY_ARRAY) {
-          if (reply->type != REDIS_REPLY_NIL) {
+        }
+        else if (reply->type != REDIS_REPLY_ARRAY)
+        {
+          if (reply->type != REDIS_REPLY_NIL)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
           }
-        } else {
+        }
+        else
+        {
           size_t i;
           size_t offset = strlen("turn/origin/");
-          for (i = 0; i < reply->elements; ++i) {
+          for (i = 0; i < reply->elements; ++i)
+          {
             add_to_secrets_list(&keys, reply->element[i]->str + offset);
           }
         }
@@ -971,27 +1262,40 @@ static int redis_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_l
       }
     }
 
-    for (isz = 0; isz < keys.sz; ++isz) {
+    for (isz = 0; isz < keys.sz; ++isz)
+    {
 
       char *o = keys.secrets[isz];
 
       reply = (redisReply *)redisCommand(rc, "get turn/origin/%s", o);
-      if (reply) {
+      if (reply)
+      {
 
-        if (reply->type == REDIS_REPLY_ERROR) {
+        if (reply->type == REDIS_REPLY_ERROR)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-        } else if (reply->type != REDIS_REPLY_STRING) {
-          if (reply->type != REDIS_REPLY_NIL) {
+        }
+        else if (reply->type != REDIS_REPLY_STRING)
+        {
+          if (reply->type != REDIS_REPLY_NIL)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
           }
-        } else {
-          if (!(realm && realm[0] && strcmp((char *)realm, reply->str))) {
-            if (origins) {
+        }
+        else
+        {
+          if (!(realm && realm[0] && strcmp((char *)realm, reply->str)))
+          {
+            if (origins)
+            {
               add_to_secrets_list(origins, o);
-              if (realms) {
+              if (realms)
+              {
                 add_to_secrets_list(realms, reply->str);
               }
-            } else {
+            }
+            else
+            {
               printf("%s ==>> %s\n", o, reply->str);
             }
           }
@@ -1006,15 +1310,20 @@ static int redis_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_l
   return ret;
 }
 
-static int redis_set_realm_option_one(uint8_t *realm, unsigned long value, const char *opt) {
+static int redis_set_realm_option_one(uint8_t *realm, unsigned long value, const char *opt)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char s[TURN_LONG_STRING_SIZE];
 
-    if (value > 0) {
+    if (value > 0)
+    {
       snprintf(s, sizeof(s), "set turn/realm/%s/%s %lu", (char *)realm, opt, (unsigned long)value);
-    } else {
+    }
+    else
+    {
       snprintf(s, sizeof(s), "del turn/realm/%s/%s", (char *)realm, opt);
     }
 
@@ -1025,11 +1334,13 @@ static int redis_set_realm_option_one(uint8_t *realm, unsigned long value, const
   return ret;
 }
 
-static int redis_list_realm_options(uint8_t *realm) {
+static int redis_list_realm_options(uint8_t *realm)
+{
   int ret = -1;
   donot_print_connection_success = 1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     secrets_list_t keys;
     size_t isz = 0;
 
@@ -1038,24 +1349,36 @@ static int redis_list_realm_options(uint8_t *realm) {
     redisReply *reply = NULL;
 
     {
-      if (realm && realm[0]) {
+      if (realm && realm[0])
+      {
         reply = (redisReply *)redisCommand(rc, "keys turn/realm/%s/*", realm);
-      } else {
+      }
+      else
+      {
         reply = (redisReply *)redisCommand(rc, "keys turn/realm/*");
       }
-      if (reply) {
+      if (reply)
+      {
 
-        if (reply->type == REDIS_REPLY_ERROR) {
+        if (reply->type == REDIS_REPLY_ERROR)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-        } else if (reply->type != REDIS_REPLY_ARRAY) {
-          if (reply->type != REDIS_REPLY_NIL) {
+        }
+        else if (reply->type != REDIS_REPLY_ARRAY)
+        {
+          if (reply->type != REDIS_REPLY_NIL)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
           }
-        } else {
+        }
+        else
+        {
           size_t i;
-          for (i = 0; i < reply->elements; ++i) {
+          for (i = 0; i < reply->elements; ++i)
+          {
             if (strstr(reply->element[i]->str, "/max-bps") || strstr(reply->element[i]->str, "/total-quota") ||
-                strstr(reply->element[i]->str, "/user-quota")) {
+                strstr(reply->element[i]->str, "/user-quota"))
+            {
               add_to_secrets_list(&keys, reply->element[i]->str);
             }
           }
@@ -1066,19 +1389,27 @@ static int redis_list_realm_options(uint8_t *realm) {
 
     size_t offset = strlen("turn/realm/");
 
-    for (isz = 0; isz < keys.sz; ++isz) {
+    for (isz = 0; isz < keys.sz; ++isz)
+    {
       char *o = keys.secrets[isz];
 
       reply = (redisReply *)redisCommand(rc, "get %s", o);
-      if (reply) {
+      if (reply)
+      {
 
-        if (reply->type == REDIS_REPLY_ERROR) {
+        if (reply->type == REDIS_REPLY_ERROR)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-        } else if (reply->type != REDIS_REPLY_STRING) {
-          if (reply->type != REDIS_REPLY_NIL) {
+        }
+        else if (reply->type != REDIS_REPLY_STRING)
+        {
+          if (reply->type != REDIS_REPLY_NIL)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
           }
-        } else {
+        }
+        else
+        {
           printf("%s = %s\n", o + offset, reply->str);
         }
         turnFreeRedisReply(reply);
@@ -1091,44 +1422,57 @@ static int redis_list_realm_options(uint8_t *realm) {
   return ret;
 }
 
-static void redis_auth_ping(void *rch) {
+static void redis_auth_ping(void *rch)
+{
   UNUSED_ARG(rch);
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     turnFreeRedisReply(redisCommand(rc, "keys turn/origin/*"));
   }
 }
 
-static int redis_get_ip_list(const char *kind, ip_range_list_t *list) {
+static int redis_get_ip_list(const char *kind, ip_range_list_t *list)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     const char *header = "turn/realm/";
     size_t header_len = strlen(header);
     snprintf(statement, sizeof(statement), "keys %s*/%s-peer-ip", header, kind);
     redisReply *reply = (redisReply *)redisCommand(rc, statement);
-    if (reply) {
+    if (reply)
+    {
       secrets_list_t keys;
       size_t isz = 0;
       char s[257];
 
       init_secrets_list(&keys);
 
-      if (reply->type == REDIS_REPLY_ERROR) {
+      if (reply->type == REDIS_REPLY_ERROR)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-      } else if (reply->type != REDIS_REPLY_ARRAY) {
-        if (reply->type != REDIS_REPLY_NIL) {
+      }
+      else if (reply->type != REDIS_REPLY_ARRAY)
+      {
+        if (reply->type != REDIS_REPLY_NIL)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
         }
-      } else {
+      }
+      else
+      {
         size_t i;
-        for (i = 0; i < reply->elements; ++i) {
+        for (i = 0; i < reply->elements; ++i)
+        {
           add_to_secrets_list(&keys, reply->element[i]->str);
         }
       }
 
-      for (isz = 0; isz < keys.sz; ++isz) {
+      for (isz = 0; isz < keys.sz; ++isz)
+      {
 
         char *realm = NULL;
 
@@ -1138,30 +1482,42 @@ static int redis_get_ip_list(const char *kind, ip_range_list_t *list) {
 
         char *ptr = ((char *)keys.secrets[isz]) + header_len;
         char *sep = strstr(ptr, "/");
-        if (sep) {
+        if (sep)
+        {
           *sep = 0;
           realm = ptr;
         }
 
-        if (rget) {
-          if (rget->type == REDIS_REPLY_ERROR) {
+        if (rget)
+        {
+          if (rget->type == REDIS_REPLY_ERROR)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", rget->str);
-          } else if (rget->type == REDIS_REPLY_STRING) {
+          }
+          else if (rget->type == REDIS_REPLY_STRING)
+          {
             add_ip_list_range(rget->str, realm, list);
-          } else if (rget->type != REDIS_REPLY_ARRAY) {
-            if (rget->type != REDIS_REPLY_NIL) {
+          }
+          else if (rget->type != REDIS_REPLY_ARRAY)
+          {
+            if (rget->type != REDIS_REPLY_NIL)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", rget->type);
             }
-          } else {
+          }
+          else
+          {
             size_t i;
-            for (i = 0; i < rget->elements; ++i) {
+            for (i = 0; i < rget->elements; ++i)
+            {
               add_ip_list_range(rget->element[i]->str, realm, list);
             }
           }
           turnFreeRedisReply(rget);
         }
 
-        if (sep) {
+        if (sep)
+        {
           *sep = '/';
         }
       }
@@ -1175,12 +1531,15 @@ static int redis_get_ip_list(const char *kind, ip_range_list_t *list) {
   return ret;
 }
 
-static void redis_reread_realms(secrets_list_t *realms_list) {
+static void redis_reread_realms(secrets_list_t *realms_list)
+{
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
 
     redisReply *reply = (redisReply *)redisCommand(rc, "keys turn/origin/*");
-    if (reply) {
+    if (reply)
+    {
 
       ur_string_map *o_to_realm_new = ur_string_map_create(free);
 
@@ -1192,33 +1551,48 @@ static void redis_reread_realms(secrets_list_t *realms_list) {
 
       char s[1025];
 
-      if (reply->type == REDIS_REPLY_ERROR) {
+      if (reply->type == REDIS_REPLY_ERROR)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-      } else if (reply->type != REDIS_REPLY_ARRAY) {
-        if (reply->type != REDIS_REPLY_NIL) {
+      }
+      else if (reply->type != REDIS_REPLY_ARRAY)
+      {
+        if (reply->type != REDIS_REPLY_NIL)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
         }
-      } else {
+      }
+      else
+      {
         size_t i;
-        for (i = 0; i < reply->elements; ++i) {
+        for (i = 0; i < reply->elements; ++i)
+        {
           add_to_secrets_list(&keys, reply->element[i]->str);
         }
       }
 
       size_t offset = strlen("turn/origin/");
 
-      for (isz = 0; isz < keys.sz; ++isz) {
+      for (isz = 0; isz < keys.sz; ++isz)
+      {
         char *origin = keys.secrets[isz] + offset;
         snprintf(s, sizeof(s), "get %s", keys.secrets[isz]);
         redisReply *rget = (redisReply *)redisCommand(rc, s);
-        if (rget) {
-          if (rget->type == REDIS_REPLY_ERROR) {
+        if (rget)
+        {
+          if (rget->type == REDIS_REPLY_ERROR)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", rget->str);
-          } else if (rget->type != REDIS_REPLY_STRING) {
-            if (rget->type != REDIS_REPLY_NIL) {
+          }
+          else if (rget->type != REDIS_REPLY_STRING)
+          {
+            if (rget->type != REDIS_REPLY_NIL)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", rget->type);
             }
-          } else {
+          }
+          else
+          {
             get_realm(rget->str);
             ur_string_map_value_type value = strdup(rget->str);
             ur_string_map_put(o_to_realm_new, (ur_string_map_key_type)origin, value);
@@ -1242,36 +1616,46 @@ static void redis_reread_realms(secrets_list_t *realms_list) {
       rlsz = realms_list->sz;
       unlock_realms();
 
-      for (i = 0; i < rlsz; ++i) {
+      for (i = 0; i < rlsz; ++i)
+      {
         char *realm = realms_list->secrets[i];
         realm_params_t *rp = get_realm(realm);
         {
           unsigned long value = 0;
-          if (!set_redis_realm_opt(realm, "max-bps", &value)) {
+          if (!set_redis_realm_opt(realm, "max-bps", &value))
+          {
             lock_realms();
             rp->options.perf_options.max_bps = turn_params.max_bps;
             unlock_realms();
-          } else {
+          }
+          else
+          {
             rp->options.perf_options.max_bps = (band_limit_t)value;
           }
         }
         {
           unsigned long value = 0;
-          if (!set_redis_realm_opt(realm, "total-quota", &value)) {
+          if (!set_redis_realm_opt(realm, "total-quota", &value))
+          {
             lock_realms();
             rp->options.perf_options.total_quota = turn_params.total_quota;
             unlock_realms();
-          } else {
+          }
+          else
+          {
             rp->options.perf_options.total_quota = (vint)value;
           }
         }
         {
           unsigned long value = 0;
-          if (!set_redis_realm_opt(realm, "user-quota", &value)) {
+          if (!set_redis_realm_opt(realm, "user-quota", &value))
+          {
             lock_realms();
             rp->options.perf_options.user_quota = turn_params.user_quota;
             unlock_realms();
-          } else {
+          }
+          else
+          {
             rp->options.perf_options.user_quota = (vint)value;
           }
         }
@@ -1282,31 +1666,45 @@ static void redis_reread_realms(secrets_list_t *realms_list) {
 
 /////////////////////////////////////////////////////
 
-static int redis_get_admin_user(const uint8_t *usname, uint8_t *realm, password_t pwd) {
+static int redis_get_admin_user(const uint8_t *usname, uint8_t *realm, password_t pwd)
+{
   int ret = -1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char s[TURN_LONG_STRING_SIZE];
     realm[0] = 0;
     pwd[0] = 0;
     snprintf(s, sizeof(s), "hgetall turn/admin_user/%s", (const char *)usname);
     redisReply *reply = (redisReply *)redisCommand(rc, s);
-    if (reply) {
-      if (reply->type == REDIS_REPLY_ERROR) {
+    if (reply)
+    {
+      if (reply->type == REDIS_REPLY_ERROR)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-      } else if (reply->type != REDIS_REPLY_ARRAY) {
-        if (reply->type != REDIS_REPLY_NIL) {
+      }
+      else if (reply->type != REDIS_REPLY_ARRAY)
+      {
+        if (reply->type != REDIS_REPLY_NIL)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
         }
-      } else if (reply->elements > 1) {
+      }
+      else if (reply->elements > 1)
+      {
         size_t i;
-        for (i = 0; i < (reply->elements) / 2; ++i) {
+        for (i = 0; i < (reply->elements) / 2; ++i)
+        {
           char *kw = reply->element[2 * i]->str;
           char *val = reply->element[2 * i + 1]->str;
-          if (kw) {
-            if (!strcmp(kw, "realm")) {
+          if (kw)
+          {
+            if (!strcmp(kw, "realm"))
+            {
               strncpy((char *)realm, val, STUN_MAX_REALM_SIZE);
-            } else if (!strcmp(kw, "password")) {
+            }
+            else if (!strcmp(kw, "password"))
+            {
               strncpy((char *)pwd, val, STUN_MAX_PWD_SIZE);
               ret = 0;
             }
@@ -1319,15 +1717,20 @@ static int redis_get_admin_user(const uint8_t *usname, uint8_t *realm, password_
   return ret;
 }
 
-static int redis_set_admin_user(const uint8_t *usname, const uint8_t *realm, const password_t pwd) {
+static int redis_set_admin_user(const uint8_t *usname, const uint8_t *realm, const password_t pwd)
+{
   int ret = -1;
   donot_print_connection_success = 1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
-    if (realm[0]) {
+    if (realm[0])
+    {
       snprintf(statement, sizeof(statement), "hmset turn/admin_user/%s realm %s password %s", usname, realm, pwd);
-    } else {
+    }
+    else
+    {
       snprintf(statement, sizeof(statement), "hmset turn/admin_user/%s password %s", usname, pwd);
     }
     turnFreeRedisReply(redisCommand(rc, statement));
@@ -1337,11 +1740,13 @@ static int redis_set_admin_user(const uint8_t *usname, const uint8_t *realm, con
   return ret;
 }
 
-static int redis_del_admin_user(const uint8_t *usname) {
+static int redis_del_admin_user(const uint8_t *usname)
+{
   int ret = -1;
   donot_print_connection_success = 1;
   redisContext *rc = get_redis_connection();
-  if (rc) {
+  if (rc)
+  {
     char statement[TURN_LONG_STRING_SIZE];
     snprintf(statement, sizeof(statement), "del turn/admin_user/%s", (const char *)usname);
     turnFreeRedisReply(redisCommand(rc, statement));
@@ -1351,7 +1756,8 @@ static int redis_del_admin_user(const uint8_t *usname) {
   return ret;
 }
 
-static int redis_list_admin_users(int no_print) {
+static int redis_list_admin_users(int no_print)
+{
   int ret = -1;
   donot_print_connection_success = 1;
   redisContext *rc = get_redis_connection();
@@ -1359,22 +1765,31 @@ static int redis_list_admin_users(int no_print) {
   size_t isz = 0;
   init_secrets_list(&keys);
 
-  if (rc) {
+  if (rc)
+  {
 
     redisReply *reply = NULL;
 
     reply = (redisReply *)redisCommand(rc, "keys turn/admin_user/*");
-    if (reply) {
+    if (reply)
+    {
 
-      if (reply->type == REDIS_REPLY_ERROR) {
+      if (reply->type == REDIS_REPLY_ERROR)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Error: %s\n", reply->str);
-      } else if (reply->type != REDIS_REPLY_ARRAY) {
-        if (reply->type != REDIS_REPLY_NIL) {
+      }
+      else if (reply->type != REDIS_REPLY_ARRAY)
+      {
+        if (reply->type != REDIS_REPLY_NIL)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unexpected type: %d\n", reply->type);
         }
-      } else {
+      }
+      else
+      {
         size_t i;
-        for (i = 0; i < reply->elements; ++i) {
+        for (i = 0; i < reply->elements; ++i)
+        {
           add_to_secrets_list(&keys, reply->element[i]->str);
         }
       }
@@ -1383,17 +1798,23 @@ static int redis_list_admin_users(int no_print) {
   }
 
   ret = 0;
-  for (isz = 0; isz < keys.sz; ++isz) {
+  for (isz = 0; isz < keys.sz; ++isz)
+  {
     char *s = keys.secrets[isz];
     s += strlen("turn/admin_user/");
     uint8_t realm[STUN_MAX_REALM_SIZE];
     password_t pwd;
-    if (redis_get_admin_user((const uint8_t *)s, realm, pwd) == 0) {
+    if (redis_get_admin_user((const uint8_t *)s, realm, pwd) == 0)
+    {
       ++ret;
-      if (!no_print) {
-        if (realm[0]) {
+      if (!no_print)
+      {
+        if (realm[0])
+        {
           printf("%s[%s]\n", s, realm);
-        } else {
+        }
+        else
+        {
           printf("%s\n", s);
         }
       }
@@ -1405,9 +1826,11 @@ static int redis_list_admin_users(int no_print) {
   return ret;
 }
 
-static void redis_disconnect(void) {
+static void redis_disconnect(void)
+{
   redisContext *redisconnection = (redisContext *)pthread_getspecific(connection_key);
-  if (redisconnection) {
+  if (redisconnection)
+  {
     redisFree(redisconnection);
     redisconnection = NULL;
   }
@@ -1434,7 +1857,8 @@ const turn_dbdriver_t *get_redis_dbdriver(void) { return &driver; }
 const turn_dbdriver_t *get_redis_dbdriver(void) { return NULL; }
 
 redis_context_handle get_redis_async_connection(struct event_base *base, redis_stats_db_t *connection_string,
-                                                int delete_keys) {
+                                                int delete_keys)
+{
   UNUSED_ARG(base);
   UNUSED_ARG(connection_string);
   UNUSED_ARG(delete_keys);

--- a/src/apps/relay/dbdrivers/dbd_redis.h
+++ b/src/apps/relay/dbdrivers/dbd_redis.h
@@ -36,7 +36,8 @@
 #include "dbdriver.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 const turn_dbdriver_t *get_redis_dbdriver(void);

--- a/src/apps/relay/dbdrivers/dbd_sqlite.h
+++ b/src/apps/relay/dbdrivers/dbd_sqlite.h
@@ -35,7 +35,8 @@
 #include "dbdriver.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 const turn_dbdriver_t *get_sqlite_dbdriver(void);

--- a/src/apps/relay/dbdrivers/dbdriver.c
+++ b/src/apps/relay/dbdrivers/dbdriver.c
@@ -45,12 +45,14 @@ static void make_connection_key(void) { (void)pthread_key_create(&connection_key
 pthread_key_t connection_key;
 pthread_once_t connection_key_once = PTHREAD_ONCE_INIT;
 
-void convert_string_key_to_binary(char const *keysource, hmackey_t key, size_t sz) {
+void convert_string_key_to_binary(char const *keysource, hmackey_t key, size_t sz)
+{
   char is[3];
   size_t i;
   unsigned int v;
   is[2] = 0;
-  for (i = 0; i < sz; i++) {
+  for (i = 0; i < sz; i++)
+  {
     is[0] = keysource[i * 2];
     is[1] = keysource[i * 2 + 1];
     sscanf(is, "%02x", &v);
@@ -60,8 +62,10 @@ void convert_string_key_to_binary(char const *keysource, hmackey_t key, size_t s
 
 persistent_users_db_t *get_persistent_users_db(void) { return &(turn_params.default_users_db.persistent_users_db); }
 
-const turn_dbdriver_t *get_dbdriver(void) {
-  if (turn_params.default_users_db.userdb_type == TURN_USERDB_TYPE_UNKNOWN) {
+const turn_dbdriver_t *get_dbdriver(void)
+{
+  if (turn_params.default_users_db.userdb_type == TURN_USERDB_TYPE_UNKNOWN)
+  {
     return NULL;
   }
 
@@ -69,9 +73,11 @@ const turn_dbdriver_t *get_dbdriver(void) {
 
   static const turn_dbdriver_t *_driver = NULL;
 
-  if (_driver == NULL) {
+  if (_driver == NULL)
+  {
 
-    switch (turn_params.default_users_db.userdb_type) {
+    switch (turn_params.default_users_db.userdb_type)
+    {
 #if !defined(TURN_NO_SQLITE)
     case TURN_USERDB_TYPE_SQLITE:
       _driver = get_sqlite_dbdriver();
@@ -102,7 +108,8 @@ const turn_dbdriver_t *get_dbdriver(void) {
   return _driver;
 }
 
-char *sanitize_userdb_string(char *udb) {
+char *sanitize_userdb_string(char *udb)
+{
   char *ret = NULL;
   char *pstart;
   char *pend;
@@ -110,21 +117,27 @@ char *sanitize_userdb_string(char *udb) {
   /* host=localhost dbname=coturn user=turn password=turn connect_timeout=30 */
   ret = strdup(udb);
   pstart = strstr(ret, "password=");
-  if (pstart != NULL) {
+  if (pstart != NULL)
+  {
     pstart += strlen("password=");
     pend = strstr(pstart, " ");
     size_t plen = pend - pstart;
-    if (pend == NULL) {
+    if (pend == NULL)
+    {
       plen = strlen(pstart);
     }
     memset(pstart, '*', plen);
-  } else {
+  }
+  else
+  {
     /* postgresql://username:password@/databasename */
     pstart = strstr(ret, "postgresql://");
-    if (pstart != NULL) {
+    if (pstart != NULL)
+    {
       pstart += strlen("postgresql://");
       pend = strstr(pstart, "@");
-      if (pend != NULL) {
+      if (pend != NULL)
+      {
         size_t plen = pend - pstart;
         memset(pstart, '*', plen);
       }

--- a/src/apps/relay/dbdrivers/dbdriver.h
+++ b/src/apps/relay/dbdrivers/dbdriver.h
@@ -39,7 +39,8 @@
 #include <pthread.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ////////////////////////////////////////////
@@ -47,7 +48,8 @@ extern "C" {
 extern pthread_key_t connection_key;
 extern pthread_once_t connection_key_once;
 
-typedef struct _turn_dbdriver_t {
+typedef struct _turn_dbdriver_t
+{
   int (*get_auth_secrets)(secrets_list_t *sl, uint8_t *realm);
   int (*get_user_key)(uint8_t *usname, uint8_t *realm, hmackey_t key);
   int (*set_user_key)(uint8_t *usname, uint8_t *realm, const char *key);

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -58,7 +58,8 @@ typedef uint16_t in_port_t;
 
 #define MAX_SINGLE_UDP_BATCH (16)
 
-struct dtls_listener_relay_server_info {
+struct dtls_listener_relay_server_info
+{
   char ifname[1025];
   ioa_addr addr;
   ioa_engine_handle e;
@@ -88,25 +89,32 @@ int get_dtls_version(const unsigned char *buf, int len);
 
 int is_dtls_message(const unsigned char *buf, int len);
 
-int is_dtls_handshake_message(const unsigned char *buf, int len) {
+int is_dtls_handshake_message(const unsigned char *buf, int len)
+{
   return (buf && len > 3 && buf[0] == 0x16 && buf[1] == 0xfe && ((buf[2] == 0xff) || (buf[2] == 0xfd)));
 }
 
-int is_dtls_data_message(const unsigned char *buf, int len) {
+int is_dtls_data_message(const unsigned char *buf, int len)
+{
   return (buf && len > 3 && buf[0] == 0x17 && buf[1] == 0xfe && ((buf[2] == 0xff) || (buf[2] == 0xfd)));
 }
 
-int is_dtls_alert_message(const unsigned char *buf, int len) {
+int is_dtls_alert_message(const unsigned char *buf, int len)
+{
   return (buf && len > 3 && buf[0] == 0x15 && buf[1] == 0xfe && ((buf[2] == 0xff) || (buf[2] == 0xfd)));
 }
 
-int is_dtls_cipher_change_message(const unsigned char *buf, int len) {
+int is_dtls_cipher_change_message(const unsigned char *buf, int len)
+{
   return (buf && len > 3 && buf[0] == 0x14 && buf[1] == 0xfe && ((buf[2] == 0xff) || (buf[2] == 0xfd)));
 }
 
-int is_dtls_message(const unsigned char *buf, int len) {
-  if (buf && (len > 3) && (buf[1]) == 0xfe && ((buf[2] == 0xff) || (buf[2] == 0xfd))) {
-    switch (buf[0]) {
+int is_dtls_message(const unsigned char *buf, int len)
+{
+  if (buf && (len > 3) && (buf[1]) == 0xfe && ((buf[2] == 0xff) || (buf[2] == 0xfd)))
+  {
+    switch (buf[0])
+    {
     case 0x14:
     case 0x15:
     case 0x16:
@@ -119,8 +127,10 @@ int is_dtls_message(const unsigned char *buf, int len) {
 }
 
 /* 0 - 1.0, 1 - 1.2 */
-int get_dtls_version(const unsigned char *buf, int len) {
-  if (buf && (len > 3) && (buf[2] == 0xfd)) {
+int get_dtls_version(const unsigned char *buf, int len)
+{
+  if (buf && (len > 3) && (buf[2] == 0xfd))
+  {
     return 1;
   }
   return 0;
@@ -130,17 +140,20 @@ int get_dtls_version(const unsigned char *buf, int len) {
 
 #if DTLS_SUPPORTED
 
-static void calculate_cookie(SSL *ssl, unsigned char *cookie_secret, unsigned int cookie_length) {
+static void calculate_cookie(SSL *ssl, unsigned char *cookie_secret, unsigned int cookie_length)
+{
   long rv = (long)ssl;
   long inum = (cookie_length - (((long)cookie_secret) % sizeof(long))) / sizeof(long);
   long i = 0;
   long *ip = (long *)cookie_secret;
-  for (i = 0; i < inum; ++i, ++ip) {
+  for (i = 0; i < inum; ++i, ++ip)
+  {
     *ip = rv;
   }
 }
 
-static int generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len) {
+static int generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len)
+{
   unsigned char *buffer, result[EVP_MAX_MD_SIZE];
   unsigned int length = 0, resultlength;
   ioa_addr peer;
@@ -155,7 +168,8 @@ static int generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie
 
   /* Create buffer with peer's address and port */
   length = 0;
-  switch (peer.ss.sa_family) {
+  switch (peer.ss.sa_family)
+  {
   case AF_INET:
     length += sizeof(struct in_addr);
     break;
@@ -169,14 +183,16 @@ static int generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie
   length += sizeof(in_port_t);
   buffer = (unsigned char *)OPENSSL_malloc(length);
 
-  if (buffer == NULL) {
+  if (buffer == NULL)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "out of memory\n");
     return 0;
   }
 
   // TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"%s: family=%u(2)\n",__FUNCTION__,(unsigned)peer.ss.sa_family);
 
-  switch (peer.ss.sa_family) {
+  switch (peer.ss.sa_family)
+  {
   case AF_INET:
     memcpy(buffer, &peer.s4.sin_port, sizeof(in_port_t));
     memcpy(buffer + sizeof(peer.s4.sin_port), &peer.s4.sin_addr, sizeof(struct in_addr));
@@ -201,16 +217,20 @@ static int generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie
   return 1;
 }
 
-static int verify_cookie(SSL *ssl, const unsigned char *cookie, unsigned int cookie_len) {
+static int verify_cookie(SSL *ssl, const unsigned char *cookie, unsigned int cookie_len)
+{
   unsigned int resultlength = 0;
   unsigned char result[COOKIE_SECRET_LENGTH];
 
   generate_cookie(ssl, result, &resultlength);
 
-  if (cookie_len == resultlength && memcmp(result, cookie, resultlength) == 0) {
+  if (cookie_len == resultlength && memcmp(result, cookie, resultlength) == 0)
+  {
     // TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"%s: cookies are OK, length=%u\n",__FUNCTION__,cookie_len);
     return 1;
-  } else {
+  }
+  else
+  {
     // TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"%s: cookies are OK, length=%u\n",__FUNCTION__,cookie_len);
     return 0;
   }
@@ -220,16 +240,19 @@ static int verify_cookie(SSL *ssl, const unsigned char *cookie, unsigned int coo
 
 static ioa_socket_handle dtls_accept_client_connection(dtls_listener_relay_server_type *server, ioa_socket_handle sock,
                                                        SSL *ssl, ioa_addr *remote_addr, ioa_addr *local_addr,
-                                                       ioa_network_buffer_handle nbh) {
+                                                       ioa_network_buffer_handle nbh)
+{
   FUNCSTART;
 
-  if (!server || !ssl) {
+  if (!server || !ssl)
+  {
     return NULL;
   }
 
   int rc = ssl_read(sock->fd, ssl, nbh, server->verbose);
 
-  if (rc < 0) {
+  if (rc < 0)
+  {
     return NULL;
   }
 
@@ -237,12 +260,15 @@ static ioa_socket_handle dtls_accept_client_connection(dtls_listener_relay_serve
 
   ioa_socket_handle ioas =
       create_ioa_socket_from_ssl(server->e, sock, ssl, DTLS_SOCKET, CLIENT_SOCKET, remote_addr, local_addr);
-  if (ioas) {
+  if (ioas)
+  {
     addr_cpy(&(server->sm.m.sm.nd.src_addr), remote_addr);
     server->sm.m.sm.nd.recv_ttl = TTL_IGNORE;
     server->sm.m.sm.nd.recv_tos = TOS_IGNORE;
     server->sm.m.sm.s = ioas;
-  } else {
+  }
+  else
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot create ioa_socket from SSL\n");
   }
 
@@ -252,10 +278,12 @@ static ioa_socket_handle dtls_accept_client_connection(dtls_listener_relay_serve
 }
 
 static ioa_socket_handle dtls_server_input_handler(dtls_listener_relay_server_type *server, ioa_socket_handle s,
-                                                   ioa_network_buffer_handle nbh) {
+                                                   ioa_network_buffer_handle nbh)
+{
   FUNCSTART;
 
-  if (!server || !nbh) {
+  if (!server || !nbh)
+  {
     return NULL;
   }
 
@@ -288,8 +316,10 @@ static ioa_socket_handle dtls_server_input_handler(dtls_listener_relay_server_ty
   ioa_socket_handle rc =
       dtls_accept_client_connection(server, s, connecting_ssl, &(server->sm.m.sm.nd.src_addr), &(server->addr), nbh);
 
-  if (!rc) {
-    if (!(SSL_get_shutdown(connecting_ssl) & SSL_SENT_SHUTDOWN)) {
+  if (!rc)
+  {
+    if (!(SSL_get_shutdown(connecting_ssl) & SSL_SENT_SHUTDOWN))
+    {
       SSL_set_shutdown(connecting_ssl, SSL_RECEIVED_SHUTDOWN);
       SSL_shutdown(connecting_ssl);
     }
@@ -302,71 +332,93 @@ static ioa_socket_handle dtls_server_input_handler(dtls_listener_relay_server_ty
 #endif
 
 static int handle_udp_packet(dtls_listener_relay_server_type *server, struct message_to_relay *sm,
-                             ioa_engine_handle ioa_eng, turn_turnserver *ts) {
+                             ioa_engine_handle ioa_eng, turn_turnserver *ts)
+{
   int verbose = ioa_eng->verbose;
   ioa_socket_handle s = sm->m.sm.s;
 
   ur_addr_map_value_type mvt = 0;
-  if (!(server->children_ss)) {
+  if (!(server->children_ss))
+  {
     server->children_ss = (ur_addr_map *)allocate_super_memory_engine(server->e, sizeof(ur_addr_map));
     ur_addr_map_init(server->children_ss);
   }
   ur_addr_map *amap = server->children_ss;
 
   ioa_socket_handle chs = NULL;
-  if ((ur_addr_map_get(amap, &(sm->m.sm.nd.src_addr), &mvt) > 0) && mvt) {
+  if ((ur_addr_map_get(amap, &(sm->m.sm.nd.src_addr), &mvt) > 0) && mvt)
+  {
     chs = (ioa_socket_handle)mvt;
   }
 
-  if (chs && !ioa_socket_tobeclosed(chs) && (chs->sockets_container == amap) && (chs->magic == SOCKET_MAGIC)) {
+  if (chs && !ioa_socket_tobeclosed(chs) && (chs->sockets_container == amap) && (chs->magic == SOCKET_MAGIC))
+  {
     s = chs;
     sm->m.sm.s = s;
-    if (s->ssl) {
+    if (s->ssl)
+    {
       int sslret = ssl_read(s->fd, s->ssl, sm->m.sm.nd.nbh, verbose);
-      if (sslret < 0) {
+      if (sslret < 0)
+      {
         ioa_network_buffer_delete(ioa_eng, sm->m.sm.nd.nbh);
         sm->m.sm.nd.nbh = NULL;
         ts_ur_super_session *ss = (ts_ur_super_session *)s->session;
-        if (ss) {
+        if (ss)
+        {
           turn_turnserver *server = (turn_turnserver *)ss->server;
-          if (server) {
+          if (server)
+          {
             shutdown_client_connection(server, ss, 0, "SSL read error");
           }
-        } else {
+        }
+        else
+        {
           close_ioa_socket(s);
         }
         ur_addr_map_del(amap, &(sm->m.sm.nd.src_addr), NULL);
         sm->m.sm.s = NULL;
         s = NULL;
         chs = NULL;
-      } else if (ioa_network_buffer_get_size(sm->m.sm.nd.nbh) > 0) {
+      }
+      else if (ioa_network_buffer_get_size(sm->m.sm.nd.nbh) > 0)
+      {
         ;
-      } else {
+      }
+      else
+      {
         ioa_network_buffer_delete(ioa_eng, sm->m.sm.nd.nbh);
         sm->m.sm.nd.nbh = NULL;
       }
     }
 
-    if (s && ioa_socket_check_bandwidth(s, sm->m.sm.nd.nbh, 1)) {
+    if (s && ioa_socket_check_bandwidth(s, sm->m.sm.nd.nbh, 1))
+    {
       s->e = ioa_eng;
-      if (s && s->read_cb && sm->m.sm.nd.nbh) {
+      if (s && s->read_cb && sm->m.sm.nd.nbh)
+      {
         s->read_cb(s, IOA_EV_READ, &(sm->m.sm.nd), s->read_ctx, 1);
         ioa_network_buffer_delete(ioa_eng, sm->m.sm.nd.nbh);
         sm->m.sm.nd.nbh = NULL;
 
-        if (ioa_socket_tobeclosed(s)) {
+        if (ioa_socket_tobeclosed(s))
+        {
           ts_ur_super_session *ss = (ts_ur_super_session *)s->session;
-          if (ss) {
+          if (ss)
+          {
             turn_turnserver *server = (turn_turnserver *)ss->server;
-            if (server) {
+            if (server)
+            {
               shutdown_client_connection(server, ss, 0, "UDP packet processing error");
             }
           }
         }
       }
     }
-  } else {
-    if (chs && ioa_socket_tobeclosed(chs)) {
+  }
+  else
+  {
+    if (chs && ioa_socket_tobeclosed(chs))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: socket to be closed\n", __FUNCTION__);
       {
         uint8_t saddr[129];
@@ -387,11 +439,13 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
       }
     }
 
-    if (chs && (chs->magic != SOCKET_MAGIC)) {
+    if (chs && (chs->magic != SOCKET_MAGIC))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: wrong socket magic\n", __FUNCTION__);
     }
 
-    if (chs && (chs->sockets_container != amap)) {
+    if (chs && (chs->sockets_container != amap))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: wrong socket container\n", __FUNCTION__);
       {
         uint8_t saddr[129];
@@ -417,16 +471,19 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
 
 #if DTLS_SUPPORTED
     if (!turn_params.no_dtls && is_dtls_handshake_message(ioa_network_buffer_data(sm->m.sm.nd.nbh),
-                                                          (int)ioa_network_buffer_get_size(sm->m.sm.nd.nbh))) {
+                                                          (int)ioa_network_buffer_get_size(sm->m.sm.nd.nbh)))
+    {
       chs = dtls_server_input_handler(server, s, sm->m.sm.nd.nbh);
       ioa_network_buffer_delete(server->e, sm->m.sm.nd.nbh);
       sm->m.sm.nd.nbh = NULL;
     }
 #endif
 
-    if (!chs) {
+    if (!chs)
+    {
       // Disallow raw UDP if no_udp is enabled
-      if (turn_params.no_udp) {
+      if (turn_params.no_udp)
+      {
         return -1;
       }
       chs = create_ioa_socket_from_fd(ioa_eng, s->fd, s, UDP_SOCKET, CLIENT_SOCKET, &(sm->m.sm.nd.src_addr),
@@ -436,8 +493,10 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
     s = chs;
     sm->m.sm.s = s;
 
-    if (s) {
-      if (verbose && turn_params.log_binding) {
+    if (s)
+    {
+      if (verbose && turn_params.log_binding)
+      {
         uint8_t saddr[129];
         uint8_t rsaddr[129];
         addr_to_string(get_local_addr_from_ioa_socket(s), saddr);
@@ -447,7 +506,8 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
       }
       s->e = ioa_eng;
       add_socket_to_map(s, amap);
-      if (open_client_connection_session(ts, &(sm->m.sm)) < 0) {
+      if (open_client_connection_session(ts, &(sm->m.sm)) < 0)
+      {
         return -1;
       }
     }
@@ -456,21 +516,25 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
   return 0;
 }
 
-static int create_new_connected_udp_socket(dtls_listener_relay_server_type *server, ioa_socket_handle s) {
+static int create_new_connected_udp_socket(dtls_listener_relay_server_type *server, ioa_socket_handle s)
+{
 
   evutil_socket_t udp_fd = socket(s->local_addr.ss.sa_family, CLIENT_DGRAM_SOCKET_TYPE, CLIENT_DGRAM_SOCKET_PROTOCOL);
-  if (udp_fd < 0) {
+  if (udp_fd < 0)
+  {
     perror("socket");
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate new socket\n", __FUNCTION__);
     return -1;
   }
 
-  if (sock_bind_to_device(udp_fd, (unsigned char *)(s->e->relay_ifname)) < 0) {
+  if (sock_bind_to_device(udp_fd, (unsigned char *)(s->e->relay_ifname)) < 0)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot bind udp server socket to device %s\n", (char *)(s->e->relay_ifname));
   }
 
   ioa_socket_handle ret = (ioa_socket *)calloc(1, sizeof(ioa_socket));
-  if (!ret) {
+  if (!ret)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate new socket structure\n", __FUNCTION__);
     socket_closesocket(udp_fd);
     return -1;
@@ -486,7 +550,8 @@ static int create_new_connected_udp_socket(dtls_listener_relay_server_type *serv
   ret->local_addr_known = 1;
   addr_cpy(&(ret->local_addr), &(s->local_addr));
 
-  if (addr_bind(udp_fd, &(s->local_addr), 1, 1, UDP_SOCKET) < 0) {
+  if (addr_bind(udp_fd, &(s->local_addr), 1, 1, UDP_SOCKET) < 0)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot bind new detached udp server socket to local addr\n");
     IOA_CLOSE_SOCKET(ret);
     return -1;
@@ -495,7 +560,8 @@ static int create_new_connected_udp_socket(dtls_listener_relay_server_type *serv
 
   {
     int connect_err = 0;
-    if (addr_connect(udp_fd, &(server->sm.m.sm.nd.src_addr), &connect_err) < 0) {
+    if (addr_connect(udp_fd, &(server->sm.m.sm.nd.src_addr), &connect_err) < 0)
+    {
       char sl[129];
       char sr[129];
       addr_to_string(&(ret->local_addr), (uint8_t *)sl);
@@ -519,7 +585,8 @@ static int create_new_connected_udp_socket(dtls_listener_relay_server_type *serv
 
 #if DTLS_SUPPORTED
   if (!turn_params.no_dtls && is_dtls_handshake_message(ioa_network_buffer_data(server->sm.m.sm.nd.nbh),
-                                                        (int)ioa_network_buffer_get_size(server->sm.m.sm.nd.nbh))) {
+                                                        (int)ioa_network_buffer_get_size(server->sm.m.sm.nd.nbh)))
+  {
 
     SSL *connecting_ssl = NULL;
 
@@ -552,8 +619,10 @@ static int create_new_connected_udp_socket(dtls_listener_relay_server_type *serv
     SSL_set_max_cert_list(connecting_ssl, 655350);
     int rc = ssl_read(ret->fd, connecting_ssl, server->sm.m.sm.nd.nbh, server->verbose);
 
-    if (rc < 0) {
-      if (!(SSL_get_shutdown(connecting_ssl) & SSL_SENT_SHUTDOWN)) {
+    if (rc < 0)
+    {
+      if (!(SSL_get_shutdown(connecting_ssl) & SSL_SENT_SHUTDOWN))
+      {
         SSL_set_shutdown(connecting_ssl, SSL_RECEIVED_SHUTDOWN);
         SSL_shutdown(connecting_ssl);
       }
@@ -577,9 +646,11 @@ static int create_new_connected_udp_socket(dtls_listener_relay_server_type *serv
   return server->connect_cb(server->e, &(server->sm));
 }
 
-static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) {
+static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg)
+{
 
-  if (!arg) {
+  if (!arg)
+  {
     return;
   }
 
@@ -590,7 +661,8 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
 
   FUNCSTART;
 
-  if (!(what & EV_READ)) {
+  if (!(what & EV_READ))
+  {
     return;
   }
 
@@ -629,9 +701,11 @@ start_udp_cycle:
   ioctlsocket(fd, FIONBIO, &iMode);
 #endif
 
-  if (bsize < 0) {
+  if (bsize < 0)
+  {
 
-    if (to_block) {
+    if (to_block)
+    {
       ioa_network_buffer_delete(server->e, server->sm.m.sm.nd.nbh);
       server->sm.m.sm.nd.nbh = NULL;
       FUNCEND;
@@ -657,7 +731,8 @@ start_udp_cycle:
     udp_recvfrom(fd, &orig_addr, &(server->addr), buffer, (int)sizeof(buffer), &ttl, &tos, server->e->cmsg, eflags,
                  &errcode);
     // try again...
-    do {
+    do
+    {
       bsize = recvfrom(fd, ioa_network_buffer_data(elem), ioa_network_buffer_get_capacity_udp(), flags,
                        (struct sockaddr *)&(server->sm.m.sm.nd.src_addr), (socklen_t *)&slen);
     } while (bsize < 0 && socket_eintr());
@@ -672,7 +747,8 @@ start_udp_cycle:
 
 #endif
 
-    if (conn_reset) {
+    if (conn_reset)
+    {
       ioa_network_buffer_delete(server->e, server->sm.m.sm.nd.nbh);
       server->sm.m.sm.nd.nbh = NULL;
       reopen_server_socket(server, fd);
@@ -681,8 +757,10 @@ start_udp_cycle:
     }
   }
 
-  if (bsize < 0) {
-    if (!to_block && !conn_reset) {
+  if (bsize < 0)
+  {
+    if (!to_block && !conn_reset)
+    {
       int ern = socket_errno();
       perror(__FUNCTION__);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: recvfrom error %d\n", __FUNCTION__, ern);
@@ -693,25 +771,31 @@ start_udp_cycle:
     return;
   }
 
-  if (bsize > 0) {
+  if (bsize > 0)
+  {
 
     int rc = 0;
     ioa_network_buffer_set_size(elem, (size_t)bsize);
 
-    if (server->connect_cb) {
+    if (server->connect_cb)
+    {
 
       rc = create_new_connected_udp_socket(server, s);
-      if (rc < 0) {
+      if (rc < 0)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot handle UDP packet, size %d\n", (int)bsize);
       }
-
-    } else {
+    }
+    else
+    {
       server->sm.m.sm.s = s;
       rc = handle_udp_packet(server, &(server->sm), server->e, server->ts);
     }
 
-    if (rc < 0) {
-      if (eve(server->e->verbose)) {
+    if (rc < 0)
+    {
+      if (eve(server->e->verbose))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot handle UDP event\n");
       }
     }
@@ -720,7 +804,8 @@ start_udp_cycle:
   ioa_network_buffer_delete(server->e, server->sm.m.sm.nd.nbh);
   server->sm.m.sm.nd.nbh = NULL;
 
-  if ((bsize > 0) && (cycle++ < MAX_SINGLE_UDP_BATCH)) {
+  if ((bsize > 0) && (cycle++ < MAX_SINGLE_UDP_BATCH))
+  {
     goto start_udp_cycle;
   }
 
@@ -729,11 +814,13 @@ start_udp_cycle:
 
 ///////////////////// operations //////////////////////////
 
-static int create_server_socket(dtls_listener_relay_server_type *server, int report_creation) {
+static int create_server_socket(dtls_listener_relay_server_type *server, int report_creation)
+{
 
   FUNCSTART;
 
-  if (!server) {
+  if (!server)
+  {
     return -1;
   }
 
@@ -743,7 +830,8 @@ static int create_server_socket(dtls_listener_relay_server_type *server, int rep
     ioa_socket_raw udp_listen_fd = -1;
 
     udp_listen_fd = socket(server->addr.ss.sa_family, CLIENT_DGRAM_SOCKET_TYPE, CLIENT_DGRAM_SOCKET_PROTOCOL);
-    if (udp_listen_fd < 0) {
+    if (udp_listen_fd < 0)
+    {
       perror("socket");
       return -1;
     }
@@ -753,7 +841,8 @@ static int create_server_socket(dtls_listener_relay_server_type *server, int rep
 
     set_sock_buf_size(udp_listen_fd, UR_SERVER_SOCK_BUF_SIZE);
 
-    if (sock_bind_to_device(udp_listen_fd, (unsigned char *)server->ifname) < 0) {
+    if (sock_bind_to_device(udp_listen_fd, (unsigned char *)server->ifname) < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Cannot bind listener socket to device %s\n", server->ifname);
     }
 
@@ -763,14 +852,16 @@ static int create_server_socket(dtls_listener_relay_server_type *server, int rep
     {
       const int max_binding_time = 60;
       int addr_bind_cycle = 0;
-    retry_addr_bind:
+retry_addr_bind:
 
-      if (addr_bind(udp_listen_fd, &server->addr, 1, 1, UDP_SOCKET) < 0) {
+      if (addr_bind(udp_listen_fd, &server->addr, 1, 1, UDP_SOCKET) < 0)
+      {
         perror("Cannot bind local socket to addr");
         char saddr[129];
         addr_to_string(&server->addr, (uint8_t *)saddr);
         TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "Cannot bind DTLS/UDP listener socket to addr %s\n", saddr);
-        if (addr_bind_cycle++ < max_binding_time) {
+        if (addr_bind_cycle++ < max_binding_time)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Trying to bind DTLS/UDP listener socket to addr %s, again...\n", saddr);
           sleep(1);
           goto retry_addr_bind;
@@ -787,12 +878,18 @@ static int create_server_socket(dtls_listener_relay_server_type *server, int rep
     event_add(server->udp_listen_ev, NULL);
   }
 
-  if (report_creation) {
-    if (!turn_params.no_udp && !turn_params.no_dtls) {
+  if (report_creation)
+  {
+    if (!turn_params.no_udp && !turn_params.no_dtls)
+    {
       addr_debug_print(server->verbose, &server->addr, "DTLS/UDP listener opened on");
-    } else if (!turn_params.no_dtls) {
+    }
+    else if (!turn_params.no_dtls)
+    {
       addr_debug_print(server->verbose, &server->addr, "DTLS listener opened on");
-    } else if (!turn_params.no_udp) {
+    }
+    else if (!turn_params.no_udp)
+    {
       addr_debug_print(server->verbose, &server->addr, "UDP listener opened on");
     }
   }
@@ -802,10 +899,12 @@ static int create_server_socket(dtls_listener_relay_server_type *server, int rep
   return 0;
 }
 
-static int reopen_server_socket(dtls_listener_relay_server_type *server, evutil_socket_t fd) {
+static int reopen_server_socket(dtls_listener_relay_server_type *server, evutil_socket_t fd)
+{
   UNUSED_ARG(fd);
 
-  if (!server) {
+  if (!server)
+  {
     return 0;
   }
 
@@ -814,18 +913,21 @@ static int reopen_server_socket(dtls_listener_relay_server_type *server, evutil_
   {
     EVENT_DEL(server->udp_listen_ev);
 
-    if (server->udp_listen_s->fd >= 0) {
+    if (server->udp_listen_s->fd >= 0)
+    {
       socket_closesocket(server->udp_listen_s->fd);
       server->udp_listen_s->fd = -1;
     }
 
-    if (!(server->udp_listen_s)) {
+    if (!(server->udp_listen_s))
+    {
       return create_server_socket(server, 1);
     }
 
     ioa_socket_raw udp_listen_fd =
         socket(server->addr.ss.sa_family, CLIENT_DGRAM_SOCKET_TYPE, CLIENT_DGRAM_SOCKET_PROTOCOL);
-    if (udp_listen_fd < 0) {
+    if (udp_listen_fd < 0)
+    {
       perror("socket");
       FUNCEND;
       return -1;
@@ -839,11 +941,13 @@ static int reopen_server_socket(dtls_listener_relay_server_type *server, evutil_
 
     set_sock_buf_size(udp_listen_fd, UR_SERVER_SOCK_BUF_SIZE);
 
-    if (sock_bind_to_device(udp_listen_fd, (unsigned char *)server->ifname) < 0) {
+    if (sock_bind_to_device(udp_listen_fd, (unsigned char *)server->ifname) < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Cannot bind listener socket to device %s\n", server->ifname);
     }
 
-    if (addr_bind(udp_listen_fd, &server->addr, 1, 1, UDP_SOCKET) < 0) {
+    if (addr_bind(udp_listen_fd, &server->addr, 1, 1, UDP_SOCKET) < 0)
+    {
       perror("Cannot bind local socket to addr");
       char saddr[129];
       addr_to_string(&server->addr, (uint8_t *)saddr);
@@ -857,11 +961,16 @@ static int reopen_server_socket(dtls_listener_relay_server_type *server, evutil_
     event_add(server->udp_listen_ev, NULL);
   }
 
-  if (!turn_params.no_udp && !turn_params.no_dtls) {
+  if (!turn_params.no_udp && !turn_params.no_dtls)
+  {
     addr_debug_print(server->verbose, &server->addr, "DTLS/UDP listener opened on ");
-  } else if (!turn_params.no_dtls) {
+  }
+  else if (!turn_params.no_dtls)
+  {
     addr_debug_print(server->verbose, &server->addr, "DTLS listener opened on ");
-  } else if (!turn_params.no_udp) {
+  }
+  else if (!turn_params.no_udp)
+  {
     addr_debug_print(server->verbose, &server->addr, "UDP listener opened on ");
   }
 
@@ -872,12 +981,14 @@ static int reopen_server_socket(dtls_listener_relay_server_type *server, evutil_
 
 #if defined(REQUEST_CLIENT_CERT)
 
-static int dtls_verify_callback(int ok, X509_STORE_CTX *ctx) {
+static int dtls_verify_callback(int ok, X509_STORE_CTX *ctx)
+{
   /* This function should ask the user
    * if he trusts the received certificate.
    * Here we always trust.
    */
-  if (ok && ctx) {
+  if (ok && ctx)
+  {
     return 1;
   }
   return -1;
@@ -887,20 +998,24 @@ static int dtls_verify_callback(int ok, X509_STORE_CTX *ctx) {
 
 static int init_server(dtls_listener_relay_server_type *server, const char *ifname, const char *local_address, int port,
                        int verbose, ioa_engine_handle e, turn_turnserver *ts, int report_creation,
-                       ioa_engine_new_connection_event_handler send_socket) {
+                       ioa_engine_new_connection_event_handler send_socket)
+{
 
-  if (!server) {
+  if (!server)
+  {
     return -1;
   }
 
   server->ts = ts;
   server->connect_cb = send_socket;
 
-  if (ifname) {
+  if (ifname)
+  {
     STRCPY(server->ifname, ifname);
   }
 
-  if (make_ioa_addr((const uint8_t *)local_address, port, &server->addr) < 0) {
+  if (make_ioa_addr((const uint8_t *)local_address, port, &server->addr) < 0)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot create a DTLS/UDP listener for address: %s\n", local_address);
     return -1;
   }
@@ -914,8 +1029,10 @@ static int init_server(dtls_listener_relay_server_type *server, const char *ifna
   return create_server_socket(server, report_creation);
 }
 
-static int clean_server(dtls_listener_relay_server_type *server) {
-  if (server) {
+static int clean_server(dtls_listener_relay_server_type *server)
+{
+  if (server)
+  {
     EVENT_DEL(server->udp_listen_ev);
     close_ioa_socket(server->udp_listen_s);
     server->udp_listen_s = NULL;
@@ -926,8 +1043,10 @@ static int clean_server(dtls_listener_relay_server_type *server) {
 ///////////////////////////////////////////////////////////
 
 #if DTLS_SUPPORTED
-void setup_dtls_callbacks(SSL_CTX *ctx) {
-  if (!ctx) {
+void setup_dtls_callbacks(SSL_CTX *ctx)
+{
+  if (!ctx)
+  {
     return;
   }
 
@@ -944,20 +1063,26 @@ void setup_dtls_callbacks(SSL_CTX *ctx) {
 dtls_listener_relay_server_type *create_dtls_listener_server(const char *ifname, const char *local_address, int port,
                                                              int verbose, ioa_engine_handle e, turn_turnserver *ts,
                                                              int report_creation,
-                                                             ioa_engine_new_connection_event_handler send_socket) {
+                                                             ioa_engine_new_connection_event_handler send_socket)
+{
 
   dtls_listener_relay_server_type *server =
       (dtls_listener_relay_server_type *)allocate_super_memory_engine(e, sizeof(dtls_listener_relay_server_type));
 
-  if (init_server(server, ifname, local_address, port, verbose, e, ts, report_creation, send_socket) < 0) {
+  if (init_server(server, ifname, local_address, port, verbose, e, ts, report_creation, send_socket) < 0)
+  {
     return NULL;
-  } else {
+  }
+  else
+  {
     return server;
   }
 }
 
-ioa_engine_handle get_engine(dtls_listener_relay_server_type *server) {
-  if (server) {
+ioa_engine_handle get_engine(dtls_listener_relay_server_type *server)
+{
+  if (server)
+  {
     return server->e;
   }
   return NULL;
@@ -965,8 +1090,10 @@ ioa_engine_handle get_engine(dtls_listener_relay_server_type *server) {
 
 //////////// UDP send ////////////////
 
-void udp_send_message(dtls_listener_relay_server_type *server, ioa_network_buffer_handle nbh, ioa_addr *dest) {
-  if (server && dest && nbh && (server->udp_listen_s)) {
+void udp_send_message(dtls_listener_relay_server_type *server, ioa_network_buffer_handle nbh, ioa_addr *dest)
+{
+  if (server && dest && nbh && (server->udp_listen_s))
+  {
     udp_send(server->udp_listen_s, dest, (char *)ioa_network_buffer_data(nbh), (int)ioa_network_buffer_get_size(nbh));
   }
 }

--- a/src/apps/relay/dtls_listener.h
+++ b/src/apps/relay/dtls_listener.h
@@ -40,7 +40,8 @@
 #include <event2/event.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ///////////////////////////////////////////

--- a/src/apps/relay/hiredis_libevent2.c
+++ b/src/apps/relay/hiredis_libevent2.c
@@ -41,7 +41,8 @@
 
 //////////////// Libevent context ///////////////////////
 
-struct redisLibeventEvents {
+struct redisLibeventEvents
+{
   redisAsyncContext *context;
   int invalid;
   int allocated;
@@ -57,7 +58,8 @@ struct redisLibeventEvents {
 
 ///////////// Messages ////////////////////////////
 
-struct redis_message {
+struct redis_message
+{
   char format[513];
   char arg[513];
 };
@@ -72,87 +74,111 @@ static int redis_le_valid(struct redisLibeventEvents *e) { return (e && !(e->inv
 
 /////////////////// Callbacks ////////////////////////////
 
-static void redisLibeventReadEvent(evutil_socket_t fd, short event, void *arg) {
+static void redisLibeventReadEvent(evutil_socket_t fd, short event, void *arg)
+{
   ((void)fd);
   ((void)event);
   struct redisLibeventEvents *e = (struct redisLibeventEvents *)arg;
-  if (redis_le_valid(e)) {
+  if (redis_le_valid(e))
+  {
     {
       char buf[8];
       int len = 0;
-      do {
+      do
+      {
         len = recv(fd, buf, sizeof(buf), MSG_PEEK);
       } while ((len < 0) && socket_eintr());
-      if (len < 1) {
+      if (len < 1)
+      {
         e->invalid = 1;
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Redis connection broken: e=0x%p\n", __FUNCTION__, e);
       }
     }
-    if (redis_le_valid(e)) {
+    if (redis_le_valid(e))
+    {
       redisAsyncHandleRead(e->context);
     }
-  } else {
+  }
+  else
+  {
     redis_reconnect(e);
   }
 }
 
-static void redisLibeventWriteEvent(evutil_socket_t fd, short event, void *arg) {
+static void redisLibeventWriteEvent(evutil_socket_t fd, short event, void *arg)
+{
   ((void)fd);
   ((void)event);
   struct redisLibeventEvents *e = (struct redisLibeventEvents *)arg;
-  if (redis_le_valid(e)) {
+  if (redis_le_valid(e))
+  {
     redisAsyncHandleWrite(e->context);
   }
 }
 
-static void redisLibeventAddRead(void *privdata) {
+static void redisLibeventAddRead(void *privdata)
+{
   struct redisLibeventEvents *e = (struct redisLibeventEvents *)privdata;
-  if (e && (e->rev) && !(e->rev_set)) {
+  if (e && (e->rev) && !(e->rev_set))
+  {
     event_add(e->rev, NULL);
     e->rev_set = 1;
   }
 }
 
-static void redisLibeventDelRead(void *privdata) {
+static void redisLibeventDelRead(void *privdata)
+{
   struct redisLibeventEvents *e = (struct redisLibeventEvents *)privdata;
-  if (e && e->rev && e->rev_set) {
+  if (e && e->rev && e->rev_set)
+  {
     event_del(e->rev);
     e->rev_set = 0;
   }
 }
 
-static void redisLibeventAddWrite(void *privdata) {
+static void redisLibeventAddWrite(void *privdata)
+{
   struct redisLibeventEvents *e = (struct redisLibeventEvents *)privdata;
-  if (e && (e->wev) && !(e->wev_set)) {
+  if (e && (e->wev) && !(e->wev_set))
+  {
     event_add(e->wev, NULL);
     e->wev_set = 1;
   }
 }
 
-static void redisLibeventDelWrite(void *privdata) {
+static void redisLibeventDelWrite(void *privdata)
+{
   struct redisLibeventEvents *e = (struct redisLibeventEvents *)privdata;
-  if (e && e->wev && e->wev_set) {
+  if (e && e->wev && e->wev_set)
+  {
     event_del(e->wev);
     e->wev_set = 0;
   }
 }
 
-static void redisLibeventCleanup(void *privdata) {
+static void redisLibeventCleanup(void *privdata)
+{
 
-  if (privdata) {
+  if (privdata)
+  {
 
     struct redisLibeventEvents *e = (struct redisLibeventEvents *)privdata;
-    if (e->allocated) {
-      if (e->rev) {
-        if (e->rev_set) {
+    if (e->allocated)
+    {
+      if (e->rev)
+      {
+        if (e->rev_set)
+        {
           event_del(e->rev);
         }
         event_free(e->rev);
         e->rev = NULL;
       }
       e->rev_set = 0;
-      if (e->wev) {
-        if (e->wev_set) {
+      if (e->wev)
+      {
+        if (e->wev_set)
+        {
           event_del(e->wev);
         }
         event_free(e->wev);
@@ -166,30 +192,41 @@ static void redisLibeventCleanup(void *privdata) {
 
 ///////////////////////// Send-receive ///////////////////////////
 
-int is_redis_asyncconn_good(redis_context_handle rch) {
-  if (rch) {
+int is_redis_asyncconn_good(redis_context_handle rch)
+{
+  if (rch)
+  {
     struct redisLibeventEvents *e = (struct redisLibeventEvents *)rch;
-    if (redis_le_valid(e)) {
+    if (redis_le_valid(e))
+    {
       return 1;
     }
   }
   return 0;
 }
 
-void send_message_to_redis(redis_context_handle rch, const char *command, const char *key, const char *format, ...) {
-  if (!rch) {
+void send_message_to_redis(redis_context_handle rch, const char *command, const char *key, const char *format, ...)
+{
+  if (!rch)
+  {
     return;
-  } else {
+  }
+  else
+  {
 
     struct redisLibeventEvents *e = (struct redisLibeventEvents *)rch;
 
-    if (!redis_le_valid(e)) {
+    if (!redis_le_valid(e))
+    {
       redis_reconnect(e);
     }
 
-    if (!redis_le_valid(e)) {
+    if (!redis_le_valid(e))
+    {
       ;
-    } else {
+    }
+    else
+    {
 
       redisAsyncContext *ac = e->context;
 
@@ -203,7 +240,8 @@ void send_message_to_redis(redis_context_handle rch, const char *command, const 
       vsnprintf(rm.arg, sizeof(rm.arg) - 1, format, args);
       va_end(args);
 
-      if ((redisAsyncCommand(ac, NULL, e, rm.format, rm.arg) != REDIS_OK)) {
+      if ((redisAsyncCommand(ac, NULL, e, rm.format, rm.arg) != REDIS_OK))
+      {
         e->invalid = 1;
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Redis connection broken: ac=0x%p, e=0x%p\n", __FUNCTION__, ac, e);
       }
@@ -213,32 +251,41 @@ void send_message_to_redis(redis_context_handle rch, const char *command, const 
 
 ///////////////////////// Attach /////////////////////////////////
 
-redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int port0, char *user, char *pwd, int db) {
+redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int port0, char *user, char *pwd, int db)
+{
 
   char ip[256];
-  if (ip0 && ip0[0]) {
+  if (ip0 && ip0[0])
+  {
     STRCPY(ip, ip0);
-  } else {
+  }
+  else
+  {
     strncpy(ip, "127.0.0.1", sizeof(ip));
   }
 
   int port = DEFAULT_REDIS_PORT;
-  if (port0 > 0) {
+  if (port0 > 0)
+  {
     port = port0;
   }
 
   redisAsyncContext *ac = redisAsyncConnect(ip, port);
-  if (!ac) {
+  if (!ac)
+  {
     fprintf(stderr, "Error: redisAsyncConnect returned NULL\n");
     return NULL;
-  } else if (ac->err) {
+  }
+  else if (ac->err)
+  {
     fprintf(stderr, "Error: %s:%s\n", ac->errstr, ac->c.errstr);
     return NULL;
   }
 
   /* Create container for context and r/w events */
   struct redisLibeventEvents *e = (struct redisLibeventEvents *)calloc(1, sizeof(struct redisLibeventEvents));
-  if (!e) {
+  if (!e)
+  {
     return NULL;
   }
 
@@ -247,10 +294,12 @@ redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int
   e->base = base;
   e->ip = strdup(ip);
   e->port = port;
-  if (user) {
+  if (user)
+  {
     e->user = strdup(user);
   }
-  if (pwd) {
+  if (pwd)
+  {
     e->pwd = strdup(pwd);
   }
   e->db = db;
@@ -269,7 +318,8 @@ redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int
 
   e->wev = event_new(e->base, e->context->c.fd, EV_WRITE, redisLibeventWriteEvent, e);
 
-  if (e->rev == NULL || e->wev == NULL) {
+  if (e->rev == NULL || e->wev == NULL)
+  {
     free(e);
     return NULL;
   }
@@ -278,20 +328,28 @@ redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int
   e->wev_set = 1;
 
   // Authentication
-  if (redis_le_valid(e) && pwd && strlen(pwd)) {
-    if (user && strlen(user)) {
-      if (redisAsyncCommand(ac, NULL, e, "AUTH %s %s", e->user, e->pwd) != REDIS_OK) {
+  if (redis_le_valid(e) && pwd && strlen(pwd))
+  {
+    if (user && strlen(user))
+    {
+      if (redisAsyncCommand(ac, NULL, e, "AUTH %s %s", e->user, e->pwd) != REDIS_OK)
+      {
         e->invalid = 1;
       }
-    } else {
-      if (redisAsyncCommand(ac, NULL, e, "AUTH %s", e->pwd) != REDIS_OK) {
+    }
+    else
+    {
+      if (redisAsyncCommand(ac, NULL, e, "AUTH %s", e->pwd) != REDIS_OK)
+      {
         e->invalid = 1;
       }
     }
   }
 
-  if (redis_le_valid(e)) {
-    if (redisAsyncCommand(ac, NULL, e, "SELECT %d", db) != REDIS_OK) {
+  if (redis_le_valid(e))
+  {
+    if (redisAsyncCommand(ac, NULL, e, "SELECT %d", db) != REDIS_OK)
+    {
       e->invalid = 1;
     }
   }
@@ -299,13 +357,17 @@ redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int
   return (redis_context_handle)e;
 }
 
-static void redis_reconnect(struct redisLibeventEvents *e) {
-  if (!e || !(e->allocated)) {
+static void redis_reconnect(struct redisLibeventEvents *e)
+{
+  if (!e || !(e->allocated))
+  {
     return;
   }
 
-  if (e->rev) {
-    if (e->rev_set) {
+  if (e->rev)
+  {
+    if (e->rev_set)
+    {
       event_del(e->rev);
     }
     event_free(e->rev);
@@ -313,8 +375,10 @@ static void redis_reconnect(struct redisLibeventEvents *e) {
   }
   e->rev_set = 0;
 
-  if (e->wev) {
-    if (e->wev_set) {
+  if (e->wev)
+  {
+    if (e->wev_set)
+    {
       event_del(e->wev);
     }
     event_free(e->wev);
@@ -324,13 +388,15 @@ static void redis_reconnect(struct redisLibeventEvents *e) {
 
   redisAsyncContext *ac = NULL;
 
-  if (e->context) {
+  if (e->context)
+  {
     redisAsyncFree(e->context);
     e->context = NULL;
   }
 
   ac = redisAsyncConnect(e->ip, e->port);
-  if (!ac) {
+  if (!ac)
+  {
     return;
   }
 
@@ -350,7 +416,8 @@ static void redis_reconnect(struct redisLibeventEvents *e) {
 
   e->wev = event_new(e->base, e->context->c.fd, EV_WRITE, redisLibeventWriteEvent, e);
 
-  if (e->rev == NULL || e->wev == NULL) {
+  if (e->rev == NULL || e->wev == NULL)
+  {
     return;
   }
 
@@ -359,25 +426,34 @@ static void redis_reconnect(struct redisLibeventEvents *e) {
   e->invalid = 0;
 
   // Authentication
-  if (redis_le_valid(e) && e->pwd && strlen(e->pwd)) {
-    if (e->user && strlen(e->user)) {
-      if (redisAsyncCommand(ac, NULL, e, "AUTH %s %s", e->user, e->pwd) != REDIS_OK) {
+  if (redis_le_valid(e) && e->pwd && strlen(e->pwd))
+  {
+    if (e->user && strlen(e->user))
+    {
+      if (redisAsyncCommand(ac, NULL, e, "AUTH %s %s", e->user, e->pwd) != REDIS_OK)
+      {
         e->invalid = 1;
       }
-    } else {
-      if (redisAsyncCommand(ac, NULL, e, "AUTH %s", e->pwd) != REDIS_OK) {
+    }
+    else
+    {
+      if (redisAsyncCommand(ac, NULL, e, "AUTH %s", e->pwd) != REDIS_OK)
+      {
         e->invalid = 1;
       }
     }
   }
 
-  if (redis_le_valid(e)) {
-    if (redisAsyncCommand(ac, NULL, e, "SELECT %d", e->db) != REDIS_OK) {
+  if (redis_le_valid(e))
+  {
+    if (redisAsyncCommand(ac, NULL, e, "SELECT %d", e->db) != REDIS_OK)
+    {
       e->invalid = 1;
     }
   }
 
-  if (redis_le_valid(e)) {
+  if (redis_le_valid(e))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: Re-connected to redis, async\n", __FUNCTION__);
   }
 }

--- a/src/apps/relay/hiredis_libevent2.h
+++ b/src/apps/relay/hiredis_libevent2.h
@@ -35,7 +35,8 @@
 #include <event2/event.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////////////////////////////////

--- a/src/apps/relay/http_server.h
+++ b/src/apps/relay/http_server.h
@@ -39,18 +39,28 @@
 #include <stdlib.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 /////////  HTTP REQUEST //////////
 
-enum _HTTP_REQUEST_TYPE { HRT_UNKNOWN = 0, HRT_GET, HRT_HEAD, HRT_POST, HRT_PUT, HRT_DELETE };
+enum _HTTP_REQUEST_TYPE
+{
+  HRT_UNKNOWN = 0,
+  HRT_GET,
+  HRT_HEAD,
+  HRT_POST,
+  HRT_PUT,
+  HRT_DELETE
+};
 
 typedef enum _HTTP_REQUEST_TYPE HTTP_REQUEST_TYPE;
 
 struct http_headers;
 
-struct http_request {
+struct http_request
+{
   HTTP_REQUEST_TYPE rtype;
   char *path;
   struct http_headers *headers;

--- a/src/apps/relay/libtelnet.c
+++ b/src/apps/relay/libtelnet.c
@@ -60,7 +60,8 @@
   (telnet)->eh((telnet), &ev, (telnet)->ud);
 
 /* telnet state codes */
-enum telnet_state_t {
+enum telnet_state_t
+{
   TELNET_STATE_DATA = 0,
   TELNET_STATE_EOL,
   TELNET_STATE_IAC,
@@ -75,7 +76,8 @@ enum telnet_state_t {
 typedef enum telnet_state_t telnet_state_t;
 
 /* telnet state tracker */
-struct telnet_t {
+struct telnet_t
+{
   /* user data */
   void *ud;
   /* telopt support table */
@@ -107,7 +109,8 @@ struct telnet_t {
 };
 
 /* RFC1143 option negotiation state */
-typedef struct telnet_rfc1143_t {
+typedef struct telnet_rfc1143_t
+{
   unsigned char telopt;
   unsigned char state;
 } telnet_rfc1143_t;
@@ -135,7 +138,8 @@ static const size_t _buffer_sizes_count = sizeof(_buffer_sizes) / sizeof(_buffer
 
 /* error generation function */
 static telnet_error_t telnet_error(telnet_t *telnet, unsigned line, const char *func, telnet_error_t err, int fatal,
-                                   const char *fmt, ...) {
+                                   const char *fmt, ...)
+{
   telnet_event_t ev;
   char buffer[512];
   va_list va;
@@ -162,30 +166,38 @@ static telnet_error_t telnet_error(telnet_t *telnet, unsigned line, const char *
  * (decompression).  returns TELNET_EOK on success, something else on
  * failure.
  */
-telnet_error_t _init_zlib(telnet_t *telnet, int deflate, int err_fatal) {
+telnet_error_t _init_zlib(telnet_t *telnet, int deflate, int err_fatal)
+{
   z_stream *z;
   int rs;
 
   /* if compression is already enabled, fail loudly */
-  if (telnet->z != 0) {
+  if (telnet->z != 0)
+  {
     return telnet_error(telnet, __LINE__, __func__, TELNET_EBADVAL, err_fatal, "cannot initialize compression twice");
   }
 
   /* allocate zstream box */
-  if ((z = (z_stream *)calloc(1, sizeof(z_stream))) == 0) {
+  if ((z = (z_stream *)calloc(1, sizeof(z_stream))) == 0)
+  {
     return telnet_error(telnet, __LINE__, __func__, TELNET_ENOMEM, err_fatal, "malloc() failed: %s", strerror(errno));
   }
 
   /* initialize */
-  if (deflate) {
-    if ((rs = deflateInit(z, Z_DEFAULT_COMPRESSION)) != Z_OK) {
+  if (deflate)
+  {
+    if ((rs = deflateInit(z, Z_DEFAULT_COMPRESSION)) != Z_OK)
+    {
       free(z);
       return telnet_error(telnet, __LINE__, __func__, TELNET_ECOMPRESS, err_fatal, "deflateInit() failed: %s",
                           zError(rs));
     }
     telnet->flags |= TELNET_PFLAG_DEFLATE;
-  } else {
-    if ((rs = inflateInit(z)) != Z_OK) {
+  }
+  else
+  {
+    if ((rs = inflateInit(z)) != Z_OK)
+    {
       free(z);
       return telnet_error(telnet, __LINE__, __func__, TELNET_ECOMPRESS, err_fatal, "inflateInit() failed: %s",
                           zError(rs));
@@ -200,12 +212,14 @@ telnet_error_t _init_zlib(telnet_t *telnet, int deflate, int err_fatal) {
 #endif /* defined(HAVE_ZLIB) */
 
 /* push bytes out, compressing them first if need be */
-static void _send(telnet_t *telnet, const char *buffer, size_t size) {
+static void _send(telnet_t *telnet, const char *buffer, size_t size)
+{
   telnet_event_t ev;
 
 #if defined(HAVE_ZLIB)
   /* if we have a deflate (compression) zlib box, use it */
-  if (telnet->z != 0 && telnet->flags & TELNET_PFLAG_DEFLATE) {
+  if (telnet->z != 0 && telnet->flags & TELNET_PFLAG_DEFLATE)
+  {
     char deflate_buffer[1024];
     int rs;
 
@@ -216,9 +230,11 @@ static void _send(telnet_t *telnet, const char *buffer, size_t size) {
     telnet->z->avail_out = sizeof(deflate_buffer);
 
     /* deflate until buffer exhausted and all output is produced */
-    while (telnet->z->avail_in > 0 || telnet->z->avail_out == 0) {
+    while (telnet->z->avail_in > 0 || telnet->z->avail_out == 0)
+    {
       /* compress */
-      if ((rs = deflate(telnet->z, Z_SYNC_FLUSH)) != Z_OK) {
+      if ((rs = deflate(telnet->z, Z_SYNC_FLUSH)) != Z_OK)
+      {
         telnet_error(telnet, __LINE__, __func__, TELNET_ECOMPRESS, 1, "deflate() failed: %s", zError(rs));
         deflateEnd(telnet->z);
         free(telnet->z);
@@ -255,22 +271,31 @@ static void _send(telnet_t *telnet, const char *buffer, size_t size) {
  * check if we (local) supports it, otherwise we check if he (remote)
  * supports it.  return non-zero if supported, zero if not supported.
  */
-static INLINE int _check_telopt(telnet_t *telnet, unsigned char telopt, int us) {
+static INLINE int _check_telopt(telnet_t *telnet, unsigned char telopt, int us)
+{
   int i;
 
   /* if we have no telopts table, we obviously don't support it */
-  if (telnet->telopts == 0) {
+  if (telnet->telopts == 0)
+  {
     return 0;
   }
 
   /* loop until found or end marker (us and him both 0) */
-  for (i = 0; telnet->telopts[i].telopt != -1; ++i) {
-    if (telnet->telopts[i].telopt == telopt) {
-      if (us && telnet->telopts[i].us == TELNET_WILL) {
+  for (i = 0; telnet->telopts[i].telopt != -1; ++i)
+  {
+    if (telnet->telopts[i].telopt == telopt)
+    {
+      if (us && telnet->telopts[i].us == TELNET_WILL)
+      {
         return 1;
-      } else if (!us && telnet->telopts[i].him == TELNET_DO) {
+      }
+      else if (!us && telnet->telopts[i].him == TELNET_DO)
+      {
         return 1;
-      } else {
+      }
+      else
+      {
         return 0;
       }
     }
@@ -281,13 +306,16 @@ static INLINE int _check_telopt(telnet_t *telnet, unsigned char telopt, int us) 
 }
 
 /* retrieve RFC1143 option state */
-static INLINE telnet_rfc1143_t _get_rfc1143(telnet_t *telnet, unsigned char telopt) {
+static INLINE telnet_rfc1143_t _get_rfc1143(telnet_t *telnet, unsigned char telopt)
+{
   telnet_rfc1143_t empty;
   unsigned int i;
 
   /* search for entry */
-  for (i = 0; i != telnet->q_cnt; ++i) {
-    if (telnet->q[i].telopt == telopt) {
+  for (i = 0; i != telnet->q_cnt; ++i)
+  {
+    if (telnet->q[i].telopt == telopt)
+    {
       return telnet->q[i];
     }
   }
@@ -299,22 +327,28 @@ static INLINE telnet_rfc1143_t _get_rfc1143(telnet_t *telnet, unsigned char telo
 }
 
 /* save RFC1143 option state */
-static INLINE void _set_rfc1143(telnet_t *telnet, unsigned char telopt, char us, char him) {
+static INLINE void _set_rfc1143(telnet_t *telnet, unsigned char telopt, char us, char him)
+{
   telnet_rfc1143_t *qtmp;
   unsigned int i;
 
   /* search for entry */
-  for (i = 0; i != telnet->q_cnt; ++i) {
-    if (telnet->q[i].telopt == telopt) {
+  for (i = 0; i != telnet->q_cnt; ++i)
+  {
+    if (telnet->q[i].telopt == telopt)
+    {
       telnet->q[i].state = Q_MAKE(us, him);
-      if (telopt != TELNET_TELOPT_BINARY) {
+      if (telopt != TELNET_TELOPT_BINARY)
+      {
         return;
       }
       telnet->flags &= ~(TELNET_FLAG_TRANSMIT_BINARY | TELNET_FLAG_RECEIVE_BINARY);
-      if (us == Q_YES) {
+      if (us == Q_YES)
+      {
         telnet->flags |= TELNET_FLAG_TRANSMIT_BINARY;
       }
-      if (him == Q_YES) {
+      if (him == Q_YES)
+      {
         telnet->flags |= TELNET_FLAG_RECEIVE_BINARY;
       }
       return;
@@ -329,10 +363,12 @@ static INLINE void _set_rfc1143(telnet_t *telnet, unsigned char telopt, char us,
    */
 
   /* Did we reach the end of the table? */
-  if (telnet->q_cnt >= telnet->q_size) {
+  if (telnet->q_cnt >= telnet->q_size)
+  {
     /* Expand the size */
     if ((qtmp = (telnet_rfc1143_t *)realloc(telnet->q, sizeof(telnet_rfc1143_t) *
-                                                           (telnet->q_size + Q_BUFFER_GROWTH_QUANTUM))) == 0) {
+                                                           (telnet->q_size + Q_BUFFER_GROWTH_QUANTUM))) == 0)
+    {
       telnet_error(telnet, __LINE__, __func__, TELNET_ENOMEM, 0, "realloc() failed: %s", strerror(errno));
       return;
     }
@@ -347,7 +383,8 @@ static INLINE void _set_rfc1143(telnet_t *telnet, unsigned char telopt, char us,
 }
 
 /* send negotiation bytes */
-static INLINE void _send_negotiate(telnet_t *telnet, unsigned char cmd, unsigned char telopt) {
+static INLINE void _send_negotiate(telnet_t *telnet, unsigned char cmd, unsigned char telopt)
+{
   unsigned char bytes[3];
   bytes[0] = TELNET_IAC;
   bytes[1] = cmd;
@@ -356,13 +393,16 @@ static INLINE void _send_negotiate(telnet_t *telnet, unsigned char cmd, unsigned
 }
 
 /* negotiation handling magic for RFC1143 */
-static void _negotiate(telnet_t *telnet, unsigned char telopt) {
+static void _negotiate(telnet_t *telnet, unsigned char telopt)
+{
   telnet_event_t ev;
   telnet_rfc1143_t q;
 
   /* in PROXY mode, just pass it thru and do nothing */
-  if (telnet->flags & TELNET_FLAG_PROXY) {
-    switch ((int)telnet->state) {
+  if (telnet->flags & TELNET_FLAG_PROXY)
+  {
+    switch ((int)telnet->state)
+    {
     case TELNET_STATE_WILL:
       NEGOTIATE_EVENT(telnet, TELNET_EV_WILL, telopt);
       break;
@@ -383,16 +423,21 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
   q = _get_rfc1143(telnet, telopt);
 
   /* start processing... */
-  switch ((int)telnet->state) {
+  switch ((int)telnet->state)
+  {
   /* request to enable option on remote end or confirm DO */
   case TELNET_STATE_WILL:
-    switch (Q_HIM(q)) {
+    switch (Q_HIM(q))
+    {
     case Q_NO:
-      if (_check_telopt(telnet, telopt, 0)) {
+      if (_check_telopt(telnet, telopt, 0))
+      {
         _set_rfc1143(telnet, telopt, Q_US(q), Q_YES);
         _send_negotiate(telnet, TELNET_DO, telopt);
         NEGOTIATE_EVENT(telnet, TELNET_EV_WILL, telopt);
-      } else {
+      }
+      else
+      {
         _send_negotiate(telnet, TELNET_DONT, telopt);
       }
       break;
@@ -419,7 +464,8 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 
   /* request to disable option on remote end, confirm DONT, reject DO */
   case TELNET_STATE_WONT:
-    switch (Q_HIM(q)) {
+    switch (Q_HIM(q))
+    {
     case Q_YES:
       _set_rfc1143(telnet, telopt, Q_US(q), Q_NO);
       _send_negotiate(telnet, TELNET_DONT, telopt);
@@ -443,13 +489,17 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 
   /* request to enable option on local end or confirm WILL */
   case TELNET_STATE_DO:
-    switch (Q_US(q)) {
+    switch (Q_US(q))
+    {
     case Q_NO:
-      if (_check_telopt(telnet, telopt, 1)) {
+      if (_check_telopt(telnet, telopt, 1))
+      {
         _set_rfc1143(telnet, telopt, Q_YES, Q_HIM(q));
         _send_negotiate(telnet, TELNET_WILL, telopt);
         NEGOTIATE_EVENT(telnet, TELNET_EV_DO, telopt);
-      } else {
+      }
+      else
+      {
         _send_negotiate(telnet, TELNET_WONT, telopt);
       }
       break;
@@ -476,7 +526,8 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
 
   /* request to disable option on local end, confirm WONT, reject WILL */
   case TELNET_STATE_DONT:
-    switch (Q_US(q)) {
+    switch (Q_US(q))
+    {
     case Q_YES:
       _set_rfc1143(telnet, telopt, Q_NO, Q_HIM(q));
       _send_negotiate(telnet, TELNET_WONT, telopt);
@@ -512,20 +563,23 @@ static void _negotiate(telnet_t *telnet, unsigned char telopt) {
  * value strings are NUL-terminated, all while fitting inside
  * of the original buffer.
  */
-static int _environ_telnet(telnet_t *telnet, unsigned char type, char *buffer, size_t size) {
+static int _environ_telnet(telnet_t *telnet, unsigned char type, char *buffer, size_t size)
+{
   telnet_event_t ev;
   struct telnet_environ_t *values = 0;
   char *c, *last, *out;
   size_t index, count;
 
   /* if we have no data, just pass it through */
-  if (size == 0) {
+  if (size == 0)
+  {
     return 0;
   }
 
   /* first byte must be a valid command */
   if ((unsigned)buffer[0] != TELNET_ENVIRON_SEND && (unsigned)buffer[0] != TELNET_ENVIRON_IS &&
-      (unsigned)buffer[0] != TELNET_ENVIRON_INFO) {
+      (unsigned)buffer[0] != TELNET_ENVIRON_INFO)
+  {
     telnet_error(telnet, __LINE__, __func__, TELNET_EPROTOCOL, 0, "telopt %d subneg has invalid command", type);
     return 0;
   }
@@ -534,7 +588,8 @@ static int _environ_telnet(telnet_t *telnet, unsigned char type, char *buffer, s
   ev.environ.cmd = buffer[0];
 
   /* if we have no arguments, send an event with no data end return */
-  if (size == 1) {
+  if (size == 1)
+  {
     /* no list of variables given */
     ev.environ.values = 0;
     ev.environ.size = 0;
@@ -547,30 +602,37 @@ static int _environ_telnet(telnet_t *telnet, unsigned char type, char *buffer, s
   }
 
   /* very second byte must be VAR or USERVAR, if present */
-  if ((unsigned)buffer[1] != TELNET_ENVIRON_VAR && (unsigned)buffer[1] != TELNET_ENVIRON_USERVAR) {
+  if ((unsigned)buffer[1] != TELNET_ENVIRON_VAR && (unsigned)buffer[1] != TELNET_ENVIRON_USERVAR)
+  {
     telnet_error(telnet, __LINE__, __func__, TELNET_EPROTOCOL, 0, "telopt %d subneg missing variable type", type);
     return 0;
   }
 
   /* ensure last byte is not an escape byte (makes parsing later easier) */
-  if ((unsigned)buffer[size - 1] == TELNET_ENVIRON_ESC) {
+  if ((unsigned)buffer[size - 1] == TELNET_ENVIRON_ESC)
+  {
     telnet_error(telnet, __LINE__, __func__, TELNET_EPROTOCOL, 0, "telopt %d subneg ends with ESC", type);
     return 0;
   }
 
   /* count arguments; each valid entry starts with VAR or USERVAR */
   count = 0;
-  for (c = buffer + 1; c < buffer + size; ++c) {
-    if (*c == TELNET_ENVIRON_VAR || *c == TELNET_ENVIRON_USERVAR) {
+  for (c = buffer + 1; c < buffer + size; ++c)
+  {
+    if (*c == TELNET_ENVIRON_VAR || *c == TELNET_ENVIRON_USERVAR)
+    {
       ++count;
-    } else if (*c == TELNET_ENVIRON_ESC) {
+    }
+    else if (*c == TELNET_ENVIRON_ESC)
+    {
       /* skip the next byte */
       ++c;
     }
   }
 
   /* allocate argument array, bail on error */
-  if ((values = (struct telnet_environ_t *)calloc(count, sizeof(struct telnet_environ_t))) == 0) {
+  if ((values = (struct telnet_environ_t *)calloc(count, sizeof(struct telnet_environ_t))) == 0)
+  {
     telnet_error(telnet, __LINE__, __func__, TELNET_ENOMEM, 0, "calloc() failed: %s", strerror(errno));
     return 0;
   }
@@ -578,22 +640,26 @@ static int _environ_telnet(telnet_t *telnet, unsigned char type, char *buffer, s
   /* parse argument array strings */
   out = buffer;
   c = buffer + 1;
-  for (index = 0; index != count; ++index) {
+  for (index = 0; index != count; ++index)
+  {
     /* remember the variable type (will be VAR or USERVAR) */
     values[index].type = *c++;
 
     /* scan until we find an end-marker, and buffer up unescaped
      * bytes into our buffer */
     last = out;
-    while (c < buffer + size) {
+    while (c < buffer + size)
+    {
       /* stop at the next variable or at the value */
       if ((unsigned)*c == TELNET_ENVIRON_VAR || (unsigned)*c == TELNET_ENVIRON_VALUE ||
-          (unsigned)*c == TELNET_ENVIRON_USERVAR) {
+          (unsigned)*c == TELNET_ENVIRON_USERVAR)
+      {
         break;
       }
 
       /* buffer next byte (taking into account ESC) */
-      if (*c == TELNET_ENVIRON_ESC) {
+      if (*c == TELNET_ENVIRON_ESC)
+      {
         ++c;
       }
 
@@ -607,17 +673,21 @@ static int _environ_telnet(telnet_t *telnet, unsigned char type, char *buffer, s
 
     /* if we got a value, find the next end marker and
      * store the value; otherwise, store empty string */
-    if (c < buffer + size && *c == TELNET_ENVIRON_VALUE) {
+    if (c < buffer + size && *c == TELNET_ENVIRON_VALUE)
+    {
       ++c;
       last = out;
-      while (c < buffer + size) {
+      while (c < buffer + size)
+      {
         /* stop when we find the start of the next variable */
-        if ((unsigned)*c == TELNET_ENVIRON_VAR || (unsigned)*c == TELNET_ENVIRON_USERVAR) {
+        if ((unsigned)*c == TELNET_ENVIRON_VAR || (unsigned)*c == TELNET_ENVIRON_USERVAR)
+        {
           break;
         }
 
         /* buffer next byte (taking into account ESC) */
-        if (*c == TELNET_ENVIRON_ESC) {
+        if (*c == TELNET_ENVIRON_ESC)
+        {
           ++c;
         }
 
@@ -644,7 +714,8 @@ static int _environ_telnet(telnet_t *telnet, unsigned char type, char *buffer, s
 }
 
 /* process an MSSP subnegotiation buffer */
-static int _mssp_telnet(telnet_t *telnet, char *buffer, size_t size) {
+static int _mssp_telnet(telnet_t *telnet, char *buffer, size_t size)
+{
   telnet_event_t ev;
   struct telnet_environ_t *values;
   char *var = 0;
@@ -653,25 +724,30 @@ static int _mssp_telnet(telnet_t *telnet, char *buffer, size_t size) {
   unsigned char next_type;
 
   /* if we have no data, just pass it through */
-  if (size == 0) {
+  if (size == 0)
+  {
     return 0;
   }
 
   /* first byte must be a VAR */
-  if ((unsigned)buffer[0] != TELNET_MSSP_VAR) {
+  if ((unsigned)buffer[0] != TELNET_MSSP_VAR)
+  {
     telnet_error(telnet, __LINE__, __func__, TELNET_EPROTOCOL, 0, "MSSP subnegotiation has invalid data");
     return 0;
   }
 
   /* count the arguments, any part that starts with VALUE */
-  for (count = 0, i = 0; i != size; ++i) {
-    if ((unsigned)buffer[i] == TELNET_MSSP_VAL) {
+  for (count = 0, i = 0; i != size; ++i)
+  {
+    if ((unsigned)buffer[i] == TELNET_MSSP_VAL)
+    {
       ++count;
     }
   }
 
   /* allocate argument array, bail on error */
-  if ((values = (struct telnet_environ_t *)calloc(count, sizeof(struct telnet_environ_t))) == 0) {
+  if ((values = (struct telnet_environ_t *)calloc(count, sizeof(struct telnet_environ_t))) == 0)
+  {
     telnet_error(telnet, __LINE__, __func__, TELNET_ENOMEM, 0, "calloc() failed: %s", strerror(errno));
     return 0;
   }
@@ -682,21 +758,28 @@ static int _mssp_telnet(telnet_t *telnet, char *buffer, size_t size) {
   /* allocate strings in argument array */
   out = last = buffer;
   next_type = buffer[0];
-  for (i = 0, c = buffer + 1; c < buffer + size;) {
+  for (i = 0, c = buffer + 1; c < buffer + size;)
+  {
     /* search for end marker */
-    while (c < buffer + size && (unsigned)*c != TELNET_MSSP_VAR && (unsigned)*c != TELNET_MSSP_VAL) {
+    while (c < buffer + size && (unsigned)*c != TELNET_MSSP_VAR && (unsigned)*c != TELNET_MSSP_VAL)
+    {
       *out++ = *c++;
     }
     *out++ = '\0';
 
     /* if it's a variable name, just store the name for now */
-    if (next_type == TELNET_MSSP_VAR) {
+    if (next_type == TELNET_MSSP_VAR)
+    {
       var = last;
-    } else if (next_type == TELNET_MSSP_VAL && var != 0) {
+    }
+    else if (next_type == TELNET_MSSP_VAL && var != 0)
+    {
       values[i].var = var;
       values[i].value = last;
       ++i;
-    } else {
+    }
+    else
+    {
       telnet_error(telnet, __LINE__, __func__, TELNET_EPROTOCOL, 0, "invalid MSSP subnegotiation data");
       free(values);
       return 0;
@@ -718,31 +801,36 @@ static int _mssp_telnet(telnet_t *telnet, char *buffer, size_t size) {
 }
 
 /* parse ZMP command subnegotiation buffers */
-static int _zmp_telnet(telnet_t *telnet, const char *buffer, size_t size) {
+static int _zmp_telnet(telnet_t *telnet, const char *buffer, size_t size)
+{
   telnet_event_t ev;
   const char **argv;
   const char *c;
   size_t i, argc;
 
   /* make sure this is a valid ZMP buffer */
-  if (size == 0 || buffer[size - 1] != 0) {
+  if (size == 0 || buffer[size - 1] != 0)
+  {
     telnet_error(telnet, __LINE__, __func__, TELNET_EPROTOCOL, 0, "incomplete ZMP frame");
     return 0;
   }
 
   /* count arguments */
-  for (argc = 0, c = buffer; c != buffer + size; ++argc) {
+  for (argc = 0, c = buffer; c != buffer + size; ++argc)
+  {
     c += strlen(c) + 1;
   }
 
   /* allocate argument array, bail on error */
-  if ((argv = (const char **)calloc(argc, sizeof(char *))) == 0) {
+  if ((argv = (const char **)calloc(argc, sizeof(char *))) == 0)
+  {
     telnet_error(telnet, __LINE__, __func__, TELNET_ENOMEM, 0, "calloc() failed: %s", strerror(errno));
     return 0;
   }
 
   /* populate argument array */
-  for (i = 0, c = buffer; i != argc; ++i) {
+  for (i = 0, c = buffer; i != argc; ++i)
+  {
     argv[i] = (const char *)c;
     c += strlen(c) + 1;
   }
@@ -759,27 +847,32 @@ static int _zmp_telnet(telnet_t *telnet, const char *buffer, size_t size) {
 }
 
 /* parse TERMINAL-TYPE command subnegotiation buffers */
-static int _ttype_telnet(telnet_t *telnet, const char *buffer, size_t size) {
+static int _ttype_telnet(telnet_t *telnet, const char *buffer, size_t size)
+{
   telnet_event_t ev;
 
   /* make sure request is not empty */
-  if (size == 0) {
+  if (size == 0)
+  {
     telnet_error(telnet, __LINE__, __func__, TELNET_EPROTOCOL, 0, "incomplete TERMINAL-TYPE request");
     return 0;
   }
 
   /* make sure request has valid command type */
-  if (buffer[0] != TELNET_TTYPE_IS && buffer[0] != TELNET_TTYPE_SEND) {
+  if (buffer[0] != TELNET_TTYPE_IS && buffer[0] != TELNET_TTYPE_SEND)
+  {
     telnet_error(telnet, __LINE__, __func__, TELNET_EPROTOCOL, 0, "TERMINAL-TYPE request has invalid type");
     return 0;
   }
 
   /* send proper event */
-  if (buffer[0] == TELNET_TTYPE_IS) {
+  if (buffer[0] == TELNET_TTYPE_IS)
+  {
     char *name;
 
     /* allocate space for name */
-    if ((name = (char *)malloc(size)) == 0) {
+    if ((name = (char *)malloc(size)) == 0)
+    {
       telnet_error(telnet, __LINE__, __func__, TELNET_ENOMEM, 0, "malloc() failed: %s", strerror(errno));
       return 0;
     }
@@ -793,7 +886,9 @@ static int _ttype_telnet(telnet_t *telnet, const char *buffer, size_t size) {
 
     /* clean up */
     free(name);
-  } else {
+  }
+  else
+  {
     ev.type = TELNET_EV_TTYPE;
     ev.ttype.cmd = TELNET_TTYPE_SEND;
     ev.ttype.name = 0;
@@ -806,7 +901,8 @@ static int _ttype_telnet(telnet_t *telnet, const char *buffer, size_t size) {
 /* process a subnegotiation buffer; return non-zero if the current buffer
  * must be aborted and reprocessed due to COMPRESS2 being activated
  */
-static int _subnegotiate(telnet_t *telnet) {
+static int _subnegotiate(telnet_t *telnet)
+{
   telnet_event_t ev;
 
   /* standard subnegotiation event */
@@ -816,13 +912,15 @@ static int _subnegotiate(telnet_t *telnet) {
   ev.sub.size = telnet->buffer_pos;
   telnet->eh(telnet, &ev, telnet->ud);
 
-  switch (telnet->sb_telopt) {
+  switch (telnet->sb_telopt)
+  {
 #if defined(HAVE_ZLIB)
   /* received COMPRESS2 begin marker, setup our zlib box and
    * start handling the compressed stream if it's not already.
    */
   case TELNET_TELOPT_COMPRESS2:
-    if (_init_zlib(telnet, 0, 1) != TELNET_EOK) {
+    if (_init_zlib(telnet, 0, 1) != TELNET_EOK)
+    {
       return 0;
     }
 
@@ -849,10 +947,12 @@ static int _subnegotiate(telnet_t *telnet) {
 }
 
 /* initialize a telnet state tracker */
-telnet_t *telnet_init(const telnet_telopt_t *telopts, telnet_event_handler_t eh, unsigned char flags, void *user_data) {
+telnet_t *telnet_init(const telnet_telopt_t *telopts, telnet_event_handler_t eh, unsigned char flags, void *user_data)
+{
   /* allocate structure */
   struct telnet_t *telnet = (telnet_t *)calloc(1, sizeof(telnet_t));
-  if (telnet == 0) {
+  if (telnet == 0)
+  {
     return 0;
   }
 
@@ -866,9 +966,11 @@ telnet_t *telnet_init(const telnet_telopt_t *telopts, telnet_event_handler_t eh,
 }
 
 /* free up any memory allocated by a state tracker */
-void telnet_free(telnet_t *telnet) {
+void telnet_free(telnet_t *telnet)
+{
   /* free sub-request buffer */
-  if (telnet->buffer != 0) {
+  if (telnet->buffer != 0)
+  {
     free(telnet->buffer);
     telnet->buffer = 0;
     telnet->buffer_size = 0;
@@ -877,10 +979,14 @@ void telnet_free(telnet_t *telnet) {
 
 #if defined(HAVE_ZLIB)
   /* free zlib box */
-  if (telnet->z != 0) {
-    if (telnet->flags & TELNET_PFLAG_DEFLATE) {
+  if (telnet->z != 0)
+  {
+    if (telnet->flags & TELNET_PFLAG_DEFLATE)
+    {
       deflateEnd(telnet->z);
-    } else {
+    }
+    else
+    {
       inflateEnd(telnet->z);
     }
     free(telnet->z);
@@ -889,7 +995,8 @@ void telnet_free(telnet_t *telnet) {
 #endif /* defined(HAVE_ZLIB) */
 
   /* free RFC1143 queue */
-  if (telnet->q) {
+  if (telnet->q)
+  {
     free(telnet->q);
     telnet->q = NULL;
     telnet->q_size = 0;
@@ -901,28 +1008,34 @@ void telnet_free(telnet_t *telnet) {
 }
 
 /* push a byte into the telnet buffer */
-static telnet_error_t _buffer_byte(telnet_t *telnet, unsigned char byte) {
+static telnet_error_t _buffer_byte(telnet_t *telnet, unsigned char byte)
+{
   char *new_buffer;
   size_t i;
 
   /* check if we're out of room */
-  if (telnet->buffer_pos == telnet->buffer_size) {
+  if (telnet->buffer_pos == telnet->buffer_size)
+  {
     /* find the next buffer size */
-    for (i = 0; i != _buffer_sizes_count; ++i) {
-      if (_buffer_sizes[i] == telnet->buffer_size) {
+    for (i = 0; i != _buffer_sizes_count; ++i)
+    {
+      if (_buffer_sizes[i] == telnet->buffer_size)
+      {
         break;
       }
     }
 
     /* overflow -- can't grow any more */
-    if (i >= _buffer_sizes_count - 1) {
+    if (i >= _buffer_sizes_count - 1)
+    {
       telnet_error(telnet, __LINE__, __func__, TELNET_EOVERFLOW, 0, "subnegotiation buffer size limit reached");
       return TELNET_EOVERFLOW;
     }
 
     /* (re)allocate buffer */
     new_buffer = (char *)realloc(telnet->buffer, _buffer_sizes[i + 1]);
-    if (new_buffer == 0) {
+    if (new_buffer == 0)
+    {
       telnet_error(telnet, __LINE__, __func__, TELNET_ENOMEM, 0, "realloc() failed");
       return TELNET_ENOMEM;
     }
@@ -936,28 +1049,35 @@ static telnet_error_t _buffer_byte(telnet_t *telnet, unsigned char byte) {
   return TELNET_EOK;
 }
 
-static void _process(telnet_t *telnet, const char *buffer, size_t size) {
+static void _process(telnet_t *telnet, const char *buffer, size_t size)
+{
   telnet_event_t ev;
   unsigned char byte;
   size_t i, start;
-  for (i = start = 0; i != size; ++i) {
+  for (i = start = 0; i != size; ++i)
+  {
     byte = buffer[i];
-    switch (telnet->state) {
+    switch (telnet->state)
+    {
     /* regular data */
     case TELNET_STATE_DATA:
       /* on an IAC byte, pass through all pending bytes and
        * switch states */
-      if (byte == TELNET_IAC) {
-        if (i != start) {
+      if (byte == TELNET_IAC)
+      {
+        if (i != start)
+        {
           ev.type = TELNET_EV_DATA;
           ev.data.buffer = buffer + start;
           ev.data.size = i - start;
           telnet->eh(telnet, &ev, telnet->ud);
         }
         telnet->state = TELNET_STATE_IAC;
-      } else if (byte == '\r' && (telnet->flags & TELNET_FLAG_NVT_EOL) &&
-                 !(telnet->flags & TELNET_FLAG_RECEIVE_BINARY)) {
-        if (i != start) {
+      }
+      else if (byte == '\r' && (telnet->flags & TELNET_FLAG_NVT_EOL) && !(telnet->flags & TELNET_FLAG_RECEIVE_BINARY))
+      {
+        if (i != start)
+        {
           ev.type = TELNET_EV_DATA;
           ev.data.buffer = buffer + start;
           ev.data.size = i - start;
@@ -969,7 +1089,8 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
 
     /* NVT EOL to be translated */
     case TELNET_STATE_EOL:
-      if (byte != '\n') {
+      if (byte != '\n')
+      {
         byte = '\r';
         ev.type = TELNET_EV_DATA;
         ev.data.buffer = (char *)&byte;
@@ -980,7 +1101,8 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
       /* any byte following '\r' other than '\n' or '\0' is invalid,
        * so pass both \r and the byte */
       start = i;
-      if (byte == '\0') {
+      if (byte == '\0')
+      {
         ++start;
       }
       /* state update */
@@ -989,7 +1111,8 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
 
     /* IAC command */
     case TELNET_STATE_IAC:
-      switch (byte) {
+      switch (byte)
+      {
       /* subnegotiation */
       case TELNET_SB:
         telnet->state = TELNET_STATE_SB;
@@ -1052,9 +1175,12 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
     /* subnegotiation -- buffer bytes until end request */
     case TELNET_STATE_SB_DATA:
       /* IAC command in subnegotiation -- either IAC SE or IAC IAC */
-      if (byte == TELNET_IAC) {
+      if (byte == TELNET_IAC)
+      {
         telnet->state = TELNET_STATE_SB_DATA_IAC;
-      } else if (telnet->sb_telopt == TELNET_TELOPT_COMPRESS && byte == TELNET_WILL) {
+      }
+      else if (telnet->sb_telopt == TELNET_TELOPT_COMPRESS && byte == TELNET_WILL)
+      {
         /* In 1998 MCCP used TELOPT 85 and the protocol defined an invalid
          * subnegotiation sequence (IAC SB 85 WILL SE) to start compression.
          * Subsequently MCCP version 2 was created in 2000 using TELOPT 86
@@ -1064,7 +1190,9 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
         start = i + 2;
         telnet->state = TELNET_STATE_DATA;
         /* buffer the byte, or bail if we can't */
-      } else if (_buffer_byte(telnet, byte) != TELNET_EOK) {
+      }
+      else if (_buffer_byte(telnet, byte) != TELNET_EOK)
+      {
         start = i + 1;
         telnet->state = TELNET_STATE_DATA;
       }
@@ -1072,7 +1200,8 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
 
     /* IAC escaping inside a subnegotiation */
     case TELNET_STATE_SB_DATA_IAC:
-      switch (byte) {
+      switch (byte)
+      {
       /* end subnegotiation */
       case TELNET_SE:
         /* return to default state */
@@ -1080,7 +1209,8 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
         telnet->state = TELNET_STATE_DATA;
 
         /* process subnegotiation */
-        if (_subnegotiate(telnet) != 0) {
+        if (_subnegotiate(telnet) != 0)
+        {
           /* any remaining bytes in the buffer are compressed.
            * we have to re-invoke telnet_recv to get those
            * bytes inflated and abort trying to process the
@@ -1094,10 +1224,13 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
       /* escaped IAC byte */
       case TELNET_IAC:
         /* push IAC into buffer */
-        if (_buffer_byte(telnet, TELNET_IAC) != TELNET_EOK) {
+        if (_buffer_byte(telnet, TELNET_IAC) != TELNET_EOK)
+        {
           start = i + 1;
           telnet->state = TELNET_STATE_DATA;
-        } else {
+        }
+        else
+        {
           telnet->state = TELNET_STATE_SB_DATA;
         }
         break;
@@ -1115,10 +1248,13 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
         /* process subnegotiation; see comment in
          * TELNET_STATE_SB_DATA_IAC about invoking telnet_recv()
          */
-        if (_subnegotiate(telnet) != 0) {
+        if (_subnegotiate(telnet) != 0)
+        {
           telnet_recv(telnet, &buffer[start], size - start);
           return;
-        } else {
+        }
+        else
+        {
           /* recursive call to get the current input byte processed
            * as a regular IAC command.  we could use a goto, but
            * that would be gross.
@@ -1132,7 +1268,8 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
   }
 
   /* pass through any remaining bytes */
-  if (telnet->state == TELNET_STATE_DATA && i != start) {
+  if (telnet->state == TELNET_STATE_DATA && i != start)
+  {
     ev.type = TELNET_EV_DATA;
     ev.data.buffer = buffer + start;
     ev.data.size = i - start;
@@ -1141,10 +1278,12 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
 }
 
 /* push a bytes into the state tracker */
-void telnet_recv(telnet_t *telnet, const char *buffer, size_t size) {
+void telnet_recv(telnet_t *telnet, const char *buffer, size_t size)
+{
 #if defined(HAVE_ZLIB)
   /* if we have an inflate (decompression) zlib stream, use it */
-  if (telnet->z != 0 && !(telnet->flags & TELNET_PFLAG_DEFLATE)) {
+  if (telnet->z != 0 && !(telnet->flags & TELNET_PFLAG_DEFLATE))
+  {
     char inflate_buffer[1024];
     int rs;
 
@@ -1155,16 +1294,20 @@ void telnet_recv(telnet_t *telnet, const char *buffer, size_t size) {
     telnet->z->avail_out = sizeof(inflate_buffer);
 
     /* inflate until buffer exhausted and all output is produced */
-    while (telnet->z->avail_in > 0 || telnet->z->avail_out == 0) {
+    while (telnet->z->avail_in > 0 || telnet->z->avail_out == 0)
+    {
       /* reset output buffer */
 
       /* decompress */
       rs = inflate(telnet->z, Z_SYNC_FLUSH);
 
       /* process the decompressed bytes on success */
-      if (rs == Z_OK || rs == Z_STREAM_END) {
+      if (rs == Z_OK || rs == Z_STREAM_END)
+      {
         _process(telnet, inflate_buffer, sizeof(inflate_buffer) - telnet->z->avail_out);
-      } else {
+      }
+      else
+      {
         telnet_error(telnet, __LINE__, __func__, TELNET_ECOMPRESS, 1, "inflate() failed: %s", zError(rs));
       }
 
@@ -1173,7 +1316,8 @@ void telnet_recv(telnet_t *telnet, const char *buffer, size_t size) {
       telnet->z->avail_out = sizeof(inflate_buffer);
 
       /* on error (or on end of stream) disable further inflation */
-      if (rs != Z_OK) {
+      if (rs != Z_OK)
+      {
         telnet_event_t ev;
 
         /* disable compression */
@@ -1191,13 +1335,15 @@ void telnet_recv(telnet_t *telnet, const char *buffer, size_t size) {
     }
 
     /* COMPRESS2 is not negotiated, just process */
-  } else
+  }
+  else
 #endif /* defined(HAVE_ZLIB) */
     _process(telnet, buffer, size);
 }
 
 /* send an iac command */
-void telnet_iac(telnet_t *telnet, unsigned char cmd) {
+void telnet_iac(telnet_t *telnet, unsigned char cmd)
+{
   unsigned char bytes[2];
   bytes[0] = TELNET_IAC;
   bytes[1] = cmd;
@@ -1205,11 +1351,13 @@ void telnet_iac(telnet_t *telnet, unsigned char cmd) {
 }
 
 /* send negotiation */
-void telnet_negotiate(telnet_t *telnet, unsigned char cmd, unsigned char telopt) {
+void telnet_negotiate(telnet_t *telnet, unsigned char cmd, unsigned char telopt)
+{
   telnet_rfc1143_t q;
 
   /* if we're in proxy mode, just send it now */
-  if (telnet->flags & TELNET_FLAG_PROXY) {
+  if (telnet->flags & TELNET_FLAG_PROXY)
+  {
     unsigned char bytes[3];
     bytes[0] = TELNET_IAC;
     bytes[1] = cmd;
@@ -1221,10 +1369,12 @@ void telnet_negotiate(telnet_t *telnet, unsigned char cmd, unsigned char telopt)
   /* get current option states */
   q = _get_rfc1143(telnet, telopt);
 
-  switch (cmd) {
+  switch (cmd)
+  {
   /* advertise willingess to support an option */
   case TELNET_WILL:
-    switch (Q_US(q)) {
+    switch (Q_US(q))
+    {
     case Q_NO:
       _set_rfc1143(telnet, telopt, Q_WANTYES, Q_HIM(q));
       _send_negotiate(telnet, TELNET_WILL, telopt);
@@ -1240,7 +1390,8 @@ void telnet_negotiate(telnet_t *telnet, unsigned char cmd, unsigned char telopt)
 
   /* force turn-off of locally enabled option */
   case TELNET_WONT:
-    switch (Q_US(q)) {
+    switch (Q_US(q))
+    {
     case Q_YES:
       _set_rfc1143(telnet, telopt, Q_WANTNO, Q_HIM(q));
       _send_negotiate(telnet, TELNET_WONT, telopt);
@@ -1256,7 +1407,8 @@ void telnet_negotiate(telnet_t *telnet, unsigned char cmd, unsigned char telopt)
 
   /* ask remote end to enable an option */
   case TELNET_DO:
-    switch (Q_HIM(q)) {
+    switch (Q_HIM(q))
+    {
     case Q_NO:
       _set_rfc1143(telnet, telopt, Q_US(q), Q_WANTYES);
       _send_negotiate(telnet, TELNET_DO, telopt);
@@ -1272,7 +1424,8 @@ void telnet_negotiate(telnet_t *telnet, unsigned char cmd, unsigned char telopt)
 
   /* demand remote end disable an option */
   case TELNET_DONT:
-    switch (Q_HIM(q)) {
+    switch (Q_HIM(q))
+    {
     case Q_YES:
       _set_rfc1143(telnet, telopt, Q_US(q), Q_WANTNO);
       _send_negotiate(telnet, TELNET_DONT, telopt);
@@ -1289,14 +1442,18 @@ void telnet_negotiate(telnet_t *telnet, unsigned char cmd, unsigned char telopt)
 }
 
 /* send non-command data (escapes IAC bytes) */
-void telnet_send(telnet_t *telnet, const char *buffer, size_t size) {
+void telnet_send(telnet_t *telnet, const char *buffer, size_t size)
+{
   size_t i, l;
 
-  for (l = i = 0; i != size; ++i) {
+  for (l = i = 0; i != size; ++i)
+  {
     /* dump prior portion of text, send escaped bytes */
-    if (buffer[i] == (char)TELNET_IAC) {
+    if (buffer[i] == (char)TELNET_IAC)
+    {
       /* dump prior text if any */
-      if (i != l) {
+      if (i != l)
+      {
         _send(telnet, buffer + l, i - l);
       }
       l = i + 1;
@@ -1307,20 +1464,25 @@ void telnet_send(telnet_t *telnet, const char *buffer, size_t size) {
   }
 
   /* send whatever portion of buffer is left */
-  if (i != l) {
+  if (i != l)
+  {
     _send(telnet, buffer + l, i - l);
   }
 }
 
 /* send non-command text (escapes IAC bytes and does NVT translation) */
-void telnet_send_text(telnet_t *telnet, const char *buffer, size_t size) {
+void telnet_send_text(telnet_t *telnet, const char *buffer, size_t size)
+{
   size_t i, l;
 
-  for (l = i = 0; i != size; ++i) {
+  for (l = i = 0; i != size; ++i)
+  {
     /* dump prior portion of text, send escaped bytes */
-    if (buffer[i] == (char)TELNET_IAC) {
+    if (buffer[i] == (char)TELNET_IAC)
+    {
       /* dump prior text if any */
-      if (i != l) {
+      if (i != l)
+      {
         _send(telnet, buffer + l, i - l);
       }
       l = i + 1;
@@ -1329,32 +1491,38 @@ void telnet_send_text(telnet_t *telnet, const char *buffer, size_t size) {
       telnet_iac(telnet, TELNET_IAC);
     }
     /* special characters if not in BINARY mode */
-    else if (!(telnet->flags & TELNET_FLAG_TRANSMIT_BINARY) && (buffer[i] == '\r' || buffer[i] == '\n')) {
+    else if (!(telnet->flags & TELNET_FLAG_TRANSMIT_BINARY) && (buffer[i] == '\r' || buffer[i] == '\n'))
+    {
       /* dump prior portion of text */
-      if (i != l) {
+      if (i != l)
+      {
         _send(telnet, buffer + l, i - l);
       }
       l = i + 1;
 
       /* automatic translation of \r -> CRNUL */
-      if (buffer[i] == '\r') {
+      if (buffer[i] == '\r')
+      {
         _send(telnet, CRNUL, 2);
       }
       /* automatic translation of \n -> CRLF */
-      else {
+      else
+      {
         _send(telnet, CRLF, 2);
       }
     }
   }
 
   /* send whatever portion of buffer is left */
-  if (i != l) {
+  if (i != l)
+  {
     _send(telnet, buffer + l, i - l);
   }
 }
 
 /* send subnegotiation header */
-void telnet_begin_sb(telnet_t *telnet, unsigned char telopt) {
+void telnet_begin_sb(telnet_t *telnet, unsigned char telopt)
+{
   unsigned char sb[3];
   sb[0] = TELNET_IAC;
   sb[1] = TELNET_SB;
@@ -1363,7 +1531,8 @@ void telnet_begin_sb(telnet_t *telnet, unsigned char telopt) {
 }
 
 /* send complete subnegotiation */
-void telnet_subnegotiation(telnet_t *telnet, unsigned char telopt, const char *buffer, size_t size) {
+void telnet_subnegotiation(telnet_t *telnet, unsigned char telopt, const char *buffer, size_t size)
+{
   unsigned char bytes[5];
   bytes[0] = TELNET_IAC;
   bytes[1] = TELNET_SB;
@@ -1379,10 +1548,12 @@ void telnet_subnegotiation(telnet_t *telnet, unsigned char telopt, const char *b
   /* if we're a proxy and we just sent the COMPRESS2 marker, we must
    * make sure all further data is compressed if not already.
    */
-  if (telnet->flags & TELNET_FLAG_PROXY && telopt == TELNET_TELOPT_COMPRESS2) {
+  if (telnet->flags & TELNET_FLAG_PROXY && telopt == TELNET_TELOPT_COMPRESS2)
+  {
     telnet_event_t ev;
 
-    if (_init_zlib(telnet, 1, 1) != TELNET_EOK) {
+    if (_init_zlib(telnet, 1, 1) != TELNET_EOK)
+    {
       return;
     }
 
@@ -1394,14 +1565,16 @@ void telnet_subnegotiation(telnet_t *telnet, unsigned char telopt, const char *b
 #endif /* defined(HAVE_ZLIB) */
 }
 
-void telnet_begin_compress2(telnet_t *telnet) {
+void telnet_begin_compress2(telnet_t *telnet)
+{
 #if defined(HAVE_ZLIB)
   static const unsigned char compress2[] = {TELNET_IAC, TELNET_SB, TELNET_TELOPT_COMPRESS2, TELNET_IAC, TELNET_SE};
 
   telnet_event_t ev;
 
   /* attempt to create output stream first, bail if we can't */
-  if (_init_zlib(telnet, 1, 0) != TELNET_EOK) {
+  if (_init_zlib(telnet, 1, 0) != TELNET_EOK)
+  {
     return;
   }
 
@@ -1424,7 +1597,8 @@ void telnet_begin_compress2(telnet_t *telnet) {
 }
 
 /* send formatted data with \r and \n translation in addition to IAC IAC */
-int telnet_vprintf(telnet_t *telnet, const char *fmt, va_list va) {
+int telnet_vprintf(telnet_t *telnet, const char *fmt, va_list va)
+{
   va_list va_temp;
   char buffer[1024];
   char *output = buffer;
@@ -1435,9 +1609,11 @@ int telnet_vprintf(telnet_t *telnet, const char *fmt, va_list va) {
   rs = vsnprintf(buffer, sizeof(buffer), fmt, va_temp);
   va_end(va_temp);
 
-  if (rs >= sizeof(buffer)) {
+  if (rs >= sizeof(buffer))
+  {
     output = (char *)malloc(rs + 1);
-    if (output == 0) {
+    if (output == 0)
+    {
       telnet_error(telnet, __LINE__, __func__, TELNET_ENOMEM, 0, "malloc() failed: %s", strerror(errno));
       return -1;
     }
@@ -1448,37 +1624,45 @@ int telnet_vprintf(telnet_t *telnet, const char *fmt, va_list va) {
   }
 
   /* send */
-  for (l = i = 0; i != rs; ++i) {
+  for (l = i = 0; i != rs; ++i)
+  {
     /* special characters */
-    if (output[i] == (char)TELNET_IAC || output[i] == '\r' || output[i] == '\n') {
+    if (output[i] == (char)TELNET_IAC || output[i] == '\r' || output[i] == '\n')
+    {
       /* dump prior portion of text */
-      if (i != l) {
+      if (i != l)
+      {
         _send(telnet, output + l, i - l);
       }
       l = i + 1;
 
       /* IAC -> IAC IAC */
-      if (output[i] == (char)TELNET_IAC) {
+      if (output[i] == (char)TELNET_IAC)
+      {
         telnet_iac(telnet, TELNET_IAC);
       }
       /* automatic translation of \r -> CRNUL */
-      else if (output[i] == '\r') {
+      else if (output[i] == '\r')
+      {
         _send(telnet, CRNUL, 2);
       }
       /* automatic translation of \n -> CRLF */
-      else if (output[i] == '\n') {
+      else if (output[i] == '\n')
+      {
         _send(telnet, CRLF, 2);
       }
     }
   }
 
   /* send whatever portion of output is left */
-  if (i != l) {
+  if (i != l)
+  {
     _send(telnet, output + l, i - l);
   }
 
   /* free allocated memory, if any */
-  if (output != buffer) {
+  if (output != buffer)
+  {
     free(output);
   }
 
@@ -1486,7 +1670,8 @@ int telnet_vprintf(telnet_t *telnet, const char *fmt, va_list va) {
 }
 
 /* see telnet_vprintf */
-int telnet_printf(telnet_t *telnet, const char *fmt, ...) {
+int telnet_printf(telnet_t *telnet, const char *fmt, ...)
+{
   va_list va;
   int rs;
 
@@ -1498,7 +1683,8 @@ int telnet_printf(telnet_t *telnet, const char *fmt, ...) {
 }
 
 /* send formatted data through telnet_send */
-int telnet_raw_vprintf(telnet_t *telnet, const char *fmt, va_list va) {
+int telnet_raw_vprintf(telnet_t *telnet, const char *fmt, va_list va)
+{
   va_list va_temp;
   char buffer[1024];
   char *output = buffer;
@@ -1509,9 +1695,11 @@ int telnet_raw_vprintf(telnet_t *telnet, const char *fmt, va_list va) {
   rs = vsnprintf(buffer, sizeof(buffer), fmt, va_temp);
   va_end(va_temp);
 
-  if (rs >= sizeof(buffer)) {
+  if (rs >= sizeof(buffer))
+  {
     output = (char *)malloc(rs + 1);
-    if (output == 0) {
+    if (output == 0)
+    {
       telnet_error(telnet, __LINE__, __func__, TELNET_ENOMEM, 0, "malloc() failed: %s", strerror(errno));
       return -1;
     }
@@ -1525,7 +1713,8 @@ int telnet_raw_vprintf(telnet_t *telnet, const char *fmt, va_list va) {
   telnet_send(telnet, output, rs);
 
   /* release allocated memory, if any */
-  if (output != buffer) {
+  if (output != buffer)
+  {
     free(output);
   }
 
@@ -1533,7 +1722,8 @@ int telnet_raw_vprintf(telnet_t *telnet, const char *fmt, va_list va) {
 }
 
 /* see telnet_raw_vprintf */
-int telnet_raw_printf(telnet_t *telnet, const char *fmt, ...) {
+int telnet_raw_printf(telnet_t *telnet, const char *fmt, ...)
+{
   va_list va;
   int rs;
 
@@ -1545,31 +1735,37 @@ int telnet_raw_printf(telnet_t *telnet, const char *fmt, ...) {
 }
 
 /* begin NEW-ENVIRON subnegotation */
-void telnet_begin_newenviron(telnet_t *telnet, unsigned char cmd) {
+void telnet_begin_newenviron(telnet_t *telnet, unsigned char cmd)
+{
   telnet_begin_sb(telnet, TELNET_TELOPT_NEW_ENVIRON);
   telnet_send(telnet, (const char *)&cmd, 1);
 }
 
 /* send a NEW-ENVIRON value */
-void telnet_newenviron_value(telnet_t *telnet, unsigned char type, const char *string) {
+void telnet_newenviron_value(telnet_t *telnet, unsigned char type, const char *string)
+{
   telnet_send(telnet, (const char *)&type, 1);
 
-  if (string != 0) {
+  if (string != 0)
+  {
     telnet_send(telnet, string, strlen(string));
   }
 }
 
 /* send TERMINAL-TYPE SEND command */
-void telnet_ttype_send(telnet_t *telnet) {
+void telnet_ttype_send(telnet_t *telnet)
+{
   static const unsigned char SEND[] = {TELNET_IAC,        TELNET_SB,  TELNET_TELOPT_TTYPE,
                                        TELNET_TTYPE_SEND, TELNET_IAC, TELNET_SE};
   _sendu(telnet, SEND, sizeof(SEND));
 }
 
 /* send TERMINAL-TYPE IS command */
-void telnet_ttype_is(telnet_t *telnet, const char *ttype) {
+void telnet_ttype_is(telnet_t *telnet, const char *ttype)
+{
   static const unsigned char IS[] = {TELNET_IAC, TELNET_SB, TELNET_TELOPT_TTYPE, TELNET_TTYPE_IS};
-  if (!ttype) {
+  if (!ttype)
+  {
     ttype = "NVT";
   }
   _sendu(telnet, IS, sizeof(IS));
@@ -1578,14 +1774,16 @@ void telnet_ttype_is(telnet_t *telnet, const char *ttype) {
 }
 
 /* send ZMP data */
-void telnet_send_zmp(telnet_t *telnet, size_t argc, const char **argv) {
+void telnet_send_zmp(telnet_t *telnet, size_t argc, const char **argv)
+{
   size_t i;
 
   /* ZMP header */
   telnet_begin_zmp(telnet, argv[0]);
 
   /* send out each argument, including trailing NUL byte */
-  for (i = 1; i != argc; ++i) {
+  for (i = 1; i != argc; ++i)
+  {
     telnet_zmp_arg(telnet, argv[i]);
   }
 
@@ -1594,14 +1792,16 @@ void telnet_send_zmp(telnet_t *telnet, size_t argc, const char **argv) {
 }
 
 /* send ZMP data using varargs  */
-void telnet_send_vzmpv(telnet_t *telnet, va_list va) {
+void telnet_send_vzmpv(telnet_t *telnet, va_list va)
+{
   const char *arg;
 
   /* ZMP header */
   telnet_begin_sb(telnet, TELNET_TELOPT_ZMP);
 
   /* send out each argument, including trailing NUL byte */
-  while ((arg = va_arg(va, const char *)) != 0) {
+  while ((arg = va_arg(va, const char *)) != 0)
+  {
     telnet_zmp_arg(telnet, arg);
   }
 
@@ -1610,7 +1810,8 @@ void telnet_send_vzmpv(telnet_t *telnet, va_list va) {
 }
 
 /* see telnet_send_vzmpv */
-void telnet_send_zmpv(telnet_t *telnet, ...) {
+void telnet_send_zmpv(telnet_t *telnet, ...)
+{
   va_list va;
 
   va_start(va, telnet);
@@ -1619,7 +1820,8 @@ void telnet_send_zmpv(telnet_t *telnet, ...) {
 }
 
 /* begin a ZMP command */
-void telnet_begin_zmp(telnet_t *telnet, const char *cmd) {
+void telnet_begin_zmp(telnet_t *telnet, const char *cmd)
+{
   telnet_begin_sb(telnet, TELNET_TELOPT_ZMP);
   telnet_zmp_arg(telnet, cmd);
 }

--- a/src/apps/relay/libtelnet.h
+++ b/src/apps/relay/libtelnet.h
@@ -48,7 +48,8 @@
 
 /* C++ support */
 #if defined(__cplusplus)
-extern "C" {
+extern "C"
+{
 #endif
 
 /* printf type checking feature in GCC and some other compilers */
@@ -190,7 +191,8 @@ typedef struct telnet_telopt_t telnet_telopt_t;
 /*!
  * error codes
  */
-enum telnet_error_t {
+enum telnet_error_t
+{
   TELNET_EOK = 0,   /*!< no error */
   TELNET_EBADVAL,   /*!< invalid parameter, or API misuse */
   TELNET_ENOMEM,    /*!< memory allocation failure */
@@ -203,7 +205,8 @@ typedef enum telnet_error_t telnet_error_t; /*!< Error code type. */
 /*!
  * event codes
  */
-enum telnet_event_type_t {
+enum telnet_event_type_t
+{
   TELNET_EV_DATA = 0,       /*!< raw text data has been received */
   TELNET_EV_SEND,           /*!< data needs to be sent to the peer */
   TELNET_EV_IAC,            /*!< generic IAC code received */
@@ -225,7 +228,8 @@ typedef enum telnet_event_type_t telnet_event_type_t; /*!< Telnet event type. */
 /*!
  * environ/MSSP command information
  */
-struct telnet_environ_t {
+struct telnet_environ_t
+{
   unsigned char type; /*!< either TELNET_ENVIRON_VAR or TELNET_ENVIRON_USERVAR */
   char *var;          /*!< name of the variable being set */
   char *value;        /*!< value of variable being set; empty string if no value */
@@ -234,7 +238,8 @@ struct telnet_environ_t {
 /*!
  * event information
  */
-union telnet_event_t {
+union telnet_event_t
+{
   /*!
    * \brief Event type
    *
@@ -248,7 +253,8 @@ union telnet_event_t {
   /*!
    * data event: for DATA and SEND events
    */
-  struct data_t {
+  struct data_t
+  {
     enum telnet_event_type_t _type; /*!< alias for type */
     const char *buffer;             /*!< byte buffer */
     size_t size;                    /*!< number of bytes in buffer */
@@ -257,7 +263,8 @@ union telnet_event_t {
   /*!
    * WARNING and ERROR events
    */
-  struct error_t {
+  struct error_t
+  {
     enum telnet_event_type_t _type; /*!< alias for type */
     const char *file;               /*!< file the error occured in */
     const char *func;               /*!< function the error occured in */
@@ -269,7 +276,8 @@ union telnet_event_t {
   /*!
    * command event: for IAC
    */
-  struct iac_t {
+  struct iac_t
+  {
     enum telnet_event_type_t _type; /*!< alias for type */
     unsigned char cmd;              /*!< telnet command received */
   } iac;                            /*!< IAC */
@@ -277,7 +285,8 @@ union telnet_event_t {
   /*!
    * negotiation event: WILL, WONT, DO, DONT
    */
-  struct negotiate_t {
+  struct negotiate_t
+  {
     enum telnet_event_type_t _type; /*!< alias for type */
     unsigned char telopt;           /*!< option being negotiated */
   } neg;                            /*!< WILL, WONT, DO, DONT */
@@ -285,7 +294,8 @@ union telnet_event_t {
   /*!
    * subnegotiation event
    */
-  struct subnegotiate_t {
+  struct subnegotiate_t
+  {
     enum telnet_event_type_t _type; /*!< alias for type */
     const char *buffer;             /*!< data of sub-negotiation */
     size_t size;                    /*!< number of bytes in buffer */
@@ -295,7 +305,8 @@ union telnet_event_t {
   /*!
    * ZMP event
    */
-  struct zmp_t {
+  struct zmp_t
+  {
     enum telnet_event_type_t _type; /*!< alias for type */
     const char **argv;              /*!< array of argument string */
     size_t argc;                    /*!< number of elements in argv */
@@ -304,7 +315,8 @@ union telnet_event_t {
   /*!
    * TTYPE event
    */
-  struct ttype_t {
+  struct ttype_t
+  {
     enum telnet_event_type_t _type; /*!< alias for type */
     unsigned char cmd;              /*!< TELNET_TTYPE_IS or TELNET_TTYPE_SEND */
     const char *name;               /*!< terminal type name (IS only) */
@@ -313,7 +325,8 @@ union telnet_event_t {
   /*!
    * COMPRESS event
    */
-  struct compress_t {
+  struct compress_t
+  {
     enum telnet_event_type_t _type; /*!< alias for type */
     unsigned char state;            /*!< 1 if compression is enabled,
                                      0 if disabled */
@@ -322,7 +335,8 @@ union telnet_event_t {
   /*!
    * ENVIRON/NEW-ENVIRON event
    */
-  struct environ_t {
+  struct environ_t
+  {
     enum telnet_event_type_t _type;        /*!< alias for type */
     const struct telnet_environ_t *values; /*!< array of variable values */
     size_t size;                           /*!< number of elements in values */
@@ -332,7 +346,8 @@ union telnet_event_t {
   /*!
    * MSSP event
    */
-  struct mssp_t {
+  struct mssp_t
+  {
     enum telnet_event_type_t _type;        /*!< alias for type */
     const struct telnet_environ_t *values; /*!< array of variable values */
     size_t size;                           /*!< number of elements in values */
@@ -356,7 +371,8 @@ typedef void (*telnet_event_handler_t)(telnet_t *telnet, telnet_event_t *event, 
 /*!
  * telopt support table element; use telopt of -1 for end marker
  */
-struct telnet_telopt_t {
+struct telnet_telopt_t
+{
   short telopt;      /*!< one of the TELOPT codes or -1 */
   unsigned char us;  /*!< TELNET_WILL or TELNET_WONT */
   unsigned char him; /*!< TELNET_DO or TELNET_DONT */

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -261,7 +261,8 @@ static void drain_handler(evutil_socket_t sock, short events, void *args);
 
 //////////////////////////////////////////////////
 
-static int make_local_listeners_list(void) {
+static int make_local_listeners_list(void)
+{
   int ret = 0;
 #if defined(WINDOWS)
 
@@ -292,20 +293,25 @@ static int make_local_listeners_list(void) {
   // Allocate a 15 KB buffer to start with.
   outBufLen = WORKING_BUFFER_SIZE;
 
-  do {
+  do
+  {
 
     pAddresses = (IP_ADAPTER_ADDRESSES *)malloc(outBufLen);
-    if (pAddresses == NULL) {
+    if (pAddresses == NULL)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Memory allocation failed for IP_ADAPTER_ADDRESSES struct\n");
       return -1;
     }
 
     dwRetVal = GetAdaptersAddresses(family, flags, NULL, pAddresses, &outBufLen);
 
-    if (dwRetVal == ERROR_BUFFER_OVERFLOW) {
+    if (dwRetVal == ERROR_BUFFER_OVERFLOW)
+    {
       free(pAddresses);
       pAddresses = NULL;
-    } else {
+    }
+    else
+    {
       break;
     }
 
@@ -313,51 +319,65 @@ static int make_local_listeners_list(void) {
 
   } while ((dwRetVal == ERROR_BUFFER_OVERFLOW) && (Iterations < MAX_TRIES));
 
-  if (dwRetVal == NO_ERROR) {
+  if (dwRetVal == NO_ERROR)
+  {
     // If successful, output some information from the data we received
     pCurrAddresses = pAddresses;
-    while (pCurrAddresses) {
+    while (pCurrAddresses)
+    {
       /*
       printf("\tLength of the IP_ADAPTER_ADDRESS struct: %ld\n",
           pCurrAddresses->Length);
       printf("\tIfIndex (IPv4 interface): %u\n", pCurrAddresses->IfIndex);
       printf("\tAdapter name: %s\n", pCurrAddresses->AdapterName);//*/
 
-      if (pCurrAddresses->OperStatus != IfOperStatusUp) {
+      if (pCurrAddresses->OperStatus != IfOperStatusUp)
+      {
         pCurrAddresses = pCurrAddresses->Next;
         continue;
       }
 
       pUnicast = pCurrAddresses->FirstUnicastAddress;
-      if (pUnicast != NULL) {
+      if (pUnicast != NULL)
+      {
         // printf("\tNumber of Unicast Addresses:\n");
-        for (i = 0; pUnicast != NULL; pUnicast = pUnicast->Next) {
+        for (i = 0; pUnicast != NULL; pUnicast = pUnicast->Next)
+        {
           char saddr[INET6_ADDRSTRLEN] = "";
           if (AF_INET == pUnicast->Address.lpSockaddr->sa_family) // IPV4
           {
             if (!inet_ntop(PF_INET, &((struct sockaddr_in *)pUnicast->Address.lpSockaddr)->sin_addr, saddr,
-                           INET6_ADDRSTRLEN)) {
+                           INET6_ADDRSTRLEN))
+            {
               continue;
             }
-            if (strstr(saddr, "169.254.") == saddr) {
+            if (strstr(saddr, "169.254.") == saddr)
+            {
               continue;
             }
-            if (!strcmp(saddr, "0.0.0.0")) {
+            if (!strcmp(saddr, "0.0.0.0"))
+            {
               continue;
             }
-          } else if (AF_INET6 == pUnicast->Address.lpSockaddr->sa_family) // IPV6
+          }
+          else if (AF_INET6 == pUnicast->Address.lpSockaddr->sa_family) // IPV6
           {
             if (!inet_ntop(PF_INET6, &((struct sockaddr_in6 *)pUnicast->Address.lpSockaddr)->sin6_addr, saddr,
-                           INET6_ADDRSTRLEN)) {
+                           INET6_ADDRSTRLEN))
+            {
               continue;
             }
-            if (strstr(saddr, "fe80") == saddr) {
+            if (strstr(saddr, "fe80") == saddr)
+            {
               continue;
             }
-            if (!strcmp(saddr, "::")) {
+            if (!strcmp(saddr, "::"))
+            {
               continue;
             }
-          } else {
+          }
+          else
+          {
             continue;
           }
 
@@ -365,7 +385,8 @@ static int make_local_listeners_list(void) {
 
           add_listener_addr(saddr);
 
-          if (MIB_IF_TYPE_LOOPBACK != pCurrAddresses->IfType) {
+          if (MIB_IF_TYPE_LOOPBACK != pCurrAddresses->IfType)
+          {
             ret++;
           }
         }
@@ -464,19 +485,26 @@ static int make_local_listeners_list(void) {
 
       pCurrAddresses = pCurrAddresses->Next;
     }
-  } else {
+  }
+  else
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Call to GetAdaptersAddresses failed with error: %d\n", dwRetVal);
-    if (dwRetVal == ERROR_NO_DATA) {
+    if (dwRetVal == ERROR_NO_DATA)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "\tNo addresses were found for the requested parameters\n");
-    } else {
+    }
+    else
+    {
 
       if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                         NULL, dwRetVal, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
                         // Default language
-                        (LPTSTR)&lpMsgBuf, 0, NULL)) {
+                        (LPTSTR)&lpMsgBuf, 0, NULL))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "\tError: %s", lpMsgBuf);
         LocalFree(lpMsgBuf);
-        if (pAddresses) {
+        if (pAddresses)
+        {
           free(pAddresses);
         }
         return -2;
@@ -484,7 +512,8 @@ static int make_local_listeners_list(void) {
     }
   }
 
-  if (pAddresses) {
+  if (pAddresses)
+  {
     free(pAddresses);
   }
 
@@ -494,45 +523,61 @@ static int make_local_listeners_list(void) {
 
   char saddr[INET6_ADDRSTRLEN] = "";
 
-  if ((getifaddrs(&ifs) == 0) && ifs) {
+  if ((getifaddrs(&ifs) == 0) && ifs)
+  {
 
-    for (ifa = ifs; ifa != NULL; ifa = ifa->ifa_next) {
+    for (ifa = ifs; ifa != NULL; ifa = ifa->ifa_next)
+    {
 
-      if (!(ifa->ifa_flags & IFF_UP)) {
+      if (!(ifa->ifa_flags & IFF_UP))
+      {
         continue;
       }
 
-      if (!(ifa->ifa_addr)) {
+      if (!(ifa->ifa_addr))
+      {
         continue;
       }
 
-      if (ifa->ifa_addr->sa_family == AF_INET) {
-        if (!inet_ntop(AF_INET, &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr, saddr, INET_ADDRSTRLEN)) {
+      if (ifa->ifa_addr->sa_family == AF_INET)
+      {
+        if (!inet_ntop(AF_INET, &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr, saddr, INET_ADDRSTRLEN))
+        {
           continue;
         }
-        if (strstr(saddr, "169.254.") == saddr) {
+        if (strstr(saddr, "169.254.") == saddr)
+        {
           continue;
         }
-        if (!strcmp(saddr, "0.0.0.0")) {
+        if (!strcmp(saddr, "0.0.0.0"))
+        {
           continue;
         }
-      } else if (ifa->ifa_addr->sa_family == AF_INET6) {
-        if (!inet_ntop(AF_INET6, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr, saddr, INET6_ADDRSTRLEN)) {
+      }
+      else if (ifa->ifa_addr->sa_family == AF_INET6)
+      {
+        if (!inet_ntop(AF_INET6, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr, saddr, INET6_ADDRSTRLEN))
+        {
           continue;
         }
-        if (strstr(saddr, "fe80") == saddr) {
+        if (strstr(saddr, "fe80") == saddr)
+        {
           continue;
         }
-        if (!strcmp(saddr, "::")) {
+        if (!strcmp(saddr, "::"))
+        {
           continue;
         }
-      } else {
+      }
+      else
+      {
         continue;
       }
 
       add_listener_addr(saddr);
 
-      if (!(ifa->ifa_flags & IFF_LOOPBACK)) {
+      if (!(ifa->ifa_flags & IFF_LOOPBACK))
+      {
         ret++;
       }
     }
@@ -543,7 +588,8 @@ static int make_local_listeners_list(void) {
   return ret;
 }
 
-static int make_local_relays_list(int allow_local, int family) {
+static int make_local_relays_list(int allow_local, int family)
+{
   int counter = 0;
 
 #if defined(WINDOWS)
@@ -566,20 +612,25 @@ static int make_local_relays_list(int allow_local, int family) {
   // Allocate a 15 KB buffer to start with.
   outBufLen = WORKING_BUFFER_SIZE;
 
-  do {
+  do
+  {
 
     pAddresses = (IP_ADAPTER_ADDRESSES *)malloc(outBufLen);
-    if (pAddresses == NULL) {
+    if (pAddresses == NULL)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Memory allocation failed for IP_ADAPTER_ADDRESSES struct\n");
       return -1;
     }
 
     dwRetVal = GetAdaptersAddresses(fm, flags, NULL, pAddresses, &outBufLen);
 
-    if (dwRetVal == ERROR_BUFFER_OVERFLOW) {
+    if (dwRetVal == ERROR_BUFFER_OVERFLOW)
+    {
       free(pAddresses);
       pAddresses = NULL;
-    } else {
+    }
+    else
+    {
       break;
     }
 
@@ -587,66 +638,84 @@ static int make_local_relays_list(int allow_local, int family) {
 
   } while ((dwRetVal == ERROR_BUFFER_OVERFLOW) && (Iterations < MAX_TRIES));
 
-  if (dwRetVal == NO_ERROR) {
+  if (dwRetVal == NO_ERROR)
+  {
     // If successful, output some information from the data we received
     pCurrAddresses = pAddresses;
-    while (pCurrAddresses) {
+    while (pCurrAddresses)
+    {
       /*
       printf("\tLength of the IP_ADAPTER_ADDRESS struct: %ld\n",
           pCurrAddresses->Length);
       printf("\tIfIndex (IPv4 interface): %u\n", pCurrAddresses->IfIndex);
       printf("\tAdapter name: %s\n", pCurrAddresses->AdapterName);//*/
 
-      if (pCurrAddresses->OperStatus != IfOperStatusUp) {
+      if (pCurrAddresses->OperStatus != IfOperStatusUp)
+      {
         pCurrAddresses = pCurrAddresses->Next;
         continue;
       }
 
       pUnicast = pCurrAddresses->FirstUnicastAddress;
-      if (pUnicast != NULL) {
+      if (pUnicast != NULL)
+      {
         // printf("\tNumber of Unicast Addresses:\n");
-        for (; pUnicast != NULL; pUnicast = pUnicast->Next) {
-          if (!allow_local && (MIB_IF_TYPE_LOOPBACK == pCurrAddresses->IfType)) {
+        for (; pUnicast != NULL; pUnicast = pUnicast->Next)
+        {
+          if (!allow_local && (MIB_IF_TYPE_LOOPBACK == pCurrAddresses->IfType))
+          {
             continue;
           }
 
           char saddr[INET6_ADDRSTRLEN] = "";
           if (AF_INET == pUnicast->Address.lpSockaddr->sa_family) // IPV4
           {
-            if (family != AF_INET) {
+            if (family != AF_INET)
+            {
               continue;
             }
             if (!inet_ntop(PF_INET, &((struct sockaddr_in *)pUnicast->Address.lpSockaddr)->sin_addr, saddr,
-                           INET6_ADDRSTRLEN)) {
+                           INET6_ADDRSTRLEN))
+            {
               continue;
             }
-            if (strstr(saddr, "169.254.") == saddr) {
+            if (strstr(saddr, "169.254.") == saddr)
+            {
               continue;
             }
-            if (!strcmp(saddr, "0.0.0.0")) {
+            if (!strcmp(saddr, "0.0.0.0"))
+            {
               continue;
             }
-          } else if (AF_INET6 == pUnicast->Address.lpSockaddr->sa_family) // IPV6
+          }
+          else if (AF_INET6 == pUnicast->Address.lpSockaddr->sa_family) // IPV6
           {
-            if (family != AF_INET6) {
+            if (family != AF_INET6)
+            {
               continue;
             }
 
             if (!inet_ntop(PF_INET6, &((struct sockaddr_in6 *)pUnicast->Address.lpSockaddr)->sin6_addr, saddr,
-                           INET6_ADDRSTRLEN)) {
+                           INET6_ADDRSTRLEN))
+            {
               continue;
             }
-            if (strstr(saddr, "fe80") == saddr) {
+            if (strstr(saddr, "fe80") == saddr)
+            {
               continue;
             }
-            if (!strcmp(saddr, "::")) {
+            if (!strcmp(saddr, "::"))
+            {
               continue;
             }
-          } else {
+          }
+          else
+          {
             continue;
           }
 
-          if (add_relay_addr(saddr) > 0) {
+          if (add_relay_addr(saddr) > 0)
+          {
             counter += 1;
           }
         }
@@ -655,7 +724,8 @@ static int make_local_relays_list(int allow_local, int family) {
     }
   }
 
-  if (pAddresses) {
+  if (pAddresses)
+  {
     free(pAddresses);
   }
 #else
@@ -666,59 +736,79 @@ static int make_local_relays_list(int allow_local, int family) {
 
   getifaddrs(&ifs);
 
-  if (ifs) {
-    for (ifa = ifs; ifa != NULL; ifa = ifa->ifa_next) {
+  if (ifs)
+  {
+    for (ifa = ifs; ifa != NULL; ifa = ifa->ifa_next)
+    {
 
-      if (!(ifa->ifa_flags & IFF_UP)) {
+      if (!(ifa->ifa_flags & IFF_UP))
+      {
         continue;
       }
 
-      if (!(ifa->ifa_name)) {
+      if (!(ifa->ifa_name))
+      {
         continue;
       }
-      if (!(ifa->ifa_addr)) {
-        continue;
-      }
-
-      if (!allow_local && (ifa->ifa_flags & IFF_LOOPBACK)) {
-        continue;
-      }
-
-      if (ifa->ifa_addr->sa_family == AF_INET) {
-
-        if (family != AF_INET) {
-          continue;
-        }
-
-        if (!inet_ntop(AF_INET, &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr, saddr, INET_ADDRSTRLEN)) {
-          continue;
-        }
-        if (strstr(saddr, "169.254.") == saddr) {
-          continue;
-        }
-        if (!strcmp(saddr, "0.0.0.0")) {
-          continue;
-        }
-      } else if (ifa->ifa_addr->sa_family == AF_INET6) {
-
-        if (family != AF_INET6) {
-          continue;
-        }
-
-        if (!inet_ntop(AF_INET6, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr, saddr, INET6_ADDRSTRLEN)) {
-          continue;
-        }
-        if (strstr(saddr, "fe80") == saddr) {
-          continue;
-        }
-        if (!strcmp(saddr, "::")) {
-          continue;
-        }
-      } else {
+      if (!(ifa->ifa_addr))
+      {
         continue;
       }
 
-      if (add_relay_addr(saddr) > 0) {
+      if (!allow_local && (ifa->ifa_flags & IFF_LOOPBACK))
+      {
+        continue;
+      }
+
+      if (ifa->ifa_addr->sa_family == AF_INET)
+      {
+
+        if (family != AF_INET)
+        {
+          continue;
+        }
+
+        if (!inet_ntop(AF_INET, &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr, saddr, INET_ADDRSTRLEN))
+        {
+          continue;
+        }
+        if (strstr(saddr, "169.254.") == saddr)
+        {
+          continue;
+        }
+        if (!strcmp(saddr, "0.0.0.0"))
+        {
+          continue;
+        }
+      }
+      else if (ifa->ifa_addr->sa_family == AF_INET6)
+      {
+
+        if (family != AF_INET6)
+        {
+          continue;
+        }
+
+        if (!inet_ntop(AF_INET6, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr, saddr, INET6_ADDRSTRLEN))
+        {
+          continue;
+        }
+        if (strstr(saddr, "fe80") == saddr)
+        {
+          continue;
+        }
+        if (!strcmp(saddr, "::"))
+        {
+          continue;
+        }
+      }
+      else
+      {
+        continue;
+      }
+
+      if (add_relay_addr(saddr) > 0)
+      {
         counter += 1;
       }
     }
@@ -729,7 +819,8 @@ static int make_local_relays_list(int allow_local, int family) {
   return counter;
 }
 
-int get_a_local_relay(int family, ioa_addr *relay_addr) {
+int get_a_local_relay(int family, ioa_addr *relay_addr)
+{
   int ret = -1;
   int allow_local = 0;
 
@@ -752,19 +843,24 @@ int get_a_local_relay(int family, ioa_addr *relay_addr) {
 
   outBufLen = WORKING_BUFFER_SIZE;
 
-  do {
+  do
+  {
     pAddresses = (IP_ADAPTER_ADDRESSES *)malloc(outBufLen);
-    if (pAddresses == NULL) {
+    if (pAddresses == NULL)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Memory allocation failed for IP_ADAPTER_ADDRESSES struct\n");
       return -1;
     }
 
     dwRetVal = GetAdaptersAddresses(fm, flags, NULL, pAddresses, &outBufLen);
 
-    if (dwRetVal == ERROR_BUFFER_OVERFLOW) {
+    if (dwRetVal == ERROR_BUFFER_OVERFLOW)
+    {
       free(pAddresses);
       pAddresses = NULL;
-    } else {
+    }
+    else
+    {
       break;
     }
 
@@ -772,58 +868,77 @@ int get_a_local_relay(int family, ioa_addr *relay_addr) {
 
   } while ((dwRetVal == ERROR_BUFFER_OVERFLOW) && (Iterations < MAX_TRIES));
 
-  if (dwRetVal == NO_ERROR) {
-  galr_start:
+  if (dwRetVal == NO_ERROR)
+  {
+galr_start:
     // If successful, output some information from the data we received
     pCurrAddresses = pAddresses;
-    while (pCurrAddresses) {
+    while (pCurrAddresses)
+    {
       pUnicast = pCurrAddresses->FirstUnicastAddress;
-      if (pUnicast != NULL) {
+      if (pUnicast != NULL)
+      {
         // printf("\tNumber of Unicast Addresses:\n");
-        for (; pUnicast != NULL; pUnicast = pUnicast->Next) {
-          if (!allow_local && (MIB_IF_TYPE_LOOPBACK == pCurrAddresses->IfType)) {
+        for (; pUnicast != NULL; pUnicast = pUnicast->Next)
+        {
+          if (!allow_local && (MIB_IF_TYPE_LOOPBACK == pCurrAddresses->IfType))
+          {
             continue;
           }
 
           char saddr[INET6_ADDRSTRLEN] = "";
           if (AF_INET == pUnicast->Address.lpSockaddr->sa_family) // IPV4
           {
-            if (family != AF_INET) {
+            if (family != AF_INET)
+            {
               continue;
             }
             if (!inet_ntop(PF_INET, &((struct sockaddr_in *)pUnicast->Address.lpSockaddr)->sin_addr, saddr,
-                           INET6_ADDRSTRLEN)) {
+                           INET6_ADDRSTRLEN))
+            {
               continue;
             }
-            if (strstr(saddr, "169.254.") == saddr) {
+            if (strstr(saddr, "169.254.") == saddr)
+            {
               continue;
             }
-            if (!strcmp(saddr, "0.0.0.0")) {
+            if (!strcmp(saddr, "0.0.0.0"))
+            {
               continue;
             }
-          } else if (AF_INET6 == pUnicast->Address.lpSockaddr->sa_family) // IPV6
+          }
+          else if (AF_INET6 == pUnicast->Address.lpSockaddr->sa_family) // IPV6
           {
-            if (family != AF_INET6) {
+            if (family != AF_INET6)
+            {
               continue;
             }
 
             if (!inet_ntop(PF_INET6, &((struct sockaddr_in6 *)pUnicast->Address.lpSockaddr)->sin6_addr, saddr,
-                           INET6_ADDRSTRLEN)) {
+                           INET6_ADDRSTRLEN))
+            {
               continue;
             }
-            if (strstr(saddr, "fe80") == saddr) {
+            if (strstr(saddr, "fe80") == saddr)
+            {
               continue;
             }
-            if (!strcmp(saddr, "::")) {
+            if (!strcmp(saddr, "::"))
+            {
               continue;
             }
-          } else {
+          }
+          else
+          {
             continue;
           }
 
-          if (make_ioa_addr((const uint8_t *)saddr, 0, relay_addr) < 0) {
+          if (make_ioa_addr((const uint8_t *)saddr, 0, relay_addr) < 0)
+          {
             continue;
-          } else {
+          }
+          else
+          {
             ret = 0;
             break;
           }
@@ -832,13 +947,15 @@ int get_a_local_relay(int family, ioa_addr *relay_addr) {
       pCurrAddresses = pCurrAddresses->Next;
     }
 
-    if (ret < 0 && !allow_local) {
+    if (ret < 0 && !allow_local)
+    {
       allow_local = 1;
       goto galr_start;
     }
   }
 
-  if (pAddresses) {
+  if (pAddresses)
+  {
     free(pAddresses);
   }
   return -1;
@@ -849,69 +966,92 @@ int get_a_local_relay(int family, ioa_addr *relay_addr) {
 
   getifaddrs(&ifs);
 
-  if (ifs) {
+  if (ifs)
+  {
 
-  galr_start:
-    for (struct ifaddrs *ifa = ifs; ifa != NULL; ifa = ifa->ifa_next) {
+galr_start:
+    for (struct ifaddrs *ifa = ifs; ifa != NULL; ifa = ifa->ifa_next)
+    {
 
-      if (!(ifa->ifa_flags & IFF_UP)) {
+      if (!(ifa->ifa_flags & IFF_UP))
+      {
         continue;
       }
 
-      if (!(ifa->ifa_name)) {
+      if (!(ifa->ifa_name))
+      {
         continue;
       }
-      if (!(ifa->ifa_addr)) {
-        continue;
-      }
-
-      if (!allow_local && (ifa->ifa_flags & IFF_LOOPBACK)) {
+      if (!(ifa->ifa_addr))
+      {
         continue;
       }
 
-      if (ifa->ifa_addr->sa_family == AF_INET) {
-
-        if (family != AF_INET) {
-          continue;
-        }
-
-        if (!inet_ntop(AF_INET, &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr, saddr, INET_ADDRSTRLEN)) {
-          continue;
-        }
-        if (strstr(saddr, "169.254.") == saddr) {
-          continue;
-        }
-        if (!strcmp(saddr, "0.0.0.0")) {
-          continue;
-        }
-      } else if (ifa->ifa_addr->sa_family == AF_INET6) {
-
-        if (family != AF_INET6) {
-          continue;
-        }
-
-        if (!inet_ntop(AF_INET6, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr, saddr, INET6_ADDRSTRLEN)) {
-          continue;
-        }
-        if (strstr(saddr, "fe80") == saddr) {
-          continue;
-        }
-        if (!strcmp(saddr, "::")) {
-          continue;
-        }
-      } else {
+      if (!allow_local && (ifa->ifa_flags & IFF_LOOPBACK))
+      {
         continue;
       }
 
-      if (make_ioa_addr((const uint8_t *)saddr, 0, relay_addr) < 0) {
+      if (ifa->ifa_addr->sa_family == AF_INET)
+      {
+
+        if (family != AF_INET)
+        {
+          continue;
+        }
+
+        if (!inet_ntop(AF_INET, &((struct sockaddr_in *)ifa->ifa_addr)->sin_addr, saddr, INET_ADDRSTRLEN))
+        {
+          continue;
+        }
+        if (strstr(saddr, "169.254.") == saddr)
+        {
+          continue;
+        }
+        if (!strcmp(saddr, "0.0.0.0"))
+        {
+          continue;
+        }
+      }
+      else if (ifa->ifa_addr->sa_family == AF_INET6)
+      {
+
+        if (family != AF_INET6)
+        {
+          continue;
+        }
+
+        if (!inet_ntop(AF_INET6, &((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr, saddr, INET6_ADDRSTRLEN))
+        {
+          continue;
+        }
+        if (strstr(saddr, "fe80") == saddr)
+        {
+          continue;
+        }
+        if (!strcmp(saddr, "::"))
+        {
+          continue;
+        }
+      }
+      else
+      {
         continue;
-      } else {
+      }
+
+      if (make_ioa_addr((const uint8_t *)saddr, 0, relay_addr) < 0)
+      {
+        continue;
+      }
+      else
+      {
         ret = 0;
         break;
       }
     }
 
-    if (ret < 0 && !allow_local) {
+    if (ret < 0 && !allow_local)
+    {
       allow_local = 1;
       goto galr_start;
     }
@@ -1410,7 +1550,8 @@ static char AdminUsage[] =
 
 #define ADMIN_OPTIONS "PEgGORIHKYlLkaADSdb:e:M:J:N:u:r:p:s:X:o:h:x:v:f:"
 
-enum EXTRA_OPTS {
+enum EXTRA_OPTS
+{
   NO_UDP_OPT = 256,
   NO_TCP_OPT,
   TCP_PROXY_PORT_OPT,
@@ -1502,7 +1643,8 @@ enum EXTRA_OPTS {
   VERSION_OPT
 };
 
-struct myoption {
+struct myoption
+{
   const char *name; /* name of long option */
   int has_arg;      /* whether option takes an argument */
   int *flag;        /* if not NULL, set *flag to val when option found */
@@ -1510,8 +1652,10 @@ struct myoption {
                     /* if flag is NULL, return value */
 };
 
-struct uoptions {
-  union {
+struct uoptions
+{
+  union
+  {
     const struct myoption *m;
     const struct option *o;
   } u;
@@ -1695,7 +1839,8 @@ static const struct myoption admin_long_options[] = {
     {"help", no_argument, NULL, 'h'},
     {NULL, no_argument, NULL, 0}};
 
-int init_ctr(struct ctr_state *state, const unsigned char iv[8]) {
+int init_ctr(struct ctr_state *state, const unsigned char iv[8])
+{
   state->num = 0;
   memset(state->ecount, 0, sizeof(state->ecount));
   memcpy(state->ivec, iv, 8);
@@ -1703,7 +1848,8 @@ int init_ctr(struct ctr_state *state, const unsigned char iv[8]) {
   return 1;
 }
 
-unsigned char *base64encode(const void *b64_encode_this, int encode_this_many_bytes) {
+unsigned char *base64encode(const void *b64_encode_this, int encode_this_many_bytes)
+{
   BIO *b64_bio, *mem_bio;                         // Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
   BUF_MEM *mem_bio_mem_ptr;                       // Pointer to a "memory BIO" structure holding our base64 data.
   b64_bio = BIO_new(BIO_f_base64());              // Initialize our base64 filter BIO.
@@ -1719,7 +1865,8 @@ unsigned char *base64encode(const void *b64_encode_this, int encode_this_many_by
   (*mem_bio_mem_ptr).data[(*mem_bio_mem_ptr).length] = '\0';    // Adds null-terminator to tail.
   return (unsigned char *)(*mem_bio_mem_ptr).data; // Returns base-64 encoded data. (See: "buf_mem_st" struct).
 }
-void encrypt_aes_128(unsigned char *in, const unsigned char *mykey) {
+void encrypt_aes_128(unsigned char *in, const unsigned char *mykey)
+{
 
   int j = 0, k = 0;
   int totalSize = 0;
@@ -1737,25 +1884,29 @@ void encrypt_aes_128(unsigned char *in, const unsigned char *mykey) {
 
   totalSize += strlen((char *)in);
   size = strlen((char *)in);
-  for (j = 0; j < size; j++) {
+  for (j = 0; j < size; j++)
+  {
     total[k++] = out[j];
   }
 
   unsigned char *base64_encoded = base64encode(total, totalSize);
   printf("%s\n", base64_encoded);
 }
-static void generate_aes_128_key(char *filePath, unsigned char *returnedKey) {
+static void generate_aes_128_key(char *filePath, unsigned char *returnedKey)
+{
   char key[16];
 
   // TODO: Document why this is called...?
   turn_srandom();
 
-  for (size_t i = 0; i < 16; ++i) {
+  for (size_t i = 0; i < 16; ++i)
+  {
     // TODO: This could be sped up by breaking the
     // returned random value into multiple 8bit values
     // instead of getting a new multi-byte random value
     // for each key index.
-    switch (turn_random() % 3) {
+    switch (turn_random() % 3)
+    {
     case 0:
       key[i] = (turn_random() % 10) + 48;
       continue;
@@ -1768,10 +1919,12 @@ static void generate_aes_128_key(char *filePath, unsigned char *returnedKey) {
     }
   }
   FILE *fptr = fopen(filePath, "w");
-  if (!fptr) {
+  if (!fptr)
+  {
     return;
   }
-  for (size_t i = 0; i < 16; ++i) {
+  for (size_t i = 0; i < 16; ++i)
+  {
     fputc(key[i], fptr);
   }
   memcpy(returnedKey, key, 16);
@@ -1781,7 +1934,8 @@ static void generate_aes_128_key(char *filePath, unsigned char *returnedKey) {
   fclose(fptr);
 }
 
-unsigned char *base64decode(const void *b64_decode_this, int decode_this_many_bytes) {
+unsigned char *base64decode(const void *b64_decode_this, int decode_this_many_bytes)
+{
   BIO *b64_bio, *mem_bio; // Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
   unsigned char *base64_decoded =
       (unsigned char *)calloc((decode_this_many_bytes * 3) / 4 + 1, sizeof(char)); //+1 = null.
@@ -1791,20 +1945,24 @@ unsigned char *base64decode(const void *b64_decode_this, int decode_this_many_by
   BIO_push(b64_bio, mem_bio);                     // Link the BIOs by creating a filter-source BIO chain.
   BIO_set_flags(b64_bio, BIO_FLAGS_BASE64_NO_NL); // Don't require trailing newlines.
   int decoded_byte_index = 0;                     // Index where the next base64_decoded byte should be written.
-  while (0 < BIO_read(b64_bio, base64_decoded + decoded_byte_index, 1)) { // Read byte-by-byte.
+  while (0 < BIO_read(b64_bio, base64_decoded + decoded_byte_index, 1))
+  {                       // Read byte-by-byte.
     decoded_byte_index++; // Increment the index until read of BIO decoded data is complete.
-  }                       // Once we're done reading decoded data, BIO_read returns -1 even though there's no error.
+  } // Once we're done reading decoded data, BIO_read returns -1 even though there's no error.
 
   BIO_free_all(b64_bio); // Destroys all BIOs in chain, starting with b64 (i.e. the 1st one).
   return base64_decoded; // Returns base-64 decoded data with trailing null terminator.
 }
 
-int decodedTextSize(char *input) {
+int decodedTextSize(char *input)
+{
   int i = 0;
   int result = 0, padding = 0;
   int size = strlen(input);
-  for (i = 0; i < size; ++i) {
-    if (input[i] == '=') {
+  for (i = 0; i < size; ++i)
+  {
+    if (input[i] == '=')
+    {
       padding++;
     }
   }
@@ -1812,7 +1970,8 @@ int decodedTextSize(char *input) {
   return result;
 }
 
-void decrypt_aes_128(char *in, const unsigned char *mykey) {
+void decrypt_aes_128(char *in, const unsigned char *mykey)
+{
   unsigned char iv[8] = {0};
   AES_KEY key;
   unsigned char outdata[256] = {0};
@@ -1831,38 +1990,49 @@ void decrypt_aes_128(char *in, const unsigned char *mykey) {
   printf("%s\n", last);
 }
 
-static int get_int_value(const char *s, int default_value) {
-  if (!s || !(s[0])) {
+static int get_int_value(const char *s, int default_value)
+{
+  if (!s || !(s[0]))
+  {
     return default_value;
   }
   return atoi(s);
 }
 
-static int get_bool_value(const char *s) {
-  if (!s || !(s[0])) {
+static int get_bool_value(const char *s)
+{
+  if (!s || !(s[0]))
+  {
     return 1;
   }
-  if (s[0] == '0' || s[0] == 'n' || s[0] == 'N' || s[0] == 'f' || s[0] == 'F') {
+  if (s[0] == '0' || s[0] == 'n' || s[0] == 'N' || s[0] == 'f' || s[0] == 'F')
+  {
     return 0;
   }
-  if (s[0] == 'y' || s[0] == 'Y' || s[0] == 't' || s[0] == 'T') {
+  if (s[0] == 'y' || s[0] == 'Y' || s[0] == 't' || s[0] == 'T')
+  {
     return 1;
   }
-  if (s[0] > '0' && s[0] <= '9') {
+  if (s[0] > '0' && s[0] <= '9')
+  {
     return 1;
   }
-  if (!strcmp(s, "off") || !strcmp(s, "OFF") || !strcmp(s, "Off")) {
+  if (!strcmp(s, "off") || !strcmp(s, "OFF") || !strcmp(s, "Off"))
+  {
     return 0;
   }
-  if (!strcmp(s, "on") || !strcmp(s, "ON") || !strcmp(s, "On")) {
+  if (!strcmp(s, "on") || !strcmp(s, "ON") || !strcmp(s, "On"))
+  {
     return 1;
   }
   TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown boolean value: %s. You can use on/off, yes/no, 1/0, true/false.\n", s);
   exit(-1);
 }
 
-static void set_option(int c, char *value) {
-  if (value && value[0] == '=') {
+static void set_option(int c, char *value)
+{
+  if (value && value[0] == '=')
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
                   "WARNING: option -%c is possibly used incorrectly. The short form of the option must be used as "
                   "this: -%c <value>, no \'equals\' sign may be used, that sign is used only with long form options "
@@ -1870,27 +2040,40 @@ static void set_option(int c, char *value) {
                   (char)c, (char)c);
   }
 
-  switch (c) {
+  switch (c)
+  {
   case 'K':
-    if (get_bool_value(value)) {
+    if (get_bool_value(value))
+    {
       turn_params.allocation_default_address_family = ALLOCATION_DEFAULT_ADDRESS_FAMILY_KEEP;
     }
     break;
   case 'A':
-    if (value && strlen(value) > 0) {
-      if (*value == '=') {
+    if (value && strlen(value) > 0)
+    {
+      if (*value == '=')
+      {
         ++value;
       }
-      if (!strcmp(value, "ipv6")) {
+      if (!strcmp(value, "ipv6"))
+      {
         turn_params.allocation_default_address_family = ALLOCATION_DEFAULT_ADDRESS_FAMILY_IPV6;
-      } else if (!strcmp(value, "keep")) {
+      }
+      else if (!strcmp(value, "keep"))
+      {
         turn_params.allocation_default_address_family = ALLOCATION_DEFAULT_ADDRESS_FAMILY_KEEP;
-      } else if (!strcmp(value, "ipv4")) {
+      }
+      else if (!strcmp(value, "ipv4"))
+      {
         turn_params.allocation_default_address_family = ALLOCATION_DEFAULT_ADDRESS_FAMILY_IPV4;
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "ERROR: invalid allocation_default_address_family parameter\n");
       }
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "ERROR: invalid allocation_default_address_family parameter\n");
     }
     break;
@@ -1898,9 +2081,12 @@ static void set_option(int c, char *value) {
     STRCPY(turn_params.oauth_server_name, value);
     break;
   case OAUTH_OPT:
-    if (ENC_ALG_NUM == 0) {
+    if (ENC_ALG_NUM == 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "WARNING: option --oauth is not supported; ignored.\n");
-    } else {
+    }
+    else
+    {
       turn_params.oauth = get_bool_value(value);
     }
     break;
@@ -1913,20 +2099,25 @@ static void set_option(int c, char *value) {
   case NO_TLSV1_2_OPT:
     turn_params.no_tlsv1_2 = get_bool_value(value);
     break;
-  case NE_TYPE_OPT: {
+  case NE_TYPE_OPT:
+  {
     int ne = atoi(value);
-    if ((ne < (int)NEV_MIN) || (ne > (int)NEV_MAX)) {
+    if ((ne < (int)NEV_MIN) || (ne > (int)NEV_MAX))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "ERROR: wrong version of the network engine: %d\n", ne);
     }
     turn_params.net_engine_version = (NET_ENG_VERSION)ne;
-  } break;
+  }
+  break;
   case DH566_OPT:
-    if (get_bool_value(value)) {
+    if (get_bool_value(value))
+    {
       turn_params.dh_key_size = DH_566;
     }
     break;
   case DH1066_OPT:
-    if (get_bool_value(value)) {
+    if (get_bool_value(value))
+    {
       turn_params.dh_key_size = DH_1066;
     }
     break;
@@ -1946,9 +2137,12 @@ static void set_option(int c, char *value) {
     use_cli = !get_bool_value(value);
     break;
   case CLI_IP_OPT:
-    if (make_ioa_addr((const uint8_t *)value, 0, &cli_addr) < 0) {
+    if (make_ioa_addr((const uint8_t *)value, 0, &cli_addr) < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot set cli address: %s\n", value);
-    } else {
+    }
+    else
+    {
       cli_addr_set = 1;
     }
     break;
@@ -1962,9 +2156,12 @@ static void set_option(int c, char *value) {
     use_web_admin = get_bool_value(value);
     break;
   case WEB_ADMIN_IP_OPT:
-    if (make_ioa_addr((const uint8_t *)value, 0, &web_admin_addr) < 0) {
+    if (make_ioa_addr((const uint8_t *)value, 0, &web_admin_addr) < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot set web-admin address: %s\n", value);
-    } else {
+    }
+    else
+    {
       web_admin_addr_set = 1;
     }
     break;
@@ -1977,39 +2174,54 @@ static void set_option(int c, char *value) {
 #if defined(WINDOWS)
     // TODO: implement it!!!
 #else
-  case PROC_USER_OPT: {
+  case PROC_USER_OPT:
+  {
     struct passwd *pwd = getpwnam(value);
-    if (!pwd) {
+    if (!pwd)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown user name: %s\n", value);
       exit(-1);
-    } else {
+    }
+    else
+    {
       procuserid = pwd->pw_uid;
       procuserid_set = 1;
       STRCPY(procusername, value);
     }
-  } break;
-  case PROC_GROUP_OPT: {
+  }
+  break;
+  case PROC_GROUP_OPT:
+  {
     struct group *gr = getgrnam(value);
-    if (!gr) {
+    if (!gr)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Unknown group name: %s\n", value);
       exit(-1);
-    } else {
+    }
+    else
+    {
       procgroupid = gr->gr_gid;
       procgroupid_set = 1;
       STRCPY(procgroupname, value);
     }
-  } break;
+  }
+  break;
 #endif
   case 'i':
     STRCPY(turn_params.relay_ifname, value);
     break;
   case 'm':
-    if (atoi(value) > MAX_NUMBER_OF_GENERAL_RELAY_SERVERS) {
+    if (atoi(value) > MAX_NUMBER_OF_GENERAL_RELAY_SERVERS)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "WARNING: max number of relay threads is 128.\n");
       turn_params.general_relay_servers_number = MAX_NUMBER_OF_GENERAL_RELAY_SERVERS;
-    } else if (atoi(value) <= 0) {
+    }
+    else if (atoi(value) <= 0)
+    {
       turn_params.general_relay_servers_number = 0;
-    } else {
+    }
+    else
+    {
       turn_params.general_relay_servers_number = atoi(value);
     }
     break;
@@ -2076,34 +2288,49 @@ static void set_option(int c, char *value) {
     add_relay_addr(value);
     break;
   case 'X':
-    if (value) {
+    if (value)
+    {
       char *div = strchr(value, '/');
-      if (div) {
+      if (div)
+      {
         char *nval = strdup(value);
         div = strchr(nval, '/');
         div[0] = 0;
         ++div;
         ioa_addr apub, apriv;
-        if (make_ioa_addr((const uint8_t *)nval, 0, &apub) < 0) {
+        if (make_ioa_addr((const uint8_t *)nval, 0, &apub) < 0)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "-X : Wrong address format: %s\n", nval);
-        } else {
-          if (make_ioa_addr((const uint8_t *)div, 0, &apriv) < 0) {
+        }
+        else
+        {
+          if (make_ioa_addr((const uint8_t *)div, 0, &apriv) < 0)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "-X : Wrong address format: %s\n", div);
-          } else {
+          }
+          else
+          {
             ioa_addr_add_mapping(&apub, &apriv);
-            if (add_ip_list_range((const char *)div, NULL, &turn_params.ip_whitelist) == 0) {
+            if (add_ip_list_range((const char *)div, NULL, &turn_params.ip_whitelist) == 0)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Whitelisting external-ip private part: %s\n", div);
             }
           }
         }
         free(nval);
-      } else {
-        if (turn_params.external_ip) {
+      }
+      else
+      {
+        if (turn_params.external_ip)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "You cannot define external IP more than once in the configuration\n");
-        } else {
+        }
+        else
+        {
           turn_params.external_ip =
               (ioa_addr *)allocate_super_memory_engine(turn_params.listener.ioa_eng, sizeof(ioa_addr));
-          if (make_ioa_addr((const uint8_t *)value, 0, turn_params.external_ip) < 0) {
+          if (make_ioa_addr((const uint8_t *)value, 0, turn_params.external_ip) < 0)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "-X : Wrong address format: %s\n", value);
             free(turn_params.external_ip);
             turn_params.external_ip = NULL;
@@ -2113,16 +2340,21 @@ static void set_option(int c, char *value) {
     }
     break;
   case 'v':
-    if (turn_params.verbose != TURN_VERBOSE_EXTRA) {
-      if (get_bool_value(value)) {
+    if (turn_params.verbose != TURN_VERBOSE_EXTRA)
+    {
+      if (get_bool_value(value))
+      {
         turn_params.verbose = TURN_VERBOSE_NORMAL;
-      } else {
+      }
+      else
+      {
         turn_params.verbose = TURN_VERBOSE_NONE;
       }
     }
     break;
   case 'V':
-    if (get_bool_value(value)) {
+    if (get_bool_value(value))
+    {
       turn_params.verbose = TURN_VERBOSE_EXTRA;
     }
     break;
@@ -2130,20 +2362,26 @@ static void set_option(int c, char *value) {
     turn_params.turn_daemon = get_bool_value(value);
     break;
   case 'a':
-    if (get_bool_value(value)) {
+    if (get_bool_value(value))
+    {
       turn_params.ct = TURN_CREDENTIALS_LONG_TERM;
       use_lt_credentials = 1;
       use_ltc = 1;
-    } else {
+    }
+    else
+    {
       turn_params.ct = TURN_CREDENTIALS_UNDEFINED;
       use_lt_credentials = 0;
     }
     break;
   case 'z':
-    if (!get_bool_value(value)) {
+    if (!get_bool_value(value))
+    {
       turn_params.ct = TURN_CREDENTIALS_UNDEFINED;
       anon_credentials = 0;
-    } else {
+    }
+    else
+    {
       turn_params.ct = TURN_CREDENTIALS_NONE;
       anon_credentials = 1;
     }
@@ -2160,7 +2398,8 @@ static void set_option(int c, char *value) {
   case 'u':
     add_static_user_account(value);
     break;
-  case 'b': {
+  case 'b':
+  {
 #if defined(TURN_NO_SQLITE)
     TURN_LOG_FUNC(
         TURN_LOG_LEVEL_WARNING,
@@ -2169,7 +2408,8 @@ static void set_option(int c, char *value) {
     STRCPY(turn_params.default_users_db.persistent_users_db.userdb, value);
     turn_params.default_users_db.userdb_type = TURN_USERDB_TYPE_SQLITE;
 #endif
-  } break;
+  }
+  break;
 #if !defined(TURN_NO_PQ)
   case 'e':
     STRCPY(turn_params.default_users_db.persistent_users_db.userdb, value);
@@ -2320,12 +2560,14 @@ static void set_option(int c, char *value) {
     add_tls_alternate_server(value);
     break;
   case ALLOWED_PEER_IPS:
-    if (add_ip_list_range(value, NULL, &turn_params.ip_whitelist) == 0) {
+    if (add_ip_list_range(value, NULL, &turn_params.ip_whitelist) == 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "White listing: %s\n", value);
     }
     break;
   case DENIED_PEER_IPS:
-    if (add_ip_list_range(value, NULL, &turn_params.ip_blacklist) == 0) {
+    if (add_ip_list_range(value, NULL, &turn_params.ip_blacklist) == 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Black listing: %s\n", value);
     }
     break;
@@ -2339,7 +2581,8 @@ static void set_option(int c, char *value) {
     STRCPY(turn_params.acme_redirect, value);
     break;
   case 'C':
-    if (value && *value) {
+    if (value && *value)
+    {
       turn_params.rest_api_separator = *value;
     }
     break;
@@ -2376,25 +2619,31 @@ static void set_option(int c, char *value) {
     exit(-1);
   }
 
-  if (turn_params.default_users_db.persistent_users_db.userdb[0]) {
+  if (turn_params.default_users_db.persistent_users_db.userdb[0])
+  {
     char *userdb_sanitized = sanitize_userdb_string(turn_params.default_users_db.persistent_users_db.userdb);
     STRCPY(turn_params.default_users_db.persistent_users_db.userdb_sanitized, userdb_sanitized);
     free(userdb_sanitized);
   }
-  if (turn_params.redis_statsdb.connection_string[0]) {
+  if (turn_params.redis_statsdb.connection_string[0])
+  {
     char *connection_string = sanitize_userdb_string(turn_params.redis_statsdb.connection_string);
     STRCPY(turn_params.redis_statsdb.connection_string_sanitized, connection_string);
     free(connection_string);
   }
 }
 
-static int parse_arg_string(char *sarg, int *c, char **value) {
+static int parse_arg_string(char *sarg, int *c, char **value)
+{
   int i = 0;
   char *name = sarg;
-  while (*sarg) {
-    if ((*sarg == ' ') || (*sarg == '=') || (*sarg == '\t')) {
+  while (*sarg)
+  {
+    if ((*sarg == ' ') || (*sarg == '=') || (*sarg == '\t'))
+    {
       *sarg = 0;
-      do {
+      do
+      {
         ++sarg;
       } while ((*sarg == ' ') || (*sarg == '=') || (*sarg == '\t'));
       *value = sarg;
@@ -2404,20 +2653,25 @@ static int parse_arg_string(char *sarg, int *c, char **value) {
     *value = sarg;
   }
 
-  if (value && *value && **value == '\"') {
+  if (value && *value && **value == '\"')
+  {
     *value += 1;
     size_t len = strlen(*value);
     while (len > 0 && (((*value)[len - 1] == '\n') || ((*value)[len - 1] == '\r') || ((*value)[len - 1] == ' ') ||
-                       ((*value)[len - 1] == '\t'))) {
+                       ((*value)[len - 1] == '\t')))
+    {
       (*value)[--len] = 0;
     }
-    if (len > 0 && (*value)[len - 1] == '\"') {
+    if (len > 0 && (*value)[len - 1] == '\"')
+    {
       (*value)[--len] = 0;
     }
   }
 
-  while (long_options[i].name) {
-    if (strcmp(long_options[i].name, name)) {
+  while (long_options[i].name)
+  {
+    if (strcmp(long_options[i].name, name))
+    {
       ++i;
       continue;
     }
@@ -2428,28 +2682,42 @@ static int parse_arg_string(char *sarg, int *c, char **value) {
   return -1;
 }
 
-static void read_config_file(int argc, char **argv, int pass) {
+static void read_config_file(int argc, char **argv, int pass)
+{
   static char config_file[1025] = DEFAULT_CONFIG_FILE;
 
-  if (pass == 0) {
+  if (pass == 0)
+  {
 
-    if (argv) {
+    if (argv)
+    {
       int i = 0;
-      for (i = 0; i < argc; i++) {
-        if (!strcmp(argv[i], "-c")) {
-          if (i < argc - 1) {
+      for (i = 0; i < argc; i++)
+      {
+        if (!strcmp(argv[i], "-c"))
+        {
+          if (i < argc - 1)
+          {
             STRCPY(config_file, argv[i + 1]);
-          } else {
+          }
+          else
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "Wrong usage of -c option\n");
           }
-        } else if (!strcmp(argv[i], "-n")) {
+        }
+        else if (!strcmp(argv[i], "-n"))
+        {
           turn_params.do_not_use_config_file = 1;
           config_file[0] = 0;
           return;
-        } else if (!strcmp(argv[i], "-h")) {
+        }
+        else if (!strcmp(argv[i], "-h"))
+        {
           printf("\n%s\n", Usage);
           exit(0);
-        } else if (!strcmp(argv[i], "--version")) {
+        }
+        else if (!strcmp(argv[i], "--version"))
+        {
           printf("%s\n", TURN_SERVER_VERSION);
           exit(0);
         }
@@ -2457,93 +2725,127 @@ static void read_config_file(int argc, char **argv, int pass) {
     }
   }
 
-  if (!turn_params.do_not_use_config_file && config_file[0]) {
+  if (!turn_params.do_not_use_config_file && config_file[0])
+  {
 
     FILE *f = NULL;
     char *full_path_to_config_file = NULL;
 
     full_path_to_config_file = find_config_file(config_file);
-    if (full_path_to_config_file) {
+    if (full_path_to_config_file)
+    {
       f = fopen(full_path_to_config_file, "r");
     }
 
-    if (f) {
+    if (f)
+    {
 
       char sbuf[1025];
       char sarg[1035];
 
-      for (;;) {
+      for (;;)
+      {
         char *s = fgets(sbuf, sizeof(sbuf) - 1, f);
-        if (!s) {
+        if (!s)
+        {
           break;
         }
         s = skip_blanks(s);
-        if (s[0] == '#') {
+        if (s[0] == '#')
+        {
           continue;
         }
-        if (!s[0]) {
+        if (!s[0])
+        {
           continue;
         }
         size_t slen = strlen(s);
 
         // strip white-spaces from config file lines end
-        while (slen && isspace(s[slen - 1])) {
+        while (slen && isspace(s[slen - 1]))
+        {
           s[--slen] = 0;
         }
-        if (slen) {
+        if (slen)
+        {
           int c = 0;
           char *value = NULL;
           STRCPY(sarg, s);
-          if (parse_arg_string(sarg, &c, &value) < 0) {
+          if (parse_arg_string(sarg, &c, &value) < 0)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "Bad configuration format: %s\n", sarg);
-          } else if ((pass == 0) && (c == 'l')) {
+          }
+          else if ((pass == 0) && (c == 'l'))
+          {
             set_logfile(value);
-          } else if ((pass == 0) && (c == NO_STDOUT_LOG_OPT)) {
+          }
+          else if ((pass == 0) && (c == NO_STDOUT_LOG_OPT))
+          {
             set_no_stdout_log(get_bool_value(value));
-          } else if ((pass == 0) && (c == SYSLOG_OPT)) {
+          }
+          else if ((pass == 0) && (c == SYSLOG_OPT))
+          {
             set_log_to_syslog(get_bool_value(value));
-          } else if ((pass == 0) && (c == SIMPLE_LOG_OPT)) {
+          }
+          else if ((pass == 0) && (c == SIMPLE_LOG_OPT))
+          {
             set_simple_log(get_bool_value(value));
-          } else if ((pass == 0) && (c == NEW_LOG_TIMESTAMP_OPT)) {
+          }
+          else if ((pass == 0) && (c == NEW_LOG_TIMESTAMP_OPT))
+          {
             use_new_log_timestamp_format = 1;
-          } else if ((pass == 0) && (c == NEW_LOG_TIMESTAMP_FORMAT_OPT)) {
+          }
+          else if ((pass == 0) && (c == NEW_LOG_TIMESTAMP_FORMAT_OPT))
+          {
             set_turn_log_timestamp_format(value);
-          } else if ((pass == 0) && (c == SYSLOG_FACILITY_OPT)) {
+          }
+          else if ((pass == 0) && (c == SYSLOG_FACILITY_OPT))
+          {
             set_syslog_facility(value);
-          } else if ((pass == 1) && (c != 'u')) {
-            set_option(c, value);
-          } else if ((pass == 2) && (c == 'u')) {
+          }
+          else if ((pass == 1) && (c != 'u'))
+          {
             set_option(c, value);
           }
-          if (s[slen - 1] == 59) {
+          else if ((pass == 2) && (c == 'u'))
+          {
+            set_option(c, value);
+          }
+          if (s[slen - 1] == 59)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "Check config! The following line ends with semicolon: \"%s\" \n", s);
           }
         }
       }
 
       fclose(f);
-
-    } else if (pass == 0) {
+    }
+    else if (pass == 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
                     "Cannot find config file: %s. Default and command-line settings will be used.\n", config_file);
     }
 
-    if (full_path_to_config_file) {
+    if (full_path_to_config_file)
+    {
       free(full_path_to_config_file);
       full_path_to_config_file = NULL;
     }
   }
 }
 
-static int disconnect_database(void) {
+static int disconnect_database(void)
+{
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->disconnect) {
+  if (dbd && dbd->disconnect)
+  {
     dbd->disconnect();
   }
   return 0;
 }
 
-static int adminmain(int argc, char **argv) {
+static int adminmain(int argc, char **argv)
+{
   int c = 0;
   int rc = 0;
 
@@ -2566,10 +2868,13 @@ static int adminmain(int argc, char **argv) {
   int print_enc_password = 0;
   int print_enc_aes_password = 0;
 
-  while (((c = getopt_long(argc, argv, ADMIN_OPTIONS, uo.u.o, NULL)) != -1)) {
-    switch (c) {
+  while (((c = getopt_long(argc, argv, ADMIN_OPTIONS, uo.u.o, NULL)) != -1))
+  {
+    switch (c)
+    {
     case 'P':
-      if (pwd[0]) {
+      if (pwd[0])
+      {
         char result[257];
         generate_new_enc_password((char *)pwd, result);
         printf("%s\n", result);
@@ -2640,7 +2945,8 @@ static int adminmain(int argc, char **argv) {
       break;
     case 'X':
       ct = TA_DEL_SECRET;
-      if (optarg) {
+      if (optarg)
+      {
         STRCPY(secret, optarg);
       }
       break;
@@ -2679,11 +2985,13 @@ static int adminmain(int argc, char **argv) {
 #endif
     case 'u':
       STRCPY(user, optarg);
-      if (!is_secure_string((uint8_t *)user, 1)) {
+      if (!is_secure_string((uint8_t *)user, 1))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong user name structure or symbols, choose another name: %s\n", user);
         exit(-1);
       }
-      if (!SASLprep((uint8_t *)user)) {
+      if (!SASLprep((uint8_t *)user))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong user name: %s\n", user);
         exit(-1);
       }
@@ -2691,24 +2999,28 @@ static int adminmain(int argc, char **argv) {
     case 'r':
       set_default_realm_name(optarg);
       STRCPY(realm, optarg);
-      if (!SASLprep((uint8_t *)realm)) {
+      if (!SASLprep((uint8_t *)realm))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong realm: %s\n", realm);
         exit(-1);
       }
       break;
     case 'p':
       STRCPY(pwd, optarg);
-      if (!SASLprep((uint8_t *)pwd)) {
+      if (!SASLprep((uint8_t *)pwd))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong password: %s\n", pwd);
         exit(-1);
       }
-      if (print_enc_password) {
+      if (print_enc_password)
+      {
         char result[257];
         generate_new_enc_password((char *)pwd, result);
         printf("%s\n", result);
         exit(0);
       }
-      if (print_enc_aes_password) {
+      if (print_enc_aes_password)
+      {
         encrypt_aes_128(pwd, generated_key);
         exit(0);
       }
@@ -2719,15 +3031,22 @@ static int adminmain(int argc, char **argv) {
       break;
     case 'f':
       fptr = fopen((char *)optarg, "r");
-      if (fptr == NULL) {
+      if (fptr == NULL)
+      {
         printf("No such file like %s\n", (char *)optarg);
-      } else {
+      }
+      else
+      {
         fseek(fptr, 0, SEEK_SET);
         rc = fread(generated_key, sizeof(char), 16, fptr);
-        if (rc == 0) {
+        if (rc == 0)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: Secret-Key file is empty\n", __FUNCTION__);
-        } else {
-          if (rc != 16) {
+        }
+        else
+        {
+          if (rc != 16)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: Secret-Key length is not enough\n", __FUNCTION__);
           }
         }
@@ -2749,12 +3068,14 @@ static int adminmain(int argc, char **argv) {
 
 #if !defined(TURN_NO_SQLITE)
   if (!strlen(turn_params.default_users_db.persistent_users_db.userdb) &&
-      (turn_params.default_users_db.userdb_type == TURN_USERDB_TYPE_SQLITE)) {
+      (turn_params.default_users_db.userdb_type == TURN_USERDB_TYPE_SQLITE))
+  {
     strncpy(turn_params.default_users_db.persistent_users_db.userdb, DEFAULT_USERDB_FILE, TURN_LONG_STRING_SIZE);
   }
 #endif
 
-  if (ct == TA_COMMAND_UNKNOWN) {
+  if (ct == TA_COMMAND_UNKNOWN)
+  {
     fprintf(stderr, "\n%s\n", AdminUsage);
     exit(-1);
   }
@@ -2762,7 +3083,8 @@ static int adminmain(int argc, char **argv) {
   argc -= optind;
   argv += optind;
 
-  if (argc != 0) {
+  if (argc != 0)
+  {
     fprintf(stderr, "\n%s\n", AdminUsage);
     exit(-1);
   }
@@ -2774,16 +3096,21 @@ static int adminmain(int argc, char **argv) {
   return result;
 }
 
-static void print_features(unsigned long mfn) {
+static void print_features(unsigned long mfn)
+{
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Coturn Version %s\n", TURN_SOFTWARE);
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Max number of open files/sockets allowed for this process: %lu\n", mfn);
-  if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_ENDPOINT) {
+  if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_ENDPOINT)
+  {
     mfn = mfn / 3;
-  } else {
+  }
+  else
+  {
     mfn = mfn / 2;
   }
   mfn = ((unsigned long)(mfn / 500)) * 500;
-  if (mfn < 500) {
+  if (mfn < 500)
+  {
     mfn = 500;
   }
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
@@ -2821,9 +3148,12 @@ static void print_features(unsigned long mfn) {
 
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "TURN/STUN ALPN supported\n");
 
-  if (ENC_ALG_NUM == 0) {
+  if (ENC_ALG_NUM == 0)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Third-party authorization (oAuth) is not supported\n");
-  } else {
+  }
+  else
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Third-party authorization (oAuth) supported\n");
 #if defined(TURN_NO_GCM)
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "GCM (AEAD) is not supported\n");
@@ -2871,8 +3201,10 @@ static void print_features(unsigned long mfn) {
 #include <linux/version.h>
 #endif
 
-static void set_network_engine(void) {
-  if (turn_params.net_engine_version != NEV_UNKNOWN) {
+static void set_network_engine(void)
+{
+  if (turn_params.net_engine_version != NEV_UNKNOWN)
+  {
     return;
   }
   turn_params.net_engine_version = NEV_UDP_SOCKET_PER_ENDPOINT;
@@ -2896,50 +3228,70 @@ static void set_network_engine(void) {
 #endif /* defined(SO_REUSEPORT) */
 }
 
-static void drop_privileges(void) {
+static void drop_privileges(void)
+{
 #if defined(WINDOWS)
   // TODO: implement it!!!
 #else
   setgroups(0, NULL);
-  if (procgroupid_set) {
-    if (getgid() != procgroupid) {
-      if (setgid(procgroupid) != 0) {
+  if (procgroupid_set)
+  {
+    if (getgid() != procgroupid)
+    {
+      if (setgid(procgroupid) != 0)
+      {
         perror("setgid: Unable to change group privileges");
         exit(-1);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "New GID: %s(%lu)\n", procgroupname, (unsigned long)procgroupid);
       }
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Keep GID: %s(%lu)\n", procgroupname, (unsigned long)procgroupid);
     }
   }
 
-  if (procuserid_set) {
-    if (procuserid != getuid()) {
-      if (setuid(procuserid) != 0) {
+  if (procuserid_set)
+  {
+    if (procuserid != getuid())
+    {
+      if (setuid(procuserid) != 0)
+      {
         perror("setuid: Unable to change user privileges");
         exit(-1);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "New UID: %s(%lu)\n", procusername, (unsigned long)procuserid);
       }
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Keep UID: %s(%lu)\n", procusername, (unsigned long)procuserid);
     }
   }
 #endif
 }
 
-static void init_domain(void) {
+static void init_domain(void)
+{
 #if !defined(TURN_NO_GETDOMAINNAME)
-  if (getdomainname(turn_params.domain, sizeof(turn_params.domain) - 1) < 0) {
+  if (getdomainname(turn_params.domain, sizeof(turn_params.domain) - 1) < 0)
+  {
     turn_params.domain[0] = 0;
-  } else if (!strcmp(turn_params.domain, "(none)")) {
+  }
+  else if (!strcmp(turn_params.domain, "(none)"))
+  {
     turn_params.domain[0] = 0;
   }
 #endif
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
   int c = 0;
 
   IS_TURN_SERVER = 1;
@@ -2963,13 +3315,16 @@ int main(int argc, char **argv) {
   init_secrets_list(&turn_params.default_users_db.ram_db.static_auth_secrets);
   init_dynamic_ip_lists();
 
-  if (!strstr(argv[0], "turnadmin")) {
+  if (!strstr(argv[0], "turnadmin"))
+  {
 
     struct uoptions uo;
     uo.u.m = long_options;
 
-    while (((c = getopt_long(argc, argv, OPTIONS, uo.u.o, NULL)) != -1)) {
-      switch (c) {
+    while (((c = getopt_long(argc, argv, OPTIONS, uo.u.o, NULL)) != -1))
+    {
+      switch (c)
+      {
       case 'l':
         set_logfile(optarg);
         break;
@@ -3006,7 +3361,8 @@ int main(int argc, char **argv) {
   turn_params.no_dtls = 1;
 #endif
 
-  if (strstr(argv[0], "turnadmin")) {
+  if (strstr(argv[0], "turnadmin"))
+  {
     return adminmain(argc, argv);
   }
 
@@ -3018,12 +3374,16 @@ int main(int argc, char **argv) {
 
   {
     unsigned long cpus = get_system_active_number_of_cpus();
-    if (cpus > 0) {
+    if (cpus > 0)
+    {
       turn_params.cpus = cpus;
     }
-    if (turn_params.cpus < DEFAULT_CPUS_NUMBER) {
+    if (turn_params.cpus < DEFAULT_CPUS_NUMBER)
+    {
       turn_params.cpus = DEFAULT_CPUS_NUMBER;
-    } else if (turn_params.cpus > MAX_NUMBER_OF_GENERAL_RELAY_SERVERS) {
+    }
+    else if (turn_params.cpus > MAX_NUMBER_OF_GENERAL_RELAY_SERVERS)
+    {
       turn_params.cpus = MAX_NUMBER_OF_GENERAL_RELAY_SERVERS;
     }
 
@@ -3039,8 +3399,10 @@ int main(int argc, char **argv) {
   struct uoptions uo;
   uo.u.m = long_options;
 
-  while (((c = getopt_long(argc, argv, OPTIONS, uo.u.o, NULL)) != -1)) {
-    if (c != 'u') {
+  while (((c = getopt_long(argc, argv, OPTIONS, uo.u.o, NULL)) != -1))
+  {
+    if (c != 'u')
+    {
       set_option(c, optarg);
     }
   }
@@ -3054,55 +3416,66 @@ int main(int argc, char **argv) {
     print_features(mfn);
   }
 
-  if (!get_realm(NULL)->options.name[0]) {
+  if (!get_realm(NULL)->options.name[0])
+  {
     STRCPY(get_realm(NULL)->options.name, turn_params.domain);
   }
 
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Domain name: %s\n", turn_params.domain);
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Default realm: %s\n", get_realm(NULL)->options.name);
 
-  if (turn_params.acme_redirect[0]) {
+  if (turn_params.acme_redirect[0])
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "ACME redirect URL: %s\n", turn_params.acme_redirect);
   }
-  if (turn_params.oauth && turn_params.oauth_server_name[0]) {
+  if (turn_params.oauth && turn_params.oauth_server_name[0])
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "oAuth server name: %s\n", turn_params.oauth_server_name);
   }
 
   optind = 0;
 
-  while (((c = getopt_long(argc, argv, OPTIONS, uo.u.o, NULL)) != -1)) {
-    if (c == 'u') {
+  while (((c = getopt_long(argc, argv, OPTIONS, uo.u.o, NULL)) != -1))
+  {
+    if (c == 'u')
+    {
       set_option(c, optarg);
     }
   }
 
-  if (turn_params.bps_capacity && !(turn_params.max_bps)) {
+  if (turn_params.bps_capacity && !(turn_params.max_bps))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
                   "\nCONFIG ERROR: If you set the --bps-capacity option, then you must set --max-bps options, too.\n");
     exit(-1);
   }
 
-  if (turn_params.no_udp_relay && turn_params.no_tcp_relay) {
+  if (turn_params.no_udp_relay && turn_params.no_tcp_relay)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
                   "\nCONFIG ERROR: --no-udp-relay and --no-tcp-relay options cannot be used together.\n");
     exit(-1);
   }
 
-  if (turn_params.no_udp_relay) {
+  if (turn_params.no_udp_relay)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "CONFIG: --no-udp-relay: UDP relay endpoints are not allowed.\n");
   }
 
-  if (turn_params.no_tcp_relay) {
+  if (turn_params.no_tcp_relay)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "CONFIG: --no-tcp-relay: TCP relay endpoints are not allowed.\n");
   }
 
-  if (turn_params.server_relay) {
+  if (turn_params.server_relay)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "CONFIG: WARNING: --server-relay: NON-STANDARD AND DANGEROUS OPTION.\n");
   }
 
 #if !defined(TURN_NO_SQLITE)
   if (!strlen(turn_params.default_users_db.persistent_users_db.userdb) &&
-      (turn_params.default_users_db.userdb_type == TURN_USERDB_TYPE_SQLITE)) {
+      (turn_params.default_users_db.userdb_type == TURN_USERDB_TYPE_SQLITE))
+  {
     strncpy(turn_params.default_users_db.persistent_users_db.userdb, DEFAULT_USERDB_FILE, TURN_LONG_STRING_SIZE);
   }
 #endif
@@ -3110,62 +3483,76 @@ int main(int argc, char **argv) {
   argc -= optind;
   argv += optind;
 
-  if (argc > 0) {
+  if (argc > 0)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "CONFIG: Unknown argument: %s\n", argv[argc - 1]);
   }
 
-  if (use_lt_credentials && anon_credentials) {
+  if (use_lt_credentials && anon_credentials)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "CONFIG: -a and -z options cannot be used together.\n");
     exit(-1);
   }
 
-  if (use_ltc && use_tltc) {
+  if (use_ltc && use_tltc)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
                   "CONFIG: You specified --lt-cred-mech and --use-auth-secret in the same time.\n"
                   "Be aware that you could not mix the username/password and the shared secret based auth methods. \n"
                   "Shared secret overrides username/password based auth method. Check your configuration!\n");
   }
 
-  if (turn_params.allow_loopback_peers) {
+  if (turn_params.allow_loopback_peers)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
                   "CONFIG: allow_loopback_peers opens a possible security vulnerability. Do not use in production!!\n");
-    if (cli_password[0] == 0 && use_cli) {
+    if (cli_password[0] == 0 && use_cli)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
                     "CONFIG: allow_loopback_peers and empty cli password cannot be used together.\n");
       exit(-1);
     }
   }
 
-  if (use_cli && cli_password[0] == 0) {
+  if (use_cli && cli_password[0] == 0)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "CONFIG: Empty cli-password, and so telnet cli interface is disabled! "
                                         "Please set a non empty cli-password!\n");
     use_cli = 0;
   }
 
-  if (!use_lt_credentials && !anon_credentials) {
-    if (turn_params.default_users_db.ram_db.users_number) {
+  if (!use_lt_credentials && !anon_credentials)
+  {
+    if (turn_params.default_users_db.ram_db.users_number)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
                     "CONFIG: you specified long-term user accounts, (-u option) \n	but you did "
                     "not specify the long-term credentials option\n	(-a or --lt-cred-mech option).\n 	I am "
                     "turning --lt-cred-mech ON for you, but double-check your configuration.\n");
       turn_params.ct = TURN_CREDENTIALS_LONG_TERM;
       use_lt_credentials = 1;
-    } else {
+    }
+    else
+    {
       turn_params.ct = TURN_CREDENTIALS_NONE;
       use_lt_credentials = 0;
     }
   }
 
-  if (use_lt_credentials) {
-    if (!get_realm(NULL)->options.name[0]) {
+  if (use_lt_credentials)
+  {
+    if (!get_realm(NULL)->options.name[0])
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
                     "CONFIG: you did specify the long-term credentials usage\n but you did not specify "
                     "the default realm option (-r option).\n		Check your configuration.\n");
     }
   }
 
-  if (anon_credentials) {
-    if (turn_params.default_users_db.ram_db.users_number) {
+  if (anon_credentials)
+  {
+    if (turn_params.default_users_db.ram_db.users_number)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
                     "CONFIG: you specified user accounts, (-u option)	but you also specified the "
                     "anonymous user access option (-z or --no-auth option).	User accounts will be ignored.\n");
@@ -3174,7 +3561,8 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (use_web_admin && turn_params.no_tls) {
+  if (use_web_admin && turn_params.no_tls)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "CONFIG: WARNING: web-admin support not compatible with --no-tls option.\n");
     use_web_admin = 0;
   }
@@ -3182,11 +3570,13 @@ int main(int argc, char **argv) {
   openssl_setup();
 
   int local_listeners = 0;
-  if (!turn_params.listener.addrs_number) {
+  if (!turn_params.listener.addrs_number)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "NO EXPLICIT LISTENER ADDRESS(ES) ARE CONFIGURED\n");
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "===========Discovering listener addresses: =========\n");
     int maddrs = make_local_listeners_list();
-    if ((maddrs < 1) || !turn_params.listener.addrs_number) {
+    if ((maddrs < 1) || !turn_params.listener.addrs_number)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot configure any meaningful IP listener address\n", __FUNCTION__);
       fprintf(stderr, "\n%s\n", Usage);
       exit(-1);
@@ -3197,23 +3587,30 @@ int main(int argc, char **argv) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "=====================================================\n");
   }
 
-  if (!turn_params.relays_number) {
-    if (!local_listeners && turn_params.listener.addrs_number && turn_params.listener.addrs) {
+  if (!turn_params.relays_number)
+  {
+    if (!local_listeners && turn_params.listener.addrs_number && turn_params.listener.addrs)
+    {
       size_t la = 0;
-      for (la = 0; la < turn_params.listener.addrs_number; la++) {
-        if (turn_params.listener.addrs[la]) {
+      for (la = 0; la < turn_params.listener.addrs_number; la++)
+      {
+        if (turn_params.listener.addrs[la])
+        {
           add_relay_addr(turn_params.listener.addrs[la]);
         }
       }
     }
-    if (!turn_params.relays_number) {
+    if (!turn_params.relays_number)
+    {
       turn_params.default_relays = 1;
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "NO EXPLICIT RELAY ADDRESS(ES) ARE CONFIGURED\n");
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "===========Discovering relay addresses: =============\n");
-      if (make_local_relays_list(0, AF_INET) < 1) {
+      if (make_local_relays_list(0, AF_INET) < 1)
+      {
         make_local_relays_list(1, AF_INET);
       }
-      if (make_local_relays_list(0, AF_INET6) < 1) {
+      if (make_local_relays_list(0, AF_INET6) < 1)
+      {
         make_local_relays_list(1, AF_INET6);
       }
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "=====================================================\n");
@@ -3221,23 +3618,31 @@ int main(int argc, char **argv) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "=====================================================\n");
     }
 
-    if (!turn_params.relays_number) {
+    if (!turn_params.relays_number)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: You must specify the relay address(es)\n", __FUNCTION__);
       fprintf(stderr, "\n%s\n", Usage);
       exit(-1);
     }
   }
 
-  if (turn_params.external_ip && turn_params.relay_addrs) {
+  if (turn_params.external_ip && turn_params.relay_addrs)
+  {
     size_t ir = 0;
-    for (ir = 0; ir < turn_params.relays_number; ++ir) {
-      if (turn_params.relay_addrs[ir]) {
+    for (ir = 0; ir < turn_params.relays_number; ++ir)
+    {
+      if (turn_params.relay_addrs[ir])
+      {
         const char *sra = (const char *)turn_params.relay_addrs[ir];
-        if ((strstr(sra, "127.0.0.1") != sra) && (strstr(sra, "::1") != sra)) {
+        if ((strstr(sra, "127.0.0.1") != sra) && (strstr(sra, "::1") != sra))
+        {
           ioa_addr ra;
-          if (make_ioa_addr((const uint8_t *)sra, 0, &ra) < 0) {
+          if (make_ioa_addr((const uint8_t *)sra, 0, &ra) < 0)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "-X : Wrong address format: %s\n", sra);
-          } else if (ra.ss.sa_family == turn_params.external_ip->ss.sa_family) {
+          }
+          else if (ra.ss.sa_family == turn_params.external_ip->ss.sa_family)
+          {
             ioa_addr_add_mapping(turn_params.external_ip, &ra);
           }
         }
@@ -3245,7 +3650,8 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (socket_init()) {
+  if (socket_init())
+  {
     return -1;
   }
 
@@ -3253,18 +3659,22 @@ int main(int argc, char **argv) {
 
   // TODO: implement deamon!!! use windows server
 #else
-  if (turn_params.turn_daemon) {
+  if (turn_params.turn_daemon)
+  {
 #if !defined(TURN_HAS_DAEMON)
     pid_t pid = fork();
-    if (pid > 0) {
+    if (pid > 0)
+    {
       exit(0);
     }
-    if (pid < 0) {
+    if (pid < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot start daemon process\n");
       exit(-1);
     }
 #else
-    if (daemon(1, 0) < 0) {
+    if (daemon(1, 0) < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot start daemon process\n");
       exit(-1);
     }
@@ -3272,13 +3682,17 @@ int main(int argc, char **argv) {
 #endif
   }
 
-  if (turn_params.pidfile[0]) {
+  if (turn_params.pidfile[0])
+  {
 
     char s[2049];
     FILE *f = fopen(turn_params.pidfile, "w");
-    if (f) {
+    if (f)
+    {
       STRCPY(s, turn_params.pidfile);
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "Cannot create pid file: %s\n", turn_params.pidfile);
 
       {
@@ -3290,19 +3704,24 @@ int main(int argc, char **argv) {
                              "turnserver.pid",
                              NULL};
         const char **ppfs = pfs;
-        while (*ppfs) {
+        while (*ppfs)
+        {
           f = fopen(*ppfs, "w");
-          if (f) {
+          if (f)
+          {
             STRCPY(s, *ppfs);
             break;
-          } else {
+          }
+          else
+          {
             ++ppfs;
           }
         }
       }
     }
 
-    if (f) {
+    if (f)
+    {
       fprintf(f, "%lu\n", (unsigned long)getpid());
       fclose(f);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "pid file created: %s\n", s);
@@ -3345,26 +3764,34 @@ int THREAD_cleanup(void);
 int THREAD_cleanup(void) { return 1; }
 #endif /* defined(OPENSSL_THREADS) */
 
-static void adjust_key_file_name(char *fn, const char *file_title, int critical) {
+static void adjust_key_file_name(char *fn, const char *file_title, int critical)
+{
   char *full_path_to_file = NULL;
 
-  if (!fn[0]) {
+  if (!fn[0])
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "\nERROR: you must set the %s file parameter\n", file_title);
     goto keyerr;
-  } else {
+  }
+  else
+  {
 
     full_path_to_file = find_config_file(fn);
     {
       FILE *f = full_path_to_file ? fopen(full_path_to_file, "r") : NULL;
-      if (!f) {
+      if (!f)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "cannot find %s file: %s (1)\n", file_title, fn);
         goto keyerr;
-      } else {
+      }
+      else
+      {
         fclose(f);
       }
     }
 
-    if (!full_path_to_file) {
+    if (!full_path_to_file)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "cannot find %s file: %s (2)\n", file_title, fn);
       goto keyerr;
     }
@@ -3377,29 +3804,35 @@ static void adjust_key_file_name(char *fn, const char *file_title, int critical)
   }
 
 keyerr:
-  if (critical) {
+  if (critical)
+  {
     turn_params.no_tls = 1;
     turn_params.no_dtls = 1;
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "cannot start TLS and DTLS listeners because %s file is not set properly\n",
                   file_title);
   }
-  if (full_path_to_file) {
+  if (full_path_to_file)
+  {
     free(full_path_to_file);
   }
   return;
 }
 
-static void adjust_key_file_names(void) {
-  if (turn_params.ca_cert_file[0]) {
+static void adjust_key_file_names(void)
+{
+  if (turn_params.ca_cert_file[0])
+  {
     adjust_key_file_name(turn_params.ca_cert_file, "CA", 1);
   }
   adjust_key_file_name(turn_params.cert_file, "certificate", 1);
   adjust_key_file_name(turn_params.pkey_file, "private key", 1);
-  if (turn_params.dh_file[0]) {
+  if (turn_params.dh_file[0])
+  {
     adjust_key_file_name(turn_params.dh_file, "DH key", 0);
   }
 }
-static DH *get_dh566(void) {
+static DH *get_dh566(void)
+{
 
   unsigned char dh566_p[] = {0x36, 0x53, 0xA8, 0x9C, 0x3C, 0xF1, 0xD1, 0x1B, 0x2D, 0xA2, 0x64, 0xDE, 0x59, 0x3B, 0xE3,
                              0x8C, 0x27, 0x74, 0xC2, 0xBE, 0x9B, 0x6D, 0x56, 0xE7, 0xDF, 0xFF, 0x67, 0x6A, 0xD2, 0x0C,
@@ -3415,14 +3848,16 @@ static DH *get_dh566(void) {
   unsigned char dh566_g[] = {0x05};
   DH *dh;
 
-  if ((dh = DH_new()) == NULL) {
+  if ((dh = DH_new()) == NULL)
+  {
     return (NULL);
   }
   DH_set0_pqg(dh, BN_bin2bn(dh566_p, sizeof(dh566_p), NULL), NULL, BN_bin2bn(dh566_g, sizeof(dh566_g), NULL));
   return (dh);
 }
 
-static DH *get_dh1066(void) {
+static DH *get_dh1066(void)
+{
 
   unsigned char dh1066_p[] = {0x02, 0x0E, 0x26, 0x6F, 0xAA, 0x9F, 0xA8, 0xE5, 0x3F, 0x70, 0x88, 0xF1, 0xA9, 0x29, 0xAE,
                               0x1A, 0x2B, 0xA8, 0x2F, 0xE8, 0xE5, 0x0E, 0x81, 0x78, 0xD7, 0x12, 0x41, 0xDC, 0xE2, 0xD5,
@@ -3443,14 +3878,16 @@ static DH *get_dh1066(void) {
   unsigned char dh1066_g[] = {0x02};
   DH *dh;
 
-  if ((dh = DH_new()) == NULL) {
+  if ((dh = DH_new()) == NULL)
+  {
     return (NULL);
   }
   DH_set0_pqg(dh, BN_bin2bn(dh1066_p, sizeof(dh1066_p), NULL), NULL, BN_bin2bn(dh1066_g, sizeof(dh1066_g), NULL));
   return (dh);
 }
 
-static DH *get_dh2066(void) {
+static DH *get_dh2066(void)
+{
 
   unsigned char dh2066_p[] = {
       0x03, 0x31, 0x77, 0x20, 0x58, 0xA6, 0x69, 0xA3, 0x9D, 0x2D, 0x5E, 0xE0, 0x5C, 0x46, 0x82, 0x0F, 0x9E, 0x80, 0xF0,
@@ -3480,14 +3917,16 @@ static DH *get_dh2066(void) {
   unsigned char dh2066_g[] = {0x05};
   DH *dh;
 
-  if ((dh = DH_new()) == NULL) {
+  if ((dh = DH_new()) == NULL)
+  {
     return (NULL);
   }
   DH_set0_pqg(dh, BN_bin2bn(dh2066_p, sizeof(dh2066_p), NULL), NULL, BN_bin2bn(dh2066_g, sizeof(dh2066_g), NULL));
   return (dh);
 }
 
-static int pem_password_func(char *buf, int size, int rwflag, void *password) {
+static int pem_password_func(char *buf, int size, int rwflag, void *password)
+{
   UNUSED_ARG(rwflag);
 
   strncpy(buf, (char *)(password), size);
@@ -3496,7 +3935,8 @@ static int pem_password_func(char *buf, int size, int rwflag, void *password) {
 }
 
 static int ServerALPNCallback(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in,
-                              unsigned int inlen, void *arg) {
+                              unsigned int inlen, void *arg)
+{
 
   UNUSED_ARG(ssl);
   UNUSED_ARG(arg);
@@ -3508,24 +3948,29 @@ static int ServerALPNCallback(SSL *ssl, const unsigned char **out, unsigned char
   int found_http = 0;
 
   const unsigned char *ptr = in;
-  while (ptr < (in + inlen)) {
+  while (ptr < (in + inlen))
+  {
     unsigned char current_len = *ptr;
-    if (ptr + 1 + current_len > in + inlen) {
+    if (ptr + 1 + current_len > in + inlen)
+    {
       break;
     }
-    if ((!turn_params.no_stun) && (current_len == sa_len) && (memcmp(ptr + 1, STUN_ALPN, sa_len) == 0)) {
+    if ((!turn_params.no_stun) && (current_len == sa_len) && (memcmp(ptr + 1, STUN_ALPN, sa_len) == 0))
+    {
       *out = ptr + 1;
       *outlen = sa_len;
       SSL_set_app_data(ssl, STUN_ALPN);
       return SSL_TLSEXT_ERR_OK;
     }
-    if ((!turn_params.stun_only) && (current_len == ta_len) && (memcmp(ptr + 1, TURN_ALPN, ta_len) == 0)) {
+    if ((!turn_params.stun_only) && (current_len == ta_len) && (memcmp(ptr + 1, TURN_ALPN, ta_len) == 0))
+    {
       *out = ptr + 1;
       *outlen = ta_len;
       SSL_set_app_data(ssl, TURN_ALPN);
       return SSL_TLSEXT_ERR_OK;
     }
-    if ((current_len == ha_len) && (memcmp(ptr + 1, HTTP_ALPN, ha_len) == 0)) {
+    if ((current_len == ha_len) && (memcmp(ptr + 1, HTTP_ALPN, ha_len) == 0))
+    {
       *out = ptr + 1;
       *outlen = ha_len;
       SSL_set_app_data(ssl, HTTP_ALPN);
@@ -3534,14 +3979,16 @@ static int ServerALPNCallback(SSL *ssl, const unsigned char **out, unsigned char
     ptr += 1 + current_len;
   }
 
-  if (found_http) {
+  if (found_http)
+  {
     return SSL_TLSEXT_ERR_OK;
   }
 
   return SSL_TLSEXT_ERR_NOACK; //???
 }
 
-static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *method) {
+static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *method)
+{
   SSL_CTX *ctx = SSL_CTX_new(method);
   int err = 0;
   int rc = 0;
@@ -3549,7 +3996,8 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
   SSL_CTX_set_default_passwd_cb_userdata(ctx, turn_params.tls_password);
   SSL_CTX_set_default_passwd_cb(ctx, pem_password_func);
 
-  if (!(turn_params.cipher_list[0])) {
+  if (!(turn_params.cipher_list[0]))
+  {
     strncpy(turn_params.cipher_list, DEFAULT_CIPHER_LIST, TURN_LONG_STRING_SIZE);
 #if defined(DEFAULT_CIPHERSUITES)
     strncat(turn_params.cipher_list, ":", TURN_LONG_STRING_SIZE - strlen(turn_params.cipher_list));
@@ -3561,26 +4009,32 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
   SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);
   SSL_CTX_set_ciphersuites(ctx, turn_params.cipher_list);
 
-  if (!SSL_CTX_use_certificate_chain_file(ctx, turn_params.cert_file)) {
+  if (!SSL_CTX_use_certificate_chain_file(ctx, turn_params.cert_file))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: no certificate found\n", protocol);
     err = 1;
   }
 
-  if (!SSL_CTX_use_PrivateKey_file(ctx, turn_params.pkey_file, SSL_FILETYPE_PEM)) {
-    if (!SSL_CTX_use_RSAPrivateKey_file(ctx, turn_params.pkey_file, SSL_FILETYPE_PEM)) {
+  if (!SSL_CTX_use_PrivateKey_file(ctx, turn_params.pkey_file, SSL_FILETYPE_PEM))
+  {
+    if (!SSL_CTX_use_RSAPrivateKey_file(ctx, turn_params.pkey_file, SSL_FILETYPE_PEM))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
                     "%s: ERROR: no valid private key found, or invalid private key password provided\n", protocol);
       err = 1;
     }
   }
-  if (!SSL_CTX_check_private_key(ctx)) {
+  if (!SSL_CTX_check_private_key(ctx))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: invalid private key\n", protocol);
     err = 1;
   }
 
-  if (turn_params.ca_cert_file[0]) {
+  if (turn_params.ca_cert_file[0])
+  {
 
-    if (!SSL_CTX_load_verify_locations(ctx, turn_params.ca_cert_file, NULL)) {
+    if (!SSL_CTX_load_verify_locations(ctx, turn_params.ca_cert_file, NULL))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot load CA from file: %s\n", turn_params.ca_cert_file);
       err = 1;
     }
@@ -3592,8 +4046,9 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
 
     /* Set the verification depth to 9 */
     SSL_CTX_set_verify_depth(ctx, 9);
-
-  } else {
+  }
+  else
+  {
     SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
   }
 
@@ -3604,17 +4059,20 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
 
     const char *curve_name = turn_params.ec_curve_name;
 
-    if (!(curve_name[0])) {
+    if (!(curve_name[0]))
+    {
 #if !SSL_SESSION_ECDH_AUTO_SUPPORTED
       curve_name = DEFAULT_EC_CURVE_NAME;
 #endif
       set_auto_curve = 1;
     }
 
-    if (curve_name[0]) {
+    if (curve_name[0])
+    {
       {
         nid = OBJ_sn2nid(curve_name);
-        if (nid == 0) {
+        if (nid == 0)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "unknown curve name: %s\n", curve_name);
           curve_name = DEFAULT_EC_CURVE_NAME;
           nid = OBJ_sn2nid(curve_name);
@@ -3624,17 +4082,21 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
 
       {
         EC_KEY *ecdh = EC_KEY_new_by_curve_name(nid);
-        if (!ecdh) {
+        if (!ecdh)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: allocate EC suite\n", __FUNCTION__);
           set_auto_curve = 1;
-        } else {
+        }
+        else
+        {
           SSL_CTX_set_tmp_ecdh(ctx, ecdh);
           EC_KEY_free(ecdh);
         }
       }
     }
 
-    if (set_auto_curve) {
+    if (set_auto_curve)
+    {
       set_auto_curve = 0;
     }
   }
@@ -3643,34 +4105,49 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
   { // DH algorithms:
 
     DH *dh = NULL;
-    if (turn_params.dh_file[0]) {
+    if (turn_params.dh_file[0])
+    {
       FILE *paramfile = fopen(turn_params.dh_file, "r");
-      if (!paramfile) {
+      if (!paramfile)
+      {
         perror("Cannot open DH file");
-      } else {
+      }
+      else
+      {
         dh = PEM_read_DHparams(paramfile, NULL, NULL, NULL);
         fclose(paramfile);
-        if (dh) {
+        if (dh)
+        {
           turn_params.dh_key_size = DH_CUSTOM;
         }
       }
     }
 
-    if (!dh) {
-      if (turn_params.dh_key_size == DH_566) {
+    if (!dh)
+    {
+      if (turn_params.dh_key_size == DH_566)
+      {
         dh = get_dh566();
-      } else if (turn_params.dh_key_size == DH_1066) {
+      }
+      else if (turn_params.dh_key_size == DH_1066)
+      {
         dh = get_dh1066();
-      } else {
+      }
+      else
+      {
         dh = get_dh2066();
       }
     }
 
-    if (!dh) {
+    if (!dh)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: cannot allocate DH suite\n", __FUNCTION__);
       err = 1;
-    } else {
-      if (1 != SSL_CTX_set_tmp_dh(ctx, dh)) {
+    }
+    else
+    {
+      if (1 != SSL_CTX_set_tmp_dh(ctx, dh))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: cannot set DH\n", __FUNCTION__);
         err = 1;
       }
@@ -3680,18 +4157,26 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
 
   { // secret key
 
-    if (turn_params.secret_key_file[0]) {
+    if (turn_params.secret_key_file[0])
+    {
       FILE *f = fopen(turn_params.secret_key_file, "r");
 
-      if (!f) {
+      if (!f)
+      {
         perror("Cannot open Secret-Key file");
-      } else {
+      }
+      else
+      {
         fseek(f, 0, SEEK_SET);
         rc = fread(turn_params.secret_key, sizeof(char), 16, f);
-        if (rc == 0) {
+        if (rc == 0)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: Secret-Key file is empty\n", __FUNCTION__);
-        } else {
-          if (rc != 16) {
+        }
+        else
+        {
+          if (rc != 16)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: Secret-Key length is not enough\n", __FUNCTION__);
           }
         }
@@ -3726,20 +4211,27 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
     SSL_CTX_set_options(ctx, op);
   }
 
-  if (*out == NULL) {
+  if (*out == NULL)
+  {
     // Always initialize, even if issues were encountered
     *out = ctx;
-  } else if (!err) {
+  }
+  else if (!err)
+  {
     SSL_CTX_free(*out);
     *out = ctx;
   }
 
 #if OPENSSL_VERSION_NUMBER >= 0x30200010L
-  if (turn_params.rpk_enabled) {
+  if (turn_params.rpk_enabled)
+  {
     unsigned char cert_type = TLSEXT_cert_type_rpk;
-    if (!SSL_CTX_set1_server_cert_type(ctx, &cert_type, 1)) {
+    if (!SSL_CTX_set1_server_cert_type(ctx, &cert_type, 1))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Could not enable raw public keys functionality (RFC7250)\n");
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Raw Public Keys (RFC7250) enabled!\n");
     }
   }
@@ -3747,68 +4239,81 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
 }
 
 static void openssl_load_certificates(void);
-static void openssl_setup(void) {
+static void openssl_setup(void)
+{
   THREAD_setup();
   SSL_load_error_strings();
   OpenSSL_add_ssl_algorithms();
 
 #if !TLS_SUPPORTED
-  if (!turn_params.no_tls) {
+  if (!turn_params.no_tls)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "WARNING: TLS is not supported\n");
     turn_params.no_tls = 1;
   }
 #endif
 
-  if (!(turn_params.no_tls && turn_params.no_dtls) && !turn_params.cert_file[0]) {
+  if (!(turn_params.no_tls && turn_params.no_dtls) && !turn_params.cert_file[0])
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "\nWARNING: certificate file is not specified, I cannot start TLS/DTLS "
                                           "services.\nOnly 'plain' UDP/TCP listeners can be started.\n");
     turn_params.no_tls = 1;
     turn_params.no_dtls = 1;
   }
 
-  if (!(turn_params.no_tls && turn_params.no_dtls) && !turn_params.pkey_file[0]) {
+  if (!(turn_params.no_tls && turn_params.no_dtls) && !turn_params.pkey_file[0])
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "\nWARNING: private key file is not specified, I cannot start TLS/DTLS "
                                           "services.\nOnly 'plain' UDP/TCP listeners can be started.\n");
     turn_params.no_tls = 1;
     turn_params.no_dtls = 1;
   }
 
-  if (!(turn_params.no_tls && turn_params.no_dtls)) {
+  if (!(turn_params.no_tls && turn_params.no_dtls))
+  {
     adjust_key_file_names();
   }
 
   openssl_load_certificates();
 }
 
-static void openssl_load_certificates(void) {
+static void openssl_load_certificates(void)
+{
 
   print_abs_file_name("", "Certificate", turn_params.cert_file);
   print_abs_file_name("", "Private key", turn_params.pkey_file);
 
   TURN_MUTEX_LOCK(&turn_params.tls_mutex);
-  if (!turn_params.no_tls) {
+  if (!turn_params.no_tls)
+  {
     set_ctx(&turn_params.tls_ctx, "TLS", TLS_server_method());
-    if (turn_params.no_tlsv1) {
+    if (turn_params.no_tlsv1)
+    {
       SSL_CTX_set_min_proto_version(turn_params.tls_ctx, TLS1_1_VERSION);
     }
-    if (turn_params.no_tlsv1_1) {
+    if (turn_params.no_tlsv1_1)
+    {
       SSL_CTX_set_min_proto_version(turn_params.tls_ctx, TLS1_2_VERSION);
     }
-    if (turn_params.no_tlsv1_2) {
+    if (turn_params.no_tlsv1_2)
+    {
       SSL_CTX_set_min_proto_version(turn_params.tls_ctx, TLS1_3_VERSION);
     }
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "TLS cipher suite: %s\n", turn_params.cipher_list);
   }
 
-  if (!turn_params.no_dtls) {
+  if (!turn_params.no_dtls)
+  {
 #if !DTLS_SUPPORTED
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "ERROR: DTLS is not supported.\n");
 #else
     set_ctx(&turn_params.dtls_ctx, "DTLS", DTLS_server_method());
-    if (turn_params.no_tlsv1 || turn_params.no_tlsv1_1) {
+    if (turn_params.no_tlsv1 || turn_params.no_tlsv1_1)
+    {
       SSL_CTX_set_min_proto_version(turn_params.dtls_ctx, DTLS1_2_VERSION);
     }
-    if (turn_params.no_tlsv1_2) {
+    if (turn_params.no_tlsv1_2)
+    {
       SSL_CTX_set_max_proto_version(turn_params.dtls_ctx, DTLS1_VERSION);
     }
     setup_dtls_callbacks(turn_params.dtls_ctx);
@@ -3818,10 +4323,12 @@ static void openssl_load_certificates(void) {
   TURN_MUTEX_UNLOCK(&turn_params.tls_mutex);
 }
 
-static void reload_ssl_certs(evutil_socket_t sock, short events, void *args) {
+static void reload_ssl_certs(evutil_socket_t sock, short events, void *args)
+{
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Reloading TLS certificates and keys\n");
   openssl_load_certificates();
-  if (turn_params.tls_ctx_update_ev != NULL) {
+  if (turn_params.tls_ctx_update_ev != NULL)
+  {
     event_active(turn_params.tls_ctx_update_ev, EV_READ, 0);
   }
 
@@ -3830,7 +4337,8 @@ static void reload_ssl_certs(evutil_socket_t sock, short events, void *args) {
   UNUSED_ARG(args);
 }
 
-static void shutdown_handler(evutil_socket_t sock, short events, void *args) {
+static void shutdown_handler(evutil_socket_t sock, short events, void *args)
+{
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Terminating on signal %d\n", sock);
   turn_params.stop_turn_server = true;
 
@@ -3838,7 +4346,8 @@ static void shutdown_handler(evutil_socket_t sock, short events, void *args) {
   UNUSED_ARG(args);
 }
 
-static void drain_handler(evutil_socket_t sock, short events, void *args) {
+static void drain_handler(evutil_socket_t sock, short events, void *args)
+{
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Draining then terminating on signal %d\n", sock);
   enable_drain_mode();
 

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -94,7 +94,8 @@
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ////////////// DEFINES ////////////////////////////
@@ -122,29 +123,43 @@ extern "C" {
 
 /////////// TYPES ///////////////////////////////////
 
-enum _DH_KEY_SIZE { DH_566, DH_1066, DH_2066, DH_CUSTOM };
+enum _DH_KEY_SIZE
+{
+  DH_566,
+  DH_1066,
+  DH_2066,
+  DH_CUSTOM
+};
 
 typedef enum _DH_KEY_SIZE DH_KEY_SIZE;
 
 ///////// LISTENER SERVER TYPES /////////////////////
 
-struct message_to_listener_to_client {
+struct message_to_listener_to_client
+{
   ioa_addr origin;
   ioa_addr destination;
   ioa_network_buffer_handle nbh;
 };
 
-enum _MESSAGE_TO_LISTENER_TYPE { LMT_UNKNOWN, LMT_TO_CLIENT };
+enum _MESSAGE_TO_LISTENER_TYPE
+{
+  LMT_UNKNOWN,
+  LMT_TO_CLIENT
+};
 typedef enum _MESSAGE_TO_LISTENER_TYPE MESSAGE_TO_LISTENER_TYPE;
 
-struct message_to_listener {
+struct message_to_listener
+{
   MESSAGE_TO_LISTENER_TYPE t;
-  union {
+  union
+  {
     struct message_to_listener_to_client tc;
   } m;
 };
 
-struct listener_server {
+struct listener_server
+{
   rtcp_map *rtcpmap;
   turnipports *tp;
   struct event_base *event_base;
@@ -160,7 +175,8 @@ struct listener_server {
   dtls_listener_relay_server_type ***aux_udp_services;
 };
 
-enum _NET_ENG_VERSION {
+enum _NET_ENG_VERSION
+{
   NEV_UNKNOWN = 0,
   NEV_MIN,
   NEV_UDP_SOCKET_PER_SESSION = NEV_MIN,
@@ -174,7 +190,8 @@ typedef enum _NET_ENG_VERSION NET_ENG_VERSION;
 
 /////////// PARAMS //////////////////////////////////
 
-typedef struct _turn_params_ {
+typedef struct _turn_params_
+{
 
   //////////////// OpenSSL group //////////////////////
 
@@ -339,15 +356,19 @@ extern turn_params_t turn_params;
 
 ////////////////  Listener server /////////////////
 
-static inline int get_alt_listener_port(void) {
-  if (turn_params.alt_listener_port < 1) {
+static inline int get_alt_listener_port(void)
+{
+  if (turn_params.alt_listener_port < 1)
+  {
     return turn_params.listener_port + 1;
   }
   return turn_params.alt_listener_port;
 }
 
-static inline int get_alt_tls_listener_port(void) {
-  if (turn_params.alt_tls_listener_port < 1) {
+static inline int get_alt_tls_listener_port(void)
+{
+  if (turn_params.alt_tls_listener_port < 1)
+  {
     return turn_params.tls_listener_port + 1;
   }
   return turn_params.alt_tls_listener_port;
@@ -389,7 +410,8 @@ void set_max_bps(band_limit_t value);
 
 ///////// AES ENCRYPTION AND DECRYPTION ////////
 
-struct ctr_state {
+struct ctr_state
+{
   unsigned char ivec[16];
   unsigned int num;
   unsigned char ecount[16];

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -48,7 +48,8 @@ static pthread_barrier_t barrier;
 
 typedef unsigned char authserver_id;
 
-struct auth_server {
+struct auth_server
+{
   authserver_id id;
   struct event_base *event_base;
   struct bufferevent *in_buf;
@@ -84,12 +85,15 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
 #define PTHREAD_BARRIER_SERIAL_THREAD (-1)
 #endif
 
-static void barrier_wait_func(const char *func, int line) {
+static void barrier_wait_func(const char *func, int line)
+{
 #if !defined(TURN_NO_THREAD_BARRIERS)
   int br = 0;
-  do {
+  do
+  {
     br = pthread_barrier_wait(&barrier);
-    if ((br < 0) && (br != PTHREAD_BARRIER_SERIAL_THREAD)) {
+    if ((br < 0) && (br != PTHREAD_BARRIER_SERIAL_THREAD))
+    {
       int err = socket_errno();
       perror("barrier wait");
       printf("%s:%s:%d: %d\n", __FUNCTION__, func, line, err);
@@ -108,32 +112,45 @@ static void barrier_wait_func(const char *func, int line) {
 
 static TURN_MUTEX_DECLARE(mutex_bps);
 
-static band_limit_t allocate_bps(band_limit_t bps, int positive) {
+static band_limit_t allocate_bps(band_limit_t bps, int positive)
+{
   band_limit_t ret = 0;
-  if (bps > 0) {
+  if (bps > 0)
+  {
     TURN_MUTEX_LOCK(&mutex_bps);
 
-    if (positive) {
+    if (positive)
+    {
 
-      if (!(turn_params.bps_capacity)) {
+      if (!(turn_params.bps_capacity))
+      {
         ret = bps;
         turn_params.bps_capacity_allocated += ret;
-      } else if (turn_params.bps_capacity_allocated < turn_params.bps_capacity) {
+      }
+      else if (turn_params.bps_capacity_allocated < turn_params.bps_capacity)
+      {
         band_limit_t reserve = turn_params.bps_capacity - turn_params.bps_capacity_allocated;
-        if (reserve <= bps) {
+        if (reserve <= bps)
+        {
           ret = reserve;
           turn_params.bps_capacity_allocated = turn_params.bps_capacity;
-        } else {
+        }
+        else
+        {
           ret = bps;
           turn_params.bps_capacity_allocated += ret;
         }
       }
+    }
+    else
+    {
 
-    } else {
-
-      if (turn_params.bps_capacity_allocated >= bps) {
+      if (turn_params.bps_capacity_allocated >= bps)
+      {
         turn_params.bps_capacity_allocated -= bps;
-      } else {
+      }
+      else
+      {
         turn_params.bps_capacity_allocated = 0;
       }
     }
@@ -144,7 +161,8 @@ static band_limit_t allocate_bps(band_limit_t bps, int positive) {
   return ret;
 }
 
-band_limit_t get_bps_capacity_allocated(void) {
+band_limit_t get_bps_capacity_allocated(void)
+{
   band_limit_t ret = 0;
   TURN_MUTEX_LOCK(&mutex_bps);
   ret = turn_params.bps_capacity_allocated;
@@ -152,7 +170,8 @@ band_limit_t get_bps_capacity_allocated(void) {
   return ret;
 }
 
-band_limit_t get_bps_capacity(void) {
+band_limit_t get_bps_capacity(void)
+{
   band_limit_t ret = 0;
   TURN_MUTEX_LOCK(&mutex_bps);
   ret = turn_params.bps_capacity;
@@ -160,13 +179,15 @@ band_limit_t get_bps_capacity(void) {
   return ret;
 }
 
-void set_bps_capacity(band_limit_t value) {
+void set_bps_capacity(band_limit_t value)
+{
   TURN_MUTEX_LOCK(&mutex_bps);
   turn_params.bps_capacity = value;
   TURN_MUTEX_UNLOCK(&mutex_bps);
 }
 
-band_limit_t get_max_bps(void) {
+band_limit_t get_max_bps(void)
+{
   band_limit_t ret = 0;
   TURN_MUTEX_LOCK(&mutex_bps);
   ret = turn_params.max_bps;
@@ -174,7 +195,8 @@ band_limit_t get_max_bps(void) {
   return ret;
 }
 
-void set_max_bps(band_limit_t value) {
+void set_max_bps(band_limit_t value)
+{
   TURN_MUTEX_LOCK(&mutex_bps);
   turn_params.max_bps = value;
   TURN_MUTEX_UNLOCK(&mutex_bps);
@@ -182,12 +204,17 @@ void set_max_bps(band_limit_t value) {
 
 /////////////// AUX SERVERS ////////////////
 
-static void add_aux_server_list(const char *saddr, turn_server_addrs_list_t *list) {
-  if (saddr && list) {
+static void add_aux_server_list(const char *saddr, turn_server_addrs_list_t *list)
+{
+  if (saddr && list)
+  {
     ioa_addr addr;
-    if (make_ioa_addr_from_full_string((const uint8_t *)saddr, 0, &addr) != 0) {
+    if (make_ioa_addr_from_full_string((const uint8_t *)saddr, 0, &addr) != 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong full address format: %s\n", saddr);
-    } else {
+    }
+    else
+    {
       list->addrs = (ioa_addr *)realloc(list->addrs, sizeof(ioa_addr) * (list->size + 1));
       addr_cpy(&(list->addrs[(list->size)++]), &addr);
       {
@@ -203,15 +230,20 @@ void add_aux_server(const char *saddr) { add_aux_server_list(saddr, &turn_params
 
 /////////////// ALTERNATE SERVERS ////////////////
 
-static void add_alt_server(const char *saddr, int default_port, turn_server_addrs_list_t *list) {
-  if (saddr && list) {
+static void add_alt_server(const char *saddr, int default_port, turn_server_addrs_list_t *list)
+{
+  if (saddr && list)
+  {
     ioa_addr addr;
 
     TURN_MUTEX_LOCK(&(list->m));
 
-    if (make_ioa_addr_from_full_string((const uint8_t *)saddr, default_port, &addr) != 0) {
+    if (make_ioa_addr_from_full_string((const uint8_t *)saddr, default_port, &addr) != 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong IP address format: %s\n", saddr);
-    } else {
+    }
+    else
+    {
       list->addrs = (ioa_addr *)realloc(list->addrs, sizeof(ioa_addr) * (list->size + 1));
       addr_cpy(&(list->addrs[(list->size)++]), &addr);
       {
@@ -225,34 +257,45 @@ static void add_alt_server(const char *saddr, int default_port, turn_server_addr
   }
 }
 
-static void del_alt_server(const char *saddr, int default_port, turn_server_addrs_list_t *list) {
-  if (saddr && list && list->size && list->addrs) {
+static void del_alt_server(const char *saddr, int default_port, turn_server_addrs_list_t *list)
+{
+  if (saddr && list && list->size && list->addrs)
+  {
 
     ioa_addr addr;
 
     TURN_MUTEX_LOCK(&(list->m));
 
-    if (make_ioa_addr_from_full_string((const uint8_t *)saddr, default_port, &addr) != 0) {
+    if (make_ioa_addr_from_full_string((const uint8_t *)saddr, default_port, &addr) != 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong IP address format: %s\n", saddr);
-    } else {
+    }
+    else
+    {
 
       size_t i;
-      for (i = 0; i < list->size; ++i) {
-        if (addr_eq(&(list->addrs[i]), &addr)) {
+      for (i = 0; i < list->size; ++i)
+      {
+        if (addr_eq(&(list->addrs[i]), &addr))
+        {
           break;
         }
       }
 
-      if (i < list->size) {
+      if (i < list->size)
+      {
 
         ioa_addr *new_addrs = (ioa_addr *)malloc(sizeof(ioa_addr) * (list->size - 1));
-        if (!new_addrs) {
+        if (!new_addrs)
+        {
           return;
         }
-        for (size_t j = 0; j < i; ++j) {
+        for (size_t j = 0; j < i; ++j)
+        {
           addr_cpy(&(new_addrs[j]), &(list->addrs[j]));
         }
-        for (size_t j = i; j < list->size - 1; ++j) {
+        for (size_t j = i; j < list->size - 1; ++j)
+        {
           addr_cpy(&(new_addrs[j]), &(list->addrs[j + 1]));
         }
 
@@ -272,25 +315,30 @@ static void del_alt_server(const char *saddr, int default_port, turn_server_addr
   }
 }
 
-void add_alternate_server(const char *saddr) {
+void add_alternate_server(const char *saddr)
+{
   add_alt_server(saddr, DEFAULT_STUN_PORT, &turn_params.alternate_servers_list);
 }
 
-void del_alternate_server(const char *saddr) {
+void del_alternate_server(const char *saddr)
+{
   del_alt_server(saddr, DEFAULT_STUN_PORT, &turn_params.alternate_servers_list);
 }
 
-void add_tls_alternate_server(const char *saddr) {
+void add_tls_alternate_server(const char *saddr)
+{
   add_alt_server(saddr, DEFAULT_STUN_TLS_PORT, &turn_params.tls_alternate_servers_list);
 }
 
-void del_tls_alternate_server(const char *saddr) {
+void del_tls_alternate_server(const char *saddr)
+{
   del_alt_server(saddr, DEFAULT_STUN_TLS_PORT, &turn_params.tls_alternate_servers_list);
 }
 
 //////////////////////////////////////////////////
 
-typedef struct update_ssl_ctx_cb_args {
+typedef struct update_ssl_ctx_cb_args
+{
   ioa_engine_handle engine;
   turn_params_t *params;
   struct event *next;
@@ -299,12 +347,15 @@ typedef struct update_ssl_ctx_cb_args {
 /*
  * Copy SSL context at "from", which may be NULL if no context in use
  */
-static void replace_one_ssl_ctx(SSL_CTX **to, SSL_CTX *from) {
-  if (*to) {
+static void replace_one_ssl_ctx(SSL_CTX **to, SSL_CTX *from)
+{
+  if (*to)
+  {
     SSL_CTX_free(*to);
   }
 
-  if (from != NULL) {
+  if (from != NULL)
+  {
     SSL_CTX_up_ref(from);
   }
 
@@ -314,7 +365,8 @@ static void replace_one_ssl_ctx(SSL_CTX **to, SSL_CTX *from) {
 /*
  * Synchronise the ioa_engine's SSL certificates with the global ones
  */
-static void update_ssl_ctx(evutil_socket_t sock, short events, update_ssl_ctx_cb_args_t *args) {
+static void update_ssl_ctx(evutil_socket_t sock, short events, update_ssl_ctx_cb_args_t *args)
+{
   ioa_engine_handle e = args->engine;
   turn_params_t *params = args->params;
 
@@ -327,7 +379,8 @@ static void update_ssl_ctx(evutil_socket_t sock, short events, update_ssl_ctx_cb
   struct event *next = args->next;
   TURN_MUTEX_UNLOCK(&turn_params.tls_mutex);
 
-  if (next != NULL) {
+  if (next != NULL)
+  {
     event_active(next, EV_READ, 0);
   }
 
@@ -335,7 +388,8 @@ static void update_ssl_ctx(evutil_socket_t sock, short events, update_ssl_ctx_cb
   UNUSED_ARG(events);
 }
 
-void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params) {
+void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params)
+{
   update_ssl_ctx_cb_args_t *args = (update_ssl_ctx_cb_args_t *)malloc(sizeof(update_ssl_ctx_cb_args_t));
   args->engine = e;
   args->params = params;
@@ -344,14 +398,18 @@ void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params) {
   update_ssl_ctx(-1, 0, args);
 
   struct event_base *base = e->event_base;
-  if (base != NULL) {
+  if (base != NULL)
+  {
     struct event *ev = event_new(base, -1, EV_PERSIST, (event_callback_fn)update_ssl_ctx, (void *)args);
     TURN_MUTEX_LOCK(&turn_params.tls_mutex);
     args->next = params->tls_ctx_update_ev;
     params->tls_ctx_update_ev = ev;
     TURN_MUTEX_UNLOCK(&turn_params.tls_mutex);
-  } else {
-    if (args) {
+  }
+  else
+  {
+    if (args)
+    {
       free(args);
     }
   }
@@ -359,18 +417,24 @@ void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params) {
 
 //////////////////////////////////////////////////
 
-void add_listener_addr(const char *addr) {
+void add_listener_addr(const char *addr)
+{
   ioa_addr baddr;
-  if (make_ioa_addr((const uint8_t *)addr, 0, &baddr) < 0) {
+  if (make_ioa_addr((const uint8_t *)addr, 0, &baddr) < 0)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot add a listener address: %s\n", addr);
-  } else {
+  }
+  else
+  {
 
     char sbaddr[129];
     addr_to_string_no_port(&baddr, (uint8_t *)sbaddr);
 
     size_t i = 0;
-    for (i = 0; i < turn_params.listener.addrs_number; ++i) {
-      if (addr_eq(turn_params.listener.encaddrs[i], &baddr)) {
+    for (i = 0; i < turn_params.listener.addrs_number; ++i)
+    {
+      if (addr_eq(turn_params.listener.encaddrs[i], &baddr))
+      {
         return;
       }
     }
@@ -387,19 +451,25 @@ void add_listener_addr(const char *addr) {
   }
 }
 
-int add_relay_addr(const char *addr) {
+int add_relay_addr(const char *addr)
+{
   ioa_addr baddr;
-  if (make_ioa_addr((const uint8_t *)addr, 0, &baddr) < 0) {
+  if (make_ioa_addr((const uint8_t *)addr, 0, &baddr) < 0)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot add a relay address: %s\n", addr);
     return -1;
-  } else {
+  }
+  else
+  {
 
     char sbaddr[129];
     addr_to_string_no_port(&baddr, (uint8_t *)sbaddr);
 
     size_t i = 0;
-    for (i = 0; i < turn_params.relays_number; ++i) {
-      if (!strcmp(turn_params.relay_addrs[i], sbaddr)) {
+    for (i = 0; i < turn_params.relays_number; ++i)
+    {
+      if (!strcmp(turn_params.relay_addrs[i], sbaddr))
+      {
         return 0;
       }
     }
@@ -413,12 +483,15 @@ int add_relay_addr(const char *addr) {
   }
 }
 
-static void allocate_relay_addrs_ports(void) {
+static void allocate_relay_addrs_ports(void)
+{
   int i;
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Wait for relay ports initialization...\n");
-  for (i = 0; i < (int)turn_params.relays_number; i++) {
+  for (i = 0; i < (int)turn_params.relays_number; i++)
+  {
     ioa_addr baddr;
-    if (make_ioa_addr((const uint8_t *)turn_params.relay_addrs[i], 0, &baddr) >= 0) {
+    if (make_ioa_addr((const uint8_t *)turn_params.relay_addrs[i], 0, &baddr) >= 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "  relay %s initialization...\n", turn_params.relay_addrs[i]);
       turnipports_add_ip(STUN_ATTRIBUTE_TRANSPORT_UDP_VALUE, &baddr);
       turnipports_add_ip(STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE, &baddr);
@@ -434,27 +507,35 @@ static void allocate_relay_addrs_ports(void) {
 
 static int handle_relay_message(relay_server_handle rs, struct message_to_relay *sm);
 
-static struct relay_server *get_relay_server(turnserver_id id) {
+static struct relay_server *get_relay_server(turnserver_id id)
+{
   struct relay_server *rs = NULL;
-  if (id >= TURNSERVER_ID_BOUNDARY_BETWEEN_TCP_AND_UDP) {
+  if (id >= TURNSERVER_ID_BOUNDARY_BETWEEN_TCP_AND_UDP)
+  {
     size_t dest = id - TURNSERVER_ID_BOUNDARY_BETWEEN_TCP_AND_UDP;
-    if (dest >= get_real_udp_relay_servers_number()) {
+    if (dest >= get_real_udp_relay_servers_number())
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Too large UDP relay number: %d, total=%d\n", __FUNCTION__, (int)dest,
                     (int)get_real_udp_relay_servers_number());
     }
     rs = udp_relay_servers[dest];
-    if (!rs) {
+    if (!rs)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Wrong UDP relay number: %d, total=%d\n", __FUNCTION__, (int)dest,
                     (int)get_real_udp_relay_servers_number());
     }
-  } else {
+  }
+  else
+  {
     size_t dest = id;
-    if (dest >= get_real_general_relay_servers_number()) {
+    if (dest >= get_real_general_relay_servers_number())
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Too large general relay number: %d, total=%d\n", __FUNCTION__, (int)dest,
                     (int)get_real_general_relay_servers_number());
     }
     rs = general_relay_servers[dest];
-    if (!rs) {
+    if (!rs)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Wrong general relay number: %d, total=%d\n", __FUNCTION__, (int)dest,
                     (int)get_real_general_relay_servers_number());
     }
@@ -465,31 +546,39 @@ static struct relay_server *get_relay_server(turnserver_id id) {
 static TURN_MUTEX_DECLARE(auth_message_counter_mutex);
 static authserver_id auth_message_counter = 1;
 
-void send_auth_message_to_auth_server(struct auth_message *am) {
+void send_auth_message_to_auth_server(struct auth_message *am)
+{
   TURN_MUTEX_LOCK(&auth_message_counter_mutex);
-  if (auth_message_counter >= authserver_number) {
+  if (auth_message_counter >= authserver_number)
+  {
     auth_message_counter = 1;
-  } else if (auth_message_counter < 1) {
+  }
+  else if (auth_message_counter < 1)
+  {
     auth_message_counter = 1;
   }
   authserver_id sn = auth_message_counter++;
   TURN_MUTEX_UNLOCK(&auth_message_counter_mutex);
 
   struct evbuffer *output = bufferevent_get_output(authserver[sn].out_buf);
-  if (evbuffer_add(output, am, sizeof(struct auth_message)) < 0) {
+  if (evbuffer_add(output, am, sizeof(struct auth_message)) < 0)
+  {
     fprintf(stderr, "%s: Weird buffer error\n", __FUNCTION__);
   }
 }
 
-static void auth_server_receive_message(struct bufferevent *bev, void *ptr) {
+static void auth_server_receive_message(struct bufferevent *bev, void *ptr)
+{
   UNUSED_ARG(ptr);
 
   struct auth_message am;
   int n = 0;
   struct evbuffer *input = bufferevent_get_input(bev);
 
-  while ((n = evbuffer_remove(input, &am, sizeof(struct auth_message))) > 0) {
-    if (n != sizeof(struct auth_message)) {
+  while ((n = evbuffer_remove(input, &am, sizeof(struct auth_message))) > 0)
+  {
+    if (n != sizeof(struct auth_message))
+    {
       fprintf(stderr, "%s: Weird buffer error: size=%d\n", __FUNCTION__, n);
       continue;
     }
@@ -497,9 +586,12 @@ static void auth_server_receive_message(struct bufferevent *bev, void *ptr) {
     {
       hmackey_t key;
       if (get_user_key(am.in_oauth, &(am.out_oauth), &(am.max_session_time), am.username, am.realm, key,
-                       am.in_buffer.nbh) < 0) {
+                       am.in_buffer.nbh) < 0)
+      {
         am.success = 0;
-      } else {
+      }
+      else
+      {
         memcpy(am.key, key, sizeof(hmackey_t));
         am.success = 1;
       }
@@ -507,25 +599,33 @@ static void auth_server_receive_message(struct bufferevent *bev, void *ptr) {
 
     struct evbuffer *output = NULL;
     struct relay_server *relay_server = get_relay_server(am.id);
-    if (relay_server) {
+    if (relay_server)
+    {
       output = bufferevent_get_output(relay_server->auth_out_buf);
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: can't find relay for turn_server_id: %d\n", __FUNCTION__, (int)am.id);
     }
 
-    if (output) {
+    if (output)
+    {
       evbuffer_add(output, &am, sizeof(struct auth_message));
-    } else {
+    }
+    else
+    {
       ioa_network_buffer_delete(NULL, am.in_buffer.nbh);
       am.in_buffer.nbh = NULL;
     }
   }
 }
 
-static int send_socket_to_general_relay(ioa_engine_handle e, struct message_to_relay *sm) {
+static int send_socket_to_general_relay(ioa_engine_handle e, struct message_to_relay *sm)
+{
   struct relay_server *rdest = sm->relay_server;
 
-  if (!rdest) {
+  if (!rdest)
+  {
     size_t dest = (hash_int32(addr_get_port(&(sm->m.sm.nd.src_addr)))) % get_real_general_relay_servers_number();
     rdest = general_relay_servers[dest];
   }
@@ -537,17 +637,22 @@ static int send_socket_to_general_relay(ioa_engine_handle e, struct message_to_r
   struct evbuffer *output = NULL;
   int success = 0;
 
-  if (!rdest) {
+  if (!rdest)
+  {
     goto label_end;
   }
 
   output = bufferevent_get_output(rdest->out_buf);
 
-  if (output) {
+  if (output)
+  {
 
-    if (evbuffer_add(output, smptr, sizeof(struct message_to_relay)) < 0) {
+    if (evbuffer_add(output, smptr, sizeof(struct message_to_relay)) < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot add message to relay output buffer\n", __FUNCTION__);
-    } else {
+    }
+    else
+    {
       success = 1;
       smptr->m.sm.nd.nbh = NULL;
     }
@@ -555,7 +660,8 @@ static int send_socket_to_general_relay(ioa_engine_handle e, struct message_to_r
 
 label_end:
 
-  if (!success) {
+  if (!success)
+  {
     ioa_network_buffer_delete(e, smptr->m.sm.nd.nbh);
     smptr->m.sm.nd.nbh = NULL;
     IOA_CLOSE_SOCKET(smptr->m.sm.s);
@@ -566,7 +672,8 @@ label_end:
 }
 
 static int send_socket_to_relay(turnserver_id id, uint64_t cid, stun_tid *tid, ioa_socket_handle s,
-                                int message_integrity, MESSAGE_TO_RELAY_TYPE rmt, ioa_net_data *nd, int can_resume) {
+                                int message_integrity, MESSAGE_TO_RELAY_TYPE rmt, ioa_net_data *nd, int can_resume)
+{
   int ret = -1;
 
   struct message_to_relay sm;
@@ -576,15 +683,19 @@ static int send_socket_to_relay(turnserver_id id, uint64_t cid, stun_tid *tid, i
   ioa_socket_handle s_to_delete = s;
 
   struct relay_server *rs = get_relay_server(id);
-  if (!rs) {
+  if (!rs)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: can't find relay for turn_server_id: %d\n", __FUNCTION__, (int)id);
     goto err;
   }
 
-  switch (rmt) {
-  case (RMT_CB_SOCKET): {
+  switch (rmt)
+  {
+  case (RMT_CB_SOCKET):
+  {
 
-    if (nd && nd->nbh) {
+    if (nd && nd->nbh)
+    {
       sm.m.cb_sm.id = id;
       sm.m.cb_sm.connection_id = (tcp_connection_id)cid;
       stun_tid_cpy(&(sm.m.cb_sm.tid), tid);
@@ -604,9 +715,11 @@ static int send_socket_to_relay(turnserver_id id, uint64_t cid, stun_tid *tid, i
 
     break;
   }
-  case (RMT_MOBILE_SOCKET): {
+  case (RMT_MOBILE_SOCKET):
+  {
 
-    if (nd && nd->nbh) {
+    if (nd && nd->nbh)
+    {
       sm.m.sm.s = s;
       addr_cpy(&(sm.m.sm.nd.src_addr), &(nd->src_addr));
       sm.m.sm.nd.recv_tos = nd->recv_tos;
@@ -617,24 +730,30 @@ static int send_socket_to_relay(turnserver_id id, uint64_t cid, stun_tid *tid, i
       nd->nbh = NULL;
       s_to_delete = NULL;
       ret = 0;
-
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Empty buffer with mobile socket\n", __FUNCTION__);
     }
 
     break;
   }
-  default: {
+  default:
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: UNKNOWN RMT message: %d\n", __FUNCTION__, (int)rmt);
   }
   }
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
 
     struct evbuffer *output = bufferevent_get_output(rs->out_buf);
-    if (output) {
+    if (output)
+    {
       evbuffer_add(output, &sm, sizeof(struct message_to_relay));
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Empty output buffer\n", __FUNCTION__);
       ret = -1;
       s_to_delete = s;
@@ -644,16 +763,21 @@ static int send_socket_to_relay(turnserver_id id, uint64_t cid, stun_tid *tid, i
 err:
 
   IOA_CLOSE_SOCKET(s_to_delete);
-  if (nd && nd->nbh) {
+  if (nd && nd->nbh)
+  {
     ioa_network_buffer_delete(NULL, nd->nbh);
     nd->nbh = NULL;
   }
 
-  if (ret < 0) {
-    if (rmt == RMT_MOBILE_SOCKET) {
+  if (ret < 0)
+  {
+    if (rmt == RMT_MOBILE_SOCKET)
+    {
       ioa_network_buffer_delete(NULL, sm.m.sm.nd.nbh);
       sm.m.sm.nd.nbh = NULL;
-    } else if (rmt == RMT_CB_SOCKET) {
+    }
+    else if (rmt == RMT_CB_SOCKET)
+    {
       ioa_network_buffer_delete(NULL, sm.m.cb_sm.nd.nbh);
       sm.m.cb_sm.nd.nbh = NULL;
     }
@@ -662,7 +786,8 @@ err:
   return ret;
 }
 
-int send_session_cancellation_to_relay(turnsession_id sid) {
+int send_session_cancellation_to_relay(turnsession_id sid)
+{
   int ret = 0;
 
   struct message_to_relay sm;
@@ -672,7 +797,8 @@ int send_session_cancellation_to_relay(turnsession_id sid) {
   turnserver_id id = (turnserver_id)(sid / TURN_SESSION_ID_FACTOR);
 
   struct relay_server *rs = get_relay_server(id);
-  if (!rs) {
+  if (!rs)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: can't find relay for turn_server_id: %d\n", __FUNCTION__, (int)id);
     ret = -1;
     goto err;
@@ -683,9 +809,12 @@ int send_session_cancellation_to_relay(turnsession_id sid) {
 
   {
     struct evbuffer *output = bufferevent_get_output(rs->out_buf);
-    if (output) {
+    if (output)
+    {
       evbuffer_add(output, &sm, sizeof(struct message_to_relay));
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Empty output buffer\n", __FUNCTION__);
       ret = -1;
     }
@@ -695,21 +824,31 @@ err:
   return ret;
 }
 
-static int handle_relay_message(relay_server_handle rs, struct message_to_relay *sm) {
-  if (rs && sm) {
+static int handle_relay_message(relay_server_handle rs, struct message_to_relay *sm)
+{
+  if (rs && sm)
+  {
 
-    switch (sm->t) {
+    switch (sm->t)
+    {
 
-    case RMT_CANCEL_SESSION: {
+    case RMT_CANCEL_SESSION:
+    {
       turn_cancel_session(&(rs->server), sm->m.csm.id);
-    } break;
-    case RMT_SOCKET: {
+    }
+    break;
+    case RMT_SOCKET:
+    {
 
-      if (sm->m.sm.s->defer_nbh) {
-        if (!sm->m.sm.nd.nbh) {
+      if (sm->m.sm.s->defer_nbh)
+      {
+        if (!sm->m.sm.nd.nbh)
+        {
           sm->m.sm.nd.nbh = sm->m.sm.s->defer_nbh;
           sm->m.sm.s->defer_nbh = NULL;
-        } else {
+        }
+        else
+        {
           ioa_network_buffer_delete(rs->ioa_eng, sm->m.sm.s->defer_nbh);
           sm->m.sm.s->defer_nbh = NULL;
         }
@@ -717,16 +856,22 @@ static int handle_relay_message(relay_server_handle rs, struct message_to_relay 
 
       ioa_socket_handle s = sm->m.sm.s;
 
-      if (!s) {
+      if (!s)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: socket EMPTY\n", __FUNCTION__);
-      } else if (s->read_event || s->bev) {
+      }
+      else if (s->read_event || s->bev)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: socket wrongly preset: %p : %p\n", __FUNCTION__, s->read_event,
                       s->bev);
         IOA_CLOSE_SOCKET(s);
         sm->m.sm.s = NULL;
-      } else {
+      }
+      else
+      {
         s->e = rs->ioa_eng;
-        if (open_client_connection_session(&(rs->server), &(sm->m.sm)) < 0) {
+        if (open_client_connection_session(&(rs->server), &(sm->m.sm)) < 0)
+        {
           IOA_CLOSE_SOCKET(s);
           sm->m.sm.s = NULL;
         }
@@ -734,7 +879,8 @@ static int handle_relay_message(relay_server_handle rs, struct message_to_relay 
 
       ioa_network_buffer_delete(rs->ioa_eng, sm->m.sm.nd.nbh);
       sm->m.sm.nd.nbh = NULL;
-    } break;
+    }
+    break;
     case RMT_CB_SOCKET:
 
       turnserver_accept_tcp_client_data_connection(
@@ -752,20 +898,27 @@ static int handle_relay_message(relay_server_handle rs, struct message_to_relay 
       sm->m.cb_sm.nd.nbh = NULL;
 
       break;
-    case RMT_MOBILE_SOCKET: {
+    case RMT_MOBILE_SOCKET:
+    {
 
       ioa_socket_handle s = sm->m.sm.s;
 
-      if (!s) {
+      if (!s)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: mobile socket EMPTY\n", __FUNCTION__);
-      } else if (s->read_event || s->bev) {
+      }
+      else if (s->read_event || s->bev)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: mobile socket wrongly preset: %p : %p\n", __FUNCTION__, s->read_event,
                       s->bev);
         IOA_CLOSE_SOCKET(s);
         sm->m.sm.s = NULL;
-      } else {
+      }
+      else
+      {
         s->e = rs->ioa_eng;
-        if (open_client_connection_session(&(rs->server), &(sm->m.sm)) < 0) {
+        if (open_client_connection_session(&(rs->server), &(sm->m.sm)) < 0)
+        {
           IOA_CLOSE_SOCKET(s);
           sm->m.sm.s = NULL;
         }
@@ -775,7 +928,8 @@ static int handle_relay_message(relay_server_handle rs, struct message_to_relay 
       sm->m.sm.nd.nbh = NULL;
       break;
     }
-    default: {
+    default:
+    {
       perror("Weird buffer type\n");
     }
     }
@@ -784,24 +938,29 @@ static int handle_relay_message(relay_server_handle rs, struct message_to_relay 
   return 0;
 }
 
-static void handle_relay_auth_message(struct relay_server *rs, struct auth_message *am) {
+static void handle_relay_auth_message(struct relay_server *rs, struct auth_message *am)
+{
   am->resume_func(am->success, am->out_oauth, am->max_session_time, am->key, am->pwd, &(rs->server), am->ctxkey,
                   &(am->in_buffer), am->realm);
-  if (am->in_buffer.nbh) {
+  if (am->in_buffer.nbh)
+  {
     ioa_network_buffer_delete(rs->ioa_eng, am->in_buffer.nbh);
     am->in_buffer.nbh = NULL;
   }
 }
 
-static void relay_receive_message(struct bufferevent *bev, void *ptr) {
+static void relay_receive_message(struct bufferevent *bev, void *ptr)
+{
   struct message_to_relay sm;
   int n = 0;
   struct evbuffer *input = bufferevent_get_input(bev);
   struct relay_server *rs = (struct relay_server *)ptr;
 
-  while ((n = evbuffer_remove(input, &sm, sizeof(struct message_to_relay))) > 0) {
+  while ((n = evbuffer_remove(input, &sm, sizeof(struct message_to_relay))) > 0)
+  {
 
-    if (n != sizeof(struct message_to_relay)) {
+    if (n != sizeof(struct message_to_relay))
+    {
       perror("Weird buffer error\n");
       continue;
     }
@@ -810,15 +969,18 @@ static void relay_receive_message(struct bufferevent *bev, void *ptr) {
   }
 }
 
-static void relay_receive_auth_message(struct bufferevent *bev, void *ptr) {
+static void relay_receive_auth_message(struct bufferevent *bev, void *ptr)
+{
   struct auth_message am;
   int n = 0;
   struct evbuffer *input = bufferevent_get_input(bev);
   struct relay_server *rs = (struct relay_server *)ptr;
 
-  while ((n = evbuffer_remove(input, &am, sizeof(struct auth_message))) > 0) {
+  while ((n = evbuffer_remove(input, &am, sizeof(struct auth_message))) > 0)
+  {
 
-    if (n != sizeof(struct auth_message)) {
+    if (n != sizeof(struct auth_message))
+    {
       perror("Weird auth_buffer error\n");
       continue;
     }
@@ -828,7 +990,8 @@ static void relay_receive_auth_message(struct bufferevent *bev, void *ptr) {
 }
 
 static int send_message_from_listener_to_client(ioa_engine_handle e, ioa_network_buffer_handle nbh, ioa_addr *origin,
-                                                ioa_addr *destination) {
+                                                ioa_addr *destination)
+{
 
   struct message_to_listener mm;
   mm.t = LMT_TO_CLIENT;
@@ -846,33 +1009,42 @@ static int send_message_from_listener_to_client(ioa_engine_handle e, ioa_network
   return 0;
 }
 
-static void listener_receive_message(struct bufferevent *bev, void *ptr) {
+static void listener_receive_message(struct bufferevent *bev, void *ptr)
+{
   UNUSED_ARG(ptr);
 
   struct message_to_listener mm;
   int n = 0;
   struct evbuffer *input = bufferevent_get_input(bev);
 
-  while ((n = evbuffer_remove(input, &mm, sizeof(struct message_to_listener))) > 0) {
-    if (n != sizeof(struct message_to_listener)) {
+  while ((n = evbuffer_remove(input, &mm, sizeof(struct message_to_listener))) > 0)
+  {
+    if (n != sizeof(struct message_to_listener))
+    {
       perror("Weird buffer error\n");
       continue;
     }
 
-    if (mm.t != LMT_TO_CLIENT) {
+    if (mm.t != LMT_TO_CLIENT)
+    {
       perror("Weird buffer type\n");
       continue;
     }
 
     size_t relay_thread_index = 0;
 
-    if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_THREAD) {
+    if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_THREAD)
+    {
       size_t ri;
-      for (ri = 0; ri < get_real_general_relay_servers_number(); ri++) {
-        if (!(general_relay_servers[ri])) {
+      for (ri = 0; ri < get_real_general_relay_servers_number(); ri++)
+      {
+        if (!(general_relay_servers[ri]))
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Wrong general relay number: %d, total %d\n", __FUNCTION__, (int)ri,
                         (int)get_real_general_relay_servers_number());
-        } else if (pthread_equal(general_relay_servers[ri]->thr, pthread_self())) {
+        }
+        else if (pthread_equal(general_relay_servers[ri]->thr, pthread_self()))
+        {
           relay_thread_index = ri;
           break;
         }
@@ -881,46 +1053,65 @@ static void listener_receive_message(struct bufferevent *bev, void *ptr) {
 
     size_t i;
     int found = 0;
-    for (i = 0; i < turn_params.listener.addrs_number; i++) {
-      if (addr_eq_no_port(turn_params.listener.encaddrs[i], &mm.m.tc.origin)) {
+    for (i = 0; i < turn_params.listener.addrs_number; i++)
+    {
+      if (addr_eq_no_port(turn_params.listener.encaddrs[i], &mm.m.tc.origin))
+      {
         int o_port = addr_get_port(&mm.m.tc.origin);
-        if (turn_params.listener.addrs_number == turn_params.listener.services_number) {
-          if (o_port == turn_params.listener_port) {
+        if (turn_params.listener.addrs_number == turn_params.listener.services_number)
+        {
+          if (o_port == turn_params.listener_port)
+          {
             if (turn_params.listener.udp_services && turn_params.listener.udp_services[i] &&
-                turn_params.listener.udp_services[i][relay_thread_index]) {
+                turn_params.listener.udp_services[i][relay_thread_index])
+            {
               found = 1;
               udp_send_message(turn_params.listener.udp_services[i][relay_thread_index], mm.m.tc.nbh,
                                &mm.m.tc.destination);
             }
-          } else {
+          }
+          else
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Wrong origin port(1): %d\n", __FUNCTION__, o_port);
           }
-        } else if ((turn_params.listener.addrs_number * 2) == turn_params.listener.services_number) {
-          if (o_port == turn_params.listener_port) {
+        }
+        else if ((turn_params.listener.addrs_number * 2) == turn_params.listener.services_number)
+        {
+          if (o_port == turn_params.listener_port)
+          {
             if (turn_params.listener.udp_services && turn_params.listener.udp_services[i * 2] &&
-                turn_params.listener.udp_services[i * 2][relay_thread_index]) {
+                turn_params.listener.udp_services[i * 2][relay_thread_index])
+            {
               found = 1;
               udp_send_message(turn_params.listener.udp_services[i * 2][relay_thread_index], mm.m.tc.nbh,
                                &mm.m.tc.destination);
             }
-          } else if (o_port == get_alt_listener_port()) {
+          }
+          else if (o_port == get_alt_listener_port())
+          {
             if (turn_params.listener.udp_services && turn_params.listener.udp_services[i * 2 + 1] &&
-                turn_params.listener.udp_services[i * 2 + 1][relay_thread_index]) {
+                turn_params.listener.udp_services[i * 2 + 1][relay_thread_index])
+            {
               found = 1;
               udp_send_message(turn_params.listener.udp_services[i * 2 + 1][relay_thread_index], mm.m.tc.nbh,
                                &mm.m.tc.destination);
             }
-          } else {
+          }
+          else
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Wrong origin port(2): %d\n", __FUNCTION__, o_port);
           }
-        } else {
+        }
+        else
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Wrong listener setup\n", __FUNCTION__);
         }
         break;
       }
     }
 
-    if (!found) {
+    if (!found)
+    {
       uint8_t saddr[129];
       addr_to_string(&mm.m.tc.origin, saddr);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot find local source %s\n", __FUNCTION__, saddr);
@@ -933,7 +1124,8 @@ static void listener_receive_message(struct bufferevent *bev, void *ptr) {
 
 // <<== communications between listener and relays
 
-static ioa_engine_handle create_new_listener_engine(void) {
+static ioa_engine_handle create_new_listener_engine(void)
+{
   struct event_base *eb = turn_event_base_new();
   super_memory_t *sm = new_super_memory_region();
   ioa_engine_handle e =
@@ -949,7 +1141,8 @@ static ioa_engine_handle create_new_listener_engine(void) {
   return e;
 }
 
-static void *run_udp_listener_thread(void *arg) {
+static void *run_udp_listener_thread(void *arg)
+{
   static int always_true = 1;
 
   ignore_sigpipe();
@@ -958,14 +1151,16 @@ static void *run_udp_listener_thread(void *arg) {
 
   dtls_listener_relay_server_type *server = (dtls_listener_relay_server_type *)arg;
 
-  while (always_true && server) {
+  while (always_true && server)
+  {
     run_events(NULL, get_engine(server));
   }
 
   return arg;
 }
 
-static void setup_listener(void) {
+static void setup_listener(void)
+{
   super_memory_t *sm = new_super_memory_region();
 
   turn_params.listener.tp = turnipports_create(sm, turn_params.min_port, turn_params.max_port);
@@ -983,7 +1178,8 @@ static void setup_listener(void) {
 #endif
   );
 
-  if (!turn_params.listener.ioa_eng) {
+  if (!turn_params.listener.ioa_eng)
+  {
     exit(-1);
   }
 
@@ -1001,14 +1197,20 @@ static void setup_listener(void) {
     bufferevent_enable(turn_params.listener.in_buf, EV_READ);
   }
 
-  if (turn_params.rfc5780 == 1) {
-    if (turn_params.listener.addrs_number < 2 || turn_params.external_ip) {
+  if (turn_params.rfc5780 == 1)
+  {
+    if (turn_params.listener.addrs_number < 2 || turn_params.external_ip)
+    {
       turn_params.rfc5780 = 0;
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "STUN CHANGE_REQUEST not supported: only one IP address is provided\n");
-    } else {
+    }
+    else
+    {
       turn_params.listener.services_number = turn_params.listener.services_number * 2;
     }
-  } else {
+  }
+  else
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "RFC5780 disabled! /NAT behavior discovery/\n");
   }
 
@@ -1022,33 +1224,40 @@ static void setup_listener(void) {
       (sizeof(dtls_listener_relay_server_type **) * turn_params.aux_servers_list.size) + sizeof(void *));
 }
 
-static void setup_barriers(void) {
+static void setup_barriers(void)
+{
   /* Adjust barriers: */
 
 #if !defined(TURN_NO_THREAD_BARRIERS)
 
-  if ((turn_params.net_engine_version == NEV_UDP_SOCKET_PER_ENDPOINT) && turn_params.general_relay_servers_number > 1) {
+  if ((turn_params.net_engine_version == NEV_UDP_SOCKET_PER_ENDPOINT) && turn_params.general_relay_servers_number > 1)
+  {
 
     /* UDP: */
-    if (!turn_params.no_udp) {
+    if (!turn_params.no_udp)
+    {
 
       barrier_count += turn_params.listener.addrs_number;
 
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         barrier_count += turn_params.listener.addrs_number;
       }
     }
 
-    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port))) {
+    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port)))
+    {
 
       barrier_count += turn_params.listener.addrs_number;
 
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         barrier_count += turn_params.listener.addrs_number;
       }
     }
 
-    if (!turn_params.no_udp || !turn_params.no_dtls) {
+    if (!turn_params.no_udp || !turn_params.no_dtls)
+    {
       barrier_count += (unsigned int)turn_params.aux_servers_list.size;
     }
   }
@@ -1056,7 +1265,8 @@ static void setup_barriers(void) {
 
 #if !defined(TURN_NO_THREAD_BARRIERS)
   {
-    if (pthread_barrier_init(&barrier, NULL, barrier_count) < 0) {
+    if (pthread_barrier_init(&barrier, NULL, barrier_count) < 0)
+    {
       perror("barrier init");
     }
   }
@@ -1064,51 +1274,64 @@ static void setup_barriers(void) {
 #endif
 }
 
-static void setup_socket_per_endpoint_udp_listener_servers(void) {
+static void setup_socket_per_endpoint_udp_listener_servers(void)
+{
   size_t i = 0;
 
   /* Adjust udp relay number */
 
-  if (turn_params.general_relay_servers_number > 1) {
+  if (turn_params.general_relay_servers_number > 1)
+  {
 
-    if (!turn_params.no_udp) {
+    if (!turn_params.no_udp)
+    {
 
       turn_params.udp_relay_servers_number += turn_params.listener.addrs_number;
 
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         turn_params.udp_relay_servers_number += turn_params.listener.addrs_number;
       }
     }
 
-    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port))) {
+    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port)))
+    {
 
       turn_params.udp_relay_servers_number += turn_params.listener.addrs_number;
 
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         turn_params.udp_relay_servers_number += turn_params.listener.addrs_number;
       }
     }
 
-    if (!turn_params.no_udp || !turn_params.no_dtls) {
+    if (!turn_params.no_udp || !turn_params.no_dtls)
+    {
       turn_params.udp_relay_servers_number += (unsigned int)turn_params.aux_servers_list.size;
     }
   }
 
   {
-    if (!turn_params.no_udp || !turn_params.no_dtls) {
+    if (!turn_params.no_udp || !turn_params.no_dtls)
+    {
 
-      for (i = 0; i < get_real_udp_relay_servers_number(); i++) {
+      for (i = 0; i < get_real_udp_relay_servers_number(); i++)
+      {
 
         ioa_engine_handle e = turn_params.listener.ioa_eng;
         int is_5780 = turn_params.rfc5780;
 
-        if (turn_params.general_relay_servers_number <= 1) {
-          while (!(general_relay_servers[0]->ioa_eng)) {
+        if (turn_params.general_relay_servers_number <= 1)
+        {
+          while (!(general_relay_servers[0]->ioa_eng))
+          {
             sched_yield();
           }
           udp_relay_servers[i] = general_relay_servers[0];
           continue;
-        } else if (turn_params.general_relay_servers_number > 1) {
+        }
+        else if (turn_params.general_relay_servers_number > 1)
+        {
           e = create_new_listener_engine();
           is_5780 = is_5780 && (i >= (size_t)(turn_params.aux_servers_list.size));
         }
@@ -1129,11 +1352,13 @@ static void setup_socket_per_endpoint_udp_listener_servers(void) {
   /* Create listeners */
 
   /* Aux UDP servers */
-  for (i = 0; i < turn_params.aux_servers_list.size; i++) {
+  for (i = 0; i < turn_params.aux_servers_list.size; i++)
+  {
 
     int index = i;
 
-    if (!turn_params.no_udp || !turn_params.no_dtls) {
+    if (!turn_params.no_udp || !turn_params.no_dtls)
+    {
 
       ioa_addr addr;
       char saddr[129];
@@ -1148,10 +1373,12 @@ static void setup_socket_per_endpoint_udp_listener_servers(void) {
                                       udp_relay_servers[udp_relay_server_index]->ioa_eng,
                                       &(udp_relay_servers[udp_relay_server_index]->server), 1, NULL);
 
-      if (turn_params.general_relay_servers_number > 1) {
+      if (turn_params.general_relay_servers_number > 1)
+      {
         ++udp_relay_server_index;
         pthread_t thr;
-        if (pthread_create(&thr, NULL, run_udp_listener_thread, turn_params.listener.aux_udp_services[index][0])) {
+        if (pthread_create(&thr, NULL, run_udp_listener_thread, turn_params.listener.aux_udp_services[index][0]))
+        {
           perror("Cannot create aux listener thread\n");
           exit(-1);
         }
@@ -1161,12 +1388,14 @@ static void setup_socket_per_endpoint_udp_listener_servers(void) {
   }
 
   /* Main servers */
-  for (i = 0; i < turn_params.listener.addrs_number; i++) {
+  for (i = 0; i < turn_params.listener.addrs_number; i++)
+  {
 
     int index = turn_params.rfc5780 ? i * 2 : i;
 
     /* UDP: */
-    if (!turn_params.no_udp) {
+    if (!turn_params.no_udp)
+    {
 
       turn_params.listener.udp_services[index] = (dtls_listener_relay_server_type **)allocate_super_memory_engine(
           udp_relay_servers[udp_relay_server_index]->ioa_eng, sizeof(dtls_listener_relay_server_type *));
@@ -1175,17 +1404,20 @@ static void setup_socket_per_endpoint_udp_listener_servers(void) {
           udp_relay_servers[udp_relay_server_index]->ioa_eng, &(udp_relay_servers[udp_relay_server_index]->server), 1,
           NULL);
 
-      if (turn_params.general_relay_servers_number > 1) {
+      if (turn_params.general_relay_servers_number > 1)
+      {
         ++udp_relay_server_index;
         pthread_t thr;
-        if (pthread_create(&thr, NULL, run_udp_listener_thread, turn_params.listener.udp_services[index][0])) {
+        if (pthread_create(&thr, NULL, run_udp_listener_thread, turn_params.listener.udp_services[index][0]))
+        {
           perror("Cannot create listener thread\n");
           exit(-1);
         }
         pthread_detach(thr);
       }
 
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
 
         turn_params.listener.udp_services[index + 1] = (dtls_listener_relay_server_type **)allocate_super_memory_engine(
             udp_relay_servers[udp_relay_server_index]->ioa_eng, sizeof(dtls_listener_relay_server_type *));
@@ -1194,23 +1426,29 @@ static void setup_socket_per_endpoint_udp_listener_servers(void) {
             udp_relay_servers[udp_relay_server_index]->ioa_eng, &(udp_relay_servers[udp_relay_server_index]->server), 1,
             NULL);
 
-        if (turn_params.general_relay_servers_number > 1) {
+        if (turn_params.general_relay_servers_number > 1)
+        {
           ++udp_relay_server_index;
           pthread_t thr;
-          if (pthread_create(&thr, NULL, run_udp_listener_thread, turn_params.listener.udp_services[index + 1][0])) {
+          if (pthread_create(&thr, NULL, run_udp_listener_thread, turn_params.listener.udp_services[index + 1][0]))
+          {
             perror("Cannot create listener thread\n");
             exit(-1);
           }
           pthread_detach(thr);
         }
       }
-    } else {
+    }
+    else
+    {
       turn_params.listener.udp_services[index] = NULL;
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         turn_params.listener.udp_services[index + 1] = NULL;
       }
     }
-    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port))) {
+    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port)))
+    {
 
       turn_params.listener.dtls_services[index] = (dtls_listener_relay_server_type **)allocate_super_memory_engine(
           udp_relay_servers[udp_relay_server_index]->ioa_eng, sizeof(dtls_listener_relay_server_type *));
@@ -1219,17 +1457,20 @@ static void setup_socket_per_endpoint_udp_listener_servers(void) {
           turn_params.verbose, udp_relay_servers[udp_relay_server_index]->ioa_eng,
           &(udp_relay_servers[udp_relay_server_index]->server), 1, NULL);
 
-      if (turn_params.general_relay_servers_number > 1) {
+      if (turn_params.general_relay_servers_number > 1)
+      {
         ++udp_relay_server_index;
         pthread_t thr;
-        if (pthread_create(&thr, NULL, run_udp_listener_thread, turn_params.listener.dtls_services[index][0])) {
+        if (pthread_create(&thr, NULL, run_udp_listener_thread, turn_params.listener.dtls_services[index][0]))
+        {
           perror("Cannot create listener thread\n");
           exit(-1);
         }
         pthread_detach(thr);
       }
 
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
 
         turn_params.listener.dtls_services[index + 1] =
             (dtls_listener_relay_server_type **)allocate_super_memory_engine(
@@ -1239,43 +1480,53 @@ static void setup_socket_per_endpoint_udp_listener_servers(void) {
             turn_params.verbose, udp_relay_servers[udp_relay_server_index]->ioa_eng,
             &(udp_relay_servers[udp_relay_server_index]->server), 1, NULL);
 
-        if (turn_params.general_relay_servers_number > 1) {
+        if (turn_params.general_relay_servers_number > 1)
+        {
           ++udp_relay_server_index;
           pthread_t thr;
-          if (pthread_create(&thr, NULL, run_udp_listener_thread, turn_params.listener.dtls_services[index + 1][0])) {
+          if (pthread_create(&thr, NULL, run_udp_listener_thread, turn_params.listener.dtls_services[index + 1][0]))
+          {
             perror("Cannot create listener thread\n");
             exit(-1);
           }
           pthread_detach(thr);
         }
       }
-    } else {
+    }
+    else
+    {
       turn_params.listener.dtls_services[index] = NULL;
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         turn_params.listener.dtls_services[index + 1] = NULL;
       }
     }
   }
 }
 
-static void setup_socket_per_thread_udp_listener_servers(void) {
+static void setup_socket_per_thread_udp_listener_servers(void)
+{
   size_t i = 0;
   size_t relayindex = 0;
 
   /* Create listeners */
 
-  for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++) {
-    while (!(general_relay_servers[relayindex]->ioa_eng) || !(general_relay_servers[relayindex]->server.e)) {
+  for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++)
+  {
+    while (!(general_relay_servers[relayindex]->ioa_eng) || !(general_relay_servers[relayindex]->server.e))
+    {
       sched_yield();
     }
   }
 
   /* Aux UDP servers */
-  for (i = 0; i < turn_params.aux_servers_list.size; i++) {
+  for (i = 0; i < turn_params.aux_servers_list.size; i++)
+  {
 
     int index = i;
 
-    if (!turn_params.no_udp || !turn_params.no_dtls) {
+    if (!turn_params.no_udp || !turn_params.no_dtls)
+    {
 
       ioa_addr addr;
       char saddr[129];
@@ -1287,7 +1538,8 @@ static void setup_socket_per_thread_udp_listener_servers(void) {
           turn_params.listener.ioa_eng,
           sizeof(dtls_listener_relay_server_type *) * get_real_general_relay_servers_number());
 
-      for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++) {
+      for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++)
+      {
         turn_params.listener.aux_udp_services[index][relayindex] = create_dtls_listener_server(
             turn_params.listener_ifname, saddr, port, turn_params.verbose, general_relay_servers[relayindex]->ioa_eng,
             &(general_relay_servers[relayindex]->server), !relayindex, NULL);
@@ -1296,88 +1548,106 @@ static void setup_socket_per_thread_udp_listener_servers(void) {
   }
 
   /* Main servers */
-  for (i = 0; i < turn_params.listener.addrs_number; i++) {
+  for (i = 0; i < turn_params.listener.addrs_number; i++)
+  {
 
     int index = turn_params.rfc5780 ? i * 2 : i;
 
     /* UDP: */
-    if (!turn_params.no_udp) {
+    if (!turn_params.no_udp)
+    {
 
       turn_params.listener.udp_services[index] = (dtls_listener_relay_server_type **)allocate_super_memory_engine(
           turn_params.listener.ioa_eng,
           sizeof(dtls_listener_relay_server_type *) * get_real_general_relay_servers_number());
 
-      for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++) {
+      for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++)
+      {
         turn_params.listener.udp_services[index][relayindex] = create_dtls_listener_server(
             turn_params.listener_ifname, turn_params.listener.addrs[i], turn_params.listener_port, turn_params.verbose,
             general_relay_servers[relayindex]->ioa_eng, &(general_relay_servers[relayindex]->server), !relayindex,
             NULL);
       }
 
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
 
         turn_params.listener.udp_services[index + 1] = (dtls_listener_relay_server_type **)allocate_super_memory_engine(
             turn_params.listener.ioa_eng,
             sizeof(dtls_listener_relay_server_type *) * get_real_general_relay_servers_number());
 
-        for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++) {
+        for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++)
+        {
           turn_params.listener.udp_services[index + 1][relayindex] = create_dtls_listener_server(
               turn_params.listener_ifname, turn_params.listener.addrs[i], get_alt_listener_port(), turn_params.verbose,
               general_relay_servers[relayindex]->ioa_eng, &(general_relay_servers[relayindex]->server), !relayindex,
               NULL);
         }
       }
-    } else {
+    }
+    else
+    {
       turn_params.listener.udp_services[index] = NULL;
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         turn_params.listener.udp_services[index + 1] = NULL;
       }
     }
-    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port))) {
+    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port)))
+    {
 
       turn_params.listener.dtls_services[index] = (dtls_listener_relay_server_type **)allocate_super_memory_engine(
           turn_params.listener.ioa_eng,
           sizeof(dtls_listener_relay_server_type *) * get_real_general_relay_servers_number());
 
-      for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++) {
+      for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++)
+      {
         turn_params.listener.dtls_services[index][relayindex] = create_dtls_listener_server(
             turn_params.listener_ifname, turn_params.listener.addrs[i], turn_params.tls_listener_port,
             turn_params.verbose, general_relay_servers[relayindex]->ioa_eng,
             &(general_relay_servers[relayindex]->server), !relayindex, NULL);
       }
 
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
 
         turn_params.listener.dtls_services[index + 1] =
             (dtls_listener_relay_server_type **)allocate_super_memory_engine(
                 turn_params.listener.ioa_eng,
                 sizeof(dtls_listener_relay_server_type *) * get_real_general_relay_servers_number());
 
-        for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++) {
+        for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++)
+        {
           turn_params.listener.dtls_services[index + 1][relayindex] = create_dtls_listener_server(
               turn_params.listener_ifname, turn_params.listener.addrs[i], get_alt_tls_listener_port(),
               turn_params.verbose, general_relay_servers[relayindex]->ioa_eng,
               &(general_relay_servers[relayindex]->server), !relayindex, NULL);
         }
       }
-    } else {
+    }
+    else
+    {
       turn_params.listener.dtls_services[index] = NULL;
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         turn_params.listener.dtls_services[index + 1] = NULL;
       }
     }
   }
 }
 
-static void setup_socket_per_session_udp_listener_servers(void) {
+static void setup_socket_per_session_udp_listener_servers(void)
+{
   size_t i = 0;
 
   /* Aux UDP servers */
-  for (i = 0; i < turn_params.aux_servers_list.size; i++) {
+  for (i = 0; i < turn_params.aux_servers_list.size; i++)
+  {
 
     int index = i;
 
-    if (!turn_params.no_udp || !turn_params.no_dtls) {
+    if (!turn_params.no_udp || !turn_params.no_dtls)
+    {
 
       ioa_addr addr;
       char saddr[129];
@@ -1395,12 +1665,14 @@ static void setup_socket_per_session_udp_listener_servers(void) {
   }
 
   /* Main servers */
-  for (i = 0; i < turn_params.listener.addrs_number; i++) {
+  for (i = 0; i < turn_params.listener.addrs_number; i++)
+  {
 
     int index = turn_params.rfc5780 ? i * 2 : i;
 
     /* UDP: */
-    if (!turn_params.no_udp) {
+    if (!turn_params.no_udp)
+    {
 
       turn_params.listener.udp_services[index] = (dtls_listener_relay_server_type **)allocate_super_memory_engine(
           turn_params.listener.ioa_eng, sizeof(dtls_listener_relay_server_type *));
@@ -1409,7 +1681,8 @@ static void setup_socket_per_session_udp_listener_servers(void) {
           turn_params.listener_ifname, turn_params.listener.addrs[i], turn_params.listener_port, turn_params.verbose,
           turn_params.listener.ioa_eng, NULL, 1, send_socket_to_general_relay);
 
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
 
         turn_params.listener.udp_services[index + 1] = (dtls_listener_relay_server_type **)allocate_super_memory_engine(
             turn_params.listener.ioa_eng, sizeof(dtls_listener_relay_server_type *));
@@ -1418,13 +1691,17 @@ static void setup_socket_per_session_udp_listener_servers(void) {
             turn_params.listener_ifname, turn_params.listener.addrs[i], get_alt_listener_port(), turn_params.verbose,
             turn_params.listener.ioa_eng, NULL, 1, send_socket_to_general_relay);
       }
-    } else {
+    }
+    else
+    {
       turn_params.listener.udp_services[index] = NULL;
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         turn_params.listener.udp_services[index + 1] = NULL;
       }
     }
-    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port))) {
+    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port)))
+    {
 
       turn_params.listener.dtls_services[index] = (dtls_listener_relay_server_type **)allocate_super_memory_engine(
           turn_params.listener.ioa_eng, sizeof(dtls_listener_relay_server_type *));
@@ -1433,7 +1710,8 @@ static void setup_socket_per_session_udp_listener_servers(void) {
           turn_params.listener_ifname, turn_params.listener.addrs[i], turn_params.tls_listener_port,
           turn_params.verbose, turn_params.listener.ioa_eng, NULL, 1, send_socket_to_general_relay);
 
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
 
         turn_params.listener.dtls_services[index + 1] =
             (dtls_listener_relay_server_type **)allocate_super_memory_engine(turn_params.listener.ioa_eng,
@@ -1443,16 +1721,20 @@ static void setup_socket_per_session_udp_listener_servers(void) {
             turn_params.listener_ifname, turn_params.listener.addrs[i], get_alt_tls_listener_port(),
             turn_params.verbose, turn_params.listener.ioa_eng, NULL, 1, send_socket_to_general_relay);
       }
-    } else {
+    }
+    else
+    {
       turn_params.listener.dtls_services[index] = NULL;
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         turn_params.listener.dtls_services[index + 1] = NULL;
       }
     }
   }
 }
 
-static void setup_tcp_listener_servers(ioa_engine_handle e, struct relay_server *relay_server) {
+static void setup_tcp_listener_servers(ioa_engine_handle e, struct relay_server *relay_server)
+{
   size_t i = 0;
 
   tls_listener_relay_server_type **tcp_services = (tls_listener_relay_server_type **)allocate_super_memory_engine(
@@ -1466,9 +1748,11 @@ static void setup_tcp_listener_servers(ioa_engine_handle e, struct relay_server 
   /* Create listeners */
 
   /* Aux TCP servers */
-  if (!turn_params.tcp_use_proxy && (!turn_params.no_tls || !turn_params.no_tcp)) {
+  if (!turn_params.tcp_use_proxy && (!turn_params.no_tls || !turn_params.no_tcp))
+  {
 
-    for (i = 0; i < turn_params.aux_servers_list.size; i++) {
+    for (i = 0; i < turn_params.aux_servers_list.size; i++)
+    {
 
       ioa_addr addr;
       char saddr[129];
@@ -1482,17 +1766,20 @@ static void setup_tcp_listener_servers(ioa_engine_handle e, struct relay_server 
   }
 
   /* Main servers */
-  for (i = 0; i < turn_params.listener.addrs_number; i++) {
+  for (i = 0; i < turn_params.listener.addrs_number; i++)
+  {
 
     int index = turn_params.rfc5780 ? i * 2 : i;
 
     /* TCP: */
-    if (!turn_params.no_tcp) {
+    if (!turn_params.no_tcp)
+    {
       tcp_services[index] =
           create_tls_listener_server(turn_params.listener_ifname, turn_params.listener.addrs[i],
                                      turn_params.tcp_use_proxy ? turn_params.tcp_proxy_port : turn_params.listener_port,
                                      turn_params.verbose, e, send_socket_to_general_relay, relay_server);
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         tcp_services[index + 1] =
             turn_params.tcp_use_proxy
                 ? NULL
@@ -1500,65 +1787,93 @@ static void setup_tcp_listener_servers(ioa_engine_handle e, struct relay_server 
                                              get_alt_listener_port(), turn_params.verbose, e,
                                              send_socket_to_general_relay, relay_server);
       }
-    } else {
+    }
+    else
+    {
       tcp_services[index] = NULL;
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         tcp_services[index + 1] = NULL;
       }
     }
     if (!turn_params.no_tls && !turn_params.tcp_use_proxy &&
-        (turn_params.no_tcp || (turn_params.listener_port != turn_params.tls_listener_port))) {
+        (turn_params.no_tcp || (turn_params.listener_port != turn_params.tls_listener_port)))
+    {
       tls_services[index] = create_tls_listener_server(turn_params.listener_ifname, turn_params.listener.addrs[i],
                                                        turn_params.tls_listener_port, turn_params.verbose, e,
                                                        send_socket_to_general_relay, relay_server);
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         tls_services[index + 1] = create_tls_listener_server(turn_params.listener_ifname, turn_params.listener.addrs[i],
                                                              get_alt_tls_listener_port(), turn_params.verbose, e,
                                                              send_socket_to_general_relay, relay_server);
       }
-    } else {
+    }
+    else
+    {
       tls_services[index] = NULL;
-      if (turn_params.rfc5780) {
+      if (turn_params.rfc5780)
+      {
         tls_services[index + 1] = NULL;
       }
     }
   }
 }
 
-static int get_alt_addr(ioa_addr *addr, ioa_addr *alt_addr) {
-  if (!addr || !turn_params.rfc5780 || (turn_params.listener.addrs_number < 2)) {
-  } else {
+static int get_alt_addr(ioa_addr *addr, ioa_addr *alt_addr)
+{
+  if (!addr || !turn_params.rfc5780 || (turn_params.listener.addrs_number < 2))
+  {
+  }
+  else
+  {
     size_t index = 0xffff;
     size_t i = 0;
     int alt_port = -1;
     int port = addr_get_port(addr);
 
-    if (port == turn_params.listener_port) {
+    if (port == turn_params.listener_port)
+    {
       alt_port = get_alt_listener_port();
-    } else if (port == get_alt_listener_port()) {
+    }
+    else if (port == get_alt_listener_port())
+    {
       alt_port = turn_params.listener_port;
-    } else if (port == turn_params.tls_listener_port) {
+    }
+    else if (port == turn_params.tls_listener_port)
+    {
       alt_port = get_alt_tls_listener_port();
-    } else if (port == get_alt_tls_listener_port()) {
+    }
+    else if (port == get_alt_tls_listener_port())
+    {
       alt_port = turn_params.tls_listener_port;
-    } else {
+    }
+    else
+    {
       return -1;
     }
 
-    for (i = 0; i < turn_params.listener.addrs_number; i++) {
-      if (turn_params.listener.encaddrs && turn_params.listener.encaddrs[i]) {
-        if (addr->ss.sa_family == turn_params.listener.encaddrs[i]->ss.sa_family) {
+    for (i = 0; i < turn_params.listener.addrs_number; i++)
+    {
+      if (turn_params.listener.encaddrs && turn_params.listener.encaddrs[i])
+      {
+        if (addr->ss.sa_family == turn_params.listener.encaddrs[i]->ss.sa_family)
+        {
           index = i;
           break;
         }
       }
     }
-    if (index != 0xffff) {
-      for (i = 0; i < turn_params.listener.addrs_number; i++) {
+    if (index != 0xffff)
+    {
+      for (i = 0; i < turn_params.listener.addrs_number; i++)
+      {
         size_t ind = (index + i + 1) % turn_params.listener.addrs_number;
-        if (turn_params.listener.encaddrs && turn_params.listener.encaddrs[ind]) {
+        if (turn_params.listener.encaddrs && turn_params.listener.encaddrs[ind])
+        {
           ioa_addr *caddr = turn_params.listener.encaddrs[ind];
-          if (caddr->ss.sa_family == addr->ss.sa_family) {
+          if (caddr->ss.sa_family == addr->ss.sa_family)
+          {
             addr_cpy(alt_addr, caddr);
             addr_set_port(alt_addr, alt_port);
             return 0;
@@ -1571,12 +1886,15 @@ static int get_alt_addr(ioa_addr *addr, ioa_addr *alt_addr) {
   return -1;
 }
 
-static void run_events(struct event_base *eb, ioa_engine_handle e) {
-  if (!eb && e) {
+static void run_events(struct event_base *eb, ioa_engine_handle e)
+{
+  if (!eb && e)
+  {
     eb = e->event_base;
   }
 
-  if (!eb) {
+  if (!eb)
+  {
     return;
   }
 
@@ -1590,21 +1908,26 @@ static void run_events(struct event_base *eb, ioa_engine_handle e) {
   event_base_dispatch(eb);
 }
 
-void run_listener_server(struct listener_server *ls) {
+void run_listener_server(struct listener_server *ls)
+{
   unsigned int cycle = 0;
-  while (!turn_params.stop_turn_server) {
+  while (!turn_params.stop_turn_server)
+  {
 
 #if !defined(TURN_NO_SYSTEMD)
     sd_notify(0, "READY=1");
 #endif
 
-    if (eve(turn_params.verbose)) {
-      if ((cycle++ & 15) == 0) {
+    if (eve(turn_params.verbose))
+    {
+      if ((cycle++ & 15) == 0)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: cycle=%u\n", __FUNCTION__, cycle);
       }
     }
 
-    if (turn_params.drain_turn_server && global_allocation_count == 0) {
+    if (turn_params.drain_turn_server && global_allocation_count == 0)
+    {
       turn_params.stop_turn_server = true;
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Drain complete, shutting down now...\n");
     }
@@ -1619,13 +1942,17 @@ void run_listener_server(struct listener_server *ls) {
 #endif
 }
 
-static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int to_set_rfc5780) {
+static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int to_set_rfc5780)
+{
   struct bufferevent *pair[2];
 
-  if (e) {
+  if (e)
+  {
     rs->event_base = e->event_base;
     rs->ioa_eng = e;
-  } else {
+  }
+  else
+  {
     rs->event_base = turn_event_base_new();
     rs->ioa_eng = create_ioa_engine(rs->sm, rs->event_base, turn_params.listener.tp, turn_params.relay_ifname,
                                     turn_params.relays_number, turn_params.relay_addrs, turn_params.default_relays,
@@ -1666,16 +1993,19 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
       &turn_params.log_binding, &turn_params.no_stun_backward_compatibility,
       &turn_params.response_origin_only_with_rfc5780, &turn_params.respond_http_unsupported);
 
-  if (to_set_rfc5780) {
+  if (to_set_rfc5780)
+  {
     set_rfc5780(&(rs->server), get_alt_addr, send_message_from_listener_to_client);
   }
 
-  if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_THREAD) {
+  if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_THREAD)
+  {
     setup_tcp_listener_servers(rs->ioa_eng, rs);
   }
 }
 
-static void *run_general_relay_thread(void *arg) {
+static void *run_general_relay_thread(void *arg)
+{
   static int always_true = 1;
   struct relay_server *rs = (struct relay_server *)arg;
 
@@ -1691,19 +2021,23 @@ static void *run_general_relay_thread(void *arg) {
 
   barrier_wait();
 
-  while (always_true) {
+  while (always_true)
+  {
     run_events(rs->event_base, rs->ioa_eng);
   }
 
   return arg;
 }
 
-static void setup_general_relay_servers(void) {
+static void setup_general_relay_servers(void)
+{
   size_t i = 0;
 
-  for (i = 0; i < get_real_general_relay_servers_number(); i++) {
+  for (i = 0; i < get_real_general_relay_servers_number(); i++)
+  {
 
-    if (turn_params.general_relay_servers_number == 0) {
+    if (turn_params.general_relay_servers_number == 0)
+    {
       general_relay_servers[i] = (struct relay_server *)allocate_super_memory_engine(turn_params.listener.ioa_eng,
                                                                                      sizeof(struct relay_server));
       general_relay_servers[i]->id = (turnserver_id)i;
@@ -1713,12 +2047,15 @@ static void setup_general_relay_servers(void) {
                           (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_SESSION)) &&
                              turn_params.rfc5780);
       general_relay_servers[i]->thr = pthread_self();
-    } else {
+    }
+    else
+    {
       super_memory_t *sm = new_super_memory_region();
       general_relay_servers[i] = (struct relay_server *)allocate_super_memory_region(sm, sizeof(struct relay_server));
       general_relay_servers[i]->id = (turnserver_id)i;
       general_relay_servers[i]->sm = sm;
-      if (pthread_create(&(general_relay_servers[i]->thr), NULL, run_general_relay_thread, general_relay_servers[i])) {
+      if (pthread_create(&(general_relay_servers[i]->thr), NULL, run_general_relay_thread, general_relay_servers[i]))
+      {
         perror("Cannot create relay thread\n");
         exit(-1);
       }
@@ -1729,21 +2066,24 @@ static void setup_general_relay_servers(void) {
 
 static int run_auth_server_flag = 1;
 
-static void *run_auth_server_thread(void *arg) {
+static void *run_auth_server_thread(void *arg)
+{
   ignore_sigpipe();
 
   struct auth_server *as = (struct auth_server *)arg;
 
   authserver_id id = as->id;
 
-  if (id == 0) {
+  if (id == 0)
+  {
 
     reread_realms();
     update_white_and_black_lists();
 
     barrier_wait();
 
-    while (run_auth_server_flag) {
+    while (run_auth_server_flag)
+    {
 #if defined(DB_TEST)
       run_db_test();
 #endif
@@ -1751,8 +2091,9 @@ static void *run_auth_server_thread(void *arg) {
       reread_realms();
       update_white_and_black_lists();
     }
-
-  } else {
+  }
+  else
+  {
 
     memset(as, 0, sizeof(struct auth_server));
 
@@ -1774,8 +2115,10 @@ static void *run_auth_server_thread(void *arg) {
 
     barrier_wait();
 
-    while (run_auth_server_flag) {
-      if (!turn_params.no_auth_pings) {
+    while (run_auth_server_flag)
+    {
+      if (!turn_params.no_auth_pings)
+      {
         auth_ping(as->rch);
       }
 
@@ -1786,35 +2129,41 @@ static void *run_auth_server_thread(void *arg) {
   return arg;
 }
 
-static void setup_auth_server(struct auth_server *as) {
+static void setup_auth_server(struct auth_server *as)
+{
   pthread_attr_t attr;
   if (pthread_attr_init(&attr) || pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) ||
-      pthread_create(&(as->thr), &attr, run_auth_server_thread, as)) {
+      pthread_create(&(as->thr), &attr, run_auth_server_thread, as))
+  {
     perror("Cannot create auth thread\n");
     exit(-1);
   }
 }
 
-static void *run_admin_server_thread(void *arg) {
+static void *run_admin_server_thread(void *arg)
+{
   ignore_sigpipe();
 
   setup_admin_thread();
 
   barrier_wait();
 
-  while (adminserver.event_base) {
+  while (adminserver.event_base)
+  {
     run_events(adminserver.event_base, NULL);
   }
 
   return arg;
 }
 
-static void setup_admin_server(void) {
+static void setup_admin_server(void)
+{
   memset(&adminserver, 0, sizeof(struct admin_server));
   adminserver.listen_fd = -1;
   adminserver.verbose = turn_params.verbose;
 
-  if (pthread_create(&(adminserver.thr), NULL, run_admin_server_thread, &adminserver)) {
+  if (pthread_create(&(adminserver.thr), NULL, run_admin_server_thread, &adminserver))
+  {
     perror("Cannot create cli thread\n");
     exit(-1);
   }
@@ -1822,7 +2171,8 @@ static void setup_admin_server(void) {
   pthread_detach(adminserver.thr);
 }
 
-void setup_server(void) {
+void setup_server(void)
+{
 #if defined(WINDOWS)
   evthread_use_windows_threads();
 #else
@@ -1834,7 +2184,8 @@ void setup_server(void) {
 
   authserver_number = 1 + (authserver_id)(turn_params.cpus / 2);
 
-  if (authserver_number < MIN_AUTHSERVER_NUMBER) {
+  if (authserver_number < MIN_AUTHSERVER_NUMBER)
+  {
     authserver_number = MIN_AUTHSERVER_NUMBER;
   }
 
@@ -1853,34 +2204,45 @@ void setup_server(void) {
   setup_general_relay_servers();
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Total General servers: %d\n", (int)get_real_general_relay_servers_number());
 
-  if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_THREAD) {
+  if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_THREAD)
+  {
     setup_socket_per_thread_udp_listener_servers();
-  } else if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_ENDPOINT) {
+  }
+  else if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_ENDPOINT)
+  {
     setup_socket_per_endpoint_udp_listener_servers();
-  } else if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_SESSION) {
+  }
+  else if (turn_params.net_engine_version == NEV_UDP_SOCKET_PER_SESSION)
+  {
     setup_socket_per_session_udp_listener_servers();
   }
 
-  if (turn_params.net_engine_version != NEV_UDP_SOCKET_PER_THREAD) {
+  if (turn_params.net_engine_version != NEV_UDP_SOCKET_PER_THREAD)
+  {
     setup_tcp_listener_servers(turn_params.listener.ioa_eng, NULL);
   }
 
   {
     int tot = 0;
-    if (udp_relay_servers[0]) {
+    if (udp_relay_servers[0])
+    {
       tot = get_real_udp_relay_servers_number();
     }
-    if (tot) {
+    if (tot)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Total UDP servers: %d\n", (int)tot);
     }
   }
 
   {
     int tot = get_real_general_relay_servers_number();
-    if (tot) {
+    if (tot)
+    {
       int i;
-      for (i = 0; i < tot; i++) {
-        if (!(general_relay_servers[i])) {
+      for (i = 0; i < tot; i++)
+      {
+        if (!(general_relay_servers[i]))
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "General server %d is not initialized !\n", (int)i);
         }
       }
@@ -1889,7 +2251,8 @@ void setup_server(void) {
 
   {
     authserver_id sn = 0;
-    for (sn = 0; sn < authserver_number; ++sn) {
+    for (sn = 0; sn < authserver_number; ++sn)
+    {
       authserver[sn].id = sn;
       setup_auth_server(&(authserver[sn]));
     }
@@ -1903,15 +2266,20 @@ void setup_server(void) {
 
 void init_listener(void) { memset(&turn_params.listener, 0, sizeof(struct listener_server)); }
 
-void enable_drain_mode(void) {
+void enable_drain_mode(void)
+{
   // Tell each turn_server we are draining
-  for (size_t i = 0; i < get_real_general_relay_servers_number(); i++) {
-    if (general_relay_servers[i]) {
+  for (size_t i = 0; i < get_real_general_relay_servers_number(); i++)
+  {
+    if (general_relay_servers[i])
+    {
       general_relay_servers[i]->server.is_draining = true;
     }
   }
-  for (size_t i = 0; i < get_real_udp_relay_servers_number(); i++) {
-    if (udp_relay_servers[i]) {
+  for (size_t i = 0; i < get_real_udp_relay_servers_number(); i++)
+  {
+    if (udp_relay_servers[i])
+    {
       udp_relay_servers[i]->server.is_draining = true;
     }
   }

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -73,7 +73,8 @@
 
 #define MAX_ERRORS_IN_UDP_BATCH (1024)
 
-struct turn_sock_extended_err {
+struct turn_sock_extended_err
+{
   uint32_t ee_errno; /* error number */
   uint8_t ee_origin; /* where the error originated */
   uint8_t ee_type;   /* type */
@@ -110,22 +111,27 @@ static void close_socket_net_data(ioa_socket_handle s);
 
 static const int tcp_congestion_control = 1;
 
-static int bufferevent_enabled(struct bufferevent *bufev, short flags) {
+static int bufferevent_enabled(struct bufferevent *bufev, short flags)
+{
   return (bufferevent_get_enabled(bufev) & flags);
 }
 
-static int is_socket_writeable(ioa_socket_handle s, size_t sz, const char *msg, int option) {
+static int is_socket_writeable(ioa_socket_handle s, size_t sz, const char *msg, int option)
+{
   UNUSED_ARG(sz);
   UNUSED_ARG(msg);
   UNUSED_ARG(option);
 
-  if (!s) {
+  if (!s)
+  {
     return 0;
   }
 
-  if (!(s->done) && !(s->broken) && !(s->tobeclosed)) {
+  if (!(s->done) && !(s->broken) && !(s->tobeclosed))
+  {
 
-    switch (s->st) {
+    switch (s->st)
+    {
 
     case SCTP_SOCKET:
     case TLS_SCTP_SOCKET:
@@ -133,28 +139,34 @@ static int is_socket_writeable(ioa_socket_handle s, size_t sz, const char *msg, 
     case TCP_SOCKET:
     case TLS_SOCKET:
 
-      if (s->bev) {
+      if (s->bev)
+      {
 
         struct evbuffer *evb = bufferevent_get_output(s->bev);
 
-        if (evb) {
+        if (evb)
+        {
           size_t bufsz = evbuffer_get_length(evb);
           size_t newsz = bufsz + sz;
 
-          switch (s->sat) {
+          switch (s->sat)
+          {
           case TCP_CLIENT_DATA_SOCKET:
           case TCP_RELAY_DATA_SOCKET:
 
-            switch (option) {
+            switch (option)
+            {
             case 0:
             case 1:
-              if (newsz >= BUFFEREVENT_MAX_TCP_TO_TCP_WRITE) {
+              if (newsz >= BUFFEREVENT_MAX_TCP_TO_TCP_WRITE)
+              {
                 return 0;
               }
               break;
             case 3:
             case 4:
-              if (newsz >= BUFFEREVENT_MAX_TCP_TO_TCP_WRITE) {
+              if (newsz >= BUFFEREVENT_MAX_TCP_TO_TCP_WRITE)
+              {
                 return 0;
               }
               break;
@@ -163,8 +175,10 @@ static int is_socket_writeable(ioa_socket_handle s, size_t sz, const char *msg, 
             };
             break;
           default:
-            if (option == 2) {
-              if (newsz >= BUFFEREVENT_MAX_UDP_TO_TCP_WRITE) {
+            if (option == 2)
+            {
+              if (newsz >= BUFFEREVENT_MAX_UDP_TO_TCP_WRITE)
+              {
                 return 0;
               }
             }
@@ -179,23 +193,30 @@ static int is_socket_writeable(ioa_socket_handle s, size_t sz, const char *msg, 
   return 1;
 }
 
-static void log_socket_event(ioa_socket_handle s, const char *msg, int error) {
-  if (s && (error || (s->e && s->e->verbose))) {
-    if (!msg) {
+static void log_socket_event(ioa_socket_handle s, const char *msg, int error)
+{
+  if (s && (error || (s->e && s->e->verbose)))
+  {
+    if (!msg)
+    {
       msg = "General socket event";
     }
     turnsession_id id = 0;
     {
       ts_ur_super_session *ss = s->session;
-      if (ss) {
+      if (ss)
+      {
         id = ss->id;
-      } else {
+      }
+      else
+      {
         return;
       }
     }
 
     TURN_LOG_LEVEL ll = TURN_LOG_LEVEL_INFO;
-    if (error) {
+    if (error)
+    {
       ll = TURN_LOG_LEVEL_ERROR;
     }
 
@@ -207,10 +228,13 @@ static void log_socket_event(ioa_socket_handle s, const char *msg, int error) {
       addr_to_string(&(s->remote_addr), (uint8_t *)sraddr);
       addr_to_string(&(s->local_addr), (uint8_t *)sladdr);
 
-      if (EVUTIL_SOCKET_ERROR()) {
+      if (EVUTIL_SOCKET_ERROR())
+      {
         TURN_LOG_FUNC(ll, "session %018llu: %s: %s (local %s, remote %s)\n", (unsigned long long)id, msg,
                       evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR()), sladdr, sraddr);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: %s (local %s, remote %s)\n", (unsigned long long)id, msg,
                       sladdr, sraddr);
       }
@@ -218,20 +242,25 @@ static void log_socket_event(ioa_socket_handle s, const char *msg, int error) {
   }
 }
 
-int set_df_on_ioa_socket(ioa_socket_handle s, int value) {
-  if (!s) {
+int set_df_on_ioa_socket(ioa_socket_handle s, int value)
+{
+  if (!s)
+  {
     return 0;
   }
 
-  if (s->parent_s) {
+  if (s->parent_s)
+  {
     return 0;
   }
 
-  if (s->do_not_use_df) {
+  if (s->do_not_use_df)
+  {
     value = 0;
   }
 
-  if (s->current_df_relay_flag != value) {
+  if (s->current_df_relay_flag != value)
+  {
     s->current_df_relay_flag = value;
     return set_socket_df(s->fd, s->family, value);
   }
@@ -239,8 +268,10 @@ int set_df_on_ioa_socket(ioa_socket_handle s, int value) {
   return 0;
 }
 
-void set_do_not_use_df(ioa_socket_handle s) {
-  if (s->parent_s) {
+void set_do_not_use_df(ioa_socket_handle s)
+{
+  if (s->parent_s)
+  {
     return;
   }
 
@@ -251,22 +282,27 @@ void set_do_not_use_df(ioa_socket_handle s) {
 
 /************** Buffer List ********************/
 
-static int buffer_list_empty(stun_buffer_list *bufs) {
-  if (bufs && bufs->head && bufs->tsz) {
+static int buffer_list_empty(stun_buffer_list *bufs)
+{
+  if (bufs && bufs->head && bufs->tsz)
+  {
     return 0;
   }
   return 1;
 }
 
-static stun_buffer_list_elem *get_elem_from_buffer_list(stun_buffer_list *bufs) {
+static stun_buffer_list_elem *get_elem_from_buffer_list(stun_buffer_list *bufs)
+{
   stun_buffer_list_elem *ret = NULL;
 
-  if (bufs && bufs->head && bufs->tsz) {
+  if (bufs && bufs->head && bufs->tsz)
+  {
 
     ret = bufs->head;
     bufs->head = ret->next;
     --bufs->tsz;
-    if (bufs->tsz == 0) {
+    if (bufs->tsz == 0)
+    {
       bufs->tail = NULL;
     }
 
@@ -279,43 +315,55 @@ static stun_buffer_list_elem *get_elem_from_buffer_list(stun_buffer_list *bufs) 
   return ret;
 }
 
-static void pop_elem_from_buffer_list(stun_buffer_list *bufs) {
-  if (bufs && bufs->head && bufs->tsz) {
+static void pop_elem_from_buffer_list(stun_buffer_list *bufs)
+{
+  if (bufs && bufs->head && bufs->tsz)
+  {
 
     stun_buffer_list_elem *ret = bufs->head;
     bufs->head = ret->next;
     --bufs->tsz;
-    if (bufs->tsz == 0) {
+    if (bufs->tsz == 0)
+    {
       bufs->tail = NULL;
     }
     free(ret);
   }
 }
 
-static stun_buffer_list_elem *new_blist_elem(ioa_engine_handle e) {
+static stun_buffer_list_elem *new_blist_elem(ioa_engine_handle e)
+{
   stun_buffer_list_elem *ret = get_elem_from_buffer_list(&(e->bufs));
 
-  if (!ret) {
+  if (!ret)
+  {
     ret = (stun_buffer_list_elem *)malloc(sizeof(stun_buffer_list_elem));
   }
 
-  if (ret) {
+  if (ret)
+  {
     ret->buf.len = 0;
     ret->buf.offset = 0;
     ret->buf.coffset = 0;
     ret->next = NULL;
-  } else {
+  }
+  else
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate memory for STUN buffer!\n", __FUNCTION__);
   }
 
   return ret;
 }
 
-static inline void add_elem_to_buffer_list(stun_buffer_list *bufs, stun_buffer_list_elem *buf_elem) {
+static inline void add_elem_to_buffer_list(stun_buffer_list *bufs, stun_buffer_list_elem *buf_elem)
+{
   // We want a queue, so add to tail
-  if (bufs->tail) {
+  if (bufs->tail)
+  {
     bufs->tail->next = buf_elem;
-  } else {
+  }
+  else
+  {
     bufs->head = buf_elem;
   }
   buf_elem->next = NULL;
@@ -323,8 +371,10 @@ static inline void add_elem_to_buffer_list(stun_buffer_list *bufs, stun_buffer_l
   bufs->tsz += 1;
 }
 
-static void add_buffer_to_buffer_list(stun_buffer_list *bufs, char *buf, size_t len) {
-  if (bufs && buf && (bufs->tsz < MAX_SOCKET_BUFFER_BACKLOG)) {
+static void add_buffer_to_buffer_list(stun_buffer_list *bufs, char *buf, size_t len)
+{
+  if (bufs && buf && (bufs->tsz < MAX_SOCKET_BUFFER_BACKLOG))
+  {
     stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)malloc(sizeof(stun_buffer_list_elem));
     memcpy(buf_elem->buf.buf, buf, len);
     buf_elem->buf.len = len;
@@ -334,11 +384,16 @@ static void add_buffer_to_buffer_list(stun_buffer_list *bufs, char *buf, size_t 
   }
 }
 
-static void free_blist_elem(ioa_engine_handle e, stun_buffer_list_elem *buf_elem) {
-  if (buf_elem) {
-    if (e && (e->bufs.tsz < MAX_BUFFER_QUEUE_SIZE_PER_ENGINE)) {
+static void free_blist_elem(ioa_engine_handle e, stun_buffer_list_elem *buf_elem)
+{
+  if (buf_elem)
+  {
+    if (e && (e->bufs.tsz < MAX_BUFFER_QUEUE_SIZE_PER_ENGINE))
+    {
       add_elem_to_buffer_list(&(e->bufs), buf_elem);
-    } else {
+    }
+    else
+    {
       free(buf_elem);
     }
   }
@@ -346,7 +401,8 @@ static void free_blist_elem(ioa_engine_handle e, stun_buffer_list_elem *buf_elem
 
 /************** ENGINE *************************/
 
-static void timer_handler(ioa_engine_handle e, void *arg) {
+static void timer_handler(ioa_engine_handle e, void *arg)
+{
 
   UNUSED_ARG(arg);
 
@@ -363,10 +419,12 @@ ioa_engine_handle create_ioa_engine(super_memory_t *sm, struct event_base *eb, t
                                     ,
                                     redis_stats_db_t *redis_stats_db
 #endif
-) {
+)
+{
   static int capabilities_checked = 0;
 
-  if (!capabilities_checked) {
+  if (!capabilities_checked)
+  {
     capabilities_checked = 1;
 #if !defined(CMSG_SPACE)
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
@@ -390,20 +448,26 @@ ioa_engine_handle create_ioa_engine(super_memory_t *sm, struct event_base *eb, t
 #endif
   }
 
-  if (!relays_number || !relay_addrs || !tp) {
+  if (!relays_number || !relay_addrs || !tp)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot create TURN engine\n", __FUNCTION__);
     return NULL;
-  } else {
+  }
+  else
+  {
     ioa_engine_handle e = (ioa_engine_handle)allocate_super_memory_region(sm, sizeof(ioa_engine));
 
     e->sm = sm;
     e->default_relays = default_relays;
     e->verbose = verbose;
     e->tp = tp;
-    if (eb) {
+    if (eb)
+    {
       e->event_base = eb;
       e->deallocate_eb = 0;
-    } else {
+    }
+    else
+    {
       e->event_base = turn_event_base_new();
       e->deallocate_eb = 1;
     }
@@ -414,30 +478,37 @@ ioa_engine_handle create_ioa_engine(super_memory_t *sm, struct event_base *eb, t
 
     {
       int t;
-      for (t = 0; t < PREDEF_TIMERS_NUM; ++t) {
+      for (t = 0; t < PREDEF_TIMERS_NUM; ++t)
+      {
         struct timeval duration;
         duration.tv_sec = predef_timer_intervals[t];
         duration.tv_usec = 0;
         const struct timeval *ptv = event_base_init_common_timeout(e->event_base, &duration);
-        if (!ptv) {
+        if (!ptv)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "FATAL: cannot create preferable timeval for %d secs (%d number)\n",
                         predef_timer_intervals[t], t);
           exit(-1);
-        } else {
+        }
+        else
+        {
           memcpy(&(e->predef_timers[t]), ptv, sizeof(struct timeval));
           e->predef_timer_intervals[t] = predef_timer_intervals[t];
         }
       }
     }
 
-    if (relay_ifname) {
+    if (relay_ifname)
+    {
       STRCPY(e->relay_ifname, relay_ifname);
     }
     {
       size_t i = 0;
       e->relay_addrs = (ioa_addr *)allocate_super_memory_region(sm, relays_number * sizeof(ioa_addr) + 8);
-      for (i = 0; i < relays_number; i++) {
-        if (make_ioa_addr((uint8_t *)relay_addrs[i], 0, &(e->relay_addrs[i])) < 0) {
+      for (i = 0; i < relays_number; i++)
+      {
+        if (make_ioa_addr((uint8_t *)relay_addrs[i], 0, &(e->relay_addrs[i])) < 0)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot add a relay address: %s\n", relay_addrs[i]);
         }
       }
@@ -450,35 +521,45 @@ ioa_engine_handle create_ioa_engine(super_memory_t *sm, struct event_base *eb, t
   }
 }
 
-void ioa_engine_set_rtcp_map(ioa_engine_handle e, rtcp_map *rtcpmap) {
-  if (e) {
+void ioa_engine_set_rtcp_map(ioa_engine_handle e, rtcp_map *rtcpmap)
+{
+  if (e)
+  {
     e->map_rtcp = rtcpmap;
   }
 }
 
 static const ioa_addr *ioa_engine_get_relay_addr(ioa_engine_handle e, ioa_socket_handle client_s, int address_family,
-                                                 int *err_code) {
-  if (e) {
+                                                 int *err_code)
+{
+  if (e)
+  {
 
     int family = AF_INET;
-    if (address_family == STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6) {
+    if (address_family == STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6)
+    {
       family = AF_INET6;
     }
 
-    if (e->default_relays) {
+    if (e->default_relays)
+    {
 
       // No relay addrs defined - just return the client address if appropriate:
 
       ioa_addr *client_addr = get_local_addr_from_ioa_socket(client_s);
-      if (client_addr) {
-        switch (address_family) {
+      if (client_addr)
+      {
+        switch (address_family)
+        {
         case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4:
-          if (client_addr->ss.sa_family == AF_INET) {
+          if (client_addr->ss.sa_family == AF_INET)
+          {
             return client_addr;
           }
           break;
         case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6:
-          if (client_addr->ss.sa_family == AF_INET6) {
+          if (client_addr->ss.sa_family == AF_INET6)
+          {
             return client_addr;
           }
           break;
@@ -488,32 +569,39 @@ static const ioa_addr *ioa_engine_get_relay_addr(ioa_engine_handle e, ioa_socket
       }
     }
 
-    if (e->relays_number > 0) {
+    if (e->relays_number > 0)
+    {
 
       size_t i = 0;
 
       // Default recommended behavior:
 
-      for (i = 0; i < e->relays_number; i++) {
+      for (i = 0; i < e->relays_number; i++)
+      {
 
-        if (e->relay_addr_counter >= e->relays_number) {
+        if (e->relay_addr_counter >= e->relays_number)
+        {
           e->relay_addr_counter = 0;
         }
         ioa_addr *relay_addr = &(e->relay_addrs[e->relay_addr_counter++]);
 
-        if (addr_any_no_port(relay_addr)) {
+        if (addr_any_no_port(relay_addr))
+        {
           get_a_local_relay(family, relay_addr);
         }
 
-        switch (address_family) {
+        switch (address_family)
+        {
         case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_DEFAULT:
         case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4:
-          if (relay_addr->ss.sa_family == AF_INET) {
+          if (relay_addr->ss.sa_family == AF_INET)
+          {
             return relay_addr;
           }
           break;
         case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6:
-          if (relay_addr->ss.sa_family == AF_INET6) {
+          if (relay_addr->ss.sa_family == AF_INET6)
+          {
             return relay_addr;
           }
           break;
@@ -521,11 +609,13 @@ static const ioa_addr *ioa_engine_get_relay_addr(ioa_engine_handle e, ioa_socket
         };
       }
 
-      if (address_family == STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_DEFAULT) {
+      if (address_family == STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_DEFAULT)
+      {
 
         // Fallback to "find whatever is available":
 
-        if (e->relay_addr_counter >= e->relays_number) {
+        if (e->relay_addr_counter >= e->relays_number)
+        {
           e->relay_addr_counter = 0;
         }
         const ioa_addr *relay_addr = &(e->relay_addrs[e->relay_addr_counter++]);
@@ -540,20 +630,24 @@ static const ioa_addr *ioa_engine_get_relay_addr(ioa_engine_handle e, ioa_socket
 
 /******************** Timers ****************************/
 
-static void timer_event_handler(evutil_socket_t fd, short what, void *arg) {
+static void timer_event_handler(evutil_socket_t fd, short what, void *arg)
+{
   timer_event *te = (timer_event *)arg;
 
-  if (!te) {
+  if (!te)
+  {
     return;
   }
 
   UNUSED_ARG(fd);
 
-  if (!(what & EV_TIMEOUT)) {
+  if (!(what & EV_TIMEOUT))
+  {
     return;
   }
 
-  if (te->e && eve(te->e->verbose)) {
+  if (te->e && eve(te->e->verbose))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: timeout %p: %s\n", __FUNCTION__, te, te->txt);
   }
 
@@ -565,14 +659,17 @@ static void timer_event_handler(evutil_socket_t fd, short what, void *arg) {
 }
 
 ioa_timer_handle set_ioa_timer(ioa_engine_handle e, int secs, int ms, ioa_timer_event_handler cb, void *ctx,
-                               int persist, const char *txt) {
+                               int persist, const char *txt)
+{
   ioa_timer_handle ret = NULL;
 
-  if (e && cb && secs > 0) {
+  if (e && cb && secs > 0)
+  {
 
     timer_event *te = (timer_event *)malloc(sizeof(timer_event));
     int flags = EV_TIMEOUT;
-    if (persist) {
+    if (persist)
+    {
       flags |= EV_PERSIST;
     }
     struct event *ev = event_new(e->event_base, -1, flags, timer_event_handler, te);
@@ -586,21 +683,27 @@ ioa_timer_handle set_ioa_timer(ioa_engine_handle e, int secs, int ms, ioa_timer_
     te->cb = cb;
     te->txt = strdup(txt);
 
-    if (!ms) {
+    if (!ms)
+    {
       tv.tv_usec = 0;
       int found = 0;
       int t;
-      for (t = 0; t < PREDEF_TIMERS_NUM; ++t) {
-        if (e->predef_timer_intervals[t] == secs) {
+      for (t = 0; t < PREDEF_TIMERS_NUM; ++t)
+      {
+        if (e->predef_timer_intervals[t] == secs)
+        {
           evtimer_add(ev, &(e->predef_timers[t]));
           found = 1;
           break;
         }
       }
-      if (!found) {
+      if (!found)
+      {
         evtimer_add(ev, &tv);
       }
-    } else {
+    }
+    else
+    {
       tv.tv_usec = ms * 1000;
       evtimer_add(ev, &tv);
     }
@@ -611,18 +714,23 @@ ioa_timer_handle set_ioa_timer(ioa_engine_handle e, int secs, int ms, ioa_timer_
   return ret;
 }
 
-void stop_ioa_timer(ioa_timer_handle th) {
-  if (th) {
+void stop_ioa_timer(ioa_timer_handle th)
+{
+  if (th)
+  {
     timer_event *te = (timer_event *)th;
     EVENT_DEL(te->ev);
   }
 }
 
-void delete_ioa_timer(ioa_timer_handle th) {
-  if (th) {
+void delete_ioa_timer(ioa_timer_handle th)
+{
+  if (th)
+  {
     stop_ioa_timer(th);
     timer_event *te = (timer_event *)th;
-    if (te->txt) {
+    if (te->txt)
+    {
       free(te->txt);
       te->txt = NULL;
     }
@@ -632,25 +740,31 @@ void delete_ioa_timer(ioa_timer_handle th) {
 
 /************** SOCKETS HELPERS ***********************/
 
-int ioa_socket_check_bandwidth(ioa_socket_handle s, ioa_network_buffer_handle nbh, int read) {
+int ioa_socket_check_bandwidth(ioa_socket_handle s, ioa_network_buffer_handle nbh, int read)
+{
   if (s && (s->e) && nbh && ((s->sat == CLIENT_SOCKET) || (s->sat == RELAY_SOCKET) || (s->sat == RELAY_RTCP_SOCKET)) &&
-      (s->session)) {
+      (s->session))
+  {
 
     size_t sz = ioa_network_buffer_get_size(nbh);
 
     band_limit_t max_bps = s->session->bps;
 
-    if (max_bps < 1) {
+    if (max_bps < 1)
+    {
       return 1;
     }
 
     struct traffic_bytes *traffic = &(s->data_traffic);
 
-    if (s->sat == CLIENT_SOCKET) {
+    if (s->sat == CLIENT_SOCKET)
+    {
       uint8_t *buf = ioa_network_buffer_data(nbh);
-      if (stun_is_command_message_str(buf, sz)) {
+      if (stun_is_command_message_str(buf, sz))
+      {
         uint16_t method = stun_get_method_str(buf, sz);
-        if ((method != STUN_METHOD_SEND) && (method != STUN_METHOD_DATA)) {
+        if ((method != STUN_METHOD_SEND) && (method != STUN_METHOD_DATA))
+        {
           traffic = &(s->control_traffic);
         }
       }
@@ -658,35 +772,53 @@ int ioa_socket_check_bandwidth(ioa_socket_handle s, ioa_network_buffer_handle nb
 
     band_limit_t bsz = (band_limit_t)sz;
 
-    if (s->jiffie != s->e->jiffie) {
+    if (s->jiffie != s->e->jiffie)
+    {
 
       s->jiffie = s->e->jiffie;
       traffic->jiffie_bytes_read = 0;
       traffic->jiffie_bytes_write = 0;
 
-      if (bsz > max_bps) {
+      if (bsz > max_bps)
+      {
         return 0;
-      } else {
-        if (read) {
+      }
+      else
+      {
+        if (read)
+        {
           traffic->jiffie_bytes_read = bsz;
-        } else {
+        }
+        else
+        {
           traffic->jiffie_bytes_write = bsz;
         }
         return 1;
       }
-    } else {
+    }
+    else
+    {
       band_limit_t nsz;
-      if (read) {
+      if (read)
+      {
         nsz = traffic->jiffie_bytes_read + bsz;
-      } else {
+      }
+      else
+      {
         nsz = traffic->jiffie_bytes_write + bsz;
       }
-      if (nsz > max_bps) {
+      if (nsz > max_bps)
+      {
         return 0;
-      } else {
-        if (read) {
+      }
+      else
+      {
+        if (read)
+        {
           traffic->jiffie_bytes_read = nsz;
-        } else {
+        }
+        else
+        {
           traffic->jiffie_bytes_write = nsz;
         }
         return 1;
@@ -697,10 +829,13 @@ int ioa_socket_check_bandwidth(ioa_socket_handle s, ioa_network_buffer_handle nb
   return 1;
 }
 
-int get_ioa_socket_from_reservation(ioa_engine_handle e, uint64_t in_reservation_token, ioa_socket_handle *s) {
-  if (e && in_reservation_token && s) {
+int get_ioa_socket_from_reservation(ioa_engine_handle e, uint64_t in_reservation_token, ioa_socket_handle *s)
+{
+  if (e && in_reservation_token && s)
+  {
     *s = rtcp_map_get(e->map_rtcp, in_reservation_token);
-    if (*s) {
+    if (*s)
+    {
       return 0;
     }
   }
@@ -709,22 +844,27 @@ int get_ioa_socket_from_reservation(ioa_engine_handle e, uint64_t in_reservation
 
 /* Socket options helpers ==>> */
 
-static int set_socket_ttl(ioa_socket_handle s, int ttl) {
-  if (s->default_ttl < 0) { // Unsupported
+static int set_socket_ttl(ioa_socket_handle s, int ttl)
+{
+  if (s->default_ttl < 0)
+  { // Unsupported
     return -1;
   }
 
-  if (ttl < 0) {
+  if (ttl < 0)
+  {
     ttl = s->default_ttl;
   }
 
   CORRECT_RAW_TTL(ttl);
 
-  if (ttl > s->default_ttl) {
+  if (ttl > s->default_ttl)
+  {
     ttl = s->default_ttl;
   }
 
-  if (s->current_ttl != ttl) {
+  if (s->current_ttl != ttl)
+  {
     int ret = set_raw_socket_ttl(s->fd, s->family, ttl);
     s->current_ttl = ttl;
     return ret;
@@ -733,18 +873,22 @@ static int set_socket_ttl(ioa_socket_handle s, int ttl) {
   return 0;
 }
 
-static int set_socket_tos(ioa_socket_handle s, int tos) {
-  if (s->default_tos < 0) { // Unsupported
+static int set_socket_tos(ioa_socket_handle s, int tos)
+{
+  if (s->default_tos < 0)
+  { // Unsupported
     return -1;
   }
 
-  if (tos < 0) {
+  if (tos < 0)
+  {
     tos = s->default_tos;
   }
 
   CORRECT_RAW_TOS(tos);
 
-  if (s->current_tos != tos) {
+  if (s->current_tos != tos)
+  {
     int ret = set_raw_socket_tos(s->fd, s->family, tos);
     s->current_tos = tos;
     return ret;
@@ -753,22 +897,28 @@ static int set_socket_tos(ioa_socket_handle s, int tos) {
   return 0;
 }
 
-int set_raw_socket_ttl_options(evutil_socket_t fd, int family) {
-  if (family == AF_INET6) {
+int set_raw_socket_ttl_options(evutil_socket_t fd, int family)
+{
+  if (family == AF_INET6)
+  {
 #if !defined(IPV6_RECVHOPLIMIT)
     UNUSED_ARG(fd);
 #else
     int recv_ttl_on = 1;
-    if (setsockopt(fd, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, (const void *)&recv_ttl_on, sizeof(recv_ttl_on)) < 0) {
+    if (setsockopt(fd, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, (const void *)&recv_ttl_on, sizeof(recv_ttl_on)) < 0)
+    {
       perror("cannot set recvhoplimit\n");
     }
 #endif
-  } else {
+  }
+  else
+  {
 #if !defined(IP_RECVTTL)
     UNUSED_ARG(fd);
 #else
     int recv_ttl_on = 1;
-    if (setsockopt(fd, IPPROTO_IP, IP_RECVTTL, (const void *)&recv_ttl_on, sizeof(recv_ttl_on)) < 0) {
+    if (setsockopt(fd, IPPROTO_IP, IP_RECVTTL, (const void *)&recv_ttl_on, sizeof(recv_ttl_on)) < 0)
+    {
       perror("cannot set recvttl\n");
     }
 #endif
@@ -777,22 +927,28 @@ int set_raw_socket_ttl_options(evutil_socket_t fd, int family) {
   return 0;
 }
 
-int set_raw_socket_tos_options(evutil_socket_t fd, int family) {
-  if (family == AF_INET6) {
+int set_raw_socket_tos_options(evutil_socket_t fd, int family)
+{
+  if (family == AF_INET6)
+  {
 #if !defined(IPV6_RECVTCLASS)
     UNUSED_ARG(fd);
 #else
     int recv_tos_on = 1;
-    if (setsockopt(fd, IPPROTO_IPV6, IPV6_RECVTCLASS, (const void *)&recv_tos_on, sizeof(recv_tos_on)) < 0) {
+    if (setsockopt(fd, IPPROTO_IPV6, IPV6_RECVTCLASS, (const void *)&recv_tos_on, sizeof(recv_tos_on)) < 0)
+    {
       perror("cannot set recvtclass\n");
     }
 #endif
-  } else {
+  }
+  else
+  {
 #if !defined(IP_RECVTOS)
     UNUSED_ARG(fd);
 #else
     int recv_tos_on = 1;
-    if (setsockopt(fd, IPPROTO_IP, IP_RECVTOS, (const void *)&recv_tos_on, sizeof(recv_tos_on)) < 0) {
+    if (setsockopt(fd, IPPROTO_IP, IP_RECVTOS, (const void *)&recv_tos_on, sizeof(recv_tos_on)) < 0)
+    {
       perror("cannot set recvtos\n");
     }
 #endif
@@ -801,18 +957,22 @@ int set_raw_socket_tos_options(evutil_socket_t fd, int family) {
   return 0;
 }
 
-int set_socket_options_fd(evutil_socket_t fd, SOCKET_TYPE st, int family) {
-  if (fd < 0) {
+int set_socket_options_fd(evutil_socket_t fd, SOCKET_TYPE st, int family)
+{
+  if (fd < 0)
+  {
     return 0;
   }
 
   set_sock_buf_size(fd, UR_CLIENT_SOCK_BUF_SIZE);
 
-  if (is_tcp_socket(st)) { /* <<== FREEBSD fix */
+  if (is_tcp_socket(st))
+  { /* <<== FREEBSD fix */
     struct linger so_linger;
     so_linger.l_onoff = 1;
     so_linger.l_linger = 0;
-    if (setsockopt(fd, SOL_SOCKET, SO_LINGER, (const void *)&so_linger, sizeof(so_linger)) < 1) {
+    if (setsockopt(fd, SOL_SOCKET, SO_LINGER, (const void *)&so_linger, sizeof(so_linger)) < 1)
+    {
       // perror("setsolinger")
       ;
     }
@@ -820,45 +980,54 @@ int set_socket_options_fd(evutil_socket_t fd, SOCKET_TYPE st, int family) {
 
   socket_set_nonblocking(fd);
 
-  if (!is_stream_socket(st)) {
+  if (!is_stream_socket(st))
+  {
     set_raw_socket_ttl_options(fd, family);
     set_raw_socket_tos_options(fd, family);
 
 #ifdef IP_RECVERR
-    if (family != AF_INET6) {
+    if (family != AF_INET6)
+    {
       int on = 0;
 #ifdef TURN_IP_RECVERR
       on = 1;
 #endif
-      if (setsockopt(fd, IPPROTO_IP, IP_RECVERR, (const void *)&on, sizeof(on)) < 0) {
+      if (setsockopt(fd, IPPROTO_IP, IP_RECVERR, (const void *)&on, sizeof(on)) < 0)
+      {
         perror("IP_RECVERR");
       }
     }
 #endif
 
 #ifdef IPV6_RECVERR
-    if (family == AF_INET6) {
+    if (family == AF_INET6)
+    {
       int on = 0;
 #ifdef TURN_IP_RECVERR
       on = 1;
 #endif
-      if (setsockopt(fd, IPPROTO_IPV6, IPV6_RECVERR, (const void *)&on, sizeof(on)) < 0) {
+      if (setsockopt(fd, IPPROTO_IPV6, IPV6_RECVERR, (const void *)&on, sizeof(on)) < 0)
+      {
         perror("IPV6_RECVERR");
       }
     }
 #endif
-
-  } else {
+  }
+  else
+  {
 
     int flag = 1;
 
-    if (is_tcp_socket(st)) {
+    if (is_tcp_socket(st))
+    {
       setsockopt(fd,                  /* socket affected */
                  IPPROTO_TCP,         /* set option at TCP level */
                  TCP_NODELAY,         /* name of option */
                  (const void *)&flag, /* value */
                  sizeof(int));        /* length of option value */
-    } else {
+    }
+    else
+    {
 #if defined(SCTP_NODELAY)
       setsockopt(fd,                  /* socket affected */
                  IPPROTO_SCTP,        /* set option at SCTP level */
@@ -874,8 +1043,10 @@ int set_socket_options_fd(evutil_socket_t fd, SOCKET_TYPE st, int family) {
   return 0;
 }
 
-int set_socket_options(ioa_socket_handle s) {
-  if (!s || (s->parent_s)) {
+int set_socket_options(ioa_socket_handle s)
+{
+  if (!s || (s->parent_s))
+  {
     return 0;
   }
 
@@ -892,15 +1063,17 @@ int set_socket_options(ioa_socket_handle s) {
 
 /* <<== Socket options helpers */
 
-ioa_socket_handle create_unbound_relay_ioa_socket(ioa_engine_handle e, int family, SOCKET_TYPE st,
-                                                  SOCKET_APP_TYPE sat) {
+ioa_socket_handle create_unbound_relay_ioa_socket(ioa_engine_handle e, int family, SOCKET_TYPE st, SOCKET_APP_TYPE sat)
+{
   evutil_socket_t fd = -1;
   ioa_socket_handle ret = NULL;
 
-  switch (st) {
+  switch (st)
+  {
   case UDP_SOCKET:
     fd = socket(family, RELAY_DGRAM_SOCKET_TYPE, RELAY_DGRAM_SOCKET_PROTOCOL);
-    if (fd < 0) {
+    if (fd < 0)
+    {
       perror("UDP socket");
       return NULL;
     }
@@ -908,7 +1081,8 @@ ioa_socket_handle create_unbound_relay_ioa_socket(ioa_engine_handle e, int famil
     break;
   case TCP_SOCKET:
     fd = socket(family, RELAY_STREAM_SOCKET_TYPE, RELAY_STREAM_SOCKET_PROTOCOL);
-    if (fd < 0) {
+    if (fd < 0)
+    {
       perror("TCP socket");
       return NULL;
     }
@@ -934,23 +1108,31 @@ ioa_socket_handle create_unbound_relay_ioa_socket(ioa_engine_handle e, int famil
   return ret;
 }
 
-static int bind_ioa_socket(ioa_socket_handle s, const ioa_addr *local_addr, int reusable) {
-  if (!s || (s->parent_s)) {
+static int bind_ioa_socket(ioa_socket_handle s, const ioa_addr *local_addr, int reusable)
+{
+  if (!s || (s->parent_s))
+  {
     return 0;
   }
 
-  if (s && s->fd >= 0 && s->e && local_addr) {
+  if (s && s->fd >= 0 && s->e && local_addr)
+  {
 
     int res = addr_bind(s->fd, local_addr, reusable, 1, s->st);
-    if (res >= 0) {
+    if (res >= 0)
+    {
       s->bound = 1;
       addr_cpy(&(s->local_addr), local_addr);
-      if (addr_get_port(local_addr) < 1) {
+      if (addr_get_port(local_addr) < 1)
+      {
         ioa_addr tmpaddr;
         addr_get_from_sock(s->fd, &tmpaddr);
-        if (addr_any(&(s->local_addr))) {
+        if (addr_any(&(s->local_addr)))
+        {
           addr_cpy(&(s->local_addr), &tmpaddr);
-        } else {
+        }
+        else
+        {
           addr_set_port(&(s->local_addr), addr_get_port(&tmpaddr));
         }
       }
@@ -964,10 +1146,12 @@ static int bind_ioa_socket(ioa_socket_handle s, const ioa_addr *local_addr, int 
 int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, int address_family, uint8_t transport,
                              int even_port, ioa_socket_handle *rtp_s, ioa_socket_handle *rtcp_s,
                              uint64_t *out_reservation_token, int *err_code, const uint8_t **reason, accept_cb acb,
-                             void *acbarg) {
+                             void *acbarg)
+{
 
   *rtp_s = NULL;
-  if (rtcp_s) {
+  if (rtcp_s)
+  {
     *rtcp_s = NULL;
   }
 
@@ -975,16 +1159,20 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
 
   size_t iip = 0;
 
-  for (iip = 0; iip < e->relays_number; ++iip) {
+  for (iip = 0; iip < e->relays_number; ++iip)
+  {
 
     ioa_addr relay_addr;
     const ioa_addr *ra = ioa_engine_get_relay_addr(e, client_s, address_family, err_code);
-    if (ra) {
+    if (ra)
+    {
       addr_cpy(&relay_addr, ra);
     }
 
-    if (*err_code) {
-      if (*err_code == 440) {
+    if (*err_code)
+    {
+      if (*err_code == 440)
+      {
         *reason = (const uint8_t *)"Unsupported address family";
       }
       return -1;
@@ -993,7 +1181,8 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
     int rtcp_port = -1;
 
     IOA_CLOSE_SOCKET(*rtp_s);
-    if (rtcp_s) {
+    if (rtcp_s)
+    {
       IOA_CLOSE_SOCKET(*rtcp_s);
     }
 
@@ -1004,19 +1193,25 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
     int port = 0;
     ioa_addr local_addr;
     addr_cpy(&local_addr, &relay_addr);
-    for (i = 0; i < 0xFFFF; i++) {
+    for (i = 0; i < 0xFFFF; i++)
+    {
       port = 0;
       rtcp_port = -1;
-      if (even_port < 0) {
+      if (even_port < 0)
+      {
         port = turnipports_allocate(tp, transport, &relay_addr);
-      } else {
+      }
+      else
+      {
 
         port = turnipports_allocate_even(tp, &relay_addr, even_port, out_reservation_token);
-        if (port >= 0 && even_port > 0) {
+        if (port >= 0 && even_port > 0)
+        {
 
           IOA_CLOSE_SOCKET(*rtcp_s);
           *rtcp_s = create_unbound_relay_ioa_socket(e, relay_addr.ss.sa_family, UDP_SOCKET, RELAY_RTCP_SOCKET);
-          if (*rtcp_s == NULL) {
+          if (*rtcp_s == NULL)
+          {
             perror("socket");
             IOA_CLOSE_SOCKET(*rtp_s);
             addr_set_port(&local_addr, port);
@@ -1030,7 +1225,8 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
 
           rtcp_port = port + 1;
           addr_set_port(&rtcp_local_addr, rtcp_port);
-          if (bind_ioa_socket(*rtcp_s, &rtcp_local_addr, (transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE)) < 0) {
+          if (bind_ioa_socket(*rtcp_s, &rtcp_local_addr, (transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE)) < 0)
+          {
             addr_set_port(&local_addr, port);
             turnipports_release(tp, transport, &local_addr);
             turnipports_release(tp, transport, &rtcp_local_addr);
@@ -1040,29 +1236,36 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
           }
         }
       }
-      if (port < 0) {
+      if (port < 0)
+      {
         IOA_CLOSE_SOCKET(*rtp_s);
-        if (rtcp_s) {
+        if (rtcp_s)
+        {
           IOA_CLOSE_SOCKET(*rtcp_s);
         }
         rtcp_port = -1;
         break;
-      } else {
+      }
+      else
+      {
 
         IOA_CLOSE_SOCKET(*rtp_s);
 
         *rtp_s = create_unbound_relay_ioa_socket(
             e, relay_addr.ss.sa_family, (transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE) ? TCP_SOCKET : UDP_SOCKET,
             RELAY_SOCKET);
-        if (*rtp_s == NULL) {
+        if (*rtp_s == NULL)
+        {
           int rtcp_bound = 0;
-          if (rtcp_s && *rtcp_s) {
+          if (rtcp_s && *rtcp_s)
+          {
             rtcp_bound = (*rtcp_s)->bound;
             IOA_CLOSE_SOCKET(*rtcp_s);
           }
           addr_set_port(&local_addr, port);
           turnipports_release(tp, transport, &local_addr);
-          if (rtcp_port >= 0 && !rtcp_bound) {
+          if (rtcp_port >= 0 && !rtcp_bound)
+          {
             addr_set_port(&rtcp_local_addr, rtcp_port);
             turnipports_release(tp, transport, &rtcp_local_addr);
           }
@@ -1073,18 +1276,23 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
         sock_bind_to_device((*rtp_s)->fd, (unsigned char *)e->relay_ifname);
 
         addr_set_port(&local_addr, port);
-        if (bind_ioa_socket(*rtp_s, &local_addr, (transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE)) >= 0) {
+        if (bind_ioa_socket(*rtp_s, &local_addr, (transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE)) >= 0)
+        {
           break;
-        } else {
+        }
+        else
+        {
           IOA_CLOSE_SOCKET(*rtp_s);
           int rtcp_bound = 0;
-          if (rtcp_s && *rtcp_s) {
+          if (rtcp_s && *rtcp_s)
+          {
             rtcp_bound = (*rtcp_s)->bound;
             IOA_CLOSE_SOCKET(*rtcp_s);
           }
           addr_set_port(&local_addr, port);
           turnipports_release(tp, transport, &local_addr);
-          if (rtcp_port >= 0 && !rtcp_bound) {
+          if (rtcp_port >= 0 && !rtcp_bound)
+          {
             addr_set_port(&rtcp_local_addr, rtcp_port);
             turnipports_release(tp, transport, &rtcp_local_addr);
           }
@@ -1093,17 +1301,21 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
       }
     }
 
-    if (i >= 0xFFFF) {
+    if (i >= 0xFFFF)
+    {
       IOA_CLOSE_SOCKET(*rtp_s);
-      if (rtcp_s) {
+      if (rtcp_s)
+      {
         IOA_CLOSE_SOCKET(*rtcp_s);
       }
     }
 
-    if (*rtp_s) {
+    if (*rtp_s)
+    {
       addr_set_port(&local_addr, port);
       addr_debug_print(e->verbose, &local_addr, "Local relay addr");
-      if (rtcp_s && *rtcp_s) {
+      if (rtcp_s && *rtcp_s)
+      {
         addr_set_port(&local_addr, port + 1);
         addr_debug_print(e->verbose, &local_addr, "Local reserved relay addr");
       }
@@ -1111,10 +1323,12 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
     }
   }
 
-  if (!(*rtp_s)) {
+  if (!(*rtp_s))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: no available ports 3\n", __FUNCTION__);
     IOA_CLOSE_SOCKET(*rtp_s);
-    if (rtcp_s) {
+    if (rtcp_s)
+    {
       IOA_CLOSE_SOCKET(*rtcp_s);
     }
     return -1;
@@ -1122,11 +1336,14 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
 
   set_accept_cb(*rtp_s, acb, acbarg);
 
-  if (rtcp_s && *rtcp_s && out_reservation_token && *out_reservation_token) {
-    if (!rtcp_map_put(e->map_rtcp, *out_reservation_token, *rtcp_s)) {
+  if (rtcp_s && *rtcp_s && out_reservation_token && *out_reservation_token)
+  {
+    if (!rtcp_map_put(e->map_rtcp, *out_reservation_token, *rtcp_s))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot update RTCP map\n", __FUNCTION__);
       IOA_CLOSE_SOCKET(*rtp_s);
-      if (rtcp_s) {
+      if (rtcp_s)
+      {
         IOA_CLOSE_SOCKET(*rtcp_s);
       }
       return -1;
@@ -1139,7 +1356,8 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
 /* RFC 6062 ==>> */
 
 static void tcp_listener_input_handler(struct evconnlistener *l, evutil_socket_t fd, struct sockaddr *sa, int socklen,
-                                       void *arg) {
+                                       void *arg)
+{
   UNUSED_ARG(l);
 
   ioa_socket_handle list_s = (ioa_socket_handle)arg;
@@ -1152,27 +1370,37 @@ static void tcp_listener_input_handler(struct evconnlistener *l, evutil_socket_t
   ioa_socket_handle s = create_ioa_socket_from_fd(list_s->e, fd, NULL, TCP_SOCKET, TCP_RELAY_DATA_SOCKET, &client_addr,
                                                   &(list_s->local_addr));
 
-  if (s) {
-    if (list_s->acb) {
+  if (s)
+  {
+    if (list_s->acb)
+    {
       list_s->acb(s, list_s->acbarg);
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Do not know what to do with accepted TCP socket\n");
       close_ioa_socket(s);
     }
-  } else {
+  }
+  else
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot create ioa_socket from FD\n");
     socket_closesocket(fd);
   }
 }
 
-static int set_accept_cb(ioa_socket_handle s, accept_cb acb, void *arg) {
-  if (!s || s->parent_s) {
+static int set_accept_cb(ioa_socket_handle s, accept_cb acb, void *arg)
+{
+  if (!s || s->parent_s)
+  {
     return -1;
   }
 
-  if (s->st == TCP_SOCKET) {
+  if (s->st == TCP_SOCKET)
+  {
     s->list_ev = evconnlistener_new(s->e->event_base, tcp_listener_input_handler, s, LEV_OPT_REUSEABLE, 1024, s->fd);
-    if (!(s->list_ev)) {
+    if (!(s->list_ev))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot start TCP listener\n", __FUNCTION__);
       return -1;
     }
@@ -1182,27 +1410,34 @@ static int set_accept_cb(ioa_socket_handle s, accept_cb acb, void *arg) {
   return 0;
 }
 
-static void connect_eventcb(struct bufferevent *bev, short events, void *ptr) {
+static void connect_eventcb(struct bufferevent *bev, short events, void *ptr)
+{
   UNUSED_ARG(bev);
 
   ioa_socket_handle ret = (ioa_socket_handle)ptr;
-  if (ret) {
+  if (ret)
+  {
     connect_cb cb = ret->conn_cb;
     void *arg = ret->conn_arg;
-    if (events & BEV_EVENT_CONNECTED) {
+    if (events & BEV_EVENT_CONNECTED)
+    {
       ret->conn_cb = NULL;
       ret->conn_arg = NULL;
       BUFFEREVENT_FREE(ret->conn_bev);
       ret->connected = 1;
-      if (cb) {
+      if (cb)
+      {
         cb(1, arg);
       }
-    } else if (events & BEV_EVENT_ERROR) {
+    }
+    else if (events & BEV_EVENT_ERROR)
+    {
       /* An error occured while connecting. */
       ret->conn_cb = NULL;
       ret->conn_arg = NULL;
       BUFFEREVENT_FREE(ret->conn_bev);
-      if (cb) {
+      if (cb)
+      {
         cb(0, arg);
       }
     }
@@ -1210,10 +1445,12 @@ static void connect_eventcb(struct bufferevent *bev, short events, void *ptr) {
 }
 
 ioa_socket_handle ioa_create_connecting_tcp_relay_socket(ioa_socket_handle s, ioa_addr *peer_addr, connect_cb cb,
-                                                         void *arg) {
+                                                         void *arg)
+{
   ioa_socket_handle ret = create_unbound_relay_ioa_socket(s->e, s->family, s->st, TCP_RELAY_DATA_SOCKET);
 
-  if (!ret) {
+  if (!ret)
+  {
     return NULL;
   }
 
@@ -1233,7 +1470,8 @@ ioa_socket_handle ioa_create_connecting_tcp_relay_socket(ioa_socket_handle s, io
 #endif
 #endif
 
-  if (bind_ioa_socket(ret, &new_local_addr, 1) < 0) {
+  if (bind_ioa_socket(ret, &new_local_addr, 1) < 0)
+  {
     IOA_CLOSE_SOCKET(ret);
     ret = NULL;
     goto ccs_end;
@@ -1251,7 +1489,8 @@ ioa_socket_handle ioa_create_connecting_tcp_relay_socket(ioa_socket_handle s, io
   ret->conn_arg = arg;
   ret->conn_cb = cb;
 
-  if (bufferevent_socket_connect(ret->conn_bev, (struct sockaddr *)peer_addr, get_ioa_addr_len(peer_addr)) < 0) {
+  if (bufferevent_socket_connect(ret->conn_bev, (struct sockaddr *)peer_addr, get_ioa_addr_len(peer_addr)) < 0)
+  {
     /* Error starting connection */
     set_ioa_socket_session(ret, NULL);
     IOA_CLOSE_SOCKET(ret);
@@ -1269,23 +1508,31 @@ ccs_end:
    * for those OSes (for example, Linux pre-3.9 kernel).
    */
   s->fd = socket(s->family, RELAY_STREAM_SOCKET_TYPE, RELAY_STREAM_SOCKET_PROTOCOL);
-  if (s->fd < 0) {
+  if (s->fd < 0)
+  {
     perror("TCP socket");
-    if (ret) {
+    if (ret)
+    {
       set_ioa_socket_session(ret, NULL);
       IOA_CLOSE_SOCKET(ret);
       ret = NULL;
     }
-  } else {
+  }
+  else
+  {
     set_socket_options(s);
     sock_bind_to_device(s->fd, (unsigned char *)s->e->relay_ifname);
-    if (bind_ioa_socket(s, &new_local_addr, 1) < 0) {
-      if (ret) {
+    if (bind_ioa_socket(s, &new_local_addr, 1) < 0)
+    {
+      if (ret)
+      {
         set_ioa_socket_session(ret, NULL);
         IOA_CLOSE_SOCKET(ret);
         ret = NULL;
       }
-    } else {
+    }
+    else
+    {
       set_accept_cb(s, s->acb, s->acbarg);
     }
   }
@@ -1297,23 +1544,29 @@ ccs_end:
 
 /* <<== RFC 6062 */
 
-void add_socket_to_parent(ioa_socket_handle parent_s, ioa_socket_handle s) {
-  if (parent_s && s) {
+void add_socket_to_parent(ioa_socket_handle parent_s, ioa_socket_handle s)
+{
+  if (parent_s && s)
+  {
     delete_socket_from_parent(s);
     s->parent_s = parent_s;
     s->fd = parent_s->fd;
   }
 }
 
-void delete_socket_from_parent(ioa_socket_handle s) {
-  if (s && s->parent_s) {
+void delete_socket_from_parent(ioa_socket_handle s)
+{
+  if (s && s->parent_s)
+  {
     s->parent_s = NULL;
     s->fd = -1;
   }
 }
 
-void add_socket_to_map(ioa_socket_handle s, ur_addr_map *amap) {
-  if (amap && s && (s->sockets_container != amap)) {
+void add_socket_to_map(ioa_socket_handle s, ur_addr_map *amap)
+{
+  if (amap && s && (s->sockets_container != amap))
+  {
     delete_socket_from_map(s);
     ur_addr_map_del(amap, &(s->remote_addr), NULL);
     ur_addr_map_put(amap, &(s->remote_addr), (ur_addr_map_value_type)s);
@@ -1321,8 +1574,10 @@ void add_socket_to_map(ioa_socket_handle s, ur_addr_map *amap) {
   }
 }
 
-void delete_socket_from_map(ioa_socket_handle s) {
-  if (s && s->sockets_container) {
+void delete_socket_from_map(ioa_socket_handle s)
+{
+  if (s && s->sockets_container)
+  {
 
     ur_addr_map_del(s->sockets_container, &(s->remote_addr), NULL);
     s->sockets_container = NULL;
@@ -1331,10 +1586,12 @@ void delete_socket_from_map(ioa_socket_handle s) {
 
 ioa_socket_handle create_ioa_socket_from_fd(ioa_engine_handle e, ioa_socket_raw fd, ioa_socket_handle parent_s,
                                             SOCKET_TYPE st, SOCKET_APP_TYPE sat, const ioa_addr *remote_addr,
-                                            const ioa_addr *local_addr) {
+                                            const ioa_addr *local_addr)
+{
   ioa_socket_handle ret = NULL;
 
-  if ((fd < 0) && !parent_s) {
+  if ((fd < 0) && !parent_s)
+  {
     return NULL;
   }
 
@@ -1347,30 +1604,37 @@ ioa_socket_handle create_ioa_socket_from_fd(ioa_engine_handle e, ioa_socket_raw 
   ret->sat = sat;
   ret->e = e;
 
-  if (local_addr) {
+  if (local_addr)
+  {
     ret->family = local_addr->ss.sa_family;
     ret->bound = 1;
     addr_cpy(&(ret->local_addr), local_addr);
   }
 
-  if (remote_addr) {
+  if (remote_addr)
+  {
     ret->connected = 1;
-    if (!(ret->family)) {
+    if (!(ret->family))
+    {
       ret->family = remote_addr->ss.sa_family;
     }
     addr_cpy(&(ret->remote_addr), remote_addr);
   }
 
-  if (parent_s) {
+  if (parent_s)
+  {
     add_socket_to_parent(parent_s, ret);
-  } else {
+  }
+  else
+  {
     set_socket_options(ret);
   }
 
   return ret;
 }
 
-static void ssl_info_callback(SSL *ssl, int where, int ret) {
+static void ssl_info_callback(SSL *ssl, int where, int ret)
+{
   UNUSED_ARG(ret);
   UNUSED_ARG(ssl);
   UNUSED_ARG(where);
@@ -1378,14 +1642,18 @@ static void ssl_info_callback(SSL *ssl, int where, int ret) {
 
 typedef void (*ssl_info_callback_t)(const SSL *ssl, int type, int val);
 
-static void set_socket_ssl(ioa_socket_handle s, SSL *ssl) {
-  if (s && (s->ssl != ssl)) {
-    if (s->ssl) {
+static void set_socket_ssl(ioa_socket_handle s, SSL *ssl)
+{
+  if (s && (s->ssl != ssl))
+  {
+    if (s->ssl)
+    {
       SSL_set_app_data(s->ssl, NULL);
       SSL_set_info_callback(s->ssl, (ssl_info_callback_t)NULL);
     }
     s->ssl = ssl;
-    if (ssl) {
+    if (ssl)
+    {
       SSL_set_app_data(ssl, s);
       SSL_set_info_callback(ssl, (ssl_info_callback_t)ssl_info_callback);
       SSL_set_options(ssl,
@@ -1404,34 +1672,43 @@ static void set_socket_ssl(ioa_socket_handle s, SSL *ssl) {
 /* Only must be called for DTLS_SOCKET */
 ioa_socket_handle create_ioa_socket_from_ssl(ioa_engine_handle e, ioa_socket_handle parent_s, SSL *ssl, SOCKET_TYPE st,
                                              SOCKET_APP_TYPE sat, const ioa_addr *remote_addr,
-                                             const ioa_addr *local_addr) {
-  if (!parent_s) {
+                                             const ioa_addr *local_addr)
+{
+  if (!parent_s)
+  {
     return NULL;
   }
 
   ioa_socket_handle ret = create_ioa_socket_from_fd(e, parent_s->fd, parent_s, st, sat, remote_addr, local_addr);
 
-  if (ret) {
+  if (ret)
+  {
     set_socket_ssl(ret, ssl);
   }
 
   return ret;
 }
 
-static void close_socket_net_data(ioa_socket_handle s) {
-  if (s) {
+static void close_socket_net_data(ioa_socket_handle s)
+{
+  if (s)
+  {
 
     EVENT_DEL(s->read_event);
-    if (s->list_ev) {
+    if (s->list_ev)
+    {
       evconnlistener_free(s->list_ev);
       s->list_ev = NULL;
     }
     BUFFEREVENT_FREE(s->conn_bev);
     BUFFEREVENT_FREE(s->bev);
 
-    if (s->ssl) {
-      if (!s->broken) {
-        if (!(SSL_get_shutdown(s->ssl) & SSL_SENT_SHUTDOWN)) {
+    if (s->ssl)
+    {
+      if (!s->broken)
+      {
+        if (!(SSL_get_shutdown(s->ssl) & SSL_SENT_SHUTDOWN))
+        {
           /*
            * SSL_RECEIVED_SHUTDOWN tells SSL_shutdown to act as if we had already
            * received a close notify from the other end.  SSL_shutdown will then
@@ -1451,19 +1728,23 @@ static void close_socket_net_data(ioa_socket_handle s) {
       SSL_free(s->ssl);
     }
 
-    if (s->fd >= 0) {
+    if (s->fd >= 0)
+    {
       socket_closesocket(s->fd);
       s->fd = -1;
     }
   }
 }
 
-void detach_socket_net_data(ioa_socket_handle s) {
-  if (s) {
+void detach_socket_net_data(ioa_socket_handle s)
+{
+  if (s)
+  {
     EVENT_DEL(s->read_event);
     s->read_cb = NULL;
     s->read_ctx = NULL;
-    if (s->list_ev) {
+    if (s->list_ev)
+    {
       evconnlistener_free(s->list_ev);
       s->list_ev = NULL;
     }
@@ -1476,16 +1757,20 @@ void detach_socket_net_data(ioa_socket_handle s) {
   }
 }
 
-void close_ioa_socket(ioa_socket_handle s) {
-  if (s) {
+void close_ioa_socket(ioa_socket_handle s)
+{
+  if (s)
+  {
 
-    if (s->magic != SOCKET_MAGIC) {
+    if (s->magic != SOCKET_MAGIC)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s wrong magic on socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st,
                     s->sat);
       return;
     }
 
-    if (s->done) {
+    if (s->done)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s double free on socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st,
                     s->sat);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
@@ -1494,19 +1779,22 @@ void close_ioa_socket(ioa_socket_handle s) {
 
     s->done = 1;
 
-    while (!buffer_list_empty(&(s->bufs))) {
+    while (!buffer_list_empty(&(s->bufs)))
+    {
       pop_elem_from_buffer_list(&(s->bufs));
     }
 
     ioa_network_buffer_delete(s->e, s->defer_nbh);
 
-    if (s->bound && s->e && s->e->tp && ((s->sat == RELAY_SOCKET) || (s->sat == RELAY_RTCP_SOCKET))) {
+    if (s->bound && s->e && s->e->tp && ((s->sat == RELAY_SOCKET) || (s->sat == RELAY_RTCP_SOCKET)))
+    {
       turnipports_release(
           s->e->tp, ((s->st == TCP_SOCKET) ? STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE : STUN_ATTRIBUTE_TRANSPORT_UDP_VALUE),
           &(s->local_addr));
     }
 
-    if (s->special_session) {
+    if (s->special_session)
+    {
       free(s->special_session);
       s->special_session = NULL;
     }
@@ -1517,7 +1805,8 @@ void close_ioa_socket(ioa_socket_handle s) {
 
     close_socket_net_data(s);
 
-    if (s->session && s->session->client_socket == s) {
+    if (s->session && s->session->client_socket == s)
+    {
       // Detaching client socket from super session to prevent mem corruption
       // in case client_to_be_allocated_timeout_handler gets triggered
       s->session->client_socket = NULL;
@@ -1531,24 +1820,31 @@ void close_ioa_socket(ioa_socket_handle s) {
   }
 }
 
-ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
+ioa_socket_handle detach_ioa_socket(ioa_socket_handle s)
+{
   ioa_socket_handle ret = NULL;
 
-  if (!s) {
+  if (!s)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Detaching NULL socket\n");
-  } else {
-    if ((s->magic != SOCKET_MAGIC) || (s->done)) {
+  }
+  else
+  {
+    if ((s->magic != SOCKET_MAGIC) || (s->done))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on bad socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st,
                     s->sat);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
       return ret;
     }
-    if (s->tobeclosed) {
+    if (s->tobeclosed)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on tobeclosed socket: %p, st=%d, sat=%d\n", __FUNCTION__, s,
                     s->st, s->sat);
       return ret;
     }
-    if (!(s->e)) {
+    if (!(s->e))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on socket without engine: %p, st=%d, sat=%d\n", __FUNCTION__,
                     s, s->st, s->sat);
       return ret;
@@ -1556,8 +1852,10 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
 
     s->tobeclosed = 1;
 
-    if (s->parent_s) {
-      if ((s->st != UDP_SOCKET) && (s->st != DTLS_SOCKET)) {
+    if (s->parent_s)
+    {
+      if ((s->st != UDP_SOCKET) && (s->st != DTLS_SOCKET))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on non-UDP child socket: %p, st=%d, sat=%d\n", __FUNCTION__,
                       s, s->st, s->sat);
         return ret;
@@ -1566,26 +1864,31 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
 
     evutil_socket_t udp_fd = -1;
 
-    if (s->parent_s) {
+    if (s->parent_s)
+    {
       udp_fd = socket(s->local_addr.ss.sa_family, CLIENT_DGRAM_SOCKET_TYPE, CLIENT_DGRAM_SOCKET_PROTOCOL);
-      if (udp_fd < 0) {
+      if (udp_fd < 0)
+      {
         perror("socket");
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate new socket\n", __FUNCTION__);
         return ret;
       }
-      if (sock_bind_to_device(udp_fd, (unsigned char *)(s->e->relay_ifname)) < 0) {
+      if (sock_bind_to_device(udp_fd, (unsigned char *)(s->e->relay_ifname)) < 0)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot bind udp server socket to device %s\n",
                       (char *)(s->e->relay_ifname));
       }
 
-      if (addr_bind(udp_fd, &(s->local_addr), 1, 1, UDP_SOCKET) < 0) {
+      if (addr_bind(udp_fd, &(s->local_addr), 1, 1, UDP_SOCKET) < 0)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot bind new detached udp server socket to local addr\n");
         socket_closesocket(udp_fd);
         return ret;
       }
 
       int connect_err = 0;
-      if (addr_connect(udp_fd, &(s->remote_addr), &connect_err) < 0) {
+      if (addr_connect(udp_fd, &(s->remote_addr), &connect_err) < 0)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot connect new detached udp server socket to remote addr\n");
         socket_closesocket(udp_fd);
         return ret;
@@ -1596,16 +1899,19 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
 
     detach_socket_net_data(s);
 
-    while (!buffer_list_empty(&(s->bufs))) {
+    while (!buffer_list_empty(&(s->bufs)))
+    {
       pop_elem_from_buffer_list(&(s->bufs));
     }
 
     ioa_network_buffer_delete(s->e, s->defer_nbh);
 
     ret = (ioa_socket *)calloc(sizeof(ioa_socket), 1);
-    if (!ret) {
+    if (!ret)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate new socket structure\n", __FUNCTION__);
-      if (udp_fd >= 0) {
+      if (udp_fd >= 0)
+      {
         socket_closesocket(udp_fd);
       }
       return ret;
@@ -1633,7 +1939,8 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
     delete_socket_from_map(s);
     delete_socket_from_parent(s);
 
-    if (udp_fd >= 0) {
+    if (udp_fd >= 0)
+    {
 
       ret->fd = udp_fd;
 
@@ -1652,100 +1959,136 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
   return ret;
 }
 
-ts_ur_super_session *get_ioa_socket_session(ioa_socket_handle s) {
-  if (s) {
+ts_ur_super_session *get_ioa_socket_session(ioa_socket_handle s)
+{
+  if (s)
+  {
     return s->session;
   }
   return NULL;
 }
 
-void set_ioa_socket_session(ioa_socket_handle s, ts_ur_super_session *ss) {
-  if (s) {
+void set_ioa_socket_session(ioa_socket_handle s, ts_ur_super_session *ss)
+{
+  if (s)
+  {
     s->session = ss;
   }
 }
 
-void clear_ioa_socket_session_if(ioa_socket_handle s, void *ss) {
-  if (s && ((void *)(s->session) == ss)) {
+void clear_ioa_socket_session_if(ioa_socket_handle s, void *ss)
+{
+  if (s && ((void *)(s->session) == ss))
+  {
     s->session = NULL;
   }
 }
 
-tcp_connection *get_ioa_socket_sub_session(ioa_socket_handle s) {
-  if (s) {
+tcp_connection *get_ioa_socket_sub_session(ioa_socket_handle s)
+{
+  if (s)
+  {
     return s->sub_session;
   }
   return NULL;
 }
 
-void set_ioa_socket_sub_session(ioa_socket_handle s, tcp_connection *tc) {
-  if (s) {
+void set_ioa_socket_sub_session(ioa_socket_handle s, tcp_connection *tc)
+{
+  if (s)
+  {
     s->sub_session = tc;
   }
 }
 
-int get_ioa_socket_address_family(ioa_socket_handle s) {
+int get_ioa_socket_address_family(ioa_socket_handle s)
+{
 
   int first_time = 1;
 beg:
-  if (!(s && (s->magic == SOCKET_MAGIC) && !(s->done))) {
+  if (!(s && (s->magic == SOCKET_MAGIC) && !(s->done)))
+  {
     return AF_INET;
-  } else if (first_time && s->parent_s && (s != s->parent_s)) {
+  }
+  else if (first_time && s->parent_s && (s != s->parent_s))
+  {
     first_time = 0;
     s = s->parent_s;
     goto beg;
-  } else {
+  }
+  else
+  {
     return s->family;
   }
 }
 
-SOCKET_TYPE get_ioa_socket_type(ioa_socket_handle s) {
-  if (s) {
+SOCKET_TYPE get_ioa_socket_type(ioa_socket_handle s)
+{
+  if (s)
+  {
     return s->st;
   }
 
   return UNKNOWN_SOCKET;
 }
 
-SOCKET_APP_TYPE get_ioa_socket_app_type(ioa_socket_handle s) {
-  if (s) {
+SOCKET_APP_TYPE get_ioa_socket_app_type(ioa_socket_handle s)
+{
+  if (s)
+  {
     return s->sat;
   }
   return UNKNOWN_APP_SOCKET;
 }
 
-void set_ioa_socket_app_type(ioa_socket_handle s, SOCKET_APP_TYPE sat) {
-  if (s) {
+void set_ioa_socket_app_type(ioa_socket_handle s, SOCKET_APP_TYPE sat)
+{
+  if (s)
+  {
     s->sat = sat;
   }
 }
 
-ioa_addr *get_local_addr_from_ioa_socket(ioa_socket_handle s) {
-  if (s && (s->magic == SOCKET_MAGIC) && !(s->done)) {
+ioa_addr *get_local_addr_from_ioa_socket(ioa_socket_handle s)
+{
+  if (s && (s->magic == SOCKET_MAGIC) && !(s->done))
+  {
 
-    if (s->parent_s) {
+    if (s->parent_s)
+    {
       s = s->parent_s;
     }
 
-    if (s->local_addr_known) {
+    if (s->local_addr_known)
+    {
       return &(s->local_addr);
-    } else if (s->bound && (addr_get_port(&(s->local_addr)) > 0)) {
+    }
+    else if (s->bound && (addr_get_port(&(s->local_addr)) > 0))
+    {
       s->local_addr_known = 1;
       return &(s->local_addr);
-    } else {
+    }
+    else
+    {
       ioa_addr tmpaddr;
-      if (addr_get_from_sock(s->fd, &tmpaddr) == 0) {
-        if (addr_get_port(&tmpaddr) > 0) {
+      if (addr_get_from_sock(s->fd, &tmpaddr) == 0)
+      {
+        if (addr_get_port(&tmpaddr) > 0)
+        {
           s->local_addr_known = 1;
           s->bound = 1;
-          if (addr_any(&(s->local_addr))) {
+          if (addr_any(&(s->local_addr)))
+          {
             addr_cpy(&(s->local_addr), &tmpaddr);
-          } else {
+          }
+          else
+          {
             addr_set_port(&(s->local_addr), addr_get_port(&tmpaddr));
           }
           return &(s->local_addr);
         }
-        if (addr_any(&(s->local_addr))) {
+        if (addr_any(&(s->local_addr)))
+        {
           addr_cpy(&(s->local_addr), &tmpaddr);
         }
         return &(s->local_addr);
@@ -1756,10 +2099,13 @@ ioa_addr *get_local_addr_from_ioa_socket(ioa_socket_handle s) {
   return NULL;
 }
 
-ioa_addr *get_remote_addr_from_ioa_socket(ioa_socket_handle s) {
-  if (s && (s->magic == SOCKET_MAGIC) && !(s->done)) {
+ioa_addr *get_remote_addr_from_ioa_socket(ioa_socket_handle s)
+{
+  if (s && (s->magic == SOCKET_MAGIC) && !(s->done))
+  {
 
-    if (s->connected) {
+    if (s->connected)
+    {
       return &(s->remote_addr);
     }
   }
@@ -1767,9 +2113,12 @@ ioa_addr *get_remote_addr_from_ioa_socket(ioa_socket_handle s) {
   return NULL;
 }
 
-int get_local_mtu_ioa_socket(ioa_socket_handle s) {
-  if (s) {
-    if (s->parent_s) {
+int get_local_mtu_ioa_socket(ioa_socket_handle s)
+{
+  if (s)
+  {
+    if (s->parent_s)
+    {
       s = s->parent_s;
     }
 
@@ -1782,10 +2131,12 @@ int get_local_mtu_ioa_socket(ioa_socket_handle s) {
  * Return: -1 - error, 0 or >0 - OK
  * *read_len -1 - no data, >=0 - data available
  */
-int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int verbose) {
+int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int verbose)
+{
   int ret = 0;
 
-  if (!ssl || !nbh) {
+  if (!ssl || !nbh)
+  {
     return -1;
   }
 
@@ -1793,7 +2144,8 @@ int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int ve
   int buf_size = (int)ioa_network_buffer_get_capacity_udp();
   int read_len = (int)ioa_network_buffer_get_size(nbh);
 
-  if (read_len < 1) {
+  if (read_len < 1)
+  {
     return -1;
   }
 
@@ -1802,12 +2154,14 @@ int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int ve
 
   int len = 0;
 
-  if (eve(verbose)) {
+  if (eve(verbose))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: before read...\n", __FUNCTION__);
   }
 
   BIO *wbio = SSL_get_wbio(ssl);
-  if (wbio) {
+  if (wbio)
+  {
     BIO_set_fd(wbio, fd, BIO_NOCLOSE);
   }
 
@@ -1822,26 +2176,32 @@ int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int ve
 
   int if1 = SSL_is_init_finished(ssl);
 
-  do {
+  do
+  {
     len = SSL_read(ssl, new_buffer, buf_size);
   } while (len < 0 && socket_eintr());
 
   int if2 = SSL_is_init_finished(ssl);
 
-  if (eve(verbose)) {
+  if (eve(verbose))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: after read: %d\n", __FUNCTION__, len);
   }
 
-  if (SSL_get_shutdown(ssl)) {
+  if (SSL_get_shutdown(ssl))
+  {
 
     ret = -1;
-
-  } else if (!if1 && if2) {
+  }
+  else if (!if1 && if2)
+  {
 
 #if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
-    if (verbose && SSL_get1_peer_certificate(ssl)) {
+    if (verbose && SSL_get1_peer_certificate(ssl))
+    {
 #else
-    if (verbose && SSL_get_peer_certificate(ssl)) {
+    if (verbose && SSL_get_peer_certificate(ssl))
+    {
 #endif
       printf("\n------------------------------------------------------------\n");
       X509_NAME_print_ex_fp(stdout, X509_get_subject_name(SSL_get_peer_certificate(ssl)), 1, XN_FLAG_MULTILINE);
@@ -1850,22 +2210,31 @@ int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int ve
     }
 
     ret = 0;
-
-  } else if (len < 0 && (socket_enobufs() || socket_eagain())) {
-    if (eve(verbose)) {
+  }
+  else if (len < 0 && (socket_enobufs() || socket_eagain()))
+  {
+    if (eve(verbose))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: ENOBUFS/EAGAIN\n", __FUNCTION__);
     }
     ret = 0;
-  } else {
+  }
+  else
+  {
 
-    if (eve(verbose)) {
+    if (eve(verbose))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: read %d bytes\n", __FUNCTION__, (int)len);
     }
 
-    if (len >= 0) {
+    if (len >= 0)
+    {
       ret = len;
-    } else {
-      switch (SSL_get_error(ssl, len)) {
+    }
+    else
+    {
+      switch (SSL_get_error(ssl, len))
+      {
       case SSL_ERROR_NONE:
         //???
         ret = 0;
@@ -1879,30 +2248,37 @@ int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int ve
       case SSL_ERROR_ZERO_RETURN:
         ret = 0;
         break;
-      case SSL_ERROR_SYSCALL: {
+      case SSL_ERROR_SYSCALL:
+      {
         int err = socket_errno();
-        if (handle_socket_error()) {
+        if (handle_socket_error())
+        {
           ret = 0;
-        } else {
+        }
+        else
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "TLS Socket read error: %d\n", err);
           ret = -1;
         }
         break;
       }
       case SSL_ERROR_SSL:
-        if (verbose) {
+        if (verbose)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "SSL read error: ");
           char buf[65536];
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s (%d)\n", ERR_error_string(ERR_get_error(), buf),
                         SSL_get_error(ssl, len));
         }
-        if (verbose) {
+        if (verbose)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "SSL connection closed.\n");
         }
         ret = -1;
         break;
       default:
-        if (verbose) {
+        if (verbose)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Unexpected error while reading!\n");
         }
         ret = -1;
@@ -1910,7 +2286,8 @@ int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int ve
     }
   }
 
-  if (ret > 0) {
+  if (ret > 0)
+  {
     ioa_network_buffer_add_offset_size(nbh, (uint16_t)buf_size, 0, (size_t)ret);
   }
 #if defined LIBRESSL_VERSION_NUMBER && LIBRESSL_VERSION_NUMBER < 0x3040000fL
@@ -1923,8 +2300,10 @@ int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int ve
   return ret;
 }
 
-static int socket_readerr(evutil_socket_t fd, ioa_addr *orig_addr) {
-  if ((fd < 0) || !orig_addr) {
+static int socket_readerr(evutil_socket_t fd, ioa_addr *orig_addr)
+{
+  if ((fd < 0) || !orig_addr)
+  {
     return -1;
   }
 
@@ -1957,9 +2336,11 @@ static int socket_readerr(evutil_socket_t fd, ioa_addr *orig_addr) {
 
   int try_cycle = 0;
 
-  do {
+  do
+  {
 
-    do {
+    do
+    {
       len = recvmsg(fd, &msg, flags);
     } while (len < 0 && socket_eintr());
 
@@ -1975,14 +2356,17 @@ typedef unsigned char recv_ttl_t;
 typedef unsigned char recv_tos_t;
 
 int udp_recvfrom(evutil_socket_t fd, ioa_addr *orig_addr, const ioa_addr *like_addr, char *buffer, int buf_size,
-                 int *ttl, int *tos, char *ecmsg, int flags, uint32_t *errcode) {
+                 int *ttl, int *tos, char *ecmsg, int flags, uint32_t *errcode)
+{
   int len = 0;
 
-  if (fd < 0 || !orig_addr || !like_addr || !buffer) {
+  if (fd < 0 || !orig_addr || !like_addr || !buffer)
+  {
     return -1;
   }
 
-  if (errcode) {
+  if (errcode)
+  {
     *errcode = 0;
   }
 
@@ -1991,10 +2375,12 @@ int udp_recvfrom(evutil_socket_t fd, ioa_addr *orig_addr, const ioa_addr *like_a
   recv_tos_t recv_tos = TOS_DEFAULT;
 
 #if defined(_MSC_VER) || !defined(CMSG_SPACE)
-  do {
+  do
+  {
     len = recvfrom(fd, buffer, buf_size, flags, (struct sockaddr *)orig_addr, (socklen_t *)&slen);
   } while (len < 0 && socket_eintr());
-  if (len < 0 && errcode) {
+  if (len < 0 && errcode)
+  {
     *errcode = (uint32_t)socket_errno();
   }
 #else
@@ -2020,42 +2406,51 @@ int udp_recvfrom(evutil_socket_t fd, ioa_addr *orig_addr, const ioa_addr *like_a
 try_again:
 #endif
 
-  do {
+  do
+  {
     len = recvmsg(fd, &msg, flags);
   } while (len < 0 && socket_eintr());
 
 #if defined(MSG_ERRQUEUE)
 
-  if (flags & MSG_ERRQUEUE) {
-    if ((len > 0) && (try_cycle++ < MAX_ERRORS_IN_UDP_BATCH)) {
+  if (flags & MSG_ERRQUEUE)
+  {
+    if ((len > 0) && (try_cycle++ < MAX_ERRORS_IN_UDP_BATCH))
+    {
       goto try_again;
     }
   }
 
-  if ((len < 0) && (!(flags & MSG_ERRQUEUE))) {
+  if ((len < 0) && (!(flags & MSG_ERRQUEUE)))
+  {
     // Linux
     int eflags = MSG_ERRQUEUE | MSG_DONTWAIT;
     uint32_t errcode1 = 0;
     udp_recvfrom(fd, orig_addr, like_addr, buffer, buf_size, ttl, tos, ecmsg, eflags, &errcode1);
     // try again...
-    do {
+    do
+    {
       len = recvmsg(fd, &msg, flags);
     } while (len < 0 && socket_eintr());
   }
 #endif
 
-  if (len >= 0) {
+  if (len >= 0)
+  {
 
     struct cmsghdr *cmsgh;
 
     // Receive auxiliary data in msg
-    for (cmsgh = CMSG_FIRSTHDR(&msg); cmsgh != NULL; cmsgh = CMSG_NXTHDR(&msg, cmsgh)) {
+    for (cmsgh = CMSG_FIRSTHDR(&msg); cmsgh != NULL; cmsgh = CMSG_NXTHDR(&msg, cmsgh))
+    {
       int l = cmsgh->cmsg_level;
       int t = cmsgh->cmsg_type;
 
-      switch (l) {
+      switch (l)
+      {
       case IPPROTO_IP:
-        switch (t) {
+        switch (t)
+        {
 #if defined(IP_RECVTTL) && !defined(__sparc_v9__)
         case IP_RECVTTL:
         case IP_TTL:
@@ -2069,19 +2464,23 @@ try_again:
           break;
 #endif
 #if defined(IP_RECVERR)
-        case IP_RECVERR: {
+        case IP_RECVERR:
+        {
           struct turn_sock_extended_err *e = (struct turn_sock_extended_err *)CMSG_DATA(cmsgh);
-          if (errcode) {
+          if (errcode)
+          {
             *errcode = e->ee_errno;
           }
-        } break;
+        }
+        break;
 #endif
         default:;
           /* no break */
         };
         break;
       case IPPROTO_IPV6:
-        switch (t) {
+        switch (t)
+        {
 #if defined(IPV6_RECVHOPLIMIT) && !defined(__sparc_v9__)
         case IPV6_RECVHOPLIMIT:
         case IPV6_HOPLIMIT:
@@ -2095,12 +2494,15 @@ try_again:
           break;
 #endif
 #if defined(IPV6_RECVERR)
-        case IPV6_RECVERR: {
+        case IPV6_RECVERR:
+        {
           struct turn_sock_extended_err *e = (struct turn_sock_extended_err *)CMSG_DATA(cmsgh);
-          if (errcode) {
+          if (errcode)
+          {
             *errcode = e->ee_errno;
           }
-        } break;
+        }
+        break;
 #endif
         default:;
           /* no break */
@@ -2127,25 +2529,34 @@ try_again:
 
 #if TLS_SUPPORTED
 
-static TURN_TLS_TYPE check_tentative_tls(ioa_socket_raw fd) {
+static TURN_TLS_TYPE check_tentative_tls(ioa_socket_raw fd)
+{
   TURN_TLS_TYPE ret = TURN_TLS_NO;
 
   char s[12];
   int len = 0;
 
-  do {
+  do
+  {
     len = (int)recv(fd, s, sizeof(s), MSG_PEEK);
   } while (len < 0 && socket_eintr());
 
-  if (len > 0 && ((size_t)len == sizeof(s))) {
-    if ((s[0] == 22) && (s[1] == 3) && (s[5] == 1) && (s[9] == 3)) {
+  if (len > 0 && ((size_t)len == sizeof(s)))
+  {
+    if ((s[0] == 22) && (s[1] == 3) && (s[5] == 1) && (s[9] == 3))
+    {
       char max_supported = (char)(TURN_TLS_TOTAL - 2);
-      if (s[10] > max_supported) {
+      if (s[10] > max_supported)
+      {
         ret = TURN_TLS_SSL23; /* compatibility mode */
-      } else {
+      }
+      else
+      {
         ret = (TURN_TLS_TYPE)(s[10] + 1);
       }
-    } else if ((s[2] == 1) && (s[3] == 3)) {
+    }
+    else if ((s[2] == 1) && (s[3] == 3))
+    {
       ret = TURN_TLS_SSL23; /* compatibility mode */
     }
   }
@@ -2154,10 +2565,13 @@ static TURN_TLS_TYPE check_tentative_tls(ioa_socket_raw fd) {
 }
 #endif
 
-static size_t proxy_string_field(char *field, size_t max, uint8_t *buf, size_t index, size_t len) {
+static size_t proxy_string_field(char *field, size_t max, uint8_t *buf, size_t index, size_t len)
+{
   size_t count = 0;
-  while ((index < len) && (count < max)) {
-    if ((0x20 == buf[index]) || (0x0D == buf[index])) {
+  while ((index < len) && (count < max))
+  {
+    if ((0x20 == buf[index]) || (0x0D == buf[index]))
+    {
       field[count] = 0x00;
       return ++index;
     }
@@ -2166,14 +2580,17 @@ static size_t proxy_string_field(char *field, size_t max, uint8_t *buf, size_t i
   return 0;
 }
 
-static ssize_t socket_parse_proxy_v1(ioa_socket_handle s, uint8_t *buf, size_t len) {
-  if (len < 11) {
+static ssize_t socket_parse_proxy_v1(ioa_socket_handle s, uint8_t *buf, size_t len)
+{
+  if (len < 11)
+  {
     return 0;
   }
 
   /* Check for proxy-v1 magic field */
   char magic[] = {0x50, 0x52, 0x4F, 0x58, 0x59, 0x20};
-  if (memcmp(magic, buf, sizeof(magic))) {
+  if (memcmp(magic, buf, sizeof(magic)))
+  {
     return -1;
   }
 
@@ -2181,11 +2598,16 @@ static ssize_t socket_parse_proxy_v1(ioa_socket_handle s, uint8_t *buf, size_t l
   char tcp4[] = {0x54, 0x43, 0x50, 0x34, 0x20};
   char tcp6[] = {0x54, 0x43, 0x50, 0x36, 0x20};
   int family;
-  if (0 == memcmp(tcp4, &buf[6], sizeof(tcp4))) { /* IPv4 */
+  if (0 == memcmp(tcp4, &buf[6], sizeof(tcp4)))
+  { /* IPv4 */
     family = AF_INET;
-  } else if (0 == memcmp(tcp6, &buf[6], sizeof(tcp6))) { /* IPv6 */
+  }
+  else if (0 == memcmp(tcp6, &buf[6], sizeof(tcp6)))
+  { /* IPv6 */
     family = AF_INET6;
-  } else {
+  }
+  else
+  {
     return -1;
   }
 
@@ -2197,30 +2619,35 @@ static ssize_t socket_parse_proxy_v1(ioa_socket_handle s, uint8_t *buf, size_t l
   size_t tlen = 11;
   /* Read source address */
   tlen = proxy_string_field(saddr, sizeof(saddr), buf, tlen, len);
-  if (0 == tlen) {
+  if (0 == tlen)
+  {
     return -1;
   }
 
   /* Read dest address */
   tlen = proxy_string_field(daddr, sizeof(daddr), buf, tlen, len);
-  if (0 == tlen) {
+  if (0 == tlen)
+  {
     return -1;
   }
 
   /* Read source port */
   tlen = proxy_string_field(sport, sizeof(sport), buf, tlen, len);
-  if (0 == tlen) {
+  if (0 == tlen)
+  {
     return -1;
   }
 
   /* Read dest port */
   tlen = proxy_string_field(dport, sizeof(dport), buf, tlen, len);
-  if (0 == tlen) {
+  if (0 == tlen)
+  {
     return -1;
   }
 
   /* Final line feed */
-  if ((len <= tlen) || (0x0A != buf[tlen])) {
+  if ((len <= tlen) || (0x0A != buf[tlen]))
+  {
     return -1;
   }
 
@@ -2228,20 +2655,25 @@ static ssize_t socket_parse_proxy_v1(ioa_socket_handle s, uint8_t *buf, size_t l
 
   int sport_int = atoi(sport);
   int dport_int = atoi(dport);
-  if ((sport_int < 0) || (0xFFFF < sport_int)) {
+  if ((sport_int < 0) || (0xFFFF < sport_int))
+  {
     return -1;
   }
-  if ((dport_int < 0) || (0xFFFF < dport_int)) {
+  if ((dport_int < 0) || (0xFFFF < dport_int))
+  {
     return -1;
   }
 
-  if (AF_INET == family) {
+  if (AF_INET == family)
+  {
     struct sockaddr_in remote, local;
     remote.sin_family = local.sin_family = AF_INET;
-    if (1 != inet_pton(AF_INET, saddr, &remote.sin_addr.s_addr)) {
+    if (1 != inet_pton(AF_INET, saddr, &remote.sin_addr.s_addr))
+    {
       return -1;
     }
-    if (1 != inet_pton(AF_INET, daddr, &local.sin_addr.s_addr)) {
+    if (1 != inet_pton(AF_INET, daddr, &local.sin_addr.s_addr))
+    {
       return -1;
     }
     remote.sin_port = htons((uint16_t)sport_int);
@@ -2249,14 +2681,17 @@ static ssize_t socket_parse_proxy_v1(ioa_socket_handle s, uint8_t *buf, size_t l
 
     addr_cpy4(&(s->local_addr), &local);
     addr_cpy4(&(s->remote_addr), &remote);
-
-  } else {
+  }
+  else
+  {
     struct sockaddr_in6 remote, local;
     remote.sin6_family = local.sin6_family = AF_INET6;
-    if (1 != inet_pton(AF_INET6, saddr, &remote.sin6_addr.s6_addr)) {
+    if (1 != inet_pton(AF_INET6, saddr, &remote.sin6_addr.s6_addr))
+    {
       return -1;
     }
-    if (1 != inet_pton(AF_INET6, daddr, &local.sin6_addr.s6_addr)) {
+    if (1 != inet_pton(AF_INET6, daddr, &local.sin6_addr.s6_addr))
+    {
       return -1;
     }
     remote.sin6_port = htons((uint16_t)sport_int);
@@ -2268,20 +2703,24 @@ static ssize_t socket_parse_proxy_v1(ioa_socket_handle s, uint8_t *buf, size_t l
   return tlen;
 }
 
-static ssize_t socket_parse_proxy_v2(ioa_socket_handle s, uint8_t *buf, size_t len) {
-  if (len < 16) {
+static ssize_t socket_parse_proxy_v2(ioa_socket_handle s, uint8_t *buf, size_t len)
+{
+  if (len < 16)
+  {
     return 0;
   }
 
   /* Check for proxy-v2 magic field */
   char magic[] = {0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A};
-  if (memcmp(magic, buf, sizeof(magic))) {
+  if (memcmp(magic, buf, sizeof(magic)))
+  {
     return -1;
   }
 
   /* Check version */
   uint8_t version = buf[12] >> 4;
-  if (version != 2) {
+  if (version != 2)
+  {
     return -1;
   }
 
@@ -2292,22 +2731,26 @@ static ssize_t socket_parse_proxy_v2(ioa_socket_handle s, uint8_t *buf, size_t l
   size_t plen = ((size_t)buf[14] << 8) | buf[15];
 
   size_t tlen = 16 + plen;
-  if (len < tlen) {
+  if (len < tlen)
+  {
     return 0;
   }
 
   /* A local connection is used by the proxy itself and does not carry a valid address */
-  if (command == 0) {
+  if (command == 0)
+  {
     return tlen;
   }
 
   /* Accept only proxied TCP connections */
-  if (command != 1 || proto != 1) {
+  if (command != 1 || proto != 1)
+  {
     return -1;
   }
 
   /* Read the address */
-  if (family == 1 && plen >= 12) { /* IPv4 */
+  if (family == 1 && plen >= 12)
+  { /* IPv4 */
     struct sockaddr_in remote, local;
     remote.sin_family = local.sin_family = AF_INET;
     memcpy(&remote.sin_addr.s_addr, &buf[16], 4);
@@ -2317,8 +2760,9 @@ static ssize_t socket_parse_proxy_v2(ioa_socket_handle s, uint8_t *buf, size_t l
 
     addr_cpy4(&(s->local_addr), &local);
     addr_cpy4(&(s->remote_addr), &remote);
-
-  } else if (family == 2 && plen >= 36) { /* IPv6 */
+  }
+  else if (family == 2 && plen >= 36)
+  { /* IPv6 */
     struct sockaddr_in6 remote, local;
     remote.sin6_family = local.sin6_family = AF_INET6;
     memcpy(&remote.sin6_addr.s6_addr, &buf[16], 16);
@@ -2328,24 +2772,28 @@ static ssize_t socket_parse_proxy_v2(ioa_socket_handle s, uint8_t *buf, size_t l
 
     addr_cpy6(&(s->local_addr), &local);
     addr_cpy6(&(s->remote_addr), &remote);
-
-  } else {
+  }
+  else
+  {
     return -1;
   }
 
   return tlen;
 }
 
-static ssize_t socket_parse_proxy(ioa_socket_handle s, uint8_t *buf, size_t len) {
+static ssize_t socket_parse_proxy(ioa_socket_handle s, uint8_t *buf, size_t len)
+{
   ssize_t tlen = socket_parse_proxy_v2(s, buf, len);
-  if (-1 == tlen) {
+  if (-1 == tlen)
+  {
     tlen = socket_parse_proxy_v1(s, buf, len);
   }
 
   return tlen;
 }
 
-static int socket_input_worker(ioa_socket_handle s) {
+static int socket_input_worker(ioa_socket_handle s)
+{
   int len = 0;
   int ret = 0;
   size_t app_msg_len = 0;
@@ -2358,94 +2806,121 @@ static int socket_input_worker(ioa_socket_handle s) {
   int try_cycle = 0;
   const int MAX_TRIES = 16;
 
-  if (!s) {
+  if (!s)
+  {
     return 0;
   }
 
-  if ((s->magic != SOCKET_MAGIC) || (s->done)) {
+  if ((s->magic != SOCKET_MAGIC) || (s->done))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st, s->sat);
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
     return -1;
   }
 
-  if (!(s->e)) {
+  if (!(s->e))
+  {
     return 0;
   }
 
-  if (s->tobeclosed) {
+  if (s->tobeclosed)
+  {
     return 0;
   }
 
-  if (s->connected) {
+  if (s->connected)
+  {
     addr_cpy(&remote_addr, &(s->remote_addr));
   }
 
-  if (tcp_congestion_control && s->sub_session && s->bev) {
-    if (s == s->sub_session->client_s && (s->sub_session->peer_s)) {
-      if (!is_socket_writeable(s->sub_session->peer_s, STUN_BUFFER_SIZE, __FUNCTION__, 0)) {
-        if (bufferevent_enabled(s->bev, EV_READ)) {
+  if (tcp_congestion_control && s->sub_session && s->bev)
+  {
+    if (s == s->sub_session->client_s && (s->sub_session->peer_s))
+    {
+      if (!is_socket_writeable(s->sub_session->peer_s, STUN_BUFFER_SIZE, __FUNCTION__, 0))
+      {
+        if (bufferevent_enabled(s->bev, EV_READ))
+        {
           bufferevent_disable(s->bev, EV_READ);
         }
       }
-    } else if (s == s->sub_session->peer_s && (s->sub_session->client_s)) {
-      if (!is_socket_writeable(s->sub_session->client_s, STUN_BUFFER_SIZE, __FUNCTION__, 1)) {
-        if (bufferevent_enabled(s->bev, EV_READ)) {
+    }
+    else if (s == s->sub_session->peer_s && (s->sub_session->client_s))
+    {
+      if (!is_socket_writeable(s->sub_session->client_s, STUN_BUFFER_SIZE, __FUNCTION__, 1))
+      {
+        if (bufferevent_enabled(s->bev, EV_READ))
+        {
           bufferevent_disable(s->bev, EV_READ);
         }
       }
     }
   }
 
-  if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET)) {
+  if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET))
+  {
 #if TLS_SUPPORTED
     SSL *ctx = bufferevent_openssl_get_ssl(s->bev);
-    if (!ctx || SSL_get_shutdown(ctx)) {
+    if (!ctx || SSL_get_shutdown(ctx))
+    {
       s->tobeclosed = 1;
       return 0;
     }
 #endif
-  } else if (s->st == DTLS_SOCKET) {
-    if (!(s->ssl) || SSL_get_shutdown(s->ssl)) {
+  }
+  else if (s->st == DTLS_SOCKET)
+  {
+    if (!(s->ssl) || SSL_get_shutdown(s->ssl))
+    {
       s->tobeclosed = 1;
       return 0;
     }
   }
 
-  if (!(s->e)) {
+  if (!(s->e))
+  {
     return 0;
   }
 
-  if (s->st == TENTATIVE_TCP_SOCKET) {
+  if (s->st == TENTATIVE_TCP_SOCKET)
+  {
     EVENT_DEL(s->read_event);
 #if TLS_SUPPORTED
     TURN_TLS_TYPE tls_type = check_tentative_tls(s->fd);
-    if (tls_type) {
+    if (tls_type)
+    {
       s->st = TLS_SOCKET;
-      if (s->ssl) {
+      if (s->ssl)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: ssl already exist\n", __FUNCTION__, s,
                       s->st, s->sat);
       }
-      if (s->bev) {
+      if (s->bev)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: bev already exist\n", __FUNCTION__, s,
                       s->st, s->sat);
       }
 
-      if (s->e->tls_ctx) {
+      if (s->e->tls_ctx)
+      {
         set_socket_ssl(s, SSL_new(s->e->tls_ctx));
       }
 
-      if (s->ssl) {
+      if (s->ssl)
+      {
         s->bev = bufferevent_openssl_socket_new(s->e->event_base, s->fd, s->ssl, BUFFEREVENT_SSL_ACCEPTING,
                                                 TURN_BUFFEREVENTS_OPTIONS);
         bufferevent_setcb(s->bev, socket_input_handler_bev, socket_output_handler_bev, eventcb_bev, s);
         bufferevent_setwatermark(s->bev, EV_READ | EV_WRITE, 0, BUFFEREVENT_HIGH_WATERMARK);
         bufferevent_enable(s->bev, EV_READ | EV_WRITE); /* Start reading. */
       }
-    } else
+    }
+    else
 #endif // TLS_SUPPORTED
     {
       s->st = TCP_SOCKET;
-      if (s->bev) {
+      if (s->bev)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: bev already exist\n", __FUNCTION__, s,
                       s->st, s->sat);
       }
@@ -2454,35 +2929,44 @@ static int socket_input_worker(ioa_socket_handle s) {
       bufferevent_setwatermark(s->bev, EV_READ | EV_WRITE, 0, BUFFEREVENT_HIGH_WATERMARK);
       bufferevent_enable(s->bev, EV_READ | EV_WRITE); /* Start reading. */
     }
-  } else if (s->st == TENTATIVE_SCTP_SOCKET) {
+  }
+  else if (s->st == TENTATIVE_SCTP_SOCKET)
+  {
     EVENT_DEL(s->read_event);
 #if TLS_SUPPORTED
     TURN_TLS_TYPE tls_type = check_tentative_tls(s->fd);
-    if (tls_type) {
+    if (tls_type)
+    {
       s->st = TLS_SCTP_SOCKET;
-      if (s->ssl) {
+      if (s->ssl)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: ssl already exist\n", __FUNCTION__, s,
                       s->st, s->sat);
       }
-      if (s->bev) {
+      if (s->bev)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: bev already exist\n", __FUNCTION__, s,
                       s->st, s->sat);
       }
-      if (s->e->tls_ctx) {
+      if (s->e->tls_ctx)
+      {
         set_socket_ssl(s, SSL_new(s->e->tls_ctx));
       }
-      if (s->ssl) {
+      if (s->ssl)
+      {
         s->bev = bufferevent_openssl_socket_new(s->e->event_base, s->fd, s->ssl, BUFFEREVENT_SSL_ACCEPTING,
                                                 TURN_BUFFEREVENTS_OPTIONS);
         bufferevent_setcb(s->bev, socket_input_handler_bev, socket_output_handler_bev, eventcb_bev, s);
         bufferevent_setwatermark(s->bev, EV_READ | EV_WRITE, 0, BUFFEREVENT_HIGH_WATERMARK);
         bufferevent_enable(s->bev, EV_READ | EV_WRITE); /* Start reading. */
       }
-    } else
+    }
+    else
 #endif // TLS_SUPPORTED
     {
       s->st = SCTP_SOCKET;
-      if (s->bev) {
+      if (s->bev)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: bev already exist\n", __FUNCTION__, s,
                       s->st, s->sat);
       }
@@ -2495,7 +2979,8 @@ static int socket_input_worker(ioa_socket_handle s) {
 
 try_start:
 
-  if (!(s->e)) {
+  if (!(s->e))
+  {
     return 0;
   }
 
@@ -2505,27 +2990,35 @@ try_start:
   stun_buffer_list_elem *buf_elem = new_blist_elem(s->e);
   len = -1;
 
-  if (s->bev) { /* TCP & TLS  & SCTP & SCTP/TLS */
+  if (s->bev)
+  { /* TCP & TLS  & SCTP & SCTP/TLS */
     struct evbuffer *inbuf = bufferevent_get_input(s->bev);
-    if (inbuf) {
+    if (inbuf)
+    {
       ev_ssize_t blen = evbuffer_copyout(inbuf, buf_elem->buf.buf, STUN_BUFFER_SIZE);
 
-      if (blen > 0) {
+      if (blen > 0)
+      {
         int mlen = 0;
 
-        if (blen > (ev_ssize_t)STUN_BUFFER_SIZE) {
+        if (blen > (ev_ssize_t)STUN_BUFFER_SIZE)
+        {
           blen = (ev_ssize_t)STUN_BUFFER_SIZE;
         }
 
-        if (s->st == TCP_SOCKET_PROXY) {
+        if (s->st == TCP_SOCKET_PROXY)
+        {
           ssize_t tlen = socket_parse_proxy(s, buf_elem->buf.buf, blen);
           blen = 0;
-          if (tlen < 0) {
+          if (tlen < 0)
+          {
             s->tobeclosed = 1;
             s->broken = 1;
             ret = -1;
             log_socket_event(s, "proxy protocol violated", 1);
-          } else if (tlen > 0) {
+          }
+          else if (tlen > 0)
+          {
             bufferevent_read(s->bev, buf_elem->buf.buf, tlen);
 
             blen = evbuffer_copyout(inbuf, buf_elem->buf.buf, STUN_BUFFER_SIZE);
@@ -2533,93 +3026,126 @@ try_start:
           }
         }
 
-        if (blen) {
-          if (is_stream_socket(s->st) && ((s->sat == TCP_CLIENT_DATA_SOCKET) || (s->sat == TCP_RELAY_DATA_SOCKET))) {
+        if (blen)
+        {
+          if (is_stream_socket(s->st) && ((s->sat == TCP_CLIENT_DATA_SOCKET) || (s->sat == TCP_RELAY_DATA_SOCKET)))
+          {
             mlen = blen;
-          } else {
+          }
+          else
+          {
             mlen = stun_get_message_len_str(buf_elem->buf.buf, blen, 1, &app_msg_len);
           }
 
-          if (mlen > 0 && mlen <= (int)blen) {
+          if (mlen > 0 && mlen <= (int)blen)
+          {
             len = (int)bufferevent_read(s->bev, buf_elem->buf.buf, mlen);
-            if (len < 0) {
+            if (len < 0)
+            {
               ret = -1;
               s->tobeclosed = 1;
               s->broken = 1;
               log_socket_event(s, "socket read failed, to be closed", 1);
-            } else if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET)) {
+            }
+            else if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET))
+            {
 #if TLS_SUPPORTED
               SSL *ctx = bufferevent_openssl_get_ssl(s->bev);
-              if (!ctx || SSL_get_shutdown(ctx)) {
+              if (!ctx || SSL_get_shutdown(ctx))
+              {
                 ret = -1;
                 s->tobeclosed = 1;
               }
 #endif
             }
-            if (ret != -1) {
+            if (ret != -1)
+            {
               ret = len;
             }
           }
         }
-      } else if (blen < 0) {
+      }
+      else if (blen < 0)
+      {
         s->tobeclosed = 1;
         s->broken = 1;
         ret = -1;
         log_socket_event(s, "socket buffer copy failed, to be closed", 1);
       }
-    } else {
+    }
+    else
+    {
       s->tobeclosed = 1;
       s->broken = 1;
       ret = -1;
       log_socket_event(s, "socket input failed, socket to be closed", 1);
     }
 
-    if (len == 0) {
+    if (len == 0)
+    {
       len = -1;
     }
-  } else if (s->fd >= 0) { /* UDP and DTLS */
+  }
+  else if (s->fd >= 0)
+  { /* UDP and DTLS */
     ret = udp_recvfrom(s->fd, &remote_addr, &(s->local_addr), (char *)(buf_elem->buf.buf), UDP_STUN_BUFFER_SIZE, &ttl,
                        &tos, s->e->cmsg, 0, NULL);
     len = ret;
-    if (s->ssl && (len > 0)) { /* DTLS */
+    if (s->ssl && (len > 0))
+    { /* DTLS */
       send_ssl_backlog_buffers(s);
       buf_elem->buf.len = (size_t)len;
       ret = ssl_read(s->fd, s->ssl, (ioa_network_buffer_handle)buf_elem, (s->e ? s->e->verbose : TURN_VERBOSE_NONE));
       addr_cpy(&remote_addr, &(s->remote_addr));
-      if (ret < 0) {
+      if (ret < 0)
+      {
         len = -1;
         s->tobeclosed = 1;
         s->broken = 1;
         log_socket_event(s, "SSL read failed, to be closed", 0);
-      } else {
+      }
+      else
+      {
         len = (int)ioa_network_buffer_get_size((ioa_network_buffer_handle)buf_elem);
       }
-      if ((ret != -1) && (len > 0)) {
-        try_again = 1;
-      }
-    } else { /* UDP */
-      if (ret >= 0) {
+      if ((ret != -1) && (len > 0))
+      {
         try_again = 1;
       }
     }
-  } else {
+    else
+    { /* UDP */
+      if (ret >= 0)
+      {
+        try_again = 1;
+      }
+    }
+  }
+  else
+  {
     s->tobeclosed = 1;
     s->broken = 1;
     ret = -1;
     log_socket_event(s, "socket unknown error, to be closed", 1);
   }
 
-  if ((ret != -1) && (len >= 0)) {
+  if ((ret != -1) && (len >= 0))
+  {
 
-    if (app_msg_len) {
+    if (app_msg_len)
+    {
       buf_elem->buf.len = app_msg_len;
-    } else {
+    }
+    else
+    {
       buf_elem->buf.len = len;
     }
 
-    if (ioa_socket_check_bandwidth(s, buf_elem, 1)) {
+    if (ioa_socket_check_bandwidth(s, buf_elem, 1))
+    {
 
-      if (s->read_cb) {
+      if (s->read_cb)
+      {
         ioa_net_data nd;
 
         memset(&nd, 0, sizeof(ioa_net_data));
@@ -2630,15 +3156,17 @@ try_start:
 
         s->read_cb(s, IOA_EV_READ, &nd, s->read_ctx, 1);
 
-        if (nd.nbh) {
+        if (nd.nbh)
+        {
           free_blist_elem(s->e, buf_elem);
         }
 
         buf_elem = NULL;
 
         try_ok = 1;
-
-      } else {
+      }
+      else
+      {
         ioa_network_buffer_delete(s->e, s->defer_nbh);
         s->defer_nbh = buf_elem;
         buf_elem = NULL;
@@ -2646,37 +3174,44 @@ try_start:
     }
   }
 
-  if (buf_elem) {
+  if (buf_elem)
+  {
     free_blist_elem(s->e, buf_elem);
     buf_elem = NULL;
   }
 
-  if (try_again && try_ok && !(s->done) && !(s->tobeclosed) && ((++try_cycle) < MAX_TRIES) && !(s->parent_s)) {
+  if (try_again && try_ok && !(s->done) && !(s->tobeclosed) && ((++try_cycle) < MAX_TRIES) && !(s->parent_s))
+  {
     goto try_start;
   }
 
   return len;
 }
 
-static void socket_input_handler(evutil_socket_t fd, short what, void *arg) {
+static void socket_input_handler(evutil_socket_t fd, short what, void *arg)
+{
 
-  if (!(what & EV_READ)) {
+  if (!(what & EV_READ))
+  {
     return;
   }
 
-  if (!arg) {
+  if (!arg)
+  {
     read_spare_buffer(fd);
     return;
   }
 
   ioa_socket_handle s = (ioa_socket_handle)arg;
 
-  if (!s) {
+  if (!s)
+  {
     read_spare_buffer(fd);
     return;
   }
 
-  if ((s->magic != SOCKET_MAGIC) || (s->done)) {
+  if ((s->magic != SOCKET_MAGIC) || (s->done))
+  {
     read_spare_buffer(fd);
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on bad socket, ev=%d: %p, st=%d, sat=%d\n", __FUNCTION__, (int)what, s,
                   s->st, s->sat);
@@ -2684,18 +3219,23 @@ static void socket_input_handler(evutil_socket_t fd, short what, void *arg) {
     return;
   }
 
-  if (fd != s->fd) {
+  if (fd != s->fd)
+  {
     read_spare_buffer(fd);
     return;
   }
 
-  if (!ioa_socket_tobeclosed(s)) {
+  if (!ioa_socket_tobeclosed(s))
+  {
     socket_input_worker(s);
-  } else {
+  }
+  else
+  {
     read_spare_buffer(fd);
   }
 
-  if ((s->magic != SOCKET_MAGIC) || (s->done)) {
+  if ((s->magic != SOCKET_MAGIC) || (s->done))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s (1) on socket, ev=%d: %p, st=%d, sat=%d\n", __FUNCTION__, (int)what, s,
                   s->st, s->sat);
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
@@ -2705,36 +3245,47 @@ static void socket_input_handler(evutil_socket_t fd, short what, void *arg) {
   close_ioa_socket_after_processing_if_necessary(s);
 }
 
-void close_ioa_socket_after_processing_if_necessary(ioa_socket_handle s) {
-  if (s && ioa_socket_tobeclosed(s)) {
+void close_ioa_socket_after_processing_if_necessary(ioa_socket_handle s)
+{
+  if (s && ioa_socket_tobeclosed(s))
+  {
 
-    if (s->special_session) {
+    if (s->special_session)
+    {
       free(s->special_session);
       s->special_session = NULL;
     }
     s->special_session_size = 0;
 
-    if (!(s->session) && !(s->sub_session)) {
+    if (!(s->session) && !(s->sub_session))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s https server socket closed: %p, st=%d, sat=%d\n", __FUNCTION__, s,
                     get_ioa_socket_type(s), get_ioa_socket_app_type(s));
       IOA_CLOSE_SOCKET(s);
       return;
     }
 
-    switch (s->sat) {
+    switch (s->sat)
+    {
     case TCP_CLIENT_DATA_SOCKET:
-    case TCP_RELAY_DATA_SOCKET: {
+    case TCP_RELAY_DATA_SOCKET:
+    {
       tcp_connection *tc = s->sub_session;
-      if (tc) {
+      if (tc)
+      {
         s->sub_session = NULL;
         delete_tcp_connection(tc);
       }
-    } break;
-    default: {
+    }
+    break;
+    default:
+    {
       ts_ur_super_session *ss = s->session;
-      if (ss) {
+      if (ss)
+      {
         turn_turnserver *server = (turn_turnserver *)ss->server;
-        if (server) {
+        if (server)
+        {
           shutdown_client_connection(server, ss, 0, "general");
         }
       }
@@ -2743,47 +3294,64 @@ void close_ioa_socket_after_processing_if_necessary(ioa_socket_handle s) {
   }
 }
 
-static void socket_output_handler_bev(struct bufferevent *bev, void *arg) {
+static void socket_output_handler_bev(struct bufferevent *bev, void *arg)
+{
 
   UNUSED_ARG(bev);
   UNUSED_ARG(arg);
 
-  if (tcp_congestion_control) {
+  if (tcp_congestion_control)
+  {
 
-    if (bev && arg) {
+    if (bev && arg)
+    {
 
       ioa_socket_handle s = (ioa_socket_handle)arg;
 
-      if (s->in_write) {
+      if (s->in_write)
+      {
         return;
       }
 
-      if ((s->magic != SOCKET_MAGIC) || (s->done) || (bev != s->bev)) {
+      if ((s->magic != SOCKET_MAGIC) || (s->done) || (bev != s->bev))
+      {
         return;
       }
 
-      if (s->tobeclosed) {
-        if (bufferevent_enabled(bev, EV_READ)) {
+      if (s->tobeclosed)
+      {
+        if (bufferevent_enabled(bev, EV_READ))
+        {
           bufferevent_disable(bev, EV_READ);
         }
         return;
       }
 
-      if (s->sub_session) {
+      if (s->sub_session)
+      {
 
-        if (s == s->sub_session->client_s) {
-          if (s->sub_session->peer_s && s->sub_session->peer_s->bev) {
-            if (!bufferevent_enabled(s->sub_session->peer_s->bev, EV_READ)) {
-              if (is_socket_writeable(s->sub_session->peer_s, STUN_BUFFER_SIZE, __FUNCTION__, 3)) {
+        if (s == s->sub_session->client_s)
+        {
+          if (s->sub_session->peer_s && s->sub_session->peer_s->bev)
+          {
+            if (!bufferevent_enabled(s->sub_session->peer_s->bev, EV_READ))
+            {
+              if (is_socket_writeable(s->sub_session->peer_s, STUN_BUFFER_SIZE, __FUNCTION__, 3))
+              {
                 bufferevent_enable(s->sub_session->peer_s->bev, EV_READ);
                 socket_input_handler_bev(s->sub_session->peer_s->bev, s->sub_session->peer_s);
               }
             }
           }
-        } else if (s == s->sub_session->peer_s) {
-          if (s->sub_session->client_s && s->sub_session->client_s->bev) {
-            if (!bufferevent_enabled(s->sub_session->client_s->bev, EV_READ)) {
-              if (is_socket_writeable(s->sub_session->client_s, STUN_BUFFER_SIZE, __FUNCTION__, 4)) {
+        }
+        else if (s == s->sub_session->peer_s)
+        {
+          if (s->sub_session->client_s && s->sub_session->client_s->bev)
+          {
+            if (!bufferevent_enabled(s->sub_session->client_s->bev, EV_READ))
+            {
+              if (is_socket_writeable(s->sub_session->client_s, STUN_BUFFER_SIZE, __FUNCTION__, 4))
+              {
                 bufferevent_enable(s->sub_session->client_s->bev, EV_READ);
                 socket_input_handler_bev(s->sub_session->client_s->bev, s->sub_session->client_s);
               }
@@ -2795,32 +3363,39 @@ static void socket_output_handler_bev(struct bufferevent *bev, void *arg) {
   }
 }
 
-static int read_spare_buffer_bev(struct bufferevent *bev) {
-  if (bev) {
+static int read_spare_buffer_bev(struct bufferevent *bev)
+{
+  if (bev)
+  {
     char some_buffer[8192];
     bufferevent_read(bev, some_buffer, sizeof(some_buffer));
   }
   return 0;
 }
 
-static void socket_input_handler_bev(struct bufferevent *bev, void *arg) {
+static void socket_input_handler_bev(struct bufferevent *bev, void *arg)
+{
 
-  if (bev) {
+  if (bev)
+  {
 
-    if (!arg) {
+    if (!arg)
+    {
       read_spare_buffer_bev(bev);
       return;
     }
 
     ioa_socket_handle s = (ioa_socket_handle)arg;
 
-    if (bev != s->bev) {
+    if (bev != s->bev)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p: wrong bev\n", __FUNCTION__, s);
       read_spare_buffer_bev(bev);
       return;
     }
 
-    if ((s->magic != SOCKET_MAGIC) || (s->done)) {
+    if ((s->magic != SOCKET_MAGIC) || (s->done))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st, s->sat);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
       read_spare_buffer_bev(bev);
@@ -2829,18 +3404,22 @@ static void socket_input_handler_bev(struct bufferevent *bev, void *arg) {
 
     {
       size_t cycle = 0;
-      do {
-        if (ioa_socket_tobeclosed(s)) {
+      do
+      {
+        if (ioa_socket_tobeclosed(s))
+        {
           read_spare_buffer_bev(s->bev);
           break;
         }
-        if (socket_input_worker(s) <= 0) {
+        if (socket_input_worker(s) <= 0)
+        {
           break;
         }
       } while ((cycle++ < 128) && (s->bev));
     }
 
-    if ((s->magic != SOCKET_MAGIC) || (s->done)) {
+    if ((s->magic != SOCKET_MAGIC) || (s->done))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s (1) on socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st, s->sat);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
       return;
@@ -2850,28 +3429,36 @@ static void socket_input_handler_bev(struct bufferevent *bev, void *arg) {
   }
 }
 
-static void eventcb_bev(struct bufferevent *bev, short events, void *arg) {
+static void eventcb_bev(struct bufferevent *bev, short events, void *arg)
+{
   UNUSED_ARG(bev);
 
-  if (events & BEV_EVENT_CONNECTED) {
+  if (events & BEV_EVENT_CONNECTED)
+  {
     // Connect okay
-  } else if (events & (BEV_EVENT_ERROR | BEV_EVENT_EOF)) {
-    if (arg) {
+  }
+  else if (events & (BEV_EVENT_ERROR | BEV_EVENT_EOF))
+  {
+    if (arg)
+    {
       ioa_socket_handle s = (ioa_socket_handle)arg;
 
-      if (!is_stream_socket(s->st)) {
+      if (!is_stream_socket(s->st))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: socket type is wrong on the socket: %p, st=%d, sat=%d\n",
                       __FUNCTION__, s, s->st, s->sat);
         return;
       }
 
-      if (s->magic != SOCKET_MAGIC) {
+      if (s->magic != SOCKET_MAGIC)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: magic is wrong on the socket: %p, st=%d, sat=%d\n", __FUNCTION__, s,
                       s->st, s->sat);
         return;
       }
 
-      if (s->done) {
+      if (s->done)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
                       "!!! %s: closed socket: %p (1): done=%d, fd=%d, br=%d, st=%d, sat=%d, tbc=%d\n", __FUNCTION__, s,
                       (int)s->done, (int)s->fd, s->broken, s->st, s->sat, s->tobeclosed);
@@ -2879,19 +3466,22 @@ static void eventcb_bev(struct bufferevent *bev, short events, void *arg) {
         return;
       }
 
-      if (events & BEV_EVENT_ERROR) {
+      if (events & BEV_EVENT_ERROR)
+      {
         s->broken = 1;
       }
 
       s->tobeclosed = 1;
 
-      if (s->special_session) {
+      if (s->special_session)
+      {
         free(s->special_session);
         s->special_session = NULL;
       }
       s->special_session_size = 0;
 
-      if (!(s->session) && !(s->sub_session)) {
+      if (!(s->session) && !(s->sub_session))
+      {
         char sraddr[129] = "\0";
         addr_to_string(&(s->remote_addr), (uint8_t *)sraddr);
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s https server socket closed: %p, st=%d, sat=%d, remote addr=%s\n",
@@ -2900,55 +3490,76 @@ static void eventcb_bev(struct bufferevent *bev, short events, void *arg) {
         return;
       }
 
-      switch (s->sat) {
+      switch (s->sat)
+      {
       case TCP_CLIENT_DATA_SOCKET:
-      case TCP_RELAY_DATA_SOCKET: {
+      case TCP_RELAY_DATA_SOCKET:
+      {
         tcp_connection *tc = s->sub_session;
-        if (tc) {
+        if (tc)
+        {
           s->sub_session = NULL;
           delete_tcp_connection(tc);
         }
-      } break;
-      default: {
+      }
+      break;
+      default:
+      {
         ts_ur_super_session *ss = s->session;
-        if (ss) {
+        if (ss)
+        {
           turn_turnserver *server = (turn_turnserver *)ss->server;
-          if (server) {
+          if (server)
+          {
 
             {
               char sraddr[129] = "\0";
               addr_to_string(&(s->remote_addr), (uint8_t *)sraddr);
-              if (events & BEV_EVENT_EOF) {
-                if (server->verbose) {
+              if (events & BEV_EVENT_EOF)
+              {
+                if (server->verbose)
+                {
                   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: %s socket closed remotely %s\n",
                                 (unsigned long long)(ss->id), socket_type_name(s->st), sraddr);
                 }
-                if (s == ss->client_socket) {
+                if (s == ss->client_socket)
+                {
                   char msg[256];
                   snprintf(msg, sizeof(msg) - 1, "%s connection closed by client (callback)", socket_type_name(s->st));
                   shutdown_client_connection(server, ss, 0, msg);
-                } else if (s == ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].s) {
+                }
+                else if (s == ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].s)
+                {
                   char msg[256];
                   snprintf(msg, sizeof(msg) - 1, "%s connection closed by peer (ipv4 callback)",
                            socket_type_name(s->st));
                   shutdown_client_connection(server, ss, 0, msg);
-                } else if (s == ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s) {
+                }
+                else if (s == ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s)
+                {
                   char msg[256];
                   snprintf(msg, sizeof(msg) - 1, "%s connection closed by peer (ipv6 callback)",
                            socket_type_name(s->st));
                   shutdown_client_connection(server, ss, 0, msg);
-                } else {
+                }
+                else
+                {
                   char msg[256];
                   snprintf(msg, sizeof(msg) - 1, "%s connection closed by remote party (callback)",
                            socket_type_name(s->st));
                   shutdown_client_connection(server, ss, 0, msg);
                 }
-              } else if (events & BEV_EVENT_ERROR) {
-                if (EVUTIL_SOCKET_ERROR()) {
+              }
+              else if (events & BEV_EVENT_ERROR)
+              {
+                if (EVUTIL_SOCKET_ERROR())
+                {
                   TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "session %018llu: %s socket error: %s %s\n",
                                 (unsigned long long)(ss->id), socket_type_name(s->st),
                                 evutil_socket_error_to_string(EVUTIL_SOCKET_ERROR()), sraddr);
-                } else if (server->verbose) {
+                }
+                else if (server->verbose)
+                {
                   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: %s socket disconnected: %s\n",
                                 (unsigned long long)(ss->id), socket_type_name(s->st), sraddr);
                 }
@@ -2965,38 +3576,49 @@ static void eventcb_bev(struct bufferevent *bev, short events, void *arg) {
   }
 }
 
-static int ssl_send(ioa_socket_handle s, const char *buffer, int len, int verbose) {
+static int ssl_send(ioa_socket_handle s, const char *buffer, int len, int verbose)
+{
 
-  if (!s || !(s->ssl) || !buffer || (s->fd < 0)) {
+  if (!s || !(s->ssl) || !buffer || (s->fd < 0))
+  {
     return -1;
   }
 
   SSL *ssl = s->ssl;
 
-  if (eve(verbose)) {
+  if (eve(verbose))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: before write: buffer=%p, len=%d\n", __FUNCTION__, buffer, len);
   }
 
-  if (s->parent_s) {
+  if (s->parent_s)
+  {
     /* Trick only for "children" sockets: */
     BIO *wbio = SSL_get_wbio(ssl);
-    if (!wbio) {
+    if (!wbio)
+    {
       return -1;
     }
     int fd = BIO_get_fd(wbio, 0);
     int sfd = s->parent_s->fd;
-    if (sfd >= 0) {
-      if (fd != sfd) {
+    if (sfd >= 0)
+    {
+      if (fd != sfd)
+      {
         BIO_set_fd(wbio, sfd, BIO_NOCLOSE);
       }
     }
-  } else {
+  }
+  else
+  {
     BIO *wbio = SSL_get_wbio(ssl);
-    if (!wbio) {
+    if (!wbio)
+    {
       return -1;
     }
     int fd = BIO_get_fd(wbio, 0);
-    if (fd != s->fd) {
+    if (fd != s->fd)
+    {
       BIO_set_fd(wbio, s->fd, BIO_NOCLOSE);
     }
   }
@@ -3010,40 +3632,50 @@ static int ssl_send(ioa_socket_handle s, const char *buffer, int len, int verbos
 
 try_start:
 
-  do {
+  do
+  {
     rc = SSL_write(ssl, buffer, len);
   } while (rc < 0 && socket_eintr());
 
-  if (eve(verbose)) {
+  if (eve(verbose))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: after write: %d\n", __FUNCTION__, rc);
   }
 
-  if (rc < 0 && (socket_enobufs() || socket_eagain())) {
-    if (eve(verbose)) {
+  if (rc < 0 && (socket_enobufs() || socket_eagain()))
+  {
+    if (eve(verbose))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: ENOBUFS/EAGAIN\n", __FUNCTION__);
     }
     return 0;
   }
 
-  if (rc >= 0) {
+  if (rc >= 0)
+  {
 
-    if (eve(verbose)) {
+    if (eve(verbose))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: wrote %d bytes\n", __FUNCTION__, (int)rc);
     }
 
     return rc;
+  }
+  else
+  {
 
-  } else {
-
-    if (eve(verbose)) {
+    if (eve(verbose))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: failure: rc=%d, err=%d\n", __FUNCTION__, (int)rc,
                     (int)SSL_get_error(ssl, rc));
     }
 
-    switch (SSL_get_error(ssl, rc)) {
+    switch (SSL_get_error(ssl, rc))
+    {
     case SSL_ERROR_NONE:
       //???
-      if (eve(verbose)) {
+      if (eve(verbose))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "wrote %d bytes\n", (int)rc);
       }
       return 0;
@@ -3051,16 +3683,23 @@ try_start:
       return 0;
     case SSL_ERROR_WANT_READ:
       return 0;
-    case SSL_ERROR_SYSCALL: {
+    case SSL_ERROR_SYSCALL:
+    {
       int err = socket_errno();
-      if (!handle_socket_error()) {
-        if (s->st == DTLS_SOCKET) {
-          if (is_connreset()) {
-            if (try_again) {
+      if (!handle_socket_error())
+      {
+        if (s->st == DTLS_SOCKET)
+        {
+          if (is_connreset())
+          {
+            if (try_again)
+            {
               BIO *wbio = SSL_get_wbio(ssl);
-              if (wbio) {
+              if (wbio)
+              {
                 int fd = BIO_get_fd(wbio, 0);
-                if (fd >= 0) {
+                if (fd >= 0)
+                {
                   try_again = 0;
                   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "DTLS Socket, tring to recover write operation...\n");
                   socket_readerr(fd, &(s->local_addr));
@@ -3075,20 +3714,24 @@ try_start:
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "DTLS Socket write error unrecoverable: %d; buffer=%p, len=%d, ssl=%p\n",
                       err, buffer, (int)len, ssl);
         return -1;
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "DTLS Socket write error recoverable: %d\n", err);
         return 0;
       }
     }
     case SSL_ERROR_SSL:
-      if (verbose) {
+      if (verbose)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "SSL write error: ");
         char buf[65536];
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s (%d)\n", ERR_error_string(ERR_get_error(), buf), SSL_get_error(ssl, rc));
       }
       return -1;
     default:
-      if (verbose) {
+      if (verbose)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Unexpected error while writing!\n");
       }
       return -1;
@@ -3096,14 +3739,18 @@ try_start:
   }
 }
 
-static int send_ssl_backlog_buffers(ioa_socket_handle s) {
+static int send_ssl_backlog_buffers(ioa_socket_handle s)
+{
   int ret = 0;
-  if (s) {
+  if (s)
+  {
     stun_buffer_list_elem *buf_elem = s->bufs.head;
-    while (buf_elem) {
+    while (buf_elem)
+    {
       int rc = ssl_send(s, (char *)buf_elem->buf.buf + buf_elem->buf.offset - buf_elem->buf.coffset,
                         (size_t)buf_elem->buf.len, (s->e ? s->e->verbose : TURN_VERBOSE_NONE));
-      if (rc < 1) {
+      if (rc < 1)
+      {
         break;
       }
       ++ret;
@@ -3115,8 +3762,10 @@ static int send_ssl_backlog_buffers(ioa_socket_handle s) {
   return ret;
 }
 
-int is_connreset(void) {
-  if (socket_econnreset() || socket_econnrefused()) {
+int is_connreset(void)
+{
+  if (socket_econnreset() || socket_econnrefused())
+  {
     return 1;
   }
   return 0;
@@ -3124,21 +3773,27 @@ int is_connreset(void) {
 
 int would_block(void) { return socket_ewouldblock(); }
 
-int udp_send(ioa_socket_handle s, const ioa_addr *dest_addr, const char *buffer, int len) {
+int udp_send(ioa_socket_handle s, const ioa_addr *dest_addr, const char *buffer, int len)
+{
   int rc = 0;
   evutil_socket_t fd = -1;
 
-  if (!s) {
+  if (!s)
+  {
     return -1;
   }
 
-  if (s->parent_s) {
+  if (s->parent_s)
+  {
     fd = s->parent_s->fd;
-  } else {
+  }
+  else
+  {
     fd = s->fd;
   }
 
-  if (fd >= 0) {
+  if (fd >= 0)
+  {
 
     int try_again = 1;
 
@@ -3148,30 +3803,39 @@ int udp_send(ioa_socket_handle s, const ioa_addr *dest_addr, const char *buffer,
     try_again = 0;
 #endif
 
-  try_start:
+try_start:
 
     cycle = 0;
 
-    if (dest_addr) {
+    if (dest_addr)
+    {
 
       int slen = get_ioa_addr_len(dest_addr);
 
-      do {
+      do
+      {
         rc = sendto(fd, buffer, len, 0, (const struct sockaddr *)dest_addr, (socklen_t)slen);
       } while (((rc < 0) && socket_eintr()) || ((rc < 0) && is_connreset() && (++cycle < TRIAL_EFFORTS_TO_SEND)));
-
-    } else {
-      do {
+    }
+    else
+    {
+      do
+      {
         rc = send(fd, buffer, len, 0);
       } while (((rc < 0) && socket_eintr()) || ((rc < 0) && is_connreset() && (++cycle < TRIAL_EFFORTS_TO_SEND)));
     }
 
-    if (rc < 0) {
-      if (socket_enobufs() || socket_eagain()) {
+    if (rc < 0)
+    {
+      if (socket_enobufs() || socket_eagain())
+      {
         // Lost packet due to overload ... fine.
         rc = len;
-      } else if (is_connreset()) {
-        if (try_again) {
+      }
+      else if (is_connreset())
+      {
+        if (try_again)
+        {
           try_again = 0;
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "UDP Socket, tring to recover write operation...\n");
           socket_readerr(fd, &(s->local_addr));
@@ -3187,52 +3851,68 @@ int udp_send(ioa_socket_handle s, const ioa_addr *dest_addr, const char *buffer,
 }
 
 int send_data_from_ioa_socket_nbh(ioa_socket_handle s, ioa_addr *dest_addr, ioa_network_buffer_handle nbh, int ttl,
-                                  int tos, int *skip) {
+                                  int tos, int *skip)
+{
   int ret = -1;
 
-  if (!s) {
+  if (!s)
+  {
     ioa_network_buffer_delete(NULL, nbh);
     return -1;
   }
 
-  if (s->done || (s->fd == -1)) {
+  if (s->done || (s->fd == -1))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
                   "!!! %s: (1) Trying to send data from closed socket: %p (1): done=%d, fd=%d, st=%d, sat=%d\n",
                   __FUNCTION__, s, (int)s->done, (int)s->fd, s->st, s->sat);
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
-
-  } else if (nbh) {
-    if (!ioa_socket_check_bandwidth(s, nbh, 0)) {
+  }
+  else if (nbh)
+  {
+    if (!ioa_socket_check_bandwidth(s, nbh, 0))
+    {
       /* Bandwidth exhausted, we pretend everything is fine: */
       ret = (int)(ioa_network_buffer_get_size(nbh));
-      if (skip) {
+      if (skip)
+      {
         *skip = 1;
       }
-    } else {
-      if (!ioa_socket_tobeclosed(s) && s->e) {
+    }
+    else
+    {
+      if (!ioa_socket_tobeclosed(s) && s->e)
+      {
 
-        if (!(s->done || (s->fd == -1))) {
+        if (!(s->done || (s->fd == -1)))
+        {
           set_socket_ttl(s, ttl);
           set_socket_tos(s, tos);
 
-          if (s->connected && s->bev) {
-            if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET)) {
+          if (s->connected && s->bev)
+          {
+            if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET))
+            {
 #if TLS_SUPPORTED
               SSL *ctx = bufferevent_openssl_get_ssl(s->bev);
-              if (!ctx || SSL_get_shutdown(ctx)) {
+              if (!ctx || SSL_get_shutdown(ctx))
+              {
                 s->tobeclosed = 1;
                 ret = 0;
               }
 #endif
             }
 
-            if (!(s->tobeclosed)) {
+            if (!(s->tobeclosed))
+            {
 
               ret = (int)ioa_network_buffer_get_size(nbh);
 
-              if (!tcp_congestion_control || is_socket_writeable(s, (size_t)ret, __FUNCTION__, 2)) {
+              if (!tcp_congestion_control || is_socket_writeable(s, (size_t)ret, __FUNCTION__, 2))
+              {
                 s->in_write = 1;
-                if (bufferevent_write(s->bev, ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh)) < 0) {
+                if (bufferevent_write(s->bev, ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh)) < 0)
+                {
                   ret = -1;
                   perror("bufev send");
                   log_socket_event(s, "socket write failed, to be closed", 1);
@@ -3245,38 +3925,52 @@ int send_data_from_ioa_socket_nbh(ioa_socket_handle s, ioa_addr *dest_addr, ioa_
                                                 BEV_FLUSH);
                                                 */
                 s->in_write = 0;
-              } else {
+              }
+              else
+              {
                 // drop the packet
                 ;
               }
             }
-          } else if (s->ssl) {
+          }
+          else if (s->ssl)
+          {
             send_ssl_backlog_buffers(s);
             ret = ssl_send(s, (char *)ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh),
                            (s->e ? s->e->verbose : TURN_VERBOSE_NONE));
-            if (ret < 0) {
+            if (ret < 0)
+            {
               s->tobeclosed = 1;
-            } else if (ret == 0) {
+            }
+            else if (ret == 0)
+            {
               add_buffer_to_buffer_list(&(s->bufs), (char *)ioa_network_buffer_data(nbh),
                                         ioa_network_buffer_get_size(nbh));
             }
-          } else if (s->fd >= 0) {
+          }
+          else if (s->fd >= 0)
+          {
 
-            if (s->connected && !(s->parent_s)) {
+            if (s->connected && !(s->parent_s))
+            {
               dest_addr = NULL; /* ignore dest_addr */
-            } else if (!dest_addr) {
+            }
+            else if (!dest_addr)
+            {
               dest_addr = &(s->remote_addr);
             }
 
             ret = udp_send(s, dest_addr, (char *)ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh));
-            if (ret < 0) {
+            if (ret < 0)
+            {
               s->tobeclosed = 1;
 #if defined(EADDRNOTAVAIL)
               int perr = socket_errno();
 #endif
               perror("udp send");
 #if defined(EADDRNOTAVAIL)
-              if (dest_addr && (perr == EADDRNOTAVAIL)) {
+              if (dest_addr && (perr == EADDRNOTAVAIL))
+              {
                 char sfrom[129];
                 addr_to_string(&(s->local_addr), (uint8_t *)sfrom);
                 char sto[129];
@@ -3297,34 +3991,42 @@ int send_data_from_ioa_socket_nbh(ioa_socket_handle s, ioa_addr *dest_addr, ioa_
   return ret;
 }
 
-int send_data_from_ioa_socket_tcp(ioa_socket_handle s, const void *data, size_t sz) {
+int send_data_from_ioa_socket_tcp(ioa_socket_handle s, const void *data, size_t sz)
+{
   int ret = -1;
 
-  if (s && data) {
+  if (s && data)
+  {
 
-    if (s->done || (s->fd == -1) || ioa_socket_tobeclosed(s) || !(s->e)) {
+    if (s->done || (s->fd == -1) || ioa_socket_tobeclosed(s) || !(s->e))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
                     "!!! %s: (1) Trying to send data from bad socket: %p (1): done=%d, fd=%d, st=%d, sat=%d\n",
                     __FUNCTION__, s, (int)s->done, (int)s->fd, s->st, s->sat);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
-
-    } else if (s->connected && s->bev) {
-      if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET)) {
+    }
+    else if (s->connected && s->bev)
+    {
+      if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET))
+      {
 #if TLS_SUPPORTED
         SSL *ctx = bufferevent_openssl_get_ssl(s->bev);
-        if (!ctx || SSL_get_shutdown(ctx)) {
+        if (!ctx || SSL_get_shutdown(ctx))
+        {
           s->tobeclosed = 1;
           ret = 0;
         }
 #endif
       }
 
-      if (!(s->tobeclosed)) {
+      if (!(s->tobeclosed))
+      {
 
         ret = (int)sz;
 
         s->in_write = 1;
-        if (bufferevent_write(s->bev, data, sz) < 0) {
+        if (bufferevent_write(s->bev, data, sz) < 0)
+        {
           ret = -1;
           perror("bufev send");
           log_socket_event(s, "socket write failed, to be closed", 1);
@@ -3339,15 +4041,20 @@ int send_data_from_ioa_socket_tcp(ioa_socket_handle s, const void *data, size_t 
   return ret;
 }
 
-int send_str_from_ioa_socket_tcp(ioa_socket_handle s, const void *data) {
-  if (data) {
+int send_str_from_ioa_socket_tcp(ioa_socket_handle s, const void *data)
+{
+  if (data)
+  {
     return send_data_from_ioa_socket_tcp(s, data, strlen((const char *)data));
-  } else {
+  }
+  else
+  {
     return 0;
   }
 }
 
-int send_ulong_from_ioa_socket_tcp(ioa_socket_handle s, size_t data) {
+int send_ulong_from_ioa_socket_tcp(ioa_socket_handle s, size_t data)
+{
   char str[129];
   snprintf(str, sizeof(str) - 1, "%lu", (unsigned long)data);
 
@@ -3355,43 +4062,60 @@ int send_ulong_from_ioa_socket_tcp(ioa_socket_handle s, size_t data) {
 }
 
 int register_callback_on_ioa_socket(ioa_engine_handle e, ioa_socket_handle s, int event_type, ioa_net_event_handler cb,
-                                    void *ctx, int clean_preexisting) {
-  if (s) {
+                                    void *ctx, int clean_preexisting)
+{
+  if (s)
+  {
 
-    if (event_type & IOA_EV_READ) {
+    if (event_type & IOA_EV_READ)
+    {
 
-      if (e) {
+      if (e)
+      {
         s->e = e;
       }
 
-      if (s->e && !(s->parent_s)) {
+      if (s->e && !(s->parent_s))
+      {
 
-        switch (s->st) {
+        switch (s->st)
+        {
         case DTLS_SOCKET:
         case UDP_SOCKET:
-          if (s->read_event) {
-            if (!clean_preexisting) {
+          if (s->read_event)
+          {
+            if (!clean_preexisting)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: software error: buffer preset 1\n", __FUNCTION__);
               return -1;
             }
-          } else {
+          }
+          else
+          {
             s->read_event = event_new(s->e->event_base, s->fd, EV_READ | EV_PERSIST, socket_input_handler, s);
             event_add(s->read_event, NULL);
           }
           break;
         case TENTATIVE_TCP_SOCKET:
         case TENTATIVE_SCTP_SOCKET:
-          if (s->bev) {
-            if (!clean_preexisting) {
+          if (s->bev)
+          {
+            if (!clean_preexisting)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: software error: buffer preset 2\n", __FUNCTION__);
               return -1;
             }
-          } else if (s->read_event) {
-            if (!clean_preexisting) {
+          }
+          else if (s->read_event)
+          {
+            if (!clean_preexisting)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: software error: buffer preset 3\n", __FUNCTION__);
               return -1;
             }
-          } else {
+          }
+          else
+          {
             s->read_event = event_new(s->e->event_base, s->fd, EV_READ | EV_PERSIST, socket_input_handler, s);
             event_add(s->read_event, NULL);
           }
@@ -3399,14 +4123,19 @@ int register_callback_on_ioa_socket(ioa_engine_handle e, ioa_socket_handle s, in
         case SCTP_SOCKET:
         case TCP_SOCKET:
         case TCP_SOCKET_PROXY:
-          if (s->bev) {
-            if (!clean_preexisting) {
+          if (s->bev)
+          {
+            if (!clean_preexisting)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: software error: buffer preset 4\n", __FUNCTION__);
               return -1;
             }
-          } else {
+          }
+          else
+          {
 #if TLS_SUPPORTED
-            if ((s->sat != TCP_CLIENT_DATA_SOCKET) && (s->sat != TCP_RELAY_DATA_SOCKET) && check_tentative_tls(s->fd)) {
+            if ((s->sat != TCP_CLIENT_DATA_SOCKET) && (s->sat != TCP_RELAY_DATA_SOCKET) && check_tentative_tls(s->fd))
+            {
               s->tobeclosed = 1;
               return -1;
             }
@@ -3419,19 +4148,26 @@ int register_callback_on_ioa_socket(ioa_engine_handle e, ioa_socket_handle s, in
           break;
         case TLS_SCTP_SOCKET:
         case TLS_SOCKET:
-          if (s->bev) {
-            if (!clean_preexisting) {
+          if (s->bev)
+          {
+            if (!clean_preexisting)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: software error: buffer preset 5\n", __FUNCTION__);
               return -1;
             }
-          } else {
+          }
+          else
+          {
 #if TLS_SUPPORTED
-            if (!(s->ssl)) {
+            if (!(s->ssl))
+            {
               //??? how we can get to this point ???
               set_socket_ssl(s, SSL_new(e->tls_ctx));
               s->bev = bufferevent_openssl_socket_new(s->e->event_base, s->fd, s->ssl, BUFFEREVENT_SSL_ACCEPTING,
                                                       TURN_BUFFEREVENTS_OPTIONS);
-            } else {
+            }
+            else
+            {
               s->bev = bufferevent_openssl_socket_new(s->e->event_base, s->fd, s->ssl, BUFFEREVENT_SSL_OPEN,
                                                       TURN_BUFFEREVENTS_OPTIONS);
             }
@@ -3458,32 +4194,44 @@ int register_callback_on_ioa_socket(ioa_engine_handle e, ioa_socket_handle s, in
   return -1;
 }
 
-int ioa_socket_tobeclosed(ioa_socket_handle s) {
-  if (s) {
-    if (s->magic != SOCKET_MAGIC) {
+int ioa_socket_tobeclosed(ioa_socket_handle s)
+{
+  if (s)
+  {
+    if (s->magic != SOCKET_MAGIC)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: magic is wrong on the socket: %p, st=%d, sat=%d\n", __FUNCTION__, s,
                     s->st, s->sat);
       return 1;
     }
 
-    if (s->done) {
+    if (s->done)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: check on already closed socket: %p, st=%d, sat=%d\n", __FUNCTION__, s,
                     s->st, s->sat);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
       return 1;
     }
-    if (s->tobeclosed) {
+    if (s->tobeclosed)
+    {
       return 1;
-    } else if (s->broken) {
+    }
+    else if (s->broken)
+    {
       s->tobeclosed = 1;
       log_socket_event(s, "socket broken", 0);
       return 1;
-    } else if (s->fd < 0) {
+    }
+    else if (s->fd < 0)
+    {
       s->tobeclosed = 1;
       log_socket_event(s, "socket fd<0", 0);
       return 1;
-    } else if (s->ssl) {
-      if (SSL_get_shutdown(s->ssl)) {
+    }
+    else if (s->ssl)
+    {
+      if (SSL_get_shutdown(s->ssl))
+      {
         s->tobeclosed = 1;
         log_socket_event(s, "socket SSL shutdown", 0);
         return 1;
@@ -3493,8 +4241,10 @@ int ioa_socket_tobeclosed(ioa_socket_handle s) {
   return 0;
 }
 
-void set_ioa_socket_tobeclosed(ioa_socket_handle s) {
-  if (s) {
+void set_ioa_socket_tobeclosed(ioa_socket_handle s)
+{
+  if (s)
+  {
     s->tobeclosed = 1;
   }
 }
@@ -3502,7 +4252,8 @@ void set_ioa_socket_tobeclosed(ioa_socket_handle s) {
 /*
  * Network buffer functions
  */
-ioa_network_buffer_handle ioa_network_buffer_allocate(ioa_engine_handle e) {
+ioa_network_buffer_handle ioa_network_buffer_allocate(ioa_engine_handle e)
+{
   stun_buffer_list_elem *buf_elem = new_blist_elem(e);
   buf_elem->buf.len = 0;
   buf_elem->buf.offset = 0;
@@ -3513,26 +4264,36 @@ ioa_network_buffer_handle ioa_network_buffer_allocate(ioa_engine_handle e) {
 /* We do not use special header in this simple implementation */
 void ioa_network_buffer_header_init(ioa_network_buffer_handle nbh) { UNUSED_ARG(nbh); }
 
-uint8_t *ioa_network_buffer_data(ioa_network_buffer_handle nbh) {
+uint8_t *ioa_network_buffer_data(ioa_network_buffer_handle nbh)
+{
   stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)nbh;
   return buf_elem->buf.buf + buf_elem->buf.offset - buf_elem->buf.coffset;
 }
 
-size_t ioa_network_buffer_get_size(ioa_network_buffer_handle nbh) {
-  if (!nbh) {
+size_t ioa_network_buffer_get_size(ioa_network_buffer_handle nbh)
+{
+  if (!nbh)
+  {
     return 0;
-  } else {
+  }
+  else
+  {
     stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)nbh;
     return (size_t)(buf_elem->buf.len);
   }
 }
 
-size_t ioa_network_buffer_get_capacity(ioa_network_buffer_handle nbh) {
-  if (!nbh) {
+size_t ioa_network_buffer_get_capacity(ioa_network_buffer_handle nbh)
+{
+  if (!nbh)
+  {
     return 0;
-  } else {
+  }
+  else
+  {
     stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)nbh;
-    if (buf_elem->buf.offset < STUN_BUFFER_SIZE) {
+    if (buf_elem->buf.offset < STUN_BUFFER_SIZE)
+    {
       return (STUN_BUFFER_SIZE - buf_elem->buf.offset);
     }
     return 0;
@@ -3541,60 +4302,72 @@ size_t ioa_network_buffer_get_capacity(ioa_network_buffer_handle nbh) {
 
 size_t ioa_network_buffer_get_capacity_udp(void) { return UDP_STUN_BUFFER_SIZE; }
 
-void ioa_network_buffer_set_size(ioa_network_buffer_handle nbh, size_t len) {
+void ioa_network_buffer_set_size(ioa_network_buffer_handle nbh, size_t len)
+{
   stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)nbh;
   buf_elem->buf.len = (size_t)len;
 }
 
-void ioa_network_buffer_add_offset_size(ioa_network_buffer_handle nbh, uint16_t offset, uint8_t coffset, size_t len) {
+void ioa_network_buffer_add_offset_size(ioa_network_buffer_handle nbh, uint16_t offset, uint8_t coffset, size_t len)
+{
   stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)nbh;
   buf_elem->buf.len = (size_t)len;
   buf_elem->buf.offset += offset;
   buf_elem->buf.coffset += coffset;
 
   if ((buf_elem->buf.offset + buf_elem->buf.len - buf_elem->buf.coffset) >= sizeof(buf_elem->buf.buf) ||
-      (buf_elem->buf.offset + sizeof(buf_elem->buf.channel) < buf_elem->buf.coffset)) {
+      (buf_elem->buf.offset + sizeof(buf_elem->buf.channel) < buf_elem->buf.coffset))
+  {
     buf_elem->buf.coffset = 0;
     buf_elem->buf.len = 0;
     buf_elem->buf.offset = 0;
   }
 }
 
-uint16_t ioa_network_buffer_get_offset(ioa_network_buffer_handle nbh) {
+uint16_t ioa_network_buffer_get_offset(ioa_network_buffer_handle nbh)
+{
   stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)nbh;
   return buf_elem->buf.offset;
 }
 
-uint8_t ioa_network_buffer_get_coffset(ioa_network_buffer_handle nbh) {
+uint8_t ioa_network_buffer_get_coffset(ioa_network_buffer_handle nbh)
+{
   stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)nbh;
   return buf_elem->buf.coffset;
 }
 
-void ioa_network_buffer_delete(ioa_engine_handle e, ioa_network_buffer_handle nbh) {
+void ioa_network_buffer_delete(ioa_engine_handle e, ioa_network_buffer_handle nbh)
+{
   stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)nbh;
   free_blist_elem(e, buf_elem);
 }
 
 /////////// REPORTING STATUS /////////////////////
 
-const char *get_ioa_socket_cipher(ioa_socket_handle s) {
-  if (s && s->ssl) {
+const char *get_ioa_socket_cipher(ioa_socket_handle s)
+{
+  if (s && s->ssl)
+  {
     return SSL_get_cipher(s->ssl);
   }
   return "no SSL";
 }
 
-const char *get_ioa_socket_ssl_method(ioa_socket_handle s) {
-  if (s && s->ssl) {
+const char *get_ioa_socket_ssl_method(ioa_socket_handle s)
+{
+  if (s && s->ssl)
+  {
     return turn_get_ssl_method(s->ssl, "UNKNOWN");
   }
   return "no SSL";
 }
 
-void stun_report_binding(void *a, STUN_PROMETHEUS_METRIC_TYPE type) {
+void stun_report_binding(void *a, STUN_PROMETHEUS_METRIC_TYPE type)
+{
 #if !defined(TURN_NO_PROMETHEUS)
   UNUSED_ARG(a);
-  switch (type) {
+  switch (type)
+  {
   case 0:
     prom_inc_stun_binding_request();
     break;
@@ -3613,25 +4386,34 @@ void stun_report_binding(void *a, STUN_PROMETHEUS_METRIC_TYPE type) {
 #endif
 }
 
-void turn_report_allocation_set(void *a, turn_time_t lifetime, int refresh) {
-  if (a) {
+void turn_report_allocation_set(void *a, turn_time_t lifetime, int refresh)
+{
+  if (a)
+  {
     ts_ur_super_session *ss = (ts_ur_super_session *)(((allocation *)a)->owner);
-    if (ss) {
+    if (ss)
+    {
       const char *status = "new";
-      if (refresh) {
+      if (refresh)
+      {
         status = "refreshed";
       }
       turn_turnserver *server = (turn_turnserver *)ss->server;
-      if (server) {
+      if (server)
+      {
         ioa_engine_handle e = turn_server_get_engine(server);
-        if (e && e->verbose && ss->client_socket) {
-          if (ss->client_socket->ssl) {
+        if (e && e->verbose && ss->client_socket)
+        {
+          if (ss->client_socket->ssl)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
                           "session %018llu: %s, realm=<%s>, username=<%s>, lifetime=%lu, cipher=%s, method=%s\n",
                           (unsigned long long)ss->id, status, (char *)ss->realm_options.name, (char *)ss->username,
                           (unsigned long)lifetime, SSL_get_cipher(ss->client_socket->ssl),
                           turn_get_ssl_method(ss->client_socket->ssl, "UNKNOWN"));
-          } else {
+          }
+          else
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: %s, realm=<%s>, username=<%s>, lifetime=%lu\n",
                           (unsigned long long)ss->id, status, (char *)ss->realm_options.name, (char *)ss->username,
                           (unsigned long)lifetime);
@@ -3640,10 +4422,13 @@ void turn_report_allocation_set(void *a, turn_time_t lifetime, int refresh) {
 #if !defined(TURN_NO_HIREDIS)
         {
           char key[1024];
-          if (ss->realm_options.name[0]) {
+          if (ss->realm_options.name[0])
+          {
             snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/status", ss->realm_options.name,
                      (char *)ss->username, (unsigned long long)ss->id);
-          } else {
+          }
+          else
+          {
             snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/status", (char *)ss->username,
                      (unsigned long long)ss->id);
           }
@@ -3662,7 +4447,8 @@ void turn_report_allocation_set(void *a, turn_time_t lifetime, int refresh) {
         }
 #endif
         {
-          if (!refresh) {
+          if (!refresh)
+          {
             prom_inc_allocation(get_ioa_socket_type(ss->client_socket));
           }
         }
@@ -3671,24 +4457,32 @@ void turn_report_allocation_set(void *a, turn_time_t lifetime, int refresh) {
   }
 }
 
-void turn_report_allocation_delete(void *a, SOCKET_TYPE socket_type) {
-  if (a) {
+void turn_report_allocation_delete(void *a, SOCKET_TYPE socket_type)
+{
+  if (a)
+  {
     ts_ur_super_session *ss = (ts_ur_super_session *)(((allocation *)a)->owner);
-    if (ss) {
+    if (ss)
+    {
       turn_turnserver *server = (turn_turnserver *)ss->server;
-      if (server) {
+      if (server)
+      {
         ioa_engine_handle e = turn_server_get_engine(server);
-        if (e && e->verbose) {
+        if (e && e->verbose)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: delete: realm=<%s>, username=<%s>\n",
                         (unsigned long long)ss->id, (char *)ss->realm_options.name, (char *)ss->username);
         }
 #if !defined(TURN_NO_HIREDIS)
         {
           char key[1024];
-          if (ss->realm_options.name[0]) {
+          if (ss->realm_options.name[0])
+          {
             snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/status", ss->realm_options.name,
                      (char *)ss->username, (unsigned long long)ss->id);
-          } else {
+          }
+          else
+          {
             snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/status", (char *)ss->username,
                      (unsigned long long)ss->id);
           }
@@ -3696,20 +4490,26 @@ void turn_report_allocation_delete(void *a, SOCKET_TYPE socket_type) {
           send_message_to_redis(e->rch, "publish", key, "deleted");
 
           // report total traffic usage for this allocation
-          if (ss->realm_options.name[0]) {
+          if (ss->realm_options.name[0])
+          {
             snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/total_traffic", ss->realm_options.name,
                      (char *)ss->username, (unsigned long long)ss->id);
-          } else {
+          }
+          else
+          {
             snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/total_traffic", (char *)ss->username,
                      (unsigned long long)ss->id);
           }
           send_message_to_redis(e->rch, "publish", key, "rcvp=%lu, rcvb=%lu, sentp=%lu, sentb=%lu",
                                 (unsigned long)(ss->t_received_packets), (unsigned long)(ss->t_received_bytes),
                                 (unsigned long)(ss->t_sent_packets), (unsigned long)(ss->t_sent_bytes));
-          if (ss->realm_options.name[0]) {
+          if (ss->realm_options.name[0])
+          {
             snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/total_traffic/peer",
                      ss->realm_options.name, (char *)ss->username, (unsigned long long)(ss->id));
-          } else {
+          }
+          else
+          {
             snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/total_traffic/peer", (char *)ss->username,
                      (unsigned long long)(ss->id));
           }
@@ -3720,7 +4520,8 @@ void turn_report_allocation_delete(void *a, SOCKET_TYPE socket_type) {
         }
 #endif
         {
-          if (ss->realm_options.name[0]) {
+          if (ss->realm_options.name[0])
+          {
 
             // Set prometheus traffic metrics
             prom_set_finished_traffic(ss->realm_options.name, (const char *)ss->username,
@@ -3730,7 +4531,9 @@ void turn_report_allocation_delete(void *a, SOCKET_TYPE socket_type) {
                 ss->realm_options.name, (const char *)ss->username, (unsigned long)(ss->t_peer_received_packets),
                 (unsigned long)(ss->t_peer_received_bytes), (unsigned long)(ss->t_peer_sent_packets),
                 (unsigned long)(ss->t_peer_sent_bytes), true);
-          } else {
+          }
+          else
+          {
             // Set prometheus traffic metrics
             prom_set_finished_traffic(NULL, (const char *)ss->username, (unsigned long)(ss->t_received_packets),
                                       (unsigned long)(ss->t_received_bytes), (unsigned long)(ss->t_sent_packets),
@@ -3747,15 +4550,20 @@ void turn_report_allocation_delete(void *a, SOCKET_TYPE socket_type) {
   }
 }
 
-void turn_report_session_usage(void *session, int force_invalid) {
-  if (session) {
+void turn_report_session_usage(void *session, int force_invalid)
+{
+  if (session)
+  {
     ts_ur_super_session *ss = (ts_ur_super_session *)session;
     turn_turnserver *server = (turn_turnserver *)ss->server;
-    if (server && (ss->received_packets || ss->sent_packets || force_invalid)) {
+    if (server && (ss->received_packets || ss->sent_packets || force_invalid))
+    {
       ioa_engine_handle e = turn_server_get_engine(server);
       if (((ss->received_packets + ss->sent_packets + ss->peer_received_packets + ss->peer_sent_packets) & 4095) == 0 ||
-          force_invalid) {
-        if (e && e->verbose) {
+          force_invalid)
+      {
+        if (e && e->verbose)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
                         "session %018llu: usage: realm=<%s>, username=<%s>, rp=%lu, rb=%lu, sp=%lu, sb=%lu\n",
                         (unsigned long long)(ss->id), (char *)ss->realm_options.name, (char *)ss->username,
@@ -3770,20 +4578,26 @@ void turn_report_session_usage(void *session, int force_invalid) {
 #if !defined(TURN_NO_HIREDIS)
         {
           char key[1024];
-          if (ss->realm_options.name[0]) {
+          if (ss->realm_options.name[0])
+          {
             snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/traffic", ss->realm_options.name,
                      (char *)ss->username, (unsigned long long)(ss->id));
-          } else {
+          }
+          else
+          {
             snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/traffic", (char *)ss->username,
                      (unsigned long long)(ss->id));
           }
           send_message_to_redis(e->rch, "publish", key, "rcvp=%lu, rcvb=%lu, sentp=%lu, sentb=%lu",
                                 (unsigned long)(ss->received_packets), (unsigned long)(ss->received_bytes),
                                 (unsigned long)(ss->sent_packets), (unsigned long)(ss->sent_bytes));
-          if (ss->realm_options.name[0]) {
+          if (ss->realm_options.name[0])
+          {
             snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/traffic/peer", ss->realm_options.name,
                      (char *)ss->username, (unsigned long long)(ss->id));
-          } else {
+          }
+          else
+          {
             snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/traffic/peer", (char *)ss->username,
                      (unsigned long long)(ss->id));
           }
@@ -3803,7 +4617,8 @@ void turn_report_session_usage(void *session, int force_invalid) {
 
         {
           turn_time_t ct = get_turn_server_time(server);
-          if (ct != ss->start_time) {
+          if (ct != ss->start_time)
+          {
             ct = ct - ss->start_time;
             ss->received_rate = (uint32_t)(ss->t_received_bytes / ct);
             ss->sent_rate = (uint32_t)(ss->t_sent_bytes / ct);
@@ -3831,15 +4646,19 @@ void turn_report_session_usage(void *session, int force_invalid) {
 
 /////////////// SSL ///////////////////
 
-const char *get_ioa_socket_tls_cipher(ioa_socket_handle s) {
-  if (s && (s->ssl)) {
+const char *get_ioa_socket_tls_cipher(ioa_socket_handle s)
+{
+  if (s && (s->ssl))
+  {
     return SSL_get_cipher(s->ssl);
   }
   return "";
 }
 
-const char *get_ioa_socket_tls_method(ioa_socket_handle s) {
-  if (s && (s->ssl)) {
+const char *get_ioa_socket_tls_method(ioa_socket_handle s)
+{
+  if (s && (s->ssl))
+  {
     return turn_get_ssl_method(s->ssl, "UNKNOWN");
   }
   return "";
@@ -3849,7 +4668,8 @@ const char *get_ioa_socket_tls_method(ioa_socket_handle s) {
 
 #define TURN_SM_SIZE (1024 << 11)
 
-struct _super_memory {
+struct _super_memory
+{
   TURN_MUTEX_DECLARE(mutex_sm)
   char **super_memory;
   size_t *sm_allocated;
@@ -3858,8 +4678,10 @@ struct _super_memory {
   uint32_t id;
 };
 
-static void init_super_memory_region(super_memory_t *r) {
-  if (r) {
+static void init_super_memory_region(super_memory_t *r)
+{
+  if (r)
+  {
     r->super_memory = (char **)malloc(sizeof(char *));
     r->super_memory[0] = (char *)calloc(1, TURN_SM_SIZE);
 
@@ -3869,7 +4691,8 @@ static void init_super_memory_region(super_memory_t *r) {
     r->sm_total_sz = TURN_SM_SIZE;
     r->sm_chunk = 0;
 
-    while (r->id == 0) {
+    while (r->id == 0)
+    {
       r->id = (uint32_t)turn_random();
     }
 
@@ -3879,20 +4702,23 @@ static void init_super_memory_region(super_memory_t *r) {
 
 void init_super_memory(void) { ; }
 
-super_memory_t *new_super_memory_region(void) {
+super_memory_t *new_super_memory_region(void)
+{
   super_memory_t *r = (super_memory_t *)calloc(1, sizeof(super_memory_t));
   init_super_memory_region(r);
   return r;
 }
 
-void *allocate_super_memory_region_func(super_memory_t *r, size_t size, const char *file, const char *func, int line) {
+void *allocate_super_memory_region_func(super_memory_t *r, size_t size, const char *file, const char *func, int line)
+{
   UNUSED_ARG(file);
   UNUSED_ARG(func);
   UNUSED_ARG(line);
 
   void *ret = NULL;
 
-  if (!r) {
+  if (!r)
+  {
     ret = calloc(1, size);
     return ret;
   }
@@ -3901,33 +4727,40 @@ void *allocate_super_memory_region_func(super_memory_t *r, size_t size, const ch
 
   size = ((size_t)((size + sizeof(void *)) / (sizeof(void *)))) * sizeof(void *);
 
-  if (size >= TURN_SM_SIZE) {
+  if (size >= TURN_SM_SIZE)
+  {
 
     TURN_LOG_FUNC(
         TURN_LOG_LEVEL_INFO,
         "(%s:%s:%d): Size too large for super memory: region id = %u, chunk=%lu, total=%lu, allocated=%lu, want=%lu\n",
         file, func, line, (unsigned int)r->id, (unsigned long)r->sm_chunk, (unsigned long)r->sm_total_sz,
         (unsigned long)r->sm_allocated[r->sm_chunk], (unsigned long)size);
-
-  } else {
+  }
+  else
+  {
 
     size_t i = 0;
     char *region = NULL;
     size_t *rsz = NULL;
-    for (i = 0; i <= r->sm_chunk; ++i) {
+    for (i = 0; i <= r->sm_chunk; ++i)
+    {
 
       size_t left = (size_t)r->sm_total_sz - r->sm_allocated[i];
 
-      if (left < size + sizeof(void *)) {
+      if (left < size + sizeof(void *))
+      {
         continue;
-      } else {
+      }
+      else
+      {
         region = r->super_memory[i];
         rsz = r->sm_allocated + i;
         break;
       }
     }
 
-    if (!region) {
+    if (!region)
+    {
       r->sm_chunk += 1;
       r->super_memory = (char **)realloc(r->super_memory, (r->sm_chunk + 1) * sizeof(char *));
       r->super_memory[r->sm_chunk] = (char *)calloc(1, TURN_SM_SIZE);
@@ -3950,16 +4783,18 @@ void *allocate_super_memory_region_func(super_memory_t *r, size_t size, const ch
 
   TURN_MUTEX_UNLOCK(&r->mutex_sm);
 
-  if (!ret) {
+  if (!ret)
+  {
     ret = calloc(1, size);
   }
 
   return ret;
 }
 
-void *allocate_super_memory_engine_func(ioa_engine_handle e, size_t size, const char *file, const char *func,
-                                        int line) {
-  if (e) {
+void *allocate_super_memory_engine_func(ioa_engine_handle e, size_t size, const char *file, const char *func, int line)
+{
+  if (e)
+  {
     return allocate_super_memory_region_func(e->sm, size, file, func, line);
   }
   return allocate_super_memory_region_func(NULL, size, file, func, line);

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -59,7 +59,8 @@
 #include <pthread.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////////////////////////////////////////////////
@@ -71,12 +72,14 @@ extern "C" {
 #define BUFFEREVENT_MAX_UDP_TO_TCP_WRITE (64 << 9)
 #define BUFFEREVENT_MAX_TCP_TO_TCP_WRITE (192 << 10)
 
-typedef struct _stun_buffer_list_elem {
+typedef struct _stun_buffer_list_elem
+{
   struct _stun_buffer_list_elem *next;
   stun_buffer buf;
 } stun_buffer_list_elem;
 
-typedef struct _stun_buffer_list {
+typedef struct _stun_buffer_list
+{
   stun_buffer_list_elem *head;
   stun_buffer_list_elem *tail;
   size_t tsz;
@@ -86,7 +89,8 @@ typedef struct _stun_buffer_list {
  * New connection callback
  */
 
-struct cb_socket_message {
+struct cb_socket_message
+{
   turnserver_id id;
   tcp_connection_id connection_id;
   stun_tid tid;
@@ -96,11 +100,13 @@ struct cb_socket_message {
   int can_resume;
 };
 
-struct cancelled_session_message {
+struct cancelled_session_message
+{
   turnsession_id id;
 };
 
-struct relay_server {
+struct relay_server
+{
   turnserver_id id;
   super_memory_t *sm;
   struct event_base *event_base;
@@ -113,10 +119,12 @@ struct relay_server {
   pthread_t thr;
 };
 
-struct message_to_relay {
+struct message_to_relay
+{
   MESSAGE_TO_RELAY_TYPE t;
   struct relay_server *relay_server;
-  union {
+  union
+  {
     struct socket_message sm;
     struct cb_socket_message cb_sm;
     struct cancelled_session_message csm;
@@ -134,7 +142,8 @@ typedef int (*ioa_engine_udp_event_handler)(relay_server_handle rs, struct messa
 #define PREDEF_TIMERS_NUM (14)
 extern const int predef_timer_intervals[PREDEF_TIMERS_NUM];
 
-struct _ioa_engine {
+struct _ioa_engine
+{
   super_memory_t *sm;
   struct event_base *event_base;
   int deallocate_eb;
@@ -160,12 +169,14 @@ struct _ioa_engine {
 
 #define SOCKET_MAGIC (0xABACADEF)
 
-struct traffic_bytes {
+struct traffic_bytes
+{
   band_limit_t jiffie_bytes_read;
   band_limit_t jiffie_bytes_write;
 };
 
-struct _ioa_socket {
+struct _ioa_socket
+{
   evutil_socket_t fd;
   struct _ioa_socket *parent_s;
   uint32_t magic;
@@ -218,7 +229,8 @@ struct _ioa_socket {
   size_t special_session_size;
 };
 
-typedef struct _timer_event {
+typedef struct _timer_event
+{
   struct event *ev;
   ioa_engine_handle e;
   ioa_timer_event_handler cb;

--- a/src/apps/relay/ns_sm.h
+++ b/src/apps/relay/ns_sm.h
@@ -40,7 +40,8 @@
 #include <pthread.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////////////////////////////////////////////////

--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -16,7 +16,8 @@
 #if !defined(TURN_NO_PROMETHEUS)
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include <microhttpd.h>

--- a/src/apps/relay/tls_listener.h
+++ b/src/apps/relay/tls_listener.h
@@ -38,7 +38,8 @@
 #include "ns_ioalib_impl.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ///////////////////////////////////////////

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -115,7 +115,8 @@ int web_admin_port = WEB_ADMIN_DEFAULT_PORT;
 
 ///////////////////////////////
 
-struct cli_session {
+struct cli_session
+{
   evutil_socket_t fd;
   int auth_completed;
   size_t cmds;
@@ -187,7 +188,8 @@ static const telnet_telopt_t cli_telopts[] = {
     {TELNET_TELOPT_MSSP, TELNET_WONT, TELNET_DONT},      {TELNET_TELOPT_BINARY, TELNET_WONT, TELNET_DONT},
     {TELNET_TELOPT_NAWS, TELNET_WONT, TELNET_DONT},      {-1, 0, 0}};
 
-struct toggleable_command {
+struct toggleable_command
+{
   const char *cmd;
   bool *data;
 };
@@ -206,92 +208,126 @@ struct toggleable_command tcmds[] = {
 
 ///////////////////////////////
 
-static void myprintf(struct cli_session *cs, const char *format, ...) {
-  if (cs && format) {
+static void myprintf(struct cli_session *cs, const char *format, ...)
+{
+  if (cs && format)
+  {
     va_list args;
     va_start(args, format);
-    if (cs->f) {
+    if (cs->f)
+    {
       vfprintf(cs->f, format, args);
-    } else {
+    }
+    else
+    {
       telnet_vprintf(cs->ts, format, args);
     }
     va_end(args);
   }
 }
 
-static void log_reset(struct cli_session *cs) {
-  if (cs) {
+static void log_reset(struct cli_session *cs)
+{
+  if (cs)
+  {
     reset_rtpprintf();
     myprintf(cs, "  log reset done\n");
   }
 }
 
-static void print_str_array(struct cli_session *cs, const char **sa) {
-  if (cs && sa) {
+static void print_str_array(struct cli_session *cs, const char **sa)
+{
+  if (cs && sa)
+  {
     int i = 0;
-    while (sa[i]) {
+    while (sa[i])
+    {
       myprintf(cs, "%s\n", sa[i]);
       i++;
     }
   }
 }
 
-static const char *get_flag(int val) {
-  if (val) {
+static const char *get_flag(int val)
+{
+  if (val)
+  {
     return "ON";
   }
   return "OFF";
 }
 
-static void cli_print_flag(struct cli_session *cs, int flag, const char *name, int changeable) {
-  if (cs && cs->ts && name) {
+static void cli_print_flag(struct cli_session *cs, int flag, const char *name, int changeable)
+{
+  if (cs && cs->ts && name)
+  {
     const char *sc = "";
-    if (changeable) {
+    if (changeable)
+    {
       sc = " (*)";
     }
     myprintf(cs, "  %s: %s%s\n", name, get_flag(flag), sc);
   }
 }
 
-static void cli_print_uint(struct cli_session *cs, unsigned long value, const char *name, int changeable) {
-  if (cs && cs->ts && name) {
+static void cli_print_uint(struct cli_session *cs, unsigned long value, const char *name, int changeable)
+{
+  if (cs && cs->ts && name)
+  {
     const char *sc = "";
-    if (changeable == 1) {
+    if (changeable == 1)
+    {
       sc = " (*)";
-    } else if (changeable == 2) {
+    }
+    else if (changeable == 2)
+    {
       sc = " (**)";
     }
     myprintf(cs, "  %s: %lu%s\n", name, value, sc);
   }
 }
 
-static void cli_print_str(struct cli_session *cs, const char *value, const char *name, int changeable) {
-  if (cs && cs->ts && name && value) {
-    if (value[0] == 0) {
+static void cli_print_str(struct cli_session *cs, const char *value, const char *name, int changeable)
+{
+  if (cs && cs->ts && name && value)
+  {
+    if (value[0] == 0)
+    {
       value = "empty";
     }
     const char *sc = "";
-    if (changeable == 1) {
+    if (changeable == 1)
+    {
       sc = " (*)";
-    } else if (changeable == 2) {
+    }
+    else if (changeable == 2)
+    {
       sc = " (**)";
     }
     myprintf(cs, "  %s: %s%s\n", name, value, sc);
   }
 }
 
-static void cli_print_addr(struct cli_session *cs, ioa_addr *value, int use_port, const char *name, int changeable) {
-  if (cs && cs->ts && name && value) {
+static void cli_print_addr(struct cli_session *cs, ioa_addr *value, int use_port, const char *name, int changeable)
+{
+  if (cs && cs->ts && name && value)
+  {
     const char *sc = "";
-    if (changeable == 1) {
+    if (changeable == 1)
+    {
       sc = " (*)";
-    } else if (changeable == 2) {
+    }
+    else if (changeable == 2)
+    {
       sc = " (**)";
     }
     char s[256];
-    if (!use_port) {
+    if (!use_port)
+    {
       addr_to_string_no_port(value, (uint8_t *)s);
-    } else {
+    }
+    else
+    {
       addr_to_string(value, (uint8_t *)s);
     }
     myprintf(cs, "  %s: %s%s\n", name, s, sc);
@@ -299,20 +335,29 @@ static void cli_print_addr(struct cli_session *cs, ioa_addr *value, int use_port
 }
 
 static void cli_print_addr_list(struct cli_session *cs, turn_server_addrs_list_t *value, int use_port, const char *name,
-                                int changeable) {
-  if (cs && cs->ts && name && value && value->size && value->addrs) {
+                                int changeable)
+{
+  if (cs && cs->ts && name && value && value->size && value->addrs)
+  {
     const char *sc = "";
-    if (changeable == 1) {
+    if (changeable == 1)
+    {
       sc = " (*)";
-    } else if (changeable == 2) {
+    }
+    else if (changeable == 2)
+    {
       sc = " (**)";
     }
     char s[256];
     size_t i;
-    for (i = 0; i < value->size; i++) {
-      if (!use_port) {
+    for (i = 0; i < value->size; i++)
+    {
+      if (!use_port)
+      {
         addr_to_string_no_port(&(value->addrs[i]), (uint8_t *)s);
-      } else {
+      }
+      else
+      {
         addr_to_string(&(value->addrs[i]), (uint8_t *)s);
       }
       myprintf(cs, "  %s: %s%s\n", name, s, sc);
@@ -320,53 +365,76 @@ static void cli_print_addr_list(struct cli_session *cs, turn_server_addrs_list_t
   }
 }
 
-static void cli_print_str_array(struct cli_session *cs, char **value, size_t sz, const char *name, int changeable) {
-  if (cs && cs->ts && name && value && sz) {
+static void cli_print_str_array(struct cli_session *cs, char **value, size_t sz, const char *name, int changeable)
+{
+  if (cs && cs->ts && name && value && sz)
+  {
     const char *sc = "";
-    if (changeable == 1) {
+    if (changeable == 1)
+    {
       sc = " (*)";
-    } else if (changeable == 2) {
+    }
+    else if (changeable == 2)
+    {
       sc = " (**)";
     }
     size_t i;
-    for (i = 0; i < sz; i++) {
-      if (value[i]) {
+    for (i = 0; i < sz; i++)
+    {
+      if (value[i])
+      {
         myprintf(cs, "  %s: %s%s\n", name, value[i], sc);
       }
     }
   }
 }
 
-static void cli_print_ip_range_list(struct cli_session *cs, ip_range_list_t *value, const char *name, int changeable) {
-  if (cs && cs->ts && name && value && value->ranges_number && value->rs) {
+static void cli_print_ip_range_list(struct cli_session *cs, ip_range_list_t *value, const char *name, int changeable)
+{
+  if (cs && cs->ts && name && value && value->ranges_number && value->rs)
+  {
     const char *sc = "";
-    if (changeable == 1) {
+    if (changeable == 1)
+    {
       sc = " (*)";
-    } else if (changeable == 2) {
+    }
+    else if (changeable == 2)
+    {
       sc = " (**)";
     }
     size_t i;
-    for (i = 0; i < value->ranges_number; ++i) {
-      if (value->rs[i].realm[0]) {
-        if (cs->realm[0] && strcmp(cs->realm, value->rs[i].realm)) {
+    for (i = 0; i < value->ranges_number; ++i)
+    {
+      if (value->rs[i].realm[0])
+      {
+        if (cs->realm[0] && strcmp(cs->realm, value->rs[i].realm))
+        {
           continue;
-        } else {
+        }
+        else
+        {
           myprintf(cs, "  %s: %s (%s)%s\n", name, value->rs[i].str, value->rs[i].realm, sc);
         }
-      } else {
+      }
+      else
+      {
         myprintf(cs, "  %s: %s%s\n", name, value->rs[i].str, sc);
       }
     }
   }
 }
 
-static void toggle_cli_param(struct cli_session *cs, const char *pn) {
-  if (cs && cs->ts && pn) {
+static void toggle_cli_param(struct cli_session *cs, const char *pn)
+{
+  if (cs && cs->ts && pn)
+  {
 
     int i = 0;
 
-    while (tcmds[i].cmd && tcmds[i].data) {
-      if (strcmp(tcmds[i].cmd, pn) == 0) {
+    while (tcmds[i].cmd && tcmds[i].data)
+    {
+      if (strcmp(tcmds[i].cmd, pn) == 0)
+      {
         *(tcmds[i].data) = !(*(tcmds[i].data));
         cli_print_flag(cs, *(tcmds[i].data), tcmds[i].cmd, 0);
         return;
@@ -381,7 +449,8 @@ static void toggle_cli_param(struct cli_session *cs, const char *pn) {
 
     i = 0;
 
-    while (tcmds[i].cmd && tcmds[i].data) {
+    while (tcmds[i].cmd && tcmds[i].data)
+    {
       cli_print_flag(cs, *(tcmds[i].data), tcmds[i].cmd, 0);
       ++i;
     }
@@ -390,26 +459,37 @@ static void toggle_cli_param(struct cli_session *cs, const char *pn) {
   }
 }
 
-static void change_cli_param(struct cli_session *cs, const char *pn) {
-  if (cs && cs->ts && pn) {
+static void change_cli_param(struct cli_session *cs, const char *pn)
+{
+  if (cs && cs->ts && pn)
+  {
 
-    if (strstr(pn, "total-quota") == pn) {
+    if (strstr(pn, "total-quota") == pn)
+    {
       turn_params.total_quota = atoi(pn + strlen("total-quota"));
       cli_print_uint(cs, (unsigned long)turn_params.total_quota, "total-quota", 2);
       return;
-    } else if (strstr(pn, "user-quota") == pn) {
+    }
+    else if (strstr(pn, "user-quota") == pn)
+    {
       turn_params.user_quota = atoi(pn + strlen("user-quota"));
       cli_print_uint(cs, (unsigned long)turn_params.user_quota, "user-quota", 2);
       return;
-    } else if (strstr(pn, "max-bps") == pn) {
+    }
+    else if (strstr(pn, "max-bps") == pn)
+    {
       set_max_bps((band_limit_t)strtoul(pn + strlen("max-bps"), NULL, 10));
       cli_print_uint(cs, (unsigned long)get_max_bps(), "max-bps", 2);
       return;
-    } else if (strstr(pn, "bps-capacity") == pn) {
+    }
+    else if (strstr(pn, "bps-capacity") == pn)
+    {
       set_bps_capacity((band_limit_t)strtoul(pn + strlen("bps-capacity"), NULL, 10));
       cli_print_uint(cs, (unsigned long)get_bps_capacity(), "bps-capacity", 2);
       return;
-    } else if (strstr(pn, "cli-max-output-sessions") == pn) {
+    }
+    else if (strstr(pn, "cli-max-output-sessions") == pn)
+    {
       cli_max_output_sessions = atoi(pn + strlen("cli-max-output-sessions"));
       cli_print_uint(cs, (unsigned long)cli_max_output_sessions, "cli-max-output-sessions", 2);
       return;
@@ -421,7 +501,8 @@ static void change_cli_param(struct cli_session *cs, const char *pn) {
   }
 }
 
-struct ps_arg {
+struct ps_arg
+{
   struct cli_session *cs;
   size_t counter;
   turn_time_t ct;
@@ -434,47 +515,67 @@ struct ps_arg {
   size_t users_number;
 };
 
-static bool print_session(ur_map_key_type key, ur_map_value_type value, void *arg) {
-  if (key && value && arg) {
+static bool print_session(ur_map_key_type key, ur_map_value_type value, void *arg)
+{
+  if (key && value && arg)
+  {
     struct ps_arg *csarg = (struct ps_arg *)arg;
     struct cli_session *cs = csarg->cs;
     struct turn_session_info *tsi = (struct turn_session_info *)value;
 
-    if (cs->realm[0] && strcmp(cs->realm, tsi->realm)) {
+    if (cs->realm[0] && strcmp(cs->realm, tsi->realm))
+    {
       return false;
     }
 
-    if (cs->origin[0] && strcmp(cs->origin, tsi->origin)) {
+    if (cs->origin[0] && strcmp(cs->origin, tsi->origin))
+    {
       return false;
     }
 
-    if (csarg->users) {
+    if (csarg->users)
+    {
 
       const char *pn = csarg->pname;
-      if (pn[0]) {
-        if (!strcmp(pn, "TLS") || !strcmp(pn, "tls") || !strcmp(pn, "Tls")) {
-          if ((tsi->client_protocol != TLS_SOCKET) && (tsi->client_protocol != TLS_SCTP_SOCKET)) {
+      if (pn[0])
+      {
+        if (!strcmp(pn, "TLS") || !strcmp(pn, "tls") || !strcmp(pn, "Tls"))
+        {
+          if ((tsi->client_protocol != TLS_SOCKET) && (tsi->client_protocol != TLS_SCTP_SOCKET))
+          {
             return false;
           }
-        } else if (!strcmp(pn, "DTLS") || !strcmp(pn, "dtls") || !strcmp(pn, "Dtls")) {
-          if (tsi->client_protocol != DTLS_SOCKET) {
+        }
+        else if (!strcmp(pn, "DTLS") || !strcmp(pn, "dtls") || !strcmp(pn, "Dtls"))
+        {
+          if (tsi->client_protocol != DTLS_SOCKET)
+          {
             return false;
           }
-        } else if (!strcmp(pn, "TCP") || !strcmp(pn, "tcp") || !strcmp(pn, "Tcp")) {
-          if ((tsi->client_protocol != TCP_SOCKET) && (tsi->client_protocol != SCTP_SOCKET)) {
+        }
+        else if (!strcmp(pn, "TCP") || !strcmp(pn, "tcp") || !strcmp(pn, "Tcp"))
+        {
+          if ((tsi->client_protocol != TCP_SOCKET) && (tsi->client_protocol != SCTP_SOCKET))
+          {
             return false;
           }
-        } else if (!strcmp(pn, "UDP") || !strcmp(pn, "udp") || !strcmp(pn, "Udp")) {
-          if (tsi->client_protocol != UDP_SOCKET) {
+        }
+        else if (!strcmp(pn, "UDP") || !strcmp(pn, "udp") || !strcmp(pn, "Udp"))
+        {
+          if (tsi->client_protocol != UDP_SOCKET)
+          {
             return false;
           }
-        } else {
+        }
+        else
+        {
           return false;
         }
       }
 
       ur_string_map_value_type value;
-      if (!ur_string_map_get(csarg->users, (ur_string_map_key_type)(char *)tsi->username, &value)) {
+      if (!ur_string_map_get(csarg->users, (ur_string_map_key_type)(char *)tsi->username, &value))
+      {
         value = (ur_string_map_value_type)csarg->users_number;
         csarg->users_number += 1;
         csarg->user_counters = (size_t *)realloc(csarg->user_counters, csarg->users_number * sizeof(size_t));
@@ -484,69 +585,94 @@ static bool print_session(ur_map_key_type key, ur_map_value_type value, void *ar
         ur_string_map_put(csarg->users, (ur_string_map_key_type)(char *)tsi->username, value);
       }
       csarg->user_counters[(size_t)value] += 1;
-    } else {
-      if (csarg->username[0]) {
-        if (csarg->exact_match) {
-          if (strcmp((char *)tsi->username, csarg->username)) {
+    }
+    else
+    {
+      if (csarg->username[0])
+      {
+        if (csarg->exact_match)
+        {
+          if (strcmp((char *)tsi->username, csarg->username))
+          {
             return false;
           }
-        } else {
-          if (!strstr((char *)tsi->username, csarg->username)) {
+        }
+        else
+        {
+          if (!strstr((char *)tsi->username, csarg->username))
+          {
             return false;
           }
         }
       }
-      if (cs->f || (unsigned long)csarg->counter < (unsigned long)cli_max_output_sessions) {
+      if (cs->f || (unsigned long)csarg->counter < (unsigned long)cli_max_output_sessions)
+      {
         myprintf(cs, "\n");
         myprintf(cs, "    %lu) id=%018llu, user <%s>:\n", (unsigned long)(csarg->counter + 1),
                  (unsigned long long)tsi->id, tsi->username);
-        if (tsi->realm[0]) {
+        if (tsi->realm[0])
+        {
           myprintf(cs, "      realm: %s\n", tsi->realm);
         }
-        if (tsi->origin[0]) {
+        if (tsi->origin[0])
+        {
           myprintf(cs, "      origin: %s\n", tsi->origin);
         }
-        if (turn_time_before(csarg->ct, tsi->start_time)) {
+        if (turn_time_before(csarg->ct, tsi->start_time))
+        {
           myprintf(cs, "      started: undefined time\n");
-        } else {
+        }
+        else
+        {
           myprintf(cs, "      started %lu secs ago\n", (unsigned long)(csarg->ct - tsi->start_time));
         }
-        if (turn_time_before(tsi->expiration_time, csarg->ct)) {
+        if (turn_time_before(tsi->expiration_time, csarg->ct))
+        {
           myprintf(cs, "      expired\n");
-        } else {
+        }
+        else
+        {
           myprintf(cs, "      expiring in %lu secs\n", (unsigned long)(tsi->expiration_time - csarg->ct));
         }
         myprintf(cs, "      client protocol %s, relay protocol %s\n", socket_type_name(tsi->client_protocol),
                  socket_type_name(tsi->peer_protocol));
         {
-          if (!tsi->local_addr_data.saddr[0]) {
+          if (!tsi->local_addr_data.saddr[0])
+          {
             addr_to_string(&(tsi->local_addr_data.addr), (uint8_t *)tsi->local_addr_data.saddr);
           }
-          if (!tsi->remote_addr_data.saddr[0]) {
+          if (!tsi->remote_addr_data.saddr[0])
+          {
             addr_to_string(&(tsi->remote_addr_data.addr), (uint8_t *)tsi->remote_addr_data.saddr);
           }
-          if (!tsi->relay_addr_data_ipv4.saddr[0]) {
+          if (!tsi->relay_addr_data_ipv4.saddr[0])
+          {
             addr_to_string(&(tsi->relay_addr_data_ipv4.addr), (uint8_t *)tsi->relay_addr_data_ipv4.saddr);
           }
-          if (!tsi->relay_addr_data_ipv6.saddr[0]) {
+          if (!tsi->relay_addr_data_ipv6.saddr[0])
+          {
             addr_to_string(&(tsi->relay_addr_data_ipv6.addr), (uint8_t *)tsi->relay_addr_data_ipv6.saddr);
           }
           myprintf(cs, "      client addr %s, server addr %s\n", tsi->remote_addr_data.saddr,
                    tsi->local_addr_data.saddr);
-          if (tsi->relay_addr_data_ipv4.saddr[0]) {
+          if (tsi->relay_addr_data_ipv4.saddr[0])
+          {
             myprintf(cs, "      relay addr %s\n", tsi->relay_addr_data_ipv4.saddr);
           }
-          if (tsi->relay_addr_data_ipv6.saddr[0]) {
+          if (tsi->relay_addr_data_ipv6.saddr[0])
+          {
             myprintf(cs, "      relay addr %s\n", tsi->relay_addr_data_ipv6.saddr);
           }
         }
         myprintf(cs, "      fingerprints enforced: %s\n", get_flag(tsi->enforce_fingerprints));
         myprintf(cs, "      mobile: %s\n", get_flag(tsi->is_mobile));
-        if (tsi->tls_method[0]) {
+        if (tsi->tls_method[0])
+        {
           myprintf(cs, "      TLS method: %s\n", tsi->tls_method);
           myprintf(cs, "      TLS cipher: %s\n", tsi->tls_cipher);
         }
-        if (tsi->bps) {
+        if (tsi->bps)
+        {
           myprintf(cs, "      Max throughput: %lu bytes per second\n", (unsigned long)tsi->bps);
         }
         myprintf(cs, "      usage: rp=%lu, rb=%lu, sp=%lu, sb=%lu\n", (unsigned long)(tsi->received_packets),
@@ -554,18 +680,24 @@ static bool print_session(ur_map_key_type key, ur_map_value_type value, void *ar
                  (unsigned long)(tsi->sent_bytes));
         myprintf(cs, "       rate: r=%lu, s=%lu, total=%lu (bytes per sec)\n", (unsigned long)(tsi->received_rate),
                  (unsigned long)(tsi->sent_rate), (unsigned long)(tsi->total_rate));
-        if (tsi->main_peers_size) {
+        if (tsi->main_peers_size)
+        {
           myprintf(cs, "      peers:\n");
           size_t i;
-          for (i = 0; i < tsi->main_peers_size; ++i) {
-            if (!(tsi->main_peers_data[i].saddr[0])) {
+          for (i = 0; i < tsi->main_peers_size; ++i)
+          {
+            if (!(tsi->main_peers_data[i].saddr[0]))
+            {
               addr_to_string(&(tsi->main_peers_data[i].addr), (uint8_t *)tsi->main_peers_data[i].saddr);
             }
             myprintf(cs, "          %s\n", tsi->main_peers_data[i].saddr);
           }
-          if (tsi->extra_peers_size && tsi->extra_peers_data) {
-            for (i = 0; i < tsi->extra_peers_size; ++i) {
-              if (!(tsi->extra_peers_data[i].saddr[0])) {
+          if (tsi->extra_peers_size && tsi->extra_peers_data)
+          {
+            for (i = 0; i < tsi->extra_peers_size; ++i)
+            {
+              if (!(tsi->extra_peers_data[i].saddr[0]))
+              {
                 addr_to_string(&(tsi->extra_peers_data[i].addr), (uint8_t *)tsi->extra_peers_data[i].saddr);
               }
               myprintf(cs, "          %s\n", tsi->extra_peers_data[i].saddr);
@@ -580,25 +712,32 @@ static bool print_session(ur_map_key_type key, ur_map_value_type value, void *ar
   return false;
 }
 
-static void cancel_session(struct cli_session *cs, const char *ssid) {
-  if (cs && cs->ts && ssid && *ssid) {
+static void cancel_session(struct cli_session *cs, const char *ssid)
+{
+  if (cs && cs->ts && ssid && *ssid)
+  {
     turnsession_id sid = strtoull(ssid, NULL, 10);
     send_session_cancellation_to_relay(sid);
   }
 }
 
-static void print_sessions(struct cli_session *cs, const char *pn, int exact_match, int print_users) {
-  if (cs && cs->ts && pn) {
+static void print_sessions(struct cli_session *cs, const char *pn, int exact_match, int print_users)
+{
+  if (cs && cs->ts && pn)
+  {
 
-    while (pn[0] == ' ') {
+    while (pn[0] == ' ')
+    {
       ++pn;
     }
-    if (pn[0] == '*') {
+    if (pn[0] == '*')
+    {
       ++pn;
     }
 
     const char *uname = "";
-    if (!print_users) {
+    if (!print_users)
+    {
       uname = pn;
       pn = "";
     }
@@ -607,7 +746,8 @@ static void print_sessions(struct cli_session *cs, const char *pn, int exact_mat
 
     arg.ct = turn_time();
 
-    if (print_users) {
+    if (print_users)
+    {
       arg.users = ur_string_map_create(NULL);
     }
 
@@ -615,15 +755,21 @@ static void print_sessions(struct cli_session *cs, const char *pn, int exact_mat
 
     myprintf(cs, "\n");
 
-    if (!print_users && !(cs->f)) {
-      if ((unsigned long)arg.counter > (unsigned long)cli_max_output_sessions) {
+    if (!print_users && !(cs->f))
+    {
+      if ((unsigned long)arg.counter > (unsigned long)cli_max_output_sessions)
+      {
         myprintf(cs, "...\n");
         myprintf(cs, "\n");
       }
-    } else if (arg.user_counters && arg.user_names) {
+    }
+    else if (arg.user_counters && arg.user_names)
+    {
       size_t i;
-      for (i = 0; i < arg.users_number; ++i) {
-        if (arg.user_names[i]) {
+      for (i = 0; i < arg.users_number; ++i)
+      {
+        if (arg.user_names[i])
+        {
           myprintf(cs, "    user: <%s>, %lu sessions\n", arg.user_names[i], (unsigned long)arg.user_counters[i]);
         }
       }
@@ -633,13 +779,18 @@ static void print_sessions(struct cli_session *cs, const char *pn, int exact_mat
     {
       char ts[1025];
       snprintf(ts, sizeof(ts), "  Total sessions");
-      if (cs->realm[0]) {
+      if (cs->realm[0])
+      {
         snprintf(ts + strlen(ts), sizeof(ts) - strlen(ts), " for realm %s", cs->realm);
-        if (cs->origin[0]) {
+        if (cs->origin[0])
+        {
           snprintf(ts + strlen(ts), sizeof(ts) - strlen(ts), " and for origin %s", cs->origin);
         }
-      } else {
-        if (cs->origin[0]) {
+      }
+      else
+      {
+        if (cs->origin[0])
+        {
           snprintf(ts + strlen(ts), sizeof(ts) - strlen(ts), " for origin %s", cs->origin);
         }
       }
@@ -648,8 +799,10 @@ static void print_sessions(struct cli_session *cs, const char *pn, int exact_mat
       myprintf(cs, "\n");
     }
 
-    if (!print_users && !(cs->f)) {
-      if ((unsigned long)arg.counter > (unsigned long)cli_max_output_sessions) {
+    if (!print_users && !(cs->f))
+    {
+      if ((unsigned long)arg.counter > (unsigned long)cli_max_output_sessions)
+      {
         myprintf(cs, "  Warning: too many output sessions, more than the\n");
         myprintf(cs, "  current value of cli-max-output-sessions CLI parameter.\n");
         myprintf(cs, "  Refine your request or increase cli-max-output-sessions value.\n");
@@ -657,26 +810,33 @@ static void print_sessions(struct cli_session *cs, const char *pn, int exact_mat
       }
     }
 
-    if (arg.user_counters) {
+    if (arg.user_counters)
+    {
       free(arg.user_counters);
     }
-    if (arg.user_names) {
+    if (arg.user_names)
+    {
       size_t i;
-      for (i = 0; i < arg.users_number; ++i) {
-        if (arg.user_names[i]) {
+      for (i = 0; i < arg.users_number; ++i)
+      {
+        if (arg.user_names[i])
+        {
           free(arg.user_names[i]);
         }
       }
       free(arg.user_names);
     }
-    if (arg.users) {
+    if (arg.users)
+    {
       ur_string_map_free(&arg.users);
     }
   }
 }
 
-static void cli_print_configuration(struct cli_session *cs) {
-  if (cs) {
+static void cli_print_configuration(struct cli_session *cs)
+{
+  if (cs)
+  {
     myprintf(cs, "\n");
 
     cli_print_flag(cs, turn_params.verbose, "verbose", 0);
@@ -702,28 +862,38 @@ static void cli_print_configuration(struct cli_session *cs) {
 
     {
       char wd[1025];
-      if (getcwd(wd, sizeof(wd) - 1)) {
+      if (getcwd(wd, sizeof(wd) - 1))
+      {
         cli_print_str(cs, wd, "process dir", 0);
       }
     }
 
     myprintf(cs, "\n");
 
-    if (turn_params.cipher_list[0]) {
+    if (turn_params.cipher_list[0])
+    {
       cli_print_str(cs, turn_params.cipher_list, "cipher-list", 0);
-    } else {
+    }
+    else
+    {
       cli_print_str(cs, DEFAULT_CIPHER_LIST, "cipher-list", 0);
     }
 
     cli_print_str(cs, turn_params.ec_curve_name, "ec-curve-name", 0);
     {
-      if (turn_params.dh_key_size == DH_CUSTOM) {
+      if (turn_params.dh_key_size == DH_CUSTOM)
+      {
         cli_print_str(cs, turn_params.dh_file, "dh-file", 0);
-      } else {
+      }
+      else
+      {
         unsigned int dh_key_length = 1066;
-        if (turn_params.dh_key_size == DH_566) {
+        if (turn_params.dh_key_size == DH_566)
+        {
           dh_key_length = 566;
-        } else if (turn_params.dh_key_size == DH_2066) {
+        }
+        else if (turn_params.dh_key_size == DH_2066)
+        {
           dh_key_length = 2066;
         }
         cli_print_uint(cs, (unsigned long)dh_key_length, "DH-key-length", 0);
@@ -736,7 +906,8 @@ static void cli_print_configuration(struct cli_session *cs) {
 
     cli_print_str_array(cs, turn_params.listener.addrs, turn_params.listener.addrs_number, "Listener addr", 0);
 
-    if (turn_params.listener_ifname[0]) {
+    if (turn_params.listener_ifname[0])
+    {
       cli_print_str(cs, turn_params.listener_ifname, "listener-ifname", 0);
     }
 
@@ -766,7 +937,8 @@ static void cli_print_configuration(struct cli_session *cs) {
 
     cli_print_str_array(cs, turn_params.relay_addrs, turn_params.relays_number, "Relay addr", 0);
 
-    if (turn_params.relay_ifname[0]) {
+    if (turn_params.relay_ifname[0])
+    {
       cli_print_str(cs, turn_params.relay_ifname, "relay-ifname", 0);
     }
 
@@ -797,16 +969,20 @@ static void cli_print_configuration(struct cli_session *cs) {
 
     myprintf(cs, "\n");
 
-    if (turn_params.default_users_db.persistent_users_db.userdb[0]) {
+    if (turn_params.default_users_db.persistent_users_db.userdb[0])
+    {
       cli_print_str(cs, userdb_type_to_string(turn_params.default_users_db.userdb_type), "DB type", 0);
       cli_print_str(cs, turn_params.default_users_db.persistent_users_db.userdb, "DB", 0);
-    } else {
+    }
+    else
+    {
       cli_print_str(cs, "none", "DB type", 0);
       cli_print_str(cs, "none", "DB", 0);
     }
 
 #if !defined(TURN_NO_HIREDIS)
-    if (turn_params.use_redis_statsdb && turn_params.redis_statsdb.connection_string[0]) {
+    if (turn_params.use_redis_statsdb && turn_params.redis_statsdb.connection_string[0])
+    {
       cli_print_str(cs, turn_params.redis_statsdb.connection_string, "Redis Statistics DB", 0);
     }
 #endif
@@ -815,25 +991,34 @@ static void cli_print_configuration(struct cli_session *cs) {
 
     {
       char *rn = get_realm(NULL)->options.name;
-      if (rn[0]) {
+      if (rn[0])
+      {
         cli_print_str(cs, rn, "Default realm", 0);
       }
     }
-    if (cs->realm[0]) {
+    if (cs->realm[0])
+    {
       cli_print_str(cs, cs->realm, "CLI session realm", 0);
-    } else {
+    }
+    else
+    {
       cli_print_str(cs, get_realm(NULL)->options.name, "CLI session realm", 0);
     }
-    if (cs->origin[0]) {
+    if (cs->origin[0])
+    {
       cli_print_str(cs, cs->origin, "CLI session origin", 0);
     }
-    if (turn_params.ct == TURN_CREDENTIALS_LONG_TERM) {
+    if (turn_params.ct == TURN_CREDENTIALS_LONG_TERM)
+    {
       cli_print_flag(cs, 1, "Long-term authorization mechanism", 0);
-    } else {
+    }
+    else
+    {
       cli_print_flag(cs, 1, "Anonymous credentials", 0);
     }
     cli_print_flag(cs, turn_params.use_auth_secret_with_timestamp, "TURN REST API support", 0);
-    if (turn_params.use_auth_secret_with_timestamp && turn_params.rest_api_separator) {
+    if (turn_params.use_auth_secret_with_timestamp && turn_params.rest_api_separator)
+    {
       cli_print_uint(cs, turn_params.rest_api_separator, "TURN REST API separator ASCII number", 0);
     }
 
@@ -873,9 +1058,12 @@ static void cli_print_configuration(struct cli_session *cs) {
 
 static void close_cli_session(struct cli_session *cs);
 
-static int run_cli_output(struct cli_session *cs, const char *buf, unsigned int len) {
-  if (cs && buf && len) {
-    if (bufferevent_write(cs->bev, buf, len) < 0) {
+static int run_cli_output(struct cli_session *cs, const char *buf, unsigned int len)
+{
+  if (cs && buf && len)
+  {
+    if (bufferevent_write(cs->bev, buf, len) < 0)
+    {
       return -1;
     }
     return 0;
@@ -883,19 +1071,23 @@ static int run_cli_output(struct cli_session *cs, const char *buf, unsigned int 
   return -1;
 }
 
-static void close_cli_session(struct cli_session *cs) {
-  if (cs) {
+static void close_cli_session(struct cli_session *cs)
+{
+  if (cs)
+  {
 
     addr_debug_print(adminserver.verbose, &(cs->addr), "CLI session disconnected from");
 
-    if (cs->ts) {
+    if (cs->ts)
+    {
       telnet_free(cs->ts);
       cs->ts = NULL;
     }
 
     BUFFEREVENT_FREE(cs->bev);
 
-    if (cs->fd >= 0) {
+    if (cs->fd >= 0)
+    {
       socket_closesocket(cs->fd);
       cs->fd = -1;
     }
@@ -904,40 +1096,52 @@ static void close_cli_session(struct cli_session *cs) {
   }
 }
 
-static void type_cli_cursor(struct cli_session *cs) {
-  if (cs && (cs->bev)) {
+static void type_cli_cursor(struct cli_session *cs)
+{
+  if (cs && (cs->bev))
+  {
     myprintf(cs, "%s", CLI_CURSOR);
   }
 }
 
-static void cli_add_alternate_server(struct cli_session *cs, const char *pn) {
-  if (cs && cs->ts && pn && *pn) {
+static void cli_add_alternate_server(struct cli_session *cs, const char *pn)
+{
+  if (cs && cs->ts && pn && *pn)
+  {
     add_alternate_server(pn);
   }
 }
 
-static void cli_add_tls_alternate_server(struct cli_session *cs, const char *pn) {
-  if (cs && cs->ts && pn && *pn) {
+static void cli_add_tls_alternate_server(struct cli_session *cs, const char *pn)
+{
+  if (cs && cs->ts && pn && *pn)
+  {
     add_tls_alternate_server(pn);
   }
 }
 
-static void cli_del_alternate_server(struct cli_session *cs, const char *pn) {
-  if (cs && cs->ts && pn && *pn) {
+static void cli_del_alternate_server(struct cli_session *cs, const char *pn)
+{
+  if (cs && cs->ts && pn && *pn)
+  {
     del_alternate_server(pn);
   }
 }
 
-static void cli_del_tls_alternate_server(struct cli_session *cs, const char *pn) {
-  if (cs && cs->ts && pn && *pn) {
+static void cli_del_tls_alternate_server(struct cli_session *cs, const char *pn)
+{
+  if (cs && cs->ts && pn && *pn)
+  {
     del_tls_alternate_server(pn);
   }
 }
 
-static int run_cli_input(struct cli_session *cs, const char *buf0, unsigned int len) {
+static int run_cli_input(struct cli_session *cs, const char *buf0, unsigned int len)
+{
   int ret = 0;
 
-  if (cs && buf0 && cs->ts && cs->bev) {
+  if (cs && buf0 && cs->ts && cs->bev)
+  {
 
     char *buf = (char *)malloc(len + 1);
     memcpy(buf, buf0, len);
@@ -945,52 +1149,71 @@ static int run_cli_input(struct cli_session *cs, const char *buf0, unsigned int 
 
     char *cmd = buf;
 
-    while ((cmd[0] == ' ') || (cmd[0] == '\t')) {
+    while ((cmd[0] == ' ') || (cmd[0] == '\t'))
+    {
       ++cmd;
     }
 
     size_t sl = strlen(cmd);
 
-    while (sl) {
+    while (sl)
+    {
       char c = cmd[sl - 1];
-      if ((c == 10) || (c == 13)) {
+      if ((c == 10) || (c == 13))
+      {
         cmd[sl - 1] = 0;
         --sl;
-      } else {
+      }
+      else
+      {
         break;
       }
     }
 
-    if (sl) {
+    if (sl)
+    {
       cs->cmds += 1;
-      if (cli_password[0] && !(cs->auth_completed)) {
-        if (!check_password_equal(cmd, cli_password)) {
-          if (cs->cmds >= CLI_PASSWORD_TRY_NUMBER) {
+      if (cli_password[0] && !(cs->auth_completed))
+      {
+        if (!check_password_equal(cmd, cli_password))
+        {
+          if (cs->cmds >= CLI_PASSWORD_TRY_NUMBER)
+          {
             addr_debug_print(1, &(cs->addr), "CLI authentication error");
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "CLI authentication error\n");
             close_cli_session(cs);
-          } else {
+          }
+          else
+          {
             const char *ipwd = "Enter password: ";
             myprintf(cs, "%s\n", ipwd);
           }
-        } else {
+        }
+        else
+        {
           cs->auth_completed = 1;
           addr_debug_print(1, &(cs->addr), "CLI authentication success");
           type_cli_cursor(cs);
         }
-      } else if ((strcmp(cmd, "bye") == 0) || (strcmp(cmd, "quit") == 0) || (strcmp(cmd, "exit") == 0) ||
-                 (strcmp(cmd, "q") == 0)) {
+      }
+      else if ((strcmp(cmd, "bye") == 0) || (strcmp(cmd, "quit") == 0) || (strcmp(cmd, "exit") == 0) ||
+               (strcmp(cmd, "q") == 0))
+      {
         const char *str = "Bye !";
         myprintf(cs, "%s\n", str);
         close_cli_session(cs);
         ret = -1;
-      } else if (strcmp(cmd, "drain") == 0) {
+      }
+      else if (strcmp(cmd, "drain") == 0)
+      {
         addr_debug_print(1, &(cs->addr), "Drain command received from CLI user");
         const char *str = "TURN server is draining then shutting down";
         myprintf(cs, "%s\n", str);
         close_cli_session(cs);
         enable_drain_mode();
-      } else if ((strcmp(cmd, "halt") == 0) || (strcmp(cmd, "shutdown") == 0) || (strcmp(cmd, "stop") == 0)) {
+      }
+      else if ((strcmp(cmd, "halt") == 0) || (strcmp(cmd, "shutdown") == 0) || (strcmp(cmd, "stop") == 0))
+      {
         addr_debug_print(1, &(cs->addr), "Shutdown command received from CLI user");
         const char *str = "TURN server is shutting down";
         myprintf(cs, "%s\n", str);
@@ -998,94 +1221,147 @@ static int run_cli_input(struct cli_session *cs, const char *buf0, unsigned int 
         turn_params.stop_turn_server = true;
         sleep(10);
         exit(0);
-      } else if ((strcmp(cmd, "?") == 0) || (strcmp(cmd, "h") == 0) || (strcmp(cmd, "help") == 0)) {
+      }
+      else if ((strcmp(cmd, "?") == 0) || (strcmp(cmd, "h") == 0) || (strcmp(cmd, "help") == 0))
+      {
         print_str_array(cs, CLI_GREETING_STR);
         print_str_array(cs, CLI_HELP_STR);
         type_cli_cursor(cs);
-      } else if (strcmp(cmd, "pc") == 0) {
+      }
+      else if (strcmp(cmd, "pc") == 0)
+      {
         cli_print_configuration(cs);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "tc ") == cmd) {
+      }
+      else if (strstr(cmd, "tc ") == cmd)
+      {
         toggle_cli_param(cs, cmd + 3);
-      } else if (strstr(cmd, "sr ") == cmd) {
+      }
+      else if (strstr(cmd, "sr ") == cmd)
+      {
         STRCPY(cs->realm, cmd + 3);
         cs->rp = get_realm(cs->realm);
         type_cli_cursor(cs);
-      } else if (strcmp(cmd, "ur") == 0) {
+      }
+      else if (strcmp(cmd, "ur") == 0)
+      {
         cs->realm[0] = 0;
         cs->rp = get_realm(NULL);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "so ") == cmd) {
+      }
+      else if (strstr(cmd, "so ") == cmd)
+      {
         STRCPY(cs->origin, cmd + 3);
         type_cli_cursor(cs);
-      } else if (strcmp(cmd, "uo") == 0) {
+      }
+      else if (strcmp(cmd, "uo") == 0)
+      {
         cs->origin[0] = 0;
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "tc") == cmd) {
+      }
+      else if (strstr(cmd, "tc") == cmd)
+      {
         toggle_cli_param(cs, cmd + 2);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "psp") == cmd) {
+      }
+      else if (strstr(cmd, "psp") == cmd)
+      {
         print_sessions(cs, cmd + 3, 0, 0);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "psd") == cmd) {
+      }
+      else if (strstr(cmd, "psd") == cmd)
+      {
         cmd += 3;
-        while (cmd[0] == ' ') {
+        while (cmd[0] == ' ')
+        {
           ++cmd;
         }
-        if (!(cmd[0])) {
+        if (!(cmd[0]))
+        {
           const char *str = "You have to provide file name for ps dump\n";
           myprintf(cs, "%s\n", str);
-        } else {
+        }
+        else
+        {
           cs->f = fopen(cmd, "w");
-          if (!(cs->f)) {
+          if (!(cs->f))
+          {
             const char *str = "Cannot open file for writing\n";
             myprintf(cs, "%s\n", str);
-          } else {
+          }
+          else
+          {
             print_sessions(cs, "", 1, 0);
             fclose(cs->f);
             cs->f = NULL;
           }
         }
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "pu ") == cmd) {
+      }
+      else if (strstr(cmd, "pu ") == cmd)
+      {
         print_sessions(cs, cmd + 3, 0, 1);
         type_cli_cursor(cs);
-      } else if (!strcmp(cmd, "pu")) {
+      }
+      else if (!strcmp(cmd, "pu"))
+      {
         print_sessions(cs, cmd + 2, 0, 1);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "ps") == cmd) {
+      }
+      else if (strstr(cmd, "ps") == cmd)
+      {
         print_sessions(cs, cmd + 2, 1, 0);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "cs ") == cmd) {
+      }
+      else if (strstr(cmd, "cs ") == cmd)
+      {
         cancel_session(cs, cmd + 3);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "lr") == cmd) {
+      }
+      else if (strstr(cmd, "lr") == cmd)
+      {
         log_reset(cs);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "cc ") == cmd) {
+      }
+      else if (strstr(cmd, "cc ") == cmd)
+      {
         change_cli_param(cs, cmd + 3);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "cc") == cmd) {
+      }
+      else if (strstr(cmd, "cc") == cmd)
+      {
         change_cli_param(cs, cmd + 2);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "aas ") == cmd) {
+      }
+      else if (strstr(cmd, "aas ") == cmd)
+      {
         cli_add_alternate_server(cs, cmd + 4);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "atas ") == cmd) {
+      }
+      else if (strstr(cmd, "atas ") == cmd)
+      {
         cli_add_tls_alternate_server(cs, cmd + 5);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "das ") == cmd) {
+      }
+      else if (strstr(cmd, "das ") == cmd)
+      {
         cli_del_alternate_server(cs, cmd + 4);
         type_cli_cursor(cs);
-      } else if (strstr(cmd, "dtas ") == cmd) {
+      }
+      else if (strstr(cmd, "dtas ") == cmd)
+      {
         cli_del_tls_alternate_server(cs, cmd + 5);
         type_cli_cursor(cs);
-      } else {
+      }
+      else
+      {
         const char *str = "Unknown command\n";
         myprintf(cs, "%s\n", str);
         type_cli_cursor(cs);
       }
-    } else {
+    }
+    else
+    {
       type_cli_cursor(cs);
     }
 
@@ -1095,24 +1371,31 @@ static int run_cli_input(struct cli_session *cs, const char *buf0, unsigned int 
   return ret;
 }
 
-static void cli_socket_input_handler_bev(struct bufferevent *bev, void *arg) {
-  if (bev && arg) {
+static void cli_socket_input_handler_bev(struct bufferevent *bev, void *arg)
+{
+  if (bev && arg)
+  {
 
     struct cli_session *cs = (struct cli_session *)arg;
 
-    if (!(cs->ts)) {
+    if (!(cs->ts))
+    {
       return;
     }
 
     stun_buffer buf;
 
-    if (cs->bev) {
+    if (cs->bev)
+    {
 
       int len = (int)bufferevent_read(cs->bev, buf.buf, STUN_BUFFER_SIZE - 1);
-      if (len < 0) {
+      if (len < 0)
+      {
         close_cli_session(cs);
         return;
-      } else if (len == 0) {
+      }
+      else if (len == 0)
+      {
         return;
       }
 
@@ -1125,13 +1408,18 @@ static void cli_socket_input_handler_bev(struct bufferevent *bev, void *arg) {
   }
 }
 
-static void cli_eventcb_bev(struct bufferevent *bev, short events, void *arg) {
+static void cli_eventcb_bev(struct bufferevent *bev, short events, void *arg)
+{
   UNUSED_ARG(bev);
 
-  if (events & BEV_EVENT_CONNECTED) {
+  if (events & BEV_EVENT_CONNECTED)
+  {
     // Connect okay
-  } else if (events & (BEV_EVENT_ERROR | BEV_EVENT_EOF)) {
-    if (arg) {
+  }
+  else if (events & (BEV_EVENT_ERROR | BEV_EVENT_EOF))
+  {
+    if (arg)
+    {
 
       struct cli_session *cs = (struct cli_session *)arg;
 
@@ -1140,12 +1428,15 @@ static void cli_eventcb_bev(struct bufferevent *bev, short events, void *arg) {
   }
 }
 
-static void cli_telnet_event_handler(telnet_t *telnet, telnet_event_t *event, void *user_data) {
-  if (user_data && telnet) {
+static void cli_telnet_event_handler(telnet_t *telnet, telnet_event_t *event, void *user_data)
+{
+  if (user_data && telnet)
+  {
 
     struct cli_session *cs = (struct cli_session *)user_data;
 
-    switch (event->type) {
+    switch (event->type)
+    {
     case TELNET_EV_DATA:
       run_cli_input(cs, event->data.buffer, event->data.size);
       break;
@@ -1161,7 +1452,8 @@ static void cli_telnet_event_handler(telnet_t *telnet, telnet_event_t *event, vo
 }
 
 static void cliserver_input_handler(struct evconnlistener *l, evutil_socket_t fd, struct sockaddr *sa, int socklen,
-                                    void *arg) {
+                                    void *arg)
+{
   UNUSED_ARG(l);
   UNUSED_ARG(arg);
   UNUSED_ARG(socklen);
@@ -1185,25 +1477,32 @@ static void cliserver_input_handler(struct evconnlistener *l, evutil_socket_t fd
 
   clisession->ts = telnet_init(cli_telopts, cli_telnet_event_handler, 0, clisession);
 
-  if (!(clisession->ts)) {
+  if (!(clisession->ts))
+  {
     const char *str = "Cannot open telnet session\n";
     addr_debug_print(adminserver.verbose, (ioa_addr *)sa, str);
     close_cli_session(clisession);
-  } else {
+  }
+  else
+  {
     print_str_array(clisession, CLI_GREETING_STR);
     telnet_printf(clisession->ts, "\n");
     telnet_printf(clisession->ts, "Type '?' for help\n");
-    if (cli_password[0]) {
+    if (cli_password[0])
+    {
       const char *ipwd = "Enter password: ";
       telnet_printf(clisession->ts, "%s\n", ipwd);
-    } else {
+    }
+    else
+    {
       type_cli_cursor(clisession);
     }
   }
 }
 
 static void web_admin_input_handler(ioa_socket_handle s, int event_type, ioa_net_data *in_buffer, void *arg,
-                                    int can_resume) {
+                                    int can_resume)
+{
   UNUSED_ARG(event_type);
   UNUSED_ARG(can_resume);
   UNUSED_ARG(arg);
@@ -1211,18 +1510,24 @@ static void web_admin_input_handler(ioa_socket_handle s, int event_type, ioa_net
   int to_be_closed = 0;
 
   int buffer_size = (int)ioa_network_buffer_get_size(in_buffer->nbh);
-  if (buffer_size >= UDP_STUN_BUFFER_SIZE) {
+  if (buffer_size >= UDP_STUN_BUFFER_SIZE)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "%s: request is too big: %d\n", __FUNCTION__, buffer_size);
     to_be_closed = 1;
-  } else if (buffer_size > 0) {
+  }
+  else if (buffer_size > 0)
+  {
 
     SOCKET_TYPE st = get_ioa_socket_type(s);
 
-    if (is_stream_socket(st)) {
-      if (is_http((char *)ioa_network_buffer_data(in_buffer->nbh), buffer_size)) {
+    if (is_stream_socket(st))
+    {
+      if (is_http((char *)ioa_network_buffer_data(in_buffer->nbh), buffer_size))
+      {
         const char *proto = "HTTP";
         ioa_network_buffer_data(in_buffer->nbh)[buffer_size] = 0;
-        if (st == TLS_SOCKET) {
+        if (st == TLS_SOCKET)
+        {
           proto = "HTTPS";
           set_ioa_socket_app_type(s, HTTPS_CLIENT_SOCKET);
 
@@ -1234,17 +1539,20 @@ static void web_admin_input_handler(ioa_socket_handle s, int event_type, ioa_net
                         get_ioa_socket_type(s), get_ioa_socket_app_type(s));
 
           ioa_socket_handle new_s = detach_ioa_socket(s);
-          if (new_s) {
+          if (new_s)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s new detached socket: %p, st=%d, sat=%d\n", __FUNCTION__, new_s,
                           get_ioa_socket_type(new_s), get_ioa_socket_app_type(new_s));
 
             send_https_socket(new_s);
           }
           to_be_closed = 1;
-
-        } else {
+        }
+        else
+        {
           set_ioa_socket_app_type(s, HTTP_CLIENT_SOCKET);
-          if (adminserver.verbose) {
+          if (adminserver.verbose)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: %s request: %s\n", __FUNCTION__, proto,
                           (char *)ioa_network_buffer_data(in_buffer->nbh));
           }
@@ -1254,8 +1562,10 @@ static void web_admin_input_handler(ioa_socket_handle s, int event_type, ioa_net
     }
   }
 
-  if (to_be_closed) {
-    if (adminserver.verbose) {
+  if (to_be_closed)
+  {
+    if (adminserver.verbose)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: web-admin socket to be closed in client handler: s=%p\n", __FUNCTION__,
                     s);
     }
@@ -1263,16 +1573,21 @@ static void web_admin_input_handler(ioa_socket_handle s, int event_type, ioa_net
   }
 }
 
-static int send_socket_to_admin_server(ioa_engine_handle e, struct message_to_relay *sm) {
+static int send_socket_to_admin_server(ioa_engine_handle e, struct message_to_relay *sm)
+{
   // sm->relay_server is null for us.
 
   sm->t = RMT_SOCKET;
 
-  if (sm->m.sm.s->defer_nbh) {
-    if (!sm->m.sm.nd.nbh) {
+  if (sm->m.sm.s->defer_nbh)
+  {
+    if (!sm->m.sm.nd.nbh)
+    {
       sm->m.sm.nd.nbh = sm->m.sm.s->defer_nbh;
       sm->m.sm.s->defer_nbh = NULL;
-    } else {
+    }
+    else
+    {
       ioa_network_buffer_delete(e, sm->m.sm.s->defer_nbh);
       sm->m.sm.s->defer_nbh = NULL;
     }
@@ -1280,29 +1595,36 @@ static int send_socket_to_admin_server(ioa_engine_handle e, struct message_to_re
 
   ioa_socket_handle s = sm->m.sm.s;
 
-  if (!s) {
+  if (!s)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: web-admin socket EMPTY\n", __FUNCTION__);
-
-  } else if (s->read_event || s->bev) {
+  }
+  else if (s->read_event || s->bev)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: web-admin socket wrongly preset: %p : %p\n", __FUNCTION__, s->read_event,
                   s->bev);
 
     IOA_CLOSE_SOCKET(s);
     sm->m.sm.s = NULL;
-  } else {
+  }
+  else
+  {
     s->e = e;
 
     struct socket_message *msg = &(sm->m.sm);
 
-    if (register_callback_on_ioa_socket(e, msg->s, IOA_EV_READ, web_admin_input_handler, NULL, 0) < 0) {
+    if (register_callback_on_ioa_socket(e, msg->s, IOA_EV_READ, web_admin_input_handler, NULL, 0) < 0)
+    {
 
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: Failed to register callback on web-admin ioa socket\n", __FUNCTION__);
       IOA_CLOSE_SOCKET(s);
       sm->m.sm.s = NULL;
+    }
+    else
+    {
 
-    } else {
-
-      if (msg->nd.nbh) {
+      if (msg->nd.nbh)
+      {
         web_admin_input_handler(msg->s, IOA_EV_READ, &(msg->nd), NULL, msg->can_resume);
         ioa_network_buffer_delete(e, msg->nd.nbh);
         msg->nd.nbh = NULL;
@@ -1316,7 +1638,8 @@ static int send_socket_to_admin_server(ioa_engine_handle e, struct message_to_re
   return 0;
 }
 
-void setup_admin_thread(void) {
+void setup_admin_thread(void)
+{
   adminserver.event_base = turn_event_base_new();
   super_memory_t *sm = new_super_memory_region();
   adminserver.e = create_ioa_engine(sm, adminserver.event_base, turn_params.listener.tp, turn_params.relay_ifname,
@@ -1328,7 +1651,8 @@ void setup_admin_thread(void) {
 #endif
   );
 
-  if (use_web_admin) {
+  if (use_web_admin)
+  {
     // Support encryption on this ioa engine
     // because the web-admin needs HTTPS
     set_ssl_ctx(adminserver.e, &turn_params);
@@ -1359,9 +1683,12 @@ void setup_admin_thread(void) {
   }
 
   // Setup the web-admin server
-  if (use_web_admin) {
-    if (!web_admin_addr_set) {
-      if (make_ioa_addr((const uint8_t *)WEB_ADMIN_DEFAULT_IP, 0, &web_admin_addr) < 0) {
+  if (use_web_admin)
+  {
+    if (!web_admin_addr_set)
+    {
+      if (make_ioa_addr((const uint8_t *)WEB_ADMIN_DEFAULT_IP, 0, &web_admin_addr) < 0)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot set web-admin address %s\n", WEB_ADMIN_DEFAULT_IP);
         return;
       }
@@ -1376,7 +1703,8 @@ void setup_admin_thread(void) {
         create_tls_listener_server(turn_params.listener_ifname, saddr, web_admin_port, turn_params.verbose,
                                    adminserver.e, send_socket_to_admin_server, NULL);
 
-    if (tls_service == NULL) {
+    if (tls_service == NULL)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot create web-admin listener\n");
       return;
     }
@@ -1384,9 +1712,12 @@ void setup_admin_thread(void) {
     addr_debug_print(adminserver.verbose, &web_admin_addr, "web-admin listener opened on ");
   }
 
-  if (use_cli) {
-    if (!cli_addr_set) {
-      if (make_ioa_addr((const uint8_t *)CLI_DEFAULT_IP, 0, &cli_addr) < 0) {
+  if (use_cli)
+  {
+    if (!cli_addr_set)
+    {
+      if (make_ioa_addr((const uint8_t *)CLI_DEFAULT_IP, 0, &cli_addr) < 0)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot set cli address %s\n", CLI_DEFAULT_IP);
         return;
       }
@@ -1395,13 +1726,15 @@ void setup_admin_thread(void) {
     addr_set_port(&cli_addr, cli_port);
 
     adminserver.listen_fd = socket(cli_addr.ss.sa_family, ADMIN_STREAM_SOCKET_TYPE, ADMIN_STREAM_SOCKET_PROTOCOL);
-    if (adminserver.listen_fd < 0) {
+    if (adminserver.listen_fd < 0)
+    {
       perror("socket");
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot open CLI socket\n");
       return;
     }
 
-    if (addr_bind(adminserver.listen_fd, &cli_addr, 1, 1, TCP_SOCKET) < 0) {
+    if (addr_bind(adminserver.listen_fd, &cli_addr, 1, 1, TCP_SOCKET) < 0)
+    {
       perror("Cannot bind CLI socket to addr");
       char saddr[129];
       addr_to_string(&cli_addr, (uint8_t *)saddr);
@@ -1417,7 +1750,8 @@ void setup_admin_thread(void) {
     adminserver.l = evconnlistener_new(adminserver.event_base, cliserver_input_handler, &adminserver,
                                        LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, 1024, adminserver.listen_fd);
 
-    if (!(adminserver.l)) {
+    if (!(adminserver.l))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot create CLI listener\n");
       socket_closesocket(adminserver.listen_fd);
       return;
@@ -1429,48 +1763,60 @@ void setup_admin_thread(void) {
   adminserver.sessions = ur_map_create();
 }
 
-void admin_server_receive_message(struct bufferevent *bev, void *ptr) {
+void admin_server_receive_message(struct bufferevent *bev, void *ptr)
+{
   UNUSED_ARG(ptr);
 
   struct turn_session_info *tsi = (struct turn_session_info *)calloc(1, sizeof(struct turn_session_info));
   int n = 0;
   struct evbuffer *input = bufferevent_get_input(bev);
 
-  while ((n = evbuffer_remove(input, tsi, sizeof(struct turn_session_info))) > 0) {
-    if (n != sizeof(struct turn_session_info)) {
+  while ((n = evbuffer_remove(input, tsi, sizeof(struct turn_session_info))) > 0)
+  {
+    if (n != sizeof(struct turn_session_info))
+    {
       fprintf(stderr, "%s: Weird CLI buffer error: size=%d\n", __FUNCTION__, n);
       continue;
     }
 
     ur_map_value_type t = 0;
-    if (ur_map_get(adminserver.sessions, (ur_map_key_type)tsi->id, &t) && t) {
+    if (ur_map_get(adminserver.sessions, (ur_map_key_type)tsi->id, &t) && t)
+    {
       struct turn_session_info *old = (struct turn_session_info *)t;
       turn_session_info_clean(old);
       free(old);
       ur_map_del(adminserver.sessions, (ur_map_key_type)tsi->id, NULL);
     }
 
-    if (tsi->valid) {
+    if (tsi->valid)
+    {
       ur_map_put(adminserver.sessions, (ur_map_key_type)tsi->id, (ur_map_value_type)tsi);
       tsi = (struct turn_session_info *)calloc(1, sizeof(struct turn_session_info));
-    } else {
+    }
+    else
+    {
       turn_session_info_clean(tsi);
     }
   }
 
-  if (tsi) {
+  if (tsi)
+  {
     turn_session_info_clean(tsi);
     free(tsi);
   }
 }
 
-int send_turn_session_info(struct turn_session_info *tsi) {
+int send_turn_session_info(struct turn_session_info *tsi)
+{
   int ret = -1;
 
-  if (tsi) {
+  if (tsi)
+  {
     struct evbuffer *output = bufferevent_get_output(adminserver.out_buf);
-    if (output) {
-      if (evbuffer_add(output, tsi, sizeof(struct turn_session_info)) >= 0) {
+    if (output)
+    {
+      if (evbuffer_add(output, tsi, sizeof(struct turn_session_info)) >= 0)
+      {
         ret = 0;
       }
     }
@@ -1481,7 +1827,8 @@ int send_turn_session_info(struct turn_session_info *tsi) {
 
 /////////// HTTPS /////////////
 
-enum _AS_FORM {
+enum _AS_FORM
+{
   AS_FORM_LOGON,
   AS_FORM_LOGOUT,
   AS_FORM_PC,
@@ -1531,7 +1878,8 @@ typedef enum _AS_FORM AS_FORM;
 #define HR_DELETE_OAUTH_KID "oauth_kid_del"
 #define HR_OAUTH_KID "kid"
 
-struct form_name {
+struct form_name
+{
   AS_FORM form;
   const char *name;
 };
@@ -1549,22 +1897,29 @@ static struct form_name form_names[] = {
 
 static ioa_socket_handle current_socket = NULL;
 
-static char *get_bold_admin_title(void) {
+static char *get_bold_admin_title(void)
+{
   static char sbat[1025];
   strncpy(sbat, __bold_admin_title, sizeof(sbat) - 1);
   sbat[sizeof(sbat) - 1] = '\0';
 
-  if (current_socket && current_socket->special_session) {
+  if (current_socket && current_socket->special_session)
+  {
     struct admin_session *as = (struct admin_session *)current_socket->special_session;
-    if (as && as->as_ok) {
-      if (as->as_login[0]) {
+    if (as && as->as_ok)
+    {
+      if (as->as_login[0])
+      {
         char *dst = sbat + strlen(sbat);
         snprintf(dst, ADMIN_USER_MAX_LENGTH * 2 + 2, " admin user: <b><i>%s</i></b><br>\r\n", as->as_login);
       }
-      if (as->as_realm[0]) {
+      if (as->as_realm[0])
+      {
         char *dst = sbat + strlen(sbat);
         snprintf(dst, STUN_MAX_REALM_SIZE * 2, " admin session realm: <b><i>%s</i></b><br>\r\n", as->as_realm);
-      } else if (as->as_eff_realm[0]) {
+      }
+      else if (as->as_eff_realm[0])
+      {
         char *dst = sbat + strlen(sbat);
         snprintf(dst, STUN_MAX_REALM_SIZE * 2, " admin session realm: <b><i>%s</i></b><br>\r\n", as->as_eff_realm);
       }
@@ -1573,9 +1928,11 @@ static char *get_bold_admin_title(void) {
   return sbat;
 }
 
-static int wrong_html_name(const char *s) {
+static int wrong_html_name(const char *s)
+{
   int ret = 0;
-  if (s) {
+  if (s)
+  {
     char *v = evhttp_encode_uri(s);
     ret = strcmp(v, s);
     free(v);
@@ -1583,60 +1940,79 @@ static int wrong_html_name(const char *s) {
   return ret;
 }
 
-static int is_as_ok(ioa_socket_handle s) {
+static int is_as_ok(ioa_socket_handle s)
+{
   return (s && s->special_session && ((struct admin_session *)s->special_session)->as_ok);
 }
 
-static int is_superuser(void) {
+static int is_superuser(void)
+{
   return (is_as_ok(current_socket) && (!((struct admin_session *)current_socket->special_session)->as_realm[0]));
 }
 
-static char *current_realm(void) {
+static char *current_realm(void)
+{
   if (current_socket && current_socket->special_session &&
-      ((struct admin_session *)current_socket->special_session)->as_ok) {
+      ((struct admin_session *)current_socket->special_session)->as_ok)
+  {
     return ((struct admin_session *)current_socket->special_session)->as_realm;
-  } else {
+  }
+  else
+  {
     static char bad_realm[1025] = "_ERROR:UNKNOWN_REALM__";
     return bad_realm;
   }
 }
 
-static char *current_eff_realm(void) {
+static char *current_eff_realm(void)
+{
   char *r = current_realm();
-  if (r && r[0]) {
+  if (r && r[0])
+  {
     return r;
-  } else if (current_socket && current_socket->special_session &&
-             ((struct admin_session *)current_socket->special_session)->as_ok) {
+  }
+  else if (current_socket && current_socket->special_session &&
+           ((struct admin_session *)current_socket->special_session)->as_ok)
+  {
     return ((struct admin_session *)current_socket->special_session)->as_eff_realm;
-  } else {
+  }
+  else
+  {
     static char bad_eff_realm[1025] = "_ERROR:UNKNOWN_REALM__";
     return bad_eff_realm;
   }
 }
 
-static size_t current_max_output_sessions(void) {
+static size_t current_max_output_sessions(void)
+{
   if (current_socket && current_socket->special_session &&
-      ((struct admin_session *)current_socket->special_session)->as_ok) {
+      ((struct admin_session *)current_socket->special_session)->as_ok)
+  {
     return ((struct admin_session *)current_socket->special_session)->number_of_user_sessions;
   }
   return DEFAULT_CLI_MAX_OUTPUT_SESSIONS;
 }
 
-static void set_current_max_output_sessions(size_t value) {
+static void set_current_max_output_sessions(size_t value)
+{
   if (current_socket && current_socket->special_session &&
-      ((struct admin_session *)current_socket->special_session)->as_ok) {
+      ((struct admin_session *)current_socket->special_session)->as_ok)
+  {
     ((struct admin_session *)current_socket->special_session)->number_of_user_sessions = value;
   }
 }
 
-static void https_cancel_session(const char *ssid) {
-  if (ssid && *ssid) {
+static void https_cancel_session(const char *ssid)
+{
+  if (ssid && *ssid)
+  {
     turnsession_id sid = (turnsession_id)strtoull(ssid, NULL, 10);
     send_session_cancellation_to_relay(sid);
   }
 }
 
-static void https_print_top_page_header(struct str_buffer *sb) {
+static void https_print_top_page_header(struct str_buffer *sb)
+{
   str_buffer_append(sb, "<!DOCTYPE html>\r\n<html>\r\n  <head>\r\n    <title>");
   str_buffer_append(sb, admin_title);
   str_buffer_append(
@@ -1645,7 +2021,8 @@ static void https_print_top_page_header(struct str_buffer *sb) {
   str_buffer_append(sb, bold_admin_title);
 }
 
-static void https_print_page_header(struct str_buffer *sb) {
+static void https_print_page_header(struct str_buffer *sb)
+{
   https_print_top_page_header(sb);
   str_buffer_append(sb, "<br><a href=\"/home?");
   str_buffer_append(sb, HR_REALM);
@@ -1655,16 +2032,19 @@ static void https_print_page_header(struct str_buffer *sb) {
   str_buffer_append(sb, "<br>\r\n");
 }
 
-static void https_finish_page(struct str_buffer *sb, ioa_socket_handle s, int cclose) {
+static void https_finish_page(struct str_buffer *sb, ioa_socket_handle s, int cclose)
+{
   str_buffer_append(sb, "</body>\r\n</html>\r\n");
 
   send_str_from_ioa_socket_tcp(s, "HTTP/1.1 200 OK\r\nServer: ");
-  if (turn_params.software_attribute) {
+  if (turn_params.software_attribute)
+  {
     send_str_from_ioa_socket_tcp(s, TURN_SOFTWARE);
   }
   send_str_from_ioa_socket_tcp(s, "\r\n");
   send_str_from_ioa_socket_tcp(s, get_http_date_header());
-  if (cclose) {
+  if (cclose)
+  {
     send_str_from_ioa_socket_tcp(s, "Connection: close\r\n");
   }
   send_str_from_ioa_socket_tcp(s, "Content-Type: text/html; charset=UTF-8\r\nContent-Length: ");
@@ -1677,11 +2057,15 @@ static void https_finish_page(struct str_buffer *sb, ioa_socket_handle s, int cc
   str_buffer_free(sb);
 }
 
-static AS_FORM get_form(const char *path) {
-  if (path) {
+static AS_FORM get_form(const char *path)
+{
+  if (path)
+  {
     size_t i = 0;
-    while (form_names[i].name) {
-      if (!strcmp(form_names[i].name, path)) {
+    while (form_names[i].name)
+    {
+      if (!strcmp(form_names[i].name, path))
+      {
         return form_names[i].form;
       }
       ++i;
@@ -1690,8 +2074,10 @@ static AS_FORM get_form(const char *path) {
   return AS_FORM_UNKNOWN;
 }
 
-static void write_https_logon_page(ioa_socket_handle s) {
-  if (s && !ioa_socket_tobeclosed(s)) {
+static void write_https_logon_page(ioa_socket_handle s)
+{
+  if (s && !ioa_socket_tobeclosed(s))
+  {
 
     struct str_buffer *sb = str_buffer_new();
 
@@ -1699,17 +2085,22 @@ static void write_https_logon_page(ioa_socket_handle s) {
 
     int we_have_admin_users = 0;
     const turn_dbdriver_t *dbd = get_dbdriver();
-    if (dbd && dbd->list_admin_users) {
+    if (dbd && dbd->list_admin_users)
+    {
       int ausers = dbd->list_admin_users(1);
-      if (ausers > 0) {
+      if (ausers > 0)
+      {
         we_have_admin_users = 1;
       }
     }
 
-    if (!we_have_admin_users) {
+    if (!we_have_admin_users)
+    {
       str_buffer_append(sb, "<br>To use the HTTPS admin connection, you have to set the database table "
                             "<b><i>admin_user</i></b> with the admin user accounts.<br>\r\n");
-    } else {
+    }
+    else
+    {
       str_buffer_append(sb, "<br><br>\r\n");
       str_buffer_append(sb, "<form action=\"");
       str_buffer_append(sb, form_names[AS_FORM_LOGON].name);
@@ -1728,12 +2119,17 @@ static void write_https_logon_page(ioa_socket_handle s) {
   }
 }
 
-static void write_https_home_page(ioa_socket_handle s) {
-  if (s && !ioa_socket_tobeclosed(s)) {
+static void write_https_home_page(ioa_socket_handle s)
+{
+  if (s && !ioa_socket_tobeclosed(s))
+  {
 
-    if (!is_as_ok(s)) {
+    if (!is_as_ok(s))
+    {
       write_https_logon_page(s);
-    } else {
+    }
+    else
+    {
 
       struct str_buffer *sb = str_buffer_new();
 
@@ -1749,9 +2145,12 @@ static void write_https_home_page(ioa_socket_handle s) {
       str_buffer_append(sb, "\" value=\"");
       str_buffer_append(sb, current_eff_realm());
       str_buffer_append(sb, "\"");
-      if (!is_superuser()) {
+      if (!is_superuser())
+      {
         str_buffer_append(sb, " disabled >");
-      } else {
+      }
+      else
+      {
         str_buffer_append(sb, "> <input type=\"submit\" value=\"Set Admin Session Realm\" >");
       }
 
@@ -1801,8 +2200,10 @@ static void write_https_home_page(ioa_socket_handle s) {
       str_buffer_append(sb, current_eff_realm());
       str_buffer_append(sb, "\">Origins</a>");
 
-      if (is_superuser()) {
-        if (ENC_ALG_NUM > 0) {
+      if (is_superuser())
+      {
+        if (ENC_ALG_NUM > 0)
+        {
           str_buffer_append(sb, "<br><a href=\"");
           str_buffer_append(sb, form_names[AS_FORM_OAUTH].name);
           str_buffer_append(sb, "?");
@@ -1821,8 +2222,10 @@ static void write_https_home_page(ioa_socket_handle s) {
   }
 }
 
-static void sbprintf(struct str_buffer *sb, const char *format, ...) {
-  if (sb && format) {
+static void sbprintf(struct str_buffer *sb, const char *format, ...)
+{
+  if (sb && format)
+  {
     va_list args;
     va_start(args, format);
     char s[1025] = "\0";
@@ -1832,38 +2235,56 @@ static void sbprintf(struct str_buffer *sb, const char *format, ...) {
   }
 }
 
-static void https_print_flag(struct str_buffer *sb, int flag, const char *name, const char *param_name) {
-  if (sb && name) {
-    if (!is_superuser()) {
+static void https_print_flag(struct str_buffer *sb, int flag, const char *name, const char *param_name)
+{
+  if (sb && name)
+  {
+    if (!is_superuser())
+    {
       param_name = 0;
     }
-    if (!param_name) {
+    if (!param_name)
+    {
       sbprintf(sb, "<tr><td>%s</td><td>%s</td></tr>\r\n", name, get_flag(flag));
-    } else {
+    }
+    else
+    {
       sbprintf(sb, "<tr><td>%s</td><td><a href=\"/toggle?%s=%s\">%s</a></td></tr>\r\n", name, HR_UPDATE_PARAMETER,
                param_name, get_flag(flag));
     }
   }
 }
 
-static void https_print_uint(struct str_buffer *sb, unsigned long value, const char *name, const char *param_name) {
-  if (sb && name) {
-    if (!is_superuser()) {
+static void https_print_uint(struct str_buffer *sb, unsigned long value, const char *name, const char *param_name)
+{
+  if (sb && name)
+  {
+    if (!is_superuser())
+    {
       param_name = 0;
     }
-    if (!param_name) {
-      if (value) {
+    if (!param_name)
+    {
+      if (value)
+      {
         sbprintf(sb, "<tr><td>%s</td><td>%lu</td></tr>\r\n", name, value);
-      } else {
+      }
+      else
+      {
         sbprintf(sb, "<tr><td>%s</td><td> </td></tr>\r\n", name);
       }
-    } else {
-      if (value) {
+    }
+    else
+    {
+      if (value)
+      {
         sbprintf(sb,
                  "<tr><td>%s</td><td> <form action=\"%s?%s=%s\" method=\"POST\"><input type=\"text\" name=\"%s\" "
                  "value=\"%lu\"><input type=\"submit\" value=\"Update\"></form> </td></tr>\r\n",
                  name, form_names[AS_FORM_UPDATE].name, HR_UPDATE_PARAMETER, param_name, param_name, value);
-      } else {
+      }
+      else
+      {
         sbprintf(sb,
                  "<tr><td>%s</td><td> <form action=\"%s?%s=%s\" method=\"POST\"><input type=\"text\" name=\"%s\" "
                  "value=\"\"><input type=\"submit\" value=\"Update\"></form> </td></tr>\r\n",
@@ -1873,14 +2294,20 @@ static void https_print_uint(struct str_buffer *sb, unsigned long value, const c
   }
 }
 
-static void https_print_str(struct str_buffer *sb, const char *value, const char *name, const char *param_name) {
-  if (sb && name && value) {
-    if (!is_superuser()) {
+static void https_print_str(struct str_buffer *sb, const char *value, const char *name, const char *param_name)
+{
+  if (sb && name && value)
+  {
+    if (!is_superuser())
+    {
       param_name = 0;
     }
-    if (!param_name) {
+    if (!param_name)
+    {
       sbprintf(sb, "<tr><td>%s</td><td>%s</td></tr>\r\n", name, value);
-    } else {
+    }
+    else
+    {
       sbprintf(sb,
                "<tr><td>%s</td><td> <form action=\"%s?%s=%s\" method=\"POST\"><input type=\"text\" name=\"%s\" "
                "value=\"%s\"><input type=\"submit\" value=\"Update\"></form> </td></tr>\r\n",
@@ -1889,23 +2316,32 @@ static void https_print_str(struct str_buffer *sb, const char *value, const char
   }
 }
 
-static void https_print_str_array(struct str_buffer *sb, char **value, size_t sz, const char *name) {
-  if (sb && name && value && sz) {
+static void https_print_str_array(struct str_buffer *sb, char **value, size_t sz, const char *name)
+{
+  if (sb && name && value && sz)
+  {
     size_t i;
-    for (i = 0; i < sz; i++) {
-      if (value[i]) {
+    for (i = 0; i < sz; i++)
+    {
+      if (value[i])
+      {
         sbprintf(sb, "<tr><td>  %s</td><td> %s</td></tr>\r\n", name, value[i]);
       }
     }
   }
 }
 
-static void https_print_addr(struct str_buffer *sb, ioa_addr *value, int use_port, const char *name) {
-  if (sb && name && value) {
+static void https_print_addr(struct str_buffer *sb, ioa_addr *value, int use_port, const char *name)
+{
+  if (sb && name && value)
+  {
     char s[256];
-    if (!use_port) {
+    if (!use_port)
+    {
       addr_to_string_no_port(value, (uint8_t *)s);
-    } else {
+    }
+    else
+    {
       addr_to_string(value, (uint8_t *)s);
     }
     sbprintf(sb, "<tr><td>  %s</td><td> %s</td></tr>\r\n", name, s);
@@ -1913,14 +2349,20 @@ static void https_print_addr(struct str_buffer *sb, ioa_addr *value, int use_por
 }
 
 static size_t https_print_addr_list(struct str_buffer *sb, turn_server_addrs_list_t *value, int use_port,
-                                    const char *name) {
-  if (sb && name && value && value->size && value->addrs) {
+                                    const char *name)
+{
+  if (sb && name && value && value->size && value->addrs)
+  {
     char s[256];
     size_t i;
-    for (i = 0; i < value->size; i++) {
-      if (!use_port) {
+    for (i = 0; i < value->size; i++)
+    {
+      if (!use_port)
+      {
         addr_to_string_no_port(&(value->addrs[i]), (uint8_t *)s);
-      } else {
+      }
+      else
+      {
         addr_to_string(&(value->addrs[i]), (uint8_t *)s);
       }
       sbprintf(sb, "</tr><td>  %s</td><td> %s</td></tr>\r\n", name, s);
@@ -1931,20 +2373,29 @@ static size_t https_print_addr_list(struct str_buffer *sb, turn_server_addrs_lis
 }
 
 static const char *change_ip_addr_html(int dynamic, const char *kind, const char *ip, const char *realm, char *buffer,
-                                       size_t sz) {
-  if (!buffer || !sz) {
+                                       size_t sz)
+{
+  if (!buffer || !sz)
+  {
     return "";
-  } else {
+  }
+  else
+  {
     buffer[0] = 0;
-    if (dynamic && kind && ip) {
+    if (dynamic && kind && ip)
+    {
 
-      if (!realm) {
+      if (!realm)
+      {
         realm = "";
       }
 
-      if (current_realm()[0] && strcmp(current_realm(), realm)) {
+      if (current_realm()[0] && strcmp(current_realm(), realm))
+      {
         // delete forbidden
-      } else {
+      }
+      else
+      {
         char *eip = evhttp_encode_uri(ip);
         snprintf(buffer, sz - 1, "<a href=\"%s?%s=%s&%s=%s&%s=%s\">delete</a>", form_names[AS_FORM_UPDATE].name,
                  HR_DELETE_IP_KIND, kind, HR_DELETE_IP_REALM, realm, HR_DELETE_IP, eip);
@@ -1956,34 +2407,46 @@ static const char *change_ip_addr_html(int dynamic, const char *kind, const char
 }
 
 static void https_print_ip_range_list(struct str_buffer *sb, ip_range_list_t *value, const char *name, const char *kind,
-                                      int dynamic) {
-  if (sb && name) {
-    if (value && value->rs) {
+                                      int dynamic)
+{
+  if (sb && name)
+  {
+    if (value && value->rs)
+    {
       size_t i;
       char buffer[1025];
-      for (i = 0; i < value->ranges_number; ++i) {
-        if (value->rs[i].realm[0]) {
-          if (current_eff_realm()[0] && strcmp(current_eff_realm(), value->rs[i].realm)) {
+      for (i = 0; i < value->ranges_number; ++i)
+      {
+        if (value->rs[i].realm[0])
+        {
+          if (current_eff_realm()[0] && strcmp(current_eff_realm(), value->rs[i].realm))
+          {
             continue;
-          } else {
+          }
+          else
+          {
             sbprintf(sb, "<tr><td>  %s</td><td> %s [%s] %s</td></tr>\r\n", name, value->rs[i].str, value->rs[i].realm,
                      change_ip_addr_html(dynamic, kind, value->rs[i].str, value->rs[i].realm, buffer, sizeof(buffer)));
           }
-        } else {
+        }
+        else
+        {
           sbprintf(sb, "<tr><td>  %s</td><td> %s %s</td></tr>\r\n", name, value->rs[i].str,
                    change_ip_addr_html(dynamic, kind, value->rs[i].str, value->rs[i].realm, buffer, sizeof(buffer)));
         }
       }
     }
 
-    if (dynamic) {
+    if (dynamic)
+    {
       sbprintf(sb, "<tr><td> Add %s</td><td>", name);
       sbprintf(
           sb,
           "<form action=\"%s?%s=%s\" method=\"POST\">IP range:<input required type=\"text\" name=\"%s\" value=\"\" >",
           form_names[AS_FORM_UPDATE].name, HR_ADD_IP_KIND, kind, HR_ADD_IP);
       sbprintf(sb, "Realm: <input type=\"text\" name=\"%s\" value=\"%s\" ", HR_ADD_IP_REALM, current_eff_realm());
-      if (!is_superuser()) {
+      if (!is_superuser())
+      {
         sbprintf(sb, " disabled ");
       }
       sbprintf(sb, ">");
@@ -1992,12 +2455,17 @@ static void https_print_ip_range_list(struct str_buffer *sb, ip_range_list_t *va
   }
 }
 
-static void toggle_param(const char *pn) {
-  if (is_superuser()) {
-    if (pn) {
+static void toggle_param(const char *pn)
+{
+  if (is_superuser())
+  {
+    if (pn)
+    {
       int i = 0;
-      while (tcmds[i].cmd && tcmds[i].data) {
-        if (strcmp(tcmds[i].cmd, pn) == 0) {
+      while (tcmds[i].cmd && tcmds[i].data)
+      {
+        if (strcmp(tcmds[i].cmd, pn) == 0)
+        {
           *(tcmds[i].data) = !(*(tcmds[i].data));
           return;
         }
@@ -2007,37 +2475,55 @@ static void toggle_param(const char *pn) {
   }
 }
 
-static void update_param(const char *pn, const char *value) {
-  if (pn) {
-    if (!value) {
+static void update_param(const char *pn, const char *value)
+{
+  if (pn)
+  {
+    if (!value)
+    {
       value = "0";
     }
-    if (is_superuser()) {
-      if (strstr(pn, "total-quota") == pn) {
+    if (is_superuser())
+    {
+      if (strstr(pn, "total-quota") == pn)
+      {
         turn_params.total_quota = atoi(value);
-      } else if (strstr(pn, "user-quota") == pn) {
+      }
+      else if (strstr(pn, "user-quota") == pn)
+      {
         turn_params.user_quota = atoi(value);
-      } else if (strstr(pn, "max-bps") == pn) {
+      }
+      else if (strstr(pn, "max-bps") == pn)
+      {
         set_max_bps((band_limit_t)strtoul(value, NULL, 10));
-      } else if (strstr(pn, "bps-capacity") == pn) {
+      }
+      else if (strstr(pn, "bps-capacity") == pn)
+      {
         set_bps_capacity((band_limit_t)strtoul(value, NULL, 10));
       }
     }
     {
       realm_params_t *rp = get_realm(current_eff_realm());
-      if (!rp) {
+      if (!rp)
+      {
         rp = get_realm(NULL);
       }
 
       const turn_dbdriver_t *dbd = get_dbdriver();
-      if (dbd && dbd->set_realm_option_one) {
-        if (strstr(pn, "cr-total-quota") == pn) {
+      if (dbd && dbd->set_realm_option_one)
+      {
+        if (strstr(pn, "cr-total-quota") == pn)
+        {
           rp->options.perf_options.total_quota = atoi(value);
           dbd->set_realm_option_one((uint8_t *)rp->options.name, rp->options.perf_options.total_quota, "total-quota");
-        } else if (strstr(pn, "cr-user-quota") == pn) {
+        }
+        else if (strstr(pn, "cr-user-quota") == pn)
+        {
           rp->options.perf_options.user_quota = atoi(value);
           dbd->set_realm_option_one((uint8_t *)rp->options.name, rp->options.perf_options.user_quota, "user-quota");
-        } else if (strstr(pn, "cr-max-bps") == pn) {
+        }
+        else if (strstr(pn, "cr-max-bps") == pn)
+        {
           rp->options.perf_options.max_bps = (band_limit_t)strtoul(value, NULL, 10);
           dbd->set_realm_option_one((uint8_t *)rp->options.name, rp->options.perf_options.max_bps, "max-bps");
         }
@@ -2046,18 +2532,24 @@ static void update_param(const char *pn, const char *value) {
   }
 }
 
-static void https_print_empty_row(struct str_buffer *sb, size_t span) {
+static void https_print_empty_row(struct str_buffer *sb, size_t span)
+{
   str_buffer_append(sb, "<tr><td colspan=");
   str_buffer_append_sz(sb, span);
   str_buffer_append(sb, "><br></td></tr>");
 }
 
-static void write_pc_page(ioa_socket_handle s) {
-  if (s && !ioa_socket_tobeclosed(s)) {
+static void write_pc_page(ioa_socket_handle s)
+{
+  if (s && !ioa_socket_tobeclosed(s))
+  {
 
-    if (!is_as_ok(s)) {
+    if (!is_as_ok(s))
+    {
       write_https_logon_page(s);
-    } else {
+    }
+    else
+    {
 
       struct str_buffer *sb = str_buffer_new();
 
@@ -2090,28 +2582,38 @@ static void write_pc_page(ioa_socket_handle s) {
 #endif
         {
           char wd[1025];
-          if (getcwd(wd, sizeof(wd) - 1)) {
+          if (getcwd(wd, sizeof(wd) - 1))
+          {
             https_print_str(sb, wd, "process dir", 0);
           }
         }
 
         https_print_empty_row(sb, 2);
 
-        if (turn_params.cipher_list[0]) {
+        if (turn_params.cipher_list[0])
+        {
           https_print_str(sb, turn_params.cipher_list, "cipher-list", 0);
-        } else {
+        }
+        else
+        {
           https_print_str(sb, DEFAULT_CIPHER_LIST, "cipher-list", 0);
         }
 
         https_print_str(sb, turn_params.ec_curve_name, "ec-curve-name", 0);
         {
-          if (turn_params.dh_key_size == DH_CUSTOM) {
+          if (turn_params.dh_key_size == DH_CUSTOM)
+          {
             https_print_str(sb, turn_params.dh_file, "dh-file", 0);
-          } else {
+          }
+          else
+          {
             unsigned int dh_key_length = 1066;
-            if (turn_params.dh_key_size == DH_566) {
+            if (turn_params.dh_key_size == DH_566)
+            {
               dh_key_length = 566;
-            } else if (turn_params.dh_key_size == DH_2066) {
+            }
+            else if (turn_params.dh_key_size == DH_2066)
+            {
               dh_key_length = 2066;
             }
             https_print_uint(sb, (unsigned long)dh_key_length, "DH-key-length", 0);
@@ -2126,7 +2628,8 @@ static void write_pc_page(ioa_socket_handle s) {
 
         https_print_str_array(sb, turn_params.listener.addrs, turn_params.listener.addrs_number, "Listener addr");
 
-        if (turn_params.listener_ifname[0]) {
+        if (turn_params.listener_ifname[0])
+        {
           https_print_str(sb, turn_params.listener_ifname, "listener-ifname", 0);
         }
 
@@ -2153,14 +2656,16 @@ static void write_pc_page(ioa_socket_handle s) {
           an += https_print_addr_list(sb, &turn_params.alternate_servers_list, 1, "Alternate server");
           an += https_print_addr_list(sb, &turn_params.tls_alternate_servers_list, 1, "TLS alternate server");
 
-          if (an) {
+          if (an)
+          {
             https_print_empty_row(sb, 2);
           }
         }
 
         https_print_str_array(sb, turn_params.relay_addrs, turn_params.relays_number, "Relay addr");
 
-        if (turn_params.relay_ifname[0]) {
+        if (turn_params.relay_ifname[0])
+        {
           https_print_str(sb, turn_params.relay_ifname, "relay-ifname", 0);
         }
 
@@ -2177,19 +2682,25 @@ static void write_pc_page(ioa_socket_handle s) {
 
         https_print_empty_row(sb, 2);
 
-        if (turn_params.default_users_db.persistent_users_db.userdb[0]) {
+        if (turn_params.default_users_db.persistent_users_db.userdb[0])
+        {
           https_print_str(sb, userdb_type_to_string(turn_params.default_users_db.userdb_type), "DB type", 0);
-          if (is_superuser()) {
+          if (is_superuser())
+          {
             https_print_str(sb, turn_params.default_users_db.persistent_users_db.userdb, "DB", 0);
           }
-        } else {
+        }
+        else
+        {
           https_print_str(sb, "none", "DB type", 0);
           https_print_str(sb, "none", "DB", 0);
         }
 
 #if !defined(TURN_NO_HIREDIS)
-        if (is_superuser()) {
-          if (turn_params.use_redis_statsdb && turn_params.redis_statsdb.connection_string_sanitized[0]) {
+        if (is_superuser())
+        {
+          if (turn_params.use_redis_statsdb && turn_params.redis_statsdb.connection_string_sanitized[0])
+          {
             https_print_str(sb, turn_params.redis_statsdb.connection_string_sanitized, "Redis Statistics DB", 0);
           }
         }
@@ -2197,32 +2708,42 @@ static void write_pc_page(ioa_socket_handle s) {
 
         https_print_empty_row(sb, 2);
 
-        if (turn_params.ct == TURN_CREDENTIALS_LONG_TERM) {
+        if (turn_params.ct == TURN_CREDENTIALS_LONG_TERM)
+        {
           https_print_flag(sb, 1, "Long-term authorization mechanism", 0);
-        } else {
+        }
+        else
+        {
           https_print_flag(sb, 1, "Anonymous credentials", 0);
         }
         https_print_flag(sb, turn_params.use_auth_secret_with_timestamp, "TURN REST API support", 0);
-        if (turn_params.use_auth_secret_with_timestamp) {
+        if (turn_params.use_auth_secret_with_timestamp)
+        {
 
-          if (!turn_params.rest_api_separator || ((unsigned int)turn_params.rest_api_separator == (unsigned int)':')) {
+          if (!turn_params.rest_api_separator || ((unsigned int)turn_params.rest_api_separator == (unsigned int)':'))
+          {
             https_print_str(sb, ":", "TURN REST API separator", 0);
-          } else {
+          }
+          else
+          {
             https_print_uint(sb, turn_params.rest_api_separator, "TURN REST API separator ASCII number", 0);
           }
         }
 
         https_print_empty_row(sb, 2);
 
-        if (is_superuser()) {
+        if (is_superuser())
+        {
           char *rn = get_realm(NULL)->options.name;
-          if (rn[0]) {
+          if (rn[0])
+          {
             https_print_str(sb, rn, "Default realm", 0);
           }
         }
 
         realm_params_t *rp = get_realm(current_eff_realm());
-        if (!rp) {
+        if (!rp)
+        {
           rp = get_realm(NULL);
         }
 
@@ -2273,7 +2794,8 @@ static void write_pc_page(ioa_socket_handle s) {
   }
 }
 
-struct https_ps_arg {
+struct https_ps_arg
+{
   struct str_buffer *sb;
   size_t counter;
   turn_time_t ct;
@@ -2283,52 +2805,73 @@ struct https_ps_arg {
   turnsession_id cs;
 };
 
-static bool https_print_session(ur_map_key_type key, ur_map_value_type value, void *arg) {
-  if (key && value && arg) {
+static bool https_print_session(ur_map_key_type key, ur_map_value_type value, void *arg)
+{
+  if (key && value && arg)
+  {
     struct https_ps_arg *csarg = (struct https_ps_arg *)arg;
     struct str_buffer *sb = csarg->sb;
     struct turn_session_info *tsi = (struct turn_session_info *)value;
 
-    if (current_eff_realm()[0] && strcmp(current_eff_realm(), tsi->realm)) {
+    if (current_eff_realm()[0] && strcmp(current_eff_realm(), tsi->realm))
+    {
       return false;
     }
 
-    if (csarg->user_pattern[0]) {
-      if (!strstr((char *)tsi->username, csarg->user_pattern)) {
+    if (csarg->user_pattern[0])
+    {
+      if (!strstr((char *)tsi->username, csarg->user_pattern))
+      {
         return false;
       }
     }
 
-    if (csarg->cs == tsi->id) {
+    if (csarg->cs == tsi->id)
+    {
       return false;
     }
 
     {
       const char *pn = csarg->client_protocol;
-      if (pn[0]) {
-        if (!strcmp(pn, "TLS") || !strcmp(pn, "tls") || !strcmp(pn, "Tls")) {
-          if ((tsi->client_protocol != TLS_SOCKET) && (tsi->client_protocol != TLS_SCTP_SOCKET)) {
+      if (pn[0])
+      {
+        if (!strcmp(pn, "TLS") || !strcmp(pn, "tls") || !strcmp(pn, "Tls"))
+        {
+          if ((tsi->client_protocol != TLS_SOCKET) && (tsi->client_protocol != TLS_SCTP_SOCKET))
+          {
             return false;
           }
-        } else if (!strcmp(pn, "DTLS") || !strcmp(pn, "dtls") || !strcmp(pn, "Dtls")) {
-          if (tsi->client_protocol != DTLS_SOCKET) {
+        }
+        else if (!strcmp(pn, "DTLS") || !strcmp(pn, "dtls") || !strcmp(pn, "Dtls"))
+        {
+          if (tsi->client_protocol != DTLS_SOCKET)
+          {
             return false;
           }
-        } else if (!strcmp(pn, "TCP") || !strcmp(pn, "tcp") || !strcmp(pn, "Tcp")) {
-          if ((tsi->client_protocol != TCP_SOCKET) && (tsi->client_protocol != SCTP_SOCKET)) {
+        }
+        else if (!strcmp(pn, "TCP") || !strcmp(pn, "tcp") || !strcmp(pn, "Tcp"))
+        {
+          if ((tsi->client_protocol != TCP_SOCKET) && (tsi->client_protocol != SCTP_SOCKET))
+          {
             return false;
           }
-        } else if (!strcmp(pn, "UDP") || !strcmp(pn, "udp") || !strcmp(pn, "Udp")) {
-          if (tsi->client_protocol != UDP_SOCKET) {
+        }
+        else if (!strcmp(pn, "UDP") || !strcmp(pn, "udp") || !strcmp(pn, "Udp"))
+        {
+          if (tsi->client_protocol != UDP_SOCKET)
+          {
             return false;
           }
-        } else {
+        }
+        else
+        {
           return false;
         }
       }
     }
 
-    if ((unsigned long)csarg->counter < (unsigned long)csarg->max_sessions) {
+    if ((unsigned long)csarg->counter < (unsigned long)csarg->max_sessions)
+    {
       str_buffer_append(sb, "<tr><td>");
       str_buffer_append_sz(sb, (size_t)(csarg->counter + 1));
       str_buffer_append(sb, "</td><td>");
@@ -2345,15 +2888,21 @@ static bool https_print_session(ur_map_key_type key, ur_map_value_type value, vo
       str_buffer_append(sb, "</td><td>");
       str_buffer_append(sb, tsi->origin);
       str_buffer_append(sb, "</td><td>");
-      if (turn_time_before(csarg->ct, tsi->start_time)) {
+      if (turn_time_before(csarg->ct, tsi->start_time))
+      {
         str_buffer_append(sb, "undefined time\n");
-      } else {
+      }
+      else
+      {
         str_buffer_append_sz(sb, (size_t)(csarg->ct - tsi->start_time));
       }
       str_buffer_append(sb, "</td><td>");
-      if (turn_time_before(tsi->expiration_time, csarg->ct)) {
+      if (turn_time_before(tsi->expiration_time, csarg->ct))
+      {
         str_buffer_append(sb, "expired");
-      } else {
+      }
+      else
+      {
         str_buffer_append_sz(sb, (size_t)(tsi->expiration_time - csarg->ct));
       }
       str_buffer_append(sb, "</td><td>");
@@ -2362,16 +2911,20 @@ static bool https_print_session(ur_map_key_type key, ur_map_value_type value, vo
       str_buffer_append(sb, socket_type_name(tsi->peer_protocol));
       str_buffer_append(sb, "</td><td>");
       {
-        if (!tsi->local_addr_data.saddr[0]) {
+        if (!tsi->local_addr_data.saddr[0])
+        {
           addr_to_string(&(tsi->local_addr_data.addr), (uint8_t *)tsi->local_addr_data.saddr);
         }
-        if (!tsi->remote_addr_data.saddr[0]) {
+        if (!tsi->remote_addr_data.saddr[0])
+        {
           addr_to_string(&(tsi->remote_addr_data.addr), (uint8_t *)tsi->remote_addr_data.saddr);
         }
-        if (!tsi->relay_addr_data_ipv4.saddr[0]) {
+        if (!tsi->relay_addr_data_ipv4.saddr[0])
+        {
           addr_to_string(&(tsi->relay_addr_data_ipv4.addr), (uint8_t *)tsi->relay_addr_data_ipv4.saddr);
         }
-        if (!tsi->relay_addr_data_ipv6.saddr[0]) {
+        if (!tsi->relay_addr_data_ipv6.saddr[0])
+        {
           addr_to_string(&(tsi->relay_addr_data_ipv6.addr), (uint8_t *)tsi->relay_addr_data_ipv6.saddr);
         }
         str_buffer_append(sb, tsi->remote_addr_data.saddr);
@@ -2409,19 +2962,25 @@ static bool https_print_session(ur_map_key_type key, ur_map_value_type value, vo
           str_buffer_append(sb, "</td><td>");
         }
 
-        if (tsi->main_peers_size) {
+        if (tsi->main_peers_size)
+        {
           size_t i;
-          for (i = 0; i < tsi->main_peers_size; ++i) {
-            if (!(tsi->main_peers_data[i].saddr[0])) {
+          for (i = 0; i < tsi->main_peers_size; ++i)
+          {
+            if (!(tsi->main_peers_data[i].saddr[0]))
+            {
               addr_to_string(&(tsi->main_peers_data[i].addr), (uint8_t *)tsi->main_peers_data[i].saddr);
             }
             str_buffer_append(sb, " ");
             str_buffer_append(sb, tsi->main_peers_data[i].saddr);
             str_buffer_append(sb, " ");
           }
-          if (tsi->extra_peers_size && tsi->extra_peers_data) {
-            for (i = 0; i < tsi->extra_peers_size; ++i) {
-              if (!(tsi->extra_peers_data[i].saddr[0])) {
+          if (tsi->extra_peers_size && tsi->extra_peers_data)
+          {
+            for (i = 0; i < tsi->extra_peers_size; ++i)
+            {
+              if (!(tsi->extra_peers_data[i].saddr[0]))
+              {
                 addr_to_string(&(tsi->extra_peers_data[i].addr), (uint8_t *)tsi->extra_peers_data[i].saddr);
               }
               str_buffer_append(sb, " ");
@@ -2440,7 +2999,8 @@ static bool https_print_session(ur_map_key_type key, ur_map_value_type value, vo
 }
 
 static size_t https_print_sessions(struct str_buffer *sb, const char *client_protocol, const char *user_pattern,
-                                   size_t max_sessions, turnsession_id cs) {
+                                   size_t max_sessions, turnsession_id cs)
+{
   struct https_ps_arg arg = {sb, 0, 0, client_protocol, user_pattern, max_sessions, cs};
 
   arg.ct = turn_time();
@@ -2451,12 +3011,17 @@ static size_t https_print_sessions(struct str_buffer *sb, const char *client_pro
 }
 
 static void write_ps_page(ioa_socket_handle s, const char *client_protocol, const char *user_pattern,
-                          size_t max_sessions, turnsession_id cs) {
-  if (s && !ioa_socket_tobeclosed(s)) {
+                          size_t max_sessions, turnsession_id cs)
+{
+  if (s && !ioa_socket_tobeclosed(s))
+  {
 
-    if (!is_as_ok(s)) {
+    if (!is_as_ok(s))
+    {
       write_https_logon_page(s);
-    } else {
+    }
+    else
+    {
 
       struct str_buffer *sb = str_buffer_new();
 
@@ -2472,7 +3037,8 @@ static void write_ps_page(ioa_socket_handle s, const char *client_protocol, cons
       str_buffer_append(sb, "\" value=\"");
       str_buffer_append(sb, current_eff_realm());
       str_buffer_append(sb, "\"");
-      if (!is_superuser()) {
+      if (!is_superuser())
+      {
         str_buffer_append(sb, " disabled ");
       }
       str_buffer_append(sb, ">");
@@ -2524,10 +3090,12 @@ static void write_ps_page(ioa_socket_handle s, const char *client_protocol, cons
   }
 }
 
-static size_t https_print_users(struct str_buffer *sb) {
+static size_t https_print_users(struct str_buffer *sb)
+{
   size_t ret = 0;
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->list_users) {
+  if (dbd && dbd->list_users)
+  {
     secrets_list_t users, realms;
     init_secrets_list(&users);
     init_secrets_list(&realms);
@@ -2535,14 +3103,16 @@ static size_t https_print_users(struct str_buffer *sb) {
 
     size_t sz = get_secrets_list_size(&users);
     size_t i;
-    for (i = 0; i < sz; ++i) {
+    for (i = 0; i < sz; ++i)
+    {
       str_buffer_append(sb, "<tr><td>");
       str_buffer_append_sz(sb, i + 1);
       str_buffer_append(sb, "</td>");
       str_buffer_append(sb, "<td>");
       str_buffer_append(sb, get_secrets_list_elem(&users, i));
       str_buffer_append(sb, "</td>");
-      if (!current_eff_realm()[0]) {
+      if (!current_eff_realm()[0])
+      {
         str_buffer_append(sb, "<td>");
         str_buffer_append(sb, get_secrets_list_elem(&realms, i));
         str_buffer_append(sb, "</td>");
@@ -2570,12 +3140,17 @@ static size_t https_print_users(struct str_buffer *sb) {
   return ret;
 }
 
-static void write_users_page(ioa_socket_handle s, const uint8_t *add_user, const uint8_t *add_realm, const char *msg) {
-  if (s && !ioa_socket_tobeclosed(s)) {
+static void write_users_page(ioa_socket_handle s, const uint8_t *add_user, const uint8_t *add_realm, const char *msg)
+{
+  if (s && !ioa_socket_tobeclosed(s))
+  {
 
-    if (!is_as_ok(s)) {
+    if (!is_as_ok(s))
+    {
       write_https_logon_page(s);
-    } else {
+    }
+    else
+    {
 
       struct str_buffer *sb = str_buffer_new();
 
@@ -2591,7 +3166,8 @@ static void write_users_page(ioa_socket_handle s, const uint8_t *add_user, const
       str_buffer_append(sb, "\" value=\"");
       str_buffer_append(sb, current_eff_realm());
       str_buffer_append(sb, "\"");
-      if (!is_superuser()) {
+      if (!is_superuser())
+      {
         str_buffer_append(sb, " disabled ");
       }
       str_buffer_append(sb, ">");
@@ -2606,7 +3182,8 @@ static void write_users_page(ioa_socket_handle s, const uint8_t *add_user, const
       str_buffer_append(sb, "\" method=\"POST\">\r\n");
       str_buffer_append(sb, "  <fieldset><legend>User:</legend>\r\n");
 
-      if (msg && msg[0]) {
+      if (msg && msg[0])
+      {
         str_buffer_append(sb, "<br><table id=\"msg\"><th>");
         str_buffer_append(sb, msg);
         str_buffer_append(sb, "</th></table><br>");
@@ -2617,7 +3194,8 @@ static void write_users_page(ioa_socket_handle s, const uint8_t *add_user, const
       str_buffer_append(sb, "\" value=\"");
       str_buffer_append(sb, (const char *)add_realm);
       str_buffer_append(sb, "\"");
-      if (!is_superuser()) {
+      if (!is_superuser())
+      {
         str_buffer_append(sb, " disabled ");
       }
       str_buffer_append(sb, "><br>\r\n");
@@ -2651,7 +3229,8 @@ static void write_users_page(ioa_socket_handle s, const uint8_t *add_user, const
       str_buffer_append(sb, "<br><b>Users:</b><br><br>\r\n");
       str_buffer_append(sb, "<table>\r\n");
       str_buffer_append(sb, "<tr><th>N</th><th>Name</th>");
-      if (!current_eff_realm()[0]) {
+      if (!current_eff_realm()[0])
+      {
         str_buffer_append(sb, "<th>Realm</th>");
       }
       str_buffer_append(sb, "<th> </th>");
@@ -2670,10 +3249,12 @@ static void write_users_page(ioa_socket_handle s, const uint8_t *add_user, const
   }
 }
 
-static size_t https_print_secrets(struct str_buffer *sb) {
+static size_t https_print_secrets(struct str_buffer *sb)
+{
   size_t ret = 0;
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->list_secrets) {
+  if (dbd && dbd->list_secrets)
+  {
     secrets_list_t secrets, realms;
     init_secrets_list(&secrets);
     init_secrets_list(&realms);
@@ -2681,14 +3262,16 @@ static size_t https_print_secrets(struct str_buffer *sb) {
 
     size_t sz = get_secrets_list_size(&secrets);
     size_t i;
-    for (i = 0; i < sz; ++i) {
+    for (i = 0; i < sz; ++i)
+    {
       str_buffer_append(sb, "<tr><td>");
       str_buffer_append_sz(sb, i + 1);
       str_buffer_append(sb, "</td>");
       str_buffer_append(sb, "<td>");
       str_buffer_append(sb, get_secrets_list_elem(&secrets, i));
       str_buffer_append(sb, "</td>");
-      if (!current_eff_realm()[0]) {
+      if (!current_eff_realm()[0])
+      {
         str_buffer_append(sb, "<td>");
         str_buffer_append(sb, get_secrets_list_elem(&realms, i));
         str_buffer_append(sb, "</td>");
@@ -2717,12 +3300,17 @@ static size_t https_print_secrets(struct str_buffer *sb) {
 }
 
 static void write_shared_secrets_page(ioa_socket_handle s, const char *add_secret, const char *add_realm,
-                                      const char *msg) {
-  if (s && !ioa_socket_tobeclosed(s)) {
+                                      const char *msg)
+{
+  if (s && !ioa_socket_tobeclosed(s))
+  {
 
-    if (!is_as_ok(s)) {
+    if (!is_as_ok(s))
+    {
       write_https_logon_page(s);
-    } else {
+    }
+    else
+    {
 
       struct str_buffer *sb = str_buffer_new();
 
@@ -2738,7 +3326,8 @@ static void write_shared_secrets_page(ioa_socket_handle s, const char *add_secre
       str_buffer_append(sb, "\" value=\"");
       str_buffer_append(sb, current_eff_realm());
       str_buffer_append(sb, "\"");
-      if (!is_superuser()) {
+      if (!is_superuser())
+      {
         str_buffer_append(sb, " disabled ");
       }
       str_buffer_append(sb, ">");
@@ -2753,7 +3342,8 @@ static void write_shared_secrets_page(ioa_socket_handle s, const char *add_secre
       str_buffer_append(sb, "\" method=\"POST\">\r\n");
       str_buffer_append(sb, "  <fieldset><legend>Secret:</legend>\r\n");
 
-      if (msg && msg[0]) {
+      if (msg && msg[0])
+      {
         str_buffer_append(sb, "<br><table id=\"msg\"><th>");
         str_buffer_append(sb, msg);
         str_buffer_append(sb, "</th></table><br>");
@@ -2764,7 +3354,8 @@ static void write_shared_secrets_page(ioa_socket_handle s, const char *add_secre
       str_buffer_append(sb, "\" value=\"");
       str_buffer_append(sb, (const char *)add_realm);
       str_buffer_append(sb, "\"");
-      if (!is_superuser()) {
+      if (!is_superuser())
+      {
         str_buffer_append(sb, " disabled ");
       }
       str_buffer_append(sb, "><br>\r\n");
@@ -2784,7 +3375,8 @@ static void write_shared_secrets_page(ioa_socket_handle s, const char *add_secre
       str_buffer_append(sb, "<br><b>Shared secrets:</b><br><br>\r\n");
       str_buffer_append(sb, "<table>\r\n");
       str_buffer_append(sb, "<tr><th>N</th><th>Value</th>");
-      if (!current_eff_realm()[0]) {
+      if (!current_eff_realm()[0])
+      {
         str_buffer_append(sb, "<th>Realm</th>");
       }
       str_buffer_append(sb, "<th> </th>");
@@ -2803,10 +3395,12 @@ static void write_shared_secrets_page(ioa_socket_handle s, const char *add_secre
   }
 }
 
-static size_t https_print_origins(struct str_buffer *sb) {
+static size_t https_print_origins(struct str_buffer *sb)
+{
   size_t ret = 0;
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->list_origins) {
+  if (dbd && dbd->list_origins)
+  {
     secrets_list_t origins, realms;
     init_secrets_list(&origins);
     init_secrets_list(&realms);
@@ -2814,19 +3408,22 @@ static size_t https_print_origins(struct str_buffer *sb) {
 
     size_t sz = get_secrets_list_size(&origins);
     size_t i;
-    for (i = 0; i < sz; ++i) {
+    for (i = 0; i < sz; ++i)
+    {
       str_buffer_append(sb, "<tr><td>");
       str_buffer_append_sz(sb, i + 1);
       str_buffer_append(sb, "</td>");
       str_buffer_append(sb, "<td>");
       str_buffer_append(sb, get_secrets_list_elem(&origins, i));
       str_buffer_append(sb, "</td>");
-      if (!current_eff_realm()[0]) {
+      if (!current_eff_realm()[0])
+      {
         str_buffer_append(sb, "<td>");
         str_buffer_append(sb, get_secrets_list_elem(&realms, i));
         str_buffer_append(sb, "</td>");
       }
-      if (is_superuser()) {
+      if (is_superuser())
+      {
         str_buffer_append(sb, "<td> <a href=\"");
         str_buffer_append(sb, form_names[AS_FORM_OS].name);
         str_buffer_append(sb, "?");
@@ -2847,12 +3444,17 @@ static size_t https_print_origins(struct str_buffer *sb) {
   return ret;
 }
 
-static void write_origins_page(ioa_socket_handle s, const char *add_origin, const char *add_realm, const char *msg) {
-  if (s && !ioa_socket_tobeclosed(s)) {
+static void write_origins_page(ioa_socket_handle s, const char *add_origin, const char *add_realm, const char *msg)
+{
+  if (s && !ioa_socket_tobeclosed(s))
+  {
 
-    if (!is_as_ok(s)) {
+    if (!is_as_ok(s))
+    {
       write_https_logon_page(s);
-    } else {
+    }
+    else
+    {
 
       struct str_buffer *sb = str_buffer_new();
 
@@ -2868,7 +3470,8 @@ static void write_origins_page(ioa_socket_handle s, const char *add_origin, cons
       str_buffer_append(sb, "\" value=\"");
       str_buffer_append(sb, current_eff_realm());
       str_buffer_append(sb, "\"");
-      if (!is_superuser()) {
+      if (!is_superuser())
+      {
         str_buffer_append(sb, " disabled ");
       }
       str_buffer_append(sb, ">");
@@ -2878,13 +3481,15 @@ static void write_origins_page(ioa_socket_handle s, const char *add_origin, cons
       str_buffer_append(sb, "</fieldset>\r\n");
       str_buffer_append(sb, "</form>\r\n");
 
-      if (is_superuser()) {
+      if (is_superuser())
+      {
         str_buffer_append(sb, "<form action=\"");
         str_buffer_append(sb, form_names[AS_FORM_OS].name);
         str_buffer_append(sb, "\" method=\"POST\">\r\n");
         str_buffer_append(sb, "  <fieldset><legend>Origin:</legend>\r\n");
 
-        if (msg && msg[0]) {
+        if (msg && msg[0])
+        {
           str_buffer_append(sb, "<br><table id=\"msg\"><th>");
           str_buffer_append(sb, msg);
           str_buffer_append(sb, "</th></table><br>");
@@ -2913,10 +3518,12 @@ static void write_origins_page(ioa_socket_handle s, const char *add_origin, cons
       str_buffer_append(sb, "<br><b>Origins:</b><br><br>\r\n");
       str_buffer_append(sb, "<table>\r\n");
       str_buffer_append(sb, "<tr><th>N</th><th>Value</th>");
-      if (!current_eff_realm()[0]) {
+      if (!current_eff_realm()[0])
+      {
         str_buffer_append(sb, "<th>Realm</th>");
       }
-      if (is_superuser()) {
+      if (is_superuser())
+      {
         str_buffer_append(sb, "<th> </th>");
       }
       str_buffer_append(sb, "</tr>\r\n");
@@ -2934,10 +3541,12 @@ static void write_origins_page(ioa_socket_handle s, const char *add_origin, cons
   }
 }
 
-static size_t https_print_oauth_keys(struct str_buffer *sb) {
+static size_t https_print_oauth_keys(struct str_buffer *sb)
+{
   size_t ret = 0;
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->list_oauth_keys) {
+  if (dbd && dbd->list_oauth_keys)
+  {
     secrets_list_t kids, teas, tss, lts, realms;
     init_secrets_list(&kids);
     init_secrets_list(&teas);
@@ -2948,7 +3557,8 @@ static size_t https_print_oauth_keys(struct str_buffer *sb) {
 
     size_t sz = get_secrets_list_size(&kids);
     size_t i;
-    for (i = 0; i < sz; ++i) {
+    for (i = 0; i < sz; ++i)
+    {
       str_buffer_append(sb, "<tr><td>");
       str_buffer_append_sz(sb, i + 1);
       str_buffer_append(sb, "</td>");
@@ -3001,14 +3611,21 @@ static size_t https_print_oauth_keys(struct str_buffer *sb) {
   return ret;
 }
 
-static void write_https_oauth_show_keys(ioa_socket_handle s, const char *kid) {
-  if (s && !ioa_socket_tobeclosed(s)) {
+static void write_https_oauth_show_keys(ioa_socket_handle s, const char *kid)
+{
+  if (s && !ioa_socket_tobeclosed(s))
+  {
 
-    if (!is_as_ok(s)) {
+    if (!is_as_ok(s))
+    {
       write_https_logon_page(s);
-    } else if (!is_superuser()) {
+    }
+    else if (!is_superuser())
+    {
       write_https_home_page(s);
-    } else {
+    }
+    else
+    {
 
       struct str_buffer *sb = str_buffer_new();
 
@@ -3018,13 +3635,18 @@ static void write_https_oauth_show_keys(ioa_socket_handle s, const char *kid) {
       str_buffer_append(sb, form_names[AS_FORM_OAUTH].name);
       str_buffer_append(sb, "\">back to oauth list</a><br><br>\r\n");
 
-      if (kid && kid[0]) {
+      if (kid && kid[0])
+      {
         const turn_dbdriver_t *dbd = get_dbdriver();
-        if (dbd && dbd->get_oauth_key) {
+        if (dbd && dbd->get_oauth_key)
+        {
           oauth_key_data_raw key;
-          if ((*dbd->get_oauth_key)((const uint8_t *)kid, &key) < 0) {
+          if ((*dbd->get_oauth_key)((const uint8_t *)kid, &key) < 0)
+          {
             str_buffer_append(sb, "data retrieval error");
-          } else {
+          }
+          else
+          {
 
             oauth_key_data okd;
             memset(&okd, 0, sizeof(okd));
@@ -3037,13 +3659,17 @@ static void write_https_oauth_show_keys(ioa_socket_handle s, const char *kid) {
             oauth_key okey;
             memset(&okey, 0, sizeof(okey));
 
-            if (!convert_oauth_key_data(&okd, &okey, err_msg, err_msg_size)) {
+            if (!convert_oauth_key_data(&okd, &okey, err_msg, err_msg_size))
+            {
               str_buffer_append(sb, err_msg);
-            } else {
+            }
+            else
+            {
 
               str_buffer_append(sb, "<table>\r\n");
 
-              if (key.ikm_key[0]) {
+              if (key.ikm_key[0])
+              {
                 str_buffer_append(sb, "<tr><td>Base64-encoded key:</td><td>");
                 str_buffer_append(sb, key.ikm_key);
                 str_buffer_append(sb, "</td></tr>\r\n");
@@ -3061,14 +3687,21 @@ static void write_https_oauth_show_keys(ioa_socket_handle s, const char *kid) {
 }
 
 static void write_https_oauth_page(ioa_socket_handle s, const char *add_kid, const char *add_ikm, const char *add_tea,
-                                   const char *add_ts, const char *add_lt, const char *add_realm, const char *msg) {
-  if (s && !ioa_socket_tobeclosed(s)) {
+                                   const char *add_ts, const char *add_lt, const char *add_realm, const char *msg)
+{
+  if (s && !ioa_socket_tobeclosed(s))
+  {
 
-    if (!is_as_ok(s)) {
+    if (!is_as_ok(s))
+    {
       write_https_logon_page(s);
-    } else if (!is_superuser()) {
+    }
+    else if (!is_superuser())
+    {
       write_https_home_page(s);
-    } else {
+    }
+    else
+    {
 
       struct str_buffer *sb = str_buffer_new();
 
@@ -3080,7 +3713,8 @@ static void write_https_oauth_page(ioa_socket_handle s, const char *add_kid, con
         str_buffer_append(sb, "\" method=\"POST\">\r\n");
         str_buffer_append(sb, "  <fieldset><legend>oAuth key:</legend>\r\n");
 
-        if (msg && msg[0]) {
+        if (msg && msg[0])
+        {
           str_buffer_append(sb, "<br><table id=\"msg\"><th>");
           str_buffer_append(sb, msg);
           str_buffer_append(sb, "</th></table><br>");
@@ -3089,7 +3723,8 @@ static void write_https_oauth_page(ioa_socket_handle s, const char *add_kid, con
         str_buffer_append(sb, "<table><tr><td>");
 
         {
-          if (!add_kid) {
+          if (!add_kid)
+          {
             add_kid = "";
           }
 
@@ -3103,7 +3738,8 @@ static void write_https_oauth_page(ioa_socket_handle s, const char *add_kid, con
         str_buffer_append(sb, "</td><td>");
 
         {
-          if (!add_ts) {
+          if (!add_ts)
+          {
             add_ts = "";
           }
 
@@ -3117,7 +3753,8 @@ static void write_https_oauth_page(ioa_socket_handle s, const char *add_kid, con
         str_buffer_append(sb, "</td><td>");
 
         {
-          if (!add_lt) {
+          if (!add_lt)
+          {
             add_lt = "";
           }
 
@@ -3133,7 +3770,8 @@ static void write_https_oauth_page(ioa_socket_handle s, const char *add_kid, con
         str_buffer_append(sb, "<tr><td colspan=\"1\">");
 
         {
-          if (!add_ikm) {
+          if (!add_ikm)
+          {
             add_ikm = "";
           }
 
@@ -3149,7 +3787,8 @@ static void write_https_oauth_page(ioa_socket_handle s, const char *add_kid, con
         str_buffer_append(sb, "</td><td>");
 
         {
-          if (!add_realm) {
+          if (!add_realm)
+          {
             add_realm = "";
           }
 
@@ -3165,14 +3804,16 @@ static void write_https_oauth_page(ioa_socket_handle s, const char *add_kid, con
         {
           str_buffer_append(sb, "<br>Token encryption algorithm (required):<br>\r\n");
 
-          if (!add_tea || !add_tea[0]) {
+          if (!add_tea || !add_tea[0])
+          {
             add_tea = "A256GCM";
           }
 
           str_buffer_append(sb, "<input type=\"radio\" name=\"");
           str_buffer_append(sb, HR_ADD_OAUTH_TEA);
           str_buffer_append(sb, "\" value=\"A128GCM\" ");
-          if (!strcmp("A128GCM", add_tea)) {
+          if (!strcmp("A128GCM", add_tea))
+          {
             str_buffer_append(sb, " checked ");
           }
           str_buffer_append(sb, ">A128GCM\r\n<br>\r\n");
@@ -3180,7 +3821,8 @@ static void write_https_oauth_page(ioa_socket_handle s, const char *add_kid, con
           str_buffer_append(sb, "<input type=\"radio\" name=\"");
           str_buffer_append(sb, HR_ADD_OAUTH_TEA);
           str_buffer_append(sb, "\" value=\"A256GCM\" ");
-          if (!strcmp("A256GCM", add_tea)) {
+          if (!strcmp("A256GCM", add_tea))
+          {
             str_buffer_append(sb, " checked ");
           }
           str_buffer_append(sb, ">A256GCM\r\n<br>\r\n");
@@ -3217,41 +3859,54 @@ static void write_https_oauth_page(ioa_socket_handle s, const char *add_kid, con
   }
 }
 
-static void handle_toggle_request(ioa_socket_handle s, struct http_request *hr) {
-  if (s && hr) {
+static void handle_toggle_request(ioa_socket_handle s, struct http_request *hr)
+{
+  if (s && hr)
+  {
     const char *param = get_http_header_value(hr, HR_UPDATE_PARAMETER, NULL);
     toggle_param(param);
   }
 }
 
-static void handle_update_request(ioa_socket_handle s, struct http_request *hr) {
-  if (s && hr) {
+static void handle_update_request(ioa_socket_handle s, struct http_request *hr)
+{
+  if (s && hr)
+  {
     {
       const char *param = get_http_header_value(hr, HR_UPDATE_PARAMETER, NULL);
-      if (param) {
+      if (param)
+      {
         update_param(param, get_http_header_value(hr, param, ""));
       }
     }
 
     {
       const char *eip = get_http_header_value(hr, HR_DELETE_IP, NULL);
-      if (eip && eip[0]) {
+      if (eip && eip[0])
+      {
         char *ip = evhttp_decode_uri(eip);
         const char *r = get_http_header_value(hr, HR_DELETE_IP_REALM, "");
         const char *kind = get_http_header_value(hr, HR_DELETE_IP_KIND, "");
 
         const turn_dbdriver_t *dbd = get_dbdriver();
-        if (dbd && dbd->set_permission_ip) {
+        if (dbd && dbd->set_permission_ip)
+        {
 
-          if (!r || !r[0]) {
+          if (!r || !r[0])
+          {
             r = current_realm();
           }
 
-          if (current_realm()[0] && strcmp(current_realm(), r)) {
+          if (current_realm()[0] && strcmp(current_realm(), r))
+          {
             // forbidden
-          } else if (strcmp(kind, "allowed") != 0 && strcmp(kind, "denied") != 0) {
+          }
+          else if (strcmp(kind, "allowed") != 0 && strcmp(kind, "denied") != 0)
+          {
             // forbidden
-          } else {
+          }
+          else
+          {
 
             uint8_t realm[STUN_MAX_REALM_SIZE + 1] = "\0";
             STRCPY(realm, r);
@@ -3265,28 +3920,39 @@ static void handle_update_request(ioa_socket_handle s, struct http_request *hr) 
 
     {
       const char *eip = get_http_header_value(hr, HR_ADD_IP, NULL);
-      if (eip && eip[0]) {
+      if (eip && eip[0])
+      {
         char *ip = evhttp_decode_uri(eip);
 
-        if (check_ip_list_range(ip) < 0) {
+        if (check_ip_list_range(ip) < 0)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong address range format: %s\n", ip);
-        } else {
+        }
+        else
+        {
 
           const char *r = get_http_header_value(hr, HR_ADD_IP_REALM, "");
           const char *kind = get_http_header_value(hr, HR_ADD_IP_KIND, "");
 
           const turn_dbdriver_t *dbd = get_dbdriver();
-          if (dbd && dbd->set_permission_ip) {
+          if (dbd && dbd->set_permission_ip)
+          {
 
-            if (!r || !r[0]) {
+            if (!r || !r[0])
+            {
               r = current_realm();
             }
 
-            if (current_realm()[0] && strcmp(current_realm(), r)) {
+            if (current_realm()[0] && strcmp(current_realm(), r))
+            {
               // forbidden
-            } else if (strcmp(kind, "allowed") != 0 && strcmp(kind, "denied") != 0) {
+            }
+            else if (strcmp(kind, "allowed") != 0 && strcmp(kind, "denied") != 0)
+            {
               // forbidden
-            } else {
+            }
+            else
+            {
 
               uint8_t realm[STUN_MAX_REALM_SIZE + 1] = "\0";
               STRCPY(realm, r);
@@ -3301,28 +3967,36 @@ static void handle_update_request(ioa_socket_handle s, struct http_request *hr) 
   }
 }
 
-static void handle_logon_request(ioa_socket_handle s, struct http_request *hr) {
-  if (s && hr) {
+static void handle_logon_request(ioa_socket_handle s, struct http_request *hr)
+{
+  if (s && hr)
+  {
     const char *uname = get_http_header_value(hr, HR_USERNAME, NULL);
     const char *pwd = get_http_header_value(hr, HR_PASSWORD, NULL);
 
     struct admin_session *as = (struct admin_session *)s->special_session;
-    if (!as) {
+    if (!as)
+    {
       as = (struct admin_session *)calloc(sizeof(struct admin_session), 1);
-      if (!as) {
+      if (!as)
+      {
         return;
       }
       s->special_session = as;
       s->special_session_size = sizeof(struct admin_session);
     }
 
-    if (!(as->as_ok) && uname && is_secure_string((const uint8_t *)uname, 1) && pwd) {
+    if (!(as->as_ok) && uname && is_secure_string((const uint8_t *)uname, 1) && pwd)
+    {
       const turn_dbdriver_t *dbd = get_dbdriver();
-      if (dbd && dbd->get_admin_user) {
+      if (dbd && dbd->get_admin_user)
+      {
         password_t password;
         char realm[STUN_MAX_REALM_SIZE + 1] = "\0";
-        if ((*(dbd->get_admin_user))((const uint8_t *)uname, (uint8_t *)realm, password) >= 0) {
-          if (!check_password_equal(pwd, (char *)password)) {
+        if ((*(dbd->get_admin_user))((const uint8_t *)uname, (uint8_t *)realm, password) >= 0)
+        {
+          if (!check_password_equal(pwd, (char *)password))
+          {
             STRCPY(as->as_login, uname);
             STRCPY(as->as_realm, realm);
             as->as_eff_realm[0] = 0;
@@ -3335,11 +4009,14 @@ static void handle_logon_request(ioa_socket_handle s, struct http_request *hr) {
   }
 }
 
-static void handle_logout_request(ioa_socket_handle s, struct http_request *hr) {
+static void handle_logout_request(ioa_socket_handle s, struct http_request *hr)
+{
   UNUSED_ARG(hr);
-  if (s) {
+  if (s)
+  {
     struct admin_session *as = (struct admin_session *)s->special_session;
-    if (as) {
+    if (as)
+    {
       as->as_login[0] = 0;
       as->as_ok = 0;
       as->as_realm[0] = 0;
@@ -3348,52 +4025,73 @@ static void handle_logout_request(ioa_socket_handle s, struct http_request *hr) 
   }
 }
 
-static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
+static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh)
+{
   current_socket = s;
 
-  if (turn_params.verbose) {
-    if (nbh) {
+  if (turn_params.verbose)
+  {
+    if (nbh)
+    {
       ((char *)ioa_network_buffer_data(nbh))[ioa_network_buffer_get_size(nbh)] = 0;
-      if (!strstr((char *)ioa_network_buffer_data(nbh), "pwd")) {
+      if (!strstr((char *)ioa_network_buffer_data(nbh), "pwd"))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: HTTPS connection input: %s\n", __FUNCTION__,
                       (char *)ioa_network_buffer_data(nbh));
       }
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: HTTPS connection initial input\n", __FUNCTION__);
     }
   }
 
-  if (!nbh) {
+  if (!nbh)
+  {
     write_https_logon_page(s);
-  } else {
+  }
+  else
+  {
     ((char *)ioa_network_buffer_data(nbh))[ioa_network_buffer_get_size(nbh)] = 0;
     struct http_request *hr = parse_http_request((char *)ioa_network_buffer_data(nbh));
-    if (!hr) {
+    if (!hr)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: wrong HTTPS request (I cannot parse it)\n", __FUNCTION__);
       write_https_logon_page(s);
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: HTTPS request, path %s\n", __FUNCTION__, hr->path);
 
       AS_FORM form = get_form(hr->path);
 
-      switch (form) {
-      case AS_FORM_PC: {
-        if (is_as_ok(s)) {
+      switch (form)
+      {
+      case AS_FORM_PC:
+      {
+        if (is_as_ok(s))
+        {
           const char *realm0 = get_http_header_value(hr, HR_REALM, current_realm());
-          if (!is_superuser()) {
+          if (!is_superuser())
+          {
             realm0 = current_realm();
           }
           strncpy(current_eff_realm(), realm0, STUN_MAX_REALM_SIZE);
           write_pc_page(s);
-        } else {
+        }
+        else
+        {
           write_https_logon_page(s);
         }
         break;
       }
-      case AS_FORM_PS: {
-        if (is_as_ok(s)) {
+      case AS_FORM_PS:
+      {
+        if (is_as_ok(s))
+        {
           const char *realm0 = get_http_header_value(hr, HR_REALM, current_realm());
-          if (!is_superuser()) {
+          if (!is_superuser())
+          {
             realm0 = current_realm();
           }
           strncpy(current_eff_realm(), realm0, STUN_MAX_REALM_SIZE);
@@ -3404,36 +4102,45 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
 
           turnsession_id csid = 0;
           const char *ssid = get_http_header_value(hr, HR_CANCEL_SESSION, NULL);
-          if (ssid) {
+          if (ssid)
+          {
             https_cancel_session(ssid);
             csid = (turnsession_id)strtoull(ssid, NULL, 10);
           }
 
           size_t max_sessions = current_max_output_sessions();
           const char *s_max_sessions = get_http_header_value(hr, HR_MAX_SESSIONS, NULL);
-          if (s_max_sessions) {
+          if (s_max_sessions)
+          {
             max_sessions = strtoul(s_max_sessions, NULL, 10);
-            if (!max_sessions) {
+            if (!max_sessions)
+            {
               max_sessions = current_max_output_sessions();
             }
             set_current_max_output_sessions(max_sessions);
           }
 
-          if (!max_sessions) {
+          if (!max_sessions)
+          {
             max_sessions = DEFAULT_CLI_MAX_OUTPUT_SESSIONS;
           }
 
           write_ps_page(s, client_protocol, user_pattern, max_sessions, csid);
-        } else {
+        }
+        else
+        {
           write_https_logon_page(s);
         }
         break;
       }
-      case AS_FORM_USERS: {
-        if (is_as_ok(s)) {
+      case AS_FORM_USERS:
+      {
+        if (is_as_ok(s))
+        {
           {
             const char *realm0 = get_http_header_value(hr, HR_REALM, current_realm());
-            if (!is_superuser()) {
+            if (!is_superuser())
+            {
               realm0 = current_realm();
             }
             strncpy(current_eff_realm(), realm0, STUN_MAX_REALM_SIZE);
@@ -3441,14 +4148,18 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
 
           {
             const uint8_t *user = (const uint8_t *)get_http_header_value(hr, HR_DELETE_USER, NULL);
-            if (user && user[0]) {
+            if (user && user[0])
+            {
               const uint8_t *realm = (const uint8_t *)get_http_header_value(hr, HR_DELETE_REALM, "");
-              if (!is_superuser()) {
+              if (!is_superuser())
+              {
                 realm = (const uint8_t *)current_realm();
               }
-              if (realm && realm[0]) {
+              if (realm && realm[0])
+              {
                 const turn_dbdriver_t *dbd = get_dbdriver();
-                if (dbd && dbd->del_user) {
+                if (dbd && dbd->del_user)
+                {
                   uint8_t u[STUN_MAX_USERNAME_SIZE + 1];
                   uint8_t r[STUN_MAX_REALM_SIZE + 1];
                   STRCPY(u, user);
@@ -3462,32 +4173,41 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
           const uint8_t *add_realm = (const uint8_t *)current_eff_realm();
           const uint8_t *add_user = (const uint8_t *)get_http_header_value(hr, HR_ADD_USER, "");
           const char *msg = "";
-          if (wrong_html_name((const char *)add_user)) {
+          if (wrong_html_name((const char *)add_user))
+          {
             msg = "Error: wrong user name";
             add_user = (const uint8_t *)"";
           }
-          if (add_user[0]) {
+          if (add_user[0])
+          {
             add_realm = (const uint8_t *)get_http_header_value(hr, HR_ADD_REALM, current_realm());
-            if (!is_superuser()) {
+            if (!is_superuser())
+            {
               add_realm = (const uint8_t *)current_realm();
             }
-            if (!add_realm[0]) {
+            if (!add_realm[0])
+            {
               add_realm = (const uint8_t *)current_eff_realm();
             }
-            if (!add_realm[0]) {
+            if (!add_realm[0])
+            {
               add_realm = (const uint8_t *)get_realm(NULL)->options.name;
             }
-            if (wrong_html_name((const char *)add_realm)) {
+            if (wrong_html_name((const char *)add_realm))
+            {
               msg = "Error: wrong realm name";
               add_realm = (const uint8_t *)"";
             }
-            if (add_realm[0]) {
+            if (add_realm[0])
+            {
               const uint8_t *pwd = (const uint8_t *)get_http_header_value(hr, HR_PASSWORD, NULL);
               const uint8_t *pwd1 = (const uint8_t *)get_http_header_value(hr, HR_PASSWORD1, NULL);
-              if (pwd && pwd1 && pwd[0] && pwd1[0] && !strcmp((const char *)pwd, (const char *)pwd1)) {
+              if (pwd && pwd1 && pwd[0] && pwd1[0] && !strcmp((const char *)pwd, (const char *)pwd1))
+              {
 
                 const turn_dbdriver_t *dbd = get_dbdriver();
-                if (dbd && dbd->set_user_key) {
+                if (dbd && dbd->set_user_key)
+                {
 
                   hmackey_t key;
                   char skey[sizeof(hmackey_t) * 2 + 1];
@@ -3504,7 +4224,8 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
                     size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
                     int maxsz = (int)(sz * 2) + 1;
                     char *s = skey;
-                    for (i = 0; (i < sz) && (maxsz > 2); i++) {
+                    for (i = 0; (i < sz) && (maxsz > 2); i++)
+                    {
                       snprintf(s, (size_t)(sz * 2), "%02x", (unsigned int)key[i]);
                       maxsz -= 2;
                       s += 2;
@@ -3517,24 +4238,30 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
                   add_realm = (const uint8_t *)"";
                   add_user = (const uint8_t *)"";
                 }
-              } else {
+              }
+              else
+              {
                 msg = "Error: wrong password";
               }
             }
           }
 
           write_users_page(s, add_user, add_realm, msg);
-
-        } else {
+        }
+        else
+        {
           write_https_logon_page(s);
         }
         break;
       }
-      case AS_FORM_SS: {
-        if (is_as_ok(s)) {
+      case AS_FORM_SS:
+      {
+        if (is_as_ok(s))
+        {
           {
             const char *realm0 = get_http_header_value(hr, HR_REALM, current_realm());
-            if (!is_superuser()) {
+            if (!is_superuser())
+            {
               realm0 = current_realm();
             }
             strncpy(current_eff_realm(), realm0, STUN_MAX_REALM_SIZE);
@@ -3542,14 +4269,18 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
 
           {
             const uint8_t *secret = (const uint8_t *)get_http_header_value(hr, HR_DELETE_SECRET, NULL);
-            if (secret && secret[0]) {
+            if (secret && secret[0])
+            {
               const uint8_t *realm = (const uint8_t *)get_http_header_value(hr, HR_DELETE_REALM, NULL);
-              if (!is_superuser()) {
+              if (!is_superuser())
+              {
                 realm = (const uint8_t *)current_realm();
               }
-              if (realm && realm[0]) {
+              if (realm && realm[0])
+              {
                 const turn_dbdriver_t *dbd = get_dbdriver();
-                if (dbd && dbd->del_secret) {
+                if (dbd && dbd->del_secret)
+                {
                   uint8_t ss[AUTH_SECRET_SIZE + 1];
                   uint8_t r[STUN_MAX_REALM_SIZE + 1];
                   STRCPY(ss, secret);
@@ -3563,28 +4294,36 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
           const uint8_t *add_realm = (const uint8_t *)current_eff_realm();
           const uint8_t *add_secret = (const uint8_t *)get_http_header_value(hr, HR_ADD_SECRET, "");
           const char *msg = "";
-          if (wrong_html_name((const char *)add_secret)) {
+          if (wrong_html_name((const char *)add_secret))
+          {
             msg = "Error: wrong secret value";
             add_secret = (const uint8_t *)"";
           }
-          if (add_secret[0]) {
+          if (add_secret[0])
+          {
             add_realm = (const uint8_t *)get_http_header_value(hr, HR_ADD_REALM, current_realm());
-            if (!is_superuser()) {
+            if (!is_superuser())
+            {
               add_realm = (const uint8_t *)current_realm();
             }
-            if (!add_realm[0]) {
+            if (!add_realm[0])
+            {
               add_realm = (const uint8_t *)current_eff_realm();
             }
-            if (!add_realm[0]) {
+            if (!add_realm[0])
+            {
               add_realm = (const uint8_t *)get_realm(NULL)->options.name;
             }
-            if (wrong_html_name((const char *)add_realm)) {
+            if (wrong_html_name((const char *)add_realm))
+            {
               msg = "Error: wrong realm name";
               add_realm = (const uint8_t *)"";
             }
-            if (add_realm[0]) {
+            if (add_realm[0])
+            {
               const turn_dbdriver_t *dbd = get_dbdriver();
-              if (dbd && dbd->set_secret) {
+              if (dbd && dbd->set_secret)
+              {
                 uint8_t ss[AUTH_SECRET_SIZE + 1];
                 uint8_t r[STUN_MAX_REALM_SIZE + 1];
                 STRCPY(ss, add_secret);
@@ -3598,27 +4337,34 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
           }
 
           write_shared_secrets_page(s, (const char *)add_secret, (const char *)add_realm, msg);
-
-        } else {
+        }
+        else
+        {
           write_https_logon_page(s);
         }
         break;
       }
-      case AS_FORM_OS: {
-        if (is_as_ok(s)) {
+      case AS_FORM_OS:
+      {
+        if (is_as_ok(s))
+        {
           {
             const char *realm0 = get_http_header_value(hr, HR_REALM, current_realm());
-            if (!is_superuser()) {
+            if (!is_superuser())
+            {
               realm0 = current_realm();
             }
             strncpy(current_eff_realm(), realm0, STUN_MAX_REALM_SIZE);
           }
 
-          if (is_superuser()) {
+          if (is_superuser())
+          {
             const uint8_t *origin = (const uint8_t *)get_http_header_value(hr, HR_DELETE_ORIGIN, NULL);
-            if (origin && origin[0]) {
+            if (origin && origin[0])
+            {
               const turn_dbdriver_t *dbd = get_dbdriver();
-              if (dbd && dbd->del_origin) {
+              if (dbd && dbd->del_origin)
+              {
                 uint8_t o[STUN_MAX_ORIGIN_SIZE + 1];
                 STRCPY(o, origin);
                 dbd->del_origin(o);
@@ -3634,20 +4380,26 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
           const char *msg = "";
           uint8_t corigin[STUN_MAX_ORIGIN_SIZE + 1] = "\0";
           get_canonic_origin((const char *)add_origin, (char *)corigin, sizeof(corigin) - 1);
-          if (corigin[0]) {
+          if (corigin[0])
+          {
             add_realm = (const uint8_t *)get_http_header_value(hr, HR_ADD_REALM, current_realm());
-            if (!is_superuser()) {
+            if (!is_superuser())
+            {
               add_realm = (const uint8_t *)current_realm();
             }
-            if (!add_realm[0]) {
+            if (!add_realm[0])
+            {
               add_realm = (const uint8_t *)current_eff_realm();
             }
-            if (!add_realm[0]) {
+            if (!add_realm[0])
+            {
               add_realm = (const uint8_t *)get_realm(NULL)->options.name;
             }
-            if (add_realm[0]) {
+            if (add_realm[0])
+            {
               const turn_dbdriver_t *dbd = get_dbdriver();
-              if (dbd && dbd->add_origin) {
+              if (dbd && dbd->add_origin)
+              {
                 uint8_t o[STUN_MAX_ORIGIN_SIZE + 1];
                 uint8_t r[STUN_MAX_REALM_SIZE + 1];
                 STRCPY(o, corigin);
@@ -3661,35 +4413,50 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
           }
 
           write_origins_page(s, (const char *)add_origin, (const char *)add_realm, msg);
-
-        } else {
+        }
+        else
+        {
           write_https_logon_page(s);
         }
         break;
       }
-      case AS_FORM_OAUTH_SHOW_KEYS: {
-        if (!is_as_ok(s)) {
+      case AS_FORM_OAUTH_SHOW_KEYS:
+      {
+        if (!is_as_ok(s))
+        {
           write_https_logon_page(s);
-        } else if (!is_superuser()) {
+        }
+        else if (!is_superuser())
+        {
           write_https_home_page(s);
-        } else {
+        }
+        else
+        {
           const char *kid = get_http_header_value(hr, HR_OAUTH_KID, "");
           write_https_oauth_show_keys(s, kid);
         }
         break;
       }
-      case AS_FORM_OAUTH: {
-        if (!is_as_ok(s)) {
+      case AS_FORM_OAUTH:
+      {
+        if (!is_as_ok(s))
+        {
           write_https_logon_page(s);
-        } else if (!is_superuser()) {
+        }
+        else if (!is_superuser())
+        {
           write_https_home_page(s);
-        } else {
+        }
+        else
+        {
 
           {
             const char *del_kid = get_http_header_value(hr, HR_DELETE_OAUTH_KID, "");
-            if (del_kid[0]) {
+            if (del_kid[0])
+            {
               const turn_dbdriver_t *dbd = get_dbdriver();
-              if (dbd && dbd->del_oauth_key) {
+              if (dbd && dbd->del_oauth_key)
+              {
                 (*dbd->del_oauth_key)((const uint8_t *)del_kid);
               }
             }
@@ -3704,7 +4471,8 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
           const char *msg = "";
 
           add_kid = get_http_header_value(hr, HR_ADD_OAUTH_KID, "");
-          if (add_kid[0]) {
+          if (add_kid[0])
+          {
             add_ikm = get_http_header_value(hr, HR_ADD_OAUTH_IKM, "");
             add_ts = get_http_header_value(hr, HR_ADD_OAUTH_TS, "");
             add_lt = get_http_header_value(hr, HR_ADD_OAUTH_LT, "");
@@ -3712,28 +4480,38 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
             add_realm = get_http_header_value(hr, HR_ADD_OAUTH_REALM, "");
 
             int keys_ok = (add_ikm[0] != 0);
-            if (!keys_ok) {
+            if (!keys_ok)
+            {
               msg = "You must enter the key value.";
-            } else {
+            }
+            else
+            {
               oauth_key_data_raw key;
               memset(&key, 0, sizeof(key));
               STRCPY(key.kid, add_kid);
 
-              if (add_lt && add_lt[0]) {
+              if (add_lt && add_lt[0])
+              {
                 key.lifetime = (uint32_t)strtoul(add_lt, NULL, 10);
-                if (key.lifetime) {
-                  if (add_ts && add_ts[0]) {
+                if (key.lifetime)
+                {
+                  if (add_ts && add_ts[0])
+                  {
                     key.timestamp = (uint64_t)strtoull(add_ts, NULL, 10);
                   }
-                  if (!key.timestamp) {
+                  if (!key.timestamp)
+                  {
                     key.timestamp = (uint64_t)time(NULL);
                   }
                 }
-              } else if (add_ts && add_ts[0]) {
+              }
+              else if (add_ts && add_ts[0])
+              {
                 key.timestamp = (uint64_t)strtoull(add_ts, NULL, 10);
               }
 
-              if (add_realm && add_realm[0]) {
+              if (add_realm && add_realm[0])
+              {
                 STRCPY(key.realm, add_realm);
               }
 
@@ -3741,10 +4519,14 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
               STRCPY(key.as_rs_alg, add_tea);
 
               const turn_dbdriver_t *dbd = get_dbdriver();
-              if (dbd && dbd->set_oauth_key) {
-                if ((*dbd->set_oauth_key)(&key) < 0) {
+              if (dbd && dbd->set_oauth_key)
+              {
+                if ((*dbd->set_oauth_key)(&key) < 0)
+                {
                   msg = "Cannot insert oAuth key into the database";
-                } else {
+                }
+                else
+                {
                   add_kid = "";
                   add_ts = "0";
                   add_lt = "0";
@@ -3761,30 +4543,42 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
         break;
       }
       case AS_FORM_TOGGLE:
-        if (is_as_ok(s)) {
+        if (is_as_ok(s))
+        {
           handle_toggle_request(s, hr);
           write_pc_page(s);
-        } else {
+        }
+        else
+        {
           write_https_logon_page(s);
         }
         break;
       case AS_FORM_UPDATE:
-        if (is_as_ok(s)) {
+        if (is_as_ok(s))
+        {
           handle_update_request(s, hr);
           write_pc_page(s);
-        } else {
+        }
+        else
+        {
           write_https_logon_page(s);
         }
         break;
       case AS_FORM_LOGON:
-        if (!is_as_ok(s)) {
+        if (!is_as_ok(s))
+        {
           handle_logon_request(s, hr);
-          if (is_as_ok(s)) {
+          if (is_as_ok(s))
+          {
             write_https_home_page(s);
-          } else {
+          }
+          else
+          {
             write_https_logon_page(s);
           }
-        } else {
+        }
+        else
+        {
           write_https_home_page(s);
         }
         break;
@@ -3792,9 +4586,11 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
         handle_logout_request(s, hr);
         write_https_logon_page(s);
         break;
-      default: {
+      default:
+      {
         const char *realm0 = get_http_header_value(hr, HR_REALM, current_realm());
-        if (!is_superuser()) {
+        if (!is_superuser())
+        {
           realm0 = current_realm();
         }
         strncpy(current_eff_realm(), realm0, STUN_MAX_REALM_SIZE);
@@ -3808,7 +4604,8 @@ static void handle_https(ioa_socket_handle s, ioa_network_buffer_handle nbh) {
   current_socket = NULL;
 }
 
-static void https_input_handler(ioa_socket_handle s, int event_type, ioa_net_data *data, void *arg, int can_resume) {
+static void https_input_handler(ioa_socket_handle s, int event_type, ioa_net_data *data, void *arg, int can_resume)
+{
 
   UNUSED_ARG(arg);
   UNUSED_ARG(s);
@@ -3821,15 +4618,18 @@ static void https_input_handler(ioa_socket_handle s, int event_type, ioa_net_dat
   data->nbh = NULL;
 }
 
-void https_admin_server_receive_message(struct bufferevent *bev, void *ptr) {
+void https_admin_server_receive_message(struct bufferevent *bev, void *ptr)
+{
   UNUSED_ARG(ptr);
 
   ioa_socket_handle s = NULL;
   int n = 0;
   struct evbuffer *input = bufferevent_get_input(bev);
 
-  while ((n = evbuffer_remove(input, &s, sizeof(s))) > 0) {
-    if (n != sizeof(s)) {
+  while ((n = evbuffer_remove(input, &s, sizeof(s))) > 0)
+  {
+    if (n != sizeof(s))
+    {
       fprintf(stderr, "%s: Weird HTTPS CLI buffer error: size=%d\n", __FUNCTION__, n);
       continue;
     }
@@ -3840,9 +4640,11 @@ void https_admin_server_receive_message(struct bufferevent *bev, void *ptr) {
   }
 }
 
-void send_https_socket(ioa_socket_handle s) {
+void send_https_socket(ioa_socket_handle s)
+{
   struct evbuffer *output = bufferevent_get_output(adminserver.https_out_buf);
-  if (output) {
+  if (output)
+  {
     evbuffer_add(output, &s, sizeof(s));
   }
 }

--- a/src/apps/relay/turn_admin_server.h
+++ b/src/apps/relay/turn_admin_server.h
@@ -46,14 +46,16 @@
 #include "apputils.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ////////////////////////////////////////////
 
 #define ADMIN_USER_MAX_LENGTH (32)
 
-struct admin_session {
+struct admin_session
+{
   int as_ok;
   char as_login[ADMIN_USER_MAX_LENGTH + 1];
   char as_realm[STUN_MAX_REALM_SIZE + 1];
@@ -61,7 +63,8 @@ struct admin_session {
   size_t number_of_user_sessions;
 };
 
-struct admin_server {
+struct admin_server
+{
   evutil_socket_t listen_fd;
   struct event_base *event_base;
   ioa_engine_handle e;

--- a/src/apps/relay/turn_ports.c
+++ b/src/apps/relay/turn_ports.c
@@ -44,7 +44,8 @@
 #define TPS_TAKEN_EVEN ((uint32_t)(-3))
 #define TPS_TAKEN_ODD ((uint32_t)(-4))
 
-struct _turnports {
+struct _turnports
+{
   uint32_t status[PORTS_SIZE];
   uint32_t low;
   uint32_t high;
@@ -70,9 +71,11 @@ static int turnports_is_available(turnports *tp, uint16_t port);
 
 /////////////// UTILS //////////////////////////////////////
 
-static int is_taken(uint32_t status) {
+static int is_taken(uint32_t status)
+{
   int ret = -1;
-  switch (status) {
+  switch (status)
+  {
   case TPS_TAKEN_SINGLE:
   case TPS_TAKEN_EVEN:
   case TPS_TAKEN_ODD:
@@ -84,15 +87,19 @@ static int is_taken(uint32_t status) {
   return ret;
 }
 
-static void turnports_randomize(turnports *tp) {
-  if (tp) {
+static void turnports_randomize(turnports *tp)
+{
+  if (tp)
+  {
     unsigned int size = (unsigned int)(tp->high - tp->low);
     unsigned int i = 0;
     unsigned int cycles = size * 10;
-    for (i = 0; i < cycles; i++) {
+    for (i = 0; i < cycles; i++)
+    {
       uint16_t port1 = (uint16_t)(tp->low + (uint16_t)(((unsigned long)turn_random()) % ((unsigned long)size)));
       uint16_t port2 = (uint16_t)(tp->low + (uint16_t)(((unsigned long)turn_random()) % ((unsigned long)size)));
-      if (port1 != port2) {
+      if (port1 != port2)
+      {
         int pos1 = tp->status[port1];
         int pos2 = tp->status[port2];
         int tmp = (int)tp->status[port1];
@@ -106,7 +113,8 @@ static void turnports_randomize(turnports *tp) {
   }
 }
 
-static void turnports_init(turnports *tp, uint16_t start, uint16_t end) {
+static void turnports_init(turnports *tp, uint16_t start, uint16_t end)
+{
 
   tp->low = start;
   tp->high = ((uint32_t)end) + 1;
@@ -115,15 +123,18 @@ static void turnports_init(turnports *tp, uint16_t start, uint16_t end) {
   tp->range_stop = end;
 
   int i = 0;
-  for (i = 0; i < start; i++) {
+  for (i = 0; i < start; i++)
+  {
     tp->status[i] = TPS_OUT_OF_RANGE;
     tp->ports[i] = (uint16_t)i;
   }
-  for (i = start; i <= end; i++) {
+  for (i = start; i <= end; i++)
+  {
     tp->status[i] = (uint32_t)i;
     tp->ports[i] = (uint16_t)i;
   }
-  for (i = ((int)end) + 1; i < PORTS_SIZE; i++) {
+  for (i = ((int)end) + 1; i < PORTS_SIZE; i++)
+  {
     tp->status[i] = TPS_OUT_OF_RANGE;
     tp->ports[i] = (uint16_t)i;
   }
@@ -135,9 +146,11 @@ static void turnports_init(turnports *tp, uint16_t start, uint16_t end) {
 
 /////////////// FUNC ///////////////////////////////////////
 
-turnports *turnports_create(super_memory_t *sm, uint16_t start, uint16_t end) {
+turnports *turnports_create(super_memory_t *sm, uint16_t start, uint16_t end)
+{
 
-  if (start > end) {
+  if (start > end)
+  {
     return NULL;
   }
 
@@ -147,10 +160,14 @@ turnports *turnports_create(super_memory_t *sm, uint16_t start, uint16_t end) {
   return ret;
 }
 
-uint16_t turnports_size(turnports *tp) {
-  if (!tp) {
+uint16_t turnports_size(turnports *tp)
+{
+  if (!tp)
+  {
     return 0;
-  } else {
+  }
+  else
+  {
     TURN_MUTEX_LOCK(&tp->mutex);
     uint16_t ret = (uint16_t)((tp->high - tp->low));
     TURN_MUTEX_UNLOCK(&tp->mutex);
@@ -158,17 +175,21 @@ uint16_t turnports_size(turnports *tp) {
   }
 }
 
-int turnports_allocate(turnports *tp) {
+int turnports_allocate(turnports *tp)
+{
 
   int port = -1;
 
   TURN_MUTEX_LOCK(&tp->mutex);
 
-  if (tp) {
+  if (tp)
+  {
 
-    while (1) {
+    while (1)
+    {
 
-      if (tp->high <= tp->low) {
+      if (tp->high <= tp->low)
+      {
         TURN_MUTEX_UNLOCK(&tp->mutex);
         return -1;
       }
@@ -176,15 +197,18 @@ int turnports_allocate(turnports *tp) {
       int position = (uint16_t)(tp->low & 0x0000FFFF);
 
       port = (int)tp->ports[position];
-      if (port < (int)(tp->range_start) || port > ((int)(tp->range_stop))) {
+      if (port < (int)(tp->range_start) || port > ((int)(tp->range_stop)))
+      {
         TURN_MUTEX_UNLOCK(&tp->mutex);
         return -1;
       }
-      if (is_taken(tp->status[port])) {
+      if (is_taken(tp->status[port]))
+      {
         ++(tp->low);
         continue;
       }
-      if (tp->status[port] != tp->low) {
+      if (tp->status[port] != tp->low)
+      {
         ++(tp->low);
         continue;
       }
@@ -199,11 +223,14 @@ int turnports_allocate(turnports *tp) {
   return port;
 }
 
-void turnports_release(turnports *tp, uint16_t port) {
+void turnports_release(turnports *tp, uint16_t port)
+{
   TURN_MUTEX_LOCK(&tp->mutex);
-  if (tp && port >= tp->range_start && port <= tp->range_stop) {
+  if (tp && port >= tp->range_start && port <= tp->range_stop)
+  {
     uint16_t position = (uint16_t)(tp->high & 0x0000FFFF);
-    if (is_taken(tp->status[port])) {
+    if (is_taken(tp->status[port]))
+    {
       tp->status[port] = tp->high;
       tp->ports[position] = port;
       ++(tp->high);
@@ -212,30 +239,46 @@ void turnports_release(turnports *tp, uint16_t port) {
   TURN_MUTEX_UNLOCK(&tp->mutex);
 }
 
-int turnports_allocate_even(turnports *tp, int allocate_rtcp, uint64_t *reservation_token) {
-  if (tp) {
+int turnports_allocate_even(turnports *tp, int allocate_rtcp, uint64_t *reservation_token)
+{
+  if (tp)
+  {
     TURN_MUTEX_LOCK(&tp->mutex);
     uint16_t size = turnports_size(tp);
-    if (size > 1) {
+    if (size > 1)
+    {
       uint16_t i = 0;
-      for (i = 0; i < size; i++) {
+      for (i = 0; i < size; i++)
+      {
         int port = turnports_allocate(tp);
-        if (port & 0x00000001) {
+        if (port & 0x00000001)
+        {
           turnports_release(tp, port);
-        } else {
-          if (!allocate_rtcp) {
+        }
+        else
+        {
+          if (!allocate_rtcp)
+          {
             TURN_MUTEX_UNLOCK(&tp->mutex);
             return port;
-          } else {
+          }
+          else
+          {
             int rtcp_port = port + 1;
-            if (rtcp_port > tp->range_stop) {
+            if (rtcp_port > tp->range_stop)
+            {
               turnports_release(tp, port);
-            } else if (!turnports_is_available(tp, rtcp_port)) {
+            }
+            else if (!turnports_is_available(tp, rtcp_port))
+            {
               turnports_release(tp, port);
-            } else {
+            }
+            else
+            {
               tp->status[port] = TPS_TAKEN_EVEN;
               tp->status[rtcp_port] = TPS_TAKEN_ODD;
-              if (reservation_token) {
+              if (reservation_token)
+              {
                 uint16_t *v16 = (uint16_t *)reservation_token;
                 uint32_t *v32 = (uint32_t *)reservation_token;
                 v16[0] = (uint16_t)(tp->ports[(uint16_t)(tp->low & 0x0000FFFF)]);
@@ -254,10 +297,14 @@ int turnports_allocate_even(turnports *tp, int allocate_rtcp, uint64_t *reservat
   return -1;
 }
 
-int turnports_is_allocated(turnports *tp, uint16_t port) {
-  if (!tp) {
+int turnports_is_allocated(turnports *tp, uint16_t port)
+{
+  if (!tp)
+  {
     return 0;
-  } else {
+  }
+  else
+  {
     TURN_MUTEX_LOCK(&tp->mutex);
     int ret = is_taken(tp->status[port]);
     TURN_MUTEX_UNLOCK(&tp->mutex);
@@ -265,13 +312,17 @@ int turnports_is_allocated(turnports *tp, uint16_t port) {
   }
 }
 
-int turnports_is_available(turnports *tp, uint16_t port) {
-  if (tp) {
+int turnports_is_available(turnports *tp, uint16_t port)
+{
+  if (tp)
+  {
     TURN_MUTEX_LOCK(&tp->mutex);
     uint32_t status = tp->status[port];
-    if ((status != TPS_OUT_OF_RANGE) && !is_taken(status)) {
+    if ((status != TPS_OUT_OF_RANGE) && !is_taken(status))
+    {
       uint16_t position = (uint16_t)(status & 0x0000FFFF);
-      if (tp->ports[position] == port) {
+      if (tp->ports[position] == port)
+      {
         TURN_MUTEX_UNLOCK(&tp->mutex);
         return 1;
       }
@@ -283,7 +334,8 @@ int turnports_is_available(turnports *tp, uint16_t port) {
 
 /////////////////// IP-mapped PORTS /////////////////////////////////////
 
-struct _turnipports {
+struct _turnipports
+{
   super_memory_t *sm;
   uint16_t start;
   uint16_t end;
@@ -294,8 +346,10 @@ struct _turnipports {
 
 //////////////////////////////////////////////////
 
-static ur_addr_map *get_map(turnipports *tp, uint8_t transport) {
-  if (transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE) {
+static ur_addr_map *get_map(turnipports *tp, uint8_t transport)
+{
+  if (transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE)
+  {
     return &(tp->ip_to_turnports_tcp);
   }
   return &(tp->ip_to_turnports_udp);
@@ -304,7 +358,8 @@ static ur_addr_map *get_map(turnipports *tp, uint8_t transport) {
 
 static turnipports *turnipports_singleton = NULL;
 
-turnipports *turnipports_create(super_memory_t *sm, uint16_t start, uint16_t end) {
+turnipports *turnipports_create(super_memory_t *sm, uint16_t start, uint16_t end)
+{
   turnipports *ret = (turnipports *)allocate_super_memory_region(sm, sizeof(turnipports));
   ret->sm = sm;
   ur_addr_map_init(&(ret->ip_to_turnports_udp));
@@ -316,14 +371,17 @@ turnipports *turnipports_create(super_memory_t *sm, uint16_t start, uint16_t end
   return ret;
 }
 
-static turnports *turnipports_add(turnipports *tp, uint8_t transport, const ioa_addr *backend_addr) {
+static turnports *turnipports_add(turnipports *tp, uint8_t transport, const ioa_addr *backend_addr)
+{
   ur_addr_map_value_type t = 0;
-  if (tp && backend_addr) {
+  if (tp && backend_addr)
+  {
     ioa_addr ba;
     addr_cpy(&ba, backend_addr);
     addr_set_port(&ba, 0);
     TURN_MUTEX_LOCK((const turn_mutex *)&(tp->mutex));
-    if (!ur_addr_map_get(get_map(tp, transport), &ba, &t)) {
+    if (!ur_addr_map_get(get_map(tp, transport), &ba, &t))
+    {
       t = (ur_addr_map_value_type)turnports_create(tp->sm, tp->start, tp->end);
       ur_addr_map_put(get_map(tp, transport), &ba, t);
     }
@@ -332,13 +390,16 @@ static turnports *turnipports_add(turnipports *tp, uint8_t transport, const ioa_
   return (turnports *)t;
 }
 
-void turnipports_add_ip(uint8_t transport, const ioa_addr *backend_addr) {
+void turnipports_add_ip(uint8_t transport, const ioa_addr *backend_addr)
+{
   turnipports_add(turnipports_singleton, transport, backend_addr);
 }
 
-int turnipports_allocate(turnipports *tp, uint8_t transport, const ioa_addr *backend_addr) {
+int turnipports_allocate(turnipports *tp, uint8_t transport, const ioa_addr *backend_addr)
+{
   int ret = -1;
-  if (tp && backend_addr) {
+  if (tp && backend_addr)
+  {
     TURN_MUTEX_LOCK((const turn_mutex *)&(tp->mutex));
     turnports *t = turnipports_add(tp, transport, backend_addr);
     ret = turnports_allocate(t);
@@ -348,9 +409,11 @@ int turnipports_allocate(turnipports *tp, uint8_t transport, const ioa_addr *bac
 }
 
 int turnipports_allocate_even(turnipports *tp, const ioa_addr *backend_addr, int allocate_rtcp,
-                              uint64_t *reservation_token) {
+                              uint64_t *reservation_token)
+{
   int ret = -1;
-  if (tp && backend_addr) {
+  if (tp && backend_addr)
+  {
     TURN_MUTEX_LOCK((const turn_mutex *)&(tp->mutex));
     turnports *t = turnipports_add(tp, STUN_ATTRIBUTE_TRANSPORT_UDP_VALUE, backend_addr);
     ret = turnports_allocate_even(t, allocate_rtcp, reservation_token);
@@ -359,29 +422,35 @@ int turnipports_allocate_even(turnipports *tp, const ioa_addr *backend_addr, int
   return ret;
 }
 
-void turnipports_release(turnipports *tp, uint8_t transport, const ioa_addr *socket_addr) {
-  if (tp && socket_addr) {
+void turnipports_release(turnipports *tp, uint8_t transport, const ioa_addr *socket_addr)
+{
+  if (tp && socket_addr)
+  {
     ioa_addr ba;
     ur_addr_map_value_type t;
     addr_cpy(&ba, socket_addr);
     addr_set_port(&ba, 0);
     TURN_MUTEX_LOCK((const turn_mutex *)&(tp->mutex));
-    if (ur_addr_map_get(get_map(tp, transport), &ba, &t)) {
+    if (ur_addr_map_get(get_map(tp, transport), &ba, &t))
+    {
       turnports_release((turnports *)t, addr_get_port(socket_addr));
     }
     TURN_MUTEX_UNLOCK((const turn_mutex *)&(tp->mutex));
   }
 }
 
-int turnipports_is_allocated(turnipports *tp, uint8_t transport, const ioa_addr *backend_addr, uint16_t port) {
+int turnipports_is_allocated(turnipports *tp, uint8_t transport, const ioa_addr *backend_addr, uint16_t port)
+{
   int ret = 0;
-  if (tp && backend_addr) {
+  if (tp && backend_addr)
+  {
     ioa_addr ba;
     ur_addr_map_value_type t;
     addr_cpy(&ba, backend_addr);
     addr_set_port(&ba, 0);
     TURN_MUTEX_LOCK((const turn_mutex *)&(tp->mutex));
-    if (ur_addr_map_get(get_map(tp, transport), &ba, &t)) {
+    if (ur_addr_map_get(get_map(tp, transport), &ba, &t))
+    {
       ret = turnports_is_allocated((turnports *)t, port);
     }
     TURN_MUTEX_UNLOCK((const turn_mutex *)&(tp->mutex));
@@ -389,17 +458,22 @@ int turnipports_is_allocated(turnipports *tp, uint8_t transport, const ioa_addr 
   return ret;
 }
 
-int turnipports_is_available(turnipports *tp, uint8_t transport, const ioa_addr *backend_addr, uint16_t port) {
+int turnipports_is_available(turnipports *tp, uint8_t transport, const ioa_addr *backend_addr, uint16_t port)
+{
   int ret = 0;
-  if (tp && backend_addr) {
+  if (tp && backend_addr)
+  {
     ioa_addr ba;
     ur_addr_map_value_type t;
     addr_cpy(&ba, backend_addr);
     addr_set_port(&ba, 0);
     TURN_MUTEX_LOCK((const turn_mutex *)&(tp->mutex));
-    if (!ur_addr_map_get(get_map(tp, transport), &ba, &t)) {
+    if (!ur_addr_map_get(get_map(tp, transport), &ba, &t))
+    {
       ret = 1;
-    } else {
+    }
+    else
+    {
       ret = turnports_is_available((turnports *)t, port);
     }
     TURN_MUTEX_UNLOCK((const turn_mutex *)&(tp->mutex));

--- a/src/apps/relay/turn_ports.h
+++ b/src/apps/relay/turn_ports.h
@@ -36,7 +36,8 @@
 #include "ns_sm.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////////////////////////////////////////////

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -82,8 +82,10 @@ static char userdb_type_mysql[] = "MySQL/MariaDB";
 static char userdb_type_mongo[] = "MongoDB";
 static char userdb_type_redis[] = "Redis";
 
-const char *userdb_type_to_string(TURN_USERDB_TYPE t) {
-  switch (t) {
+const char *userdb_type_to_string(TURN_USERDB_TYPE t)
+{
+  switch (t)
+  {
   case TURN_USERDB_TYPE_SQLITE:
     return userdb_type_sqlite;
     break;
@@ -108,15 +110,18 @@ void lock_realms(void) { ur_string_map_lock(realms); }
 
 void unlock_realms(void) { ur_string_map_unlock(realms); }
 
-void update_o_to_realm(ur_string_map *o_to_realm_new) {
+void update_o_to_realm(ur_string_map *o_to_realm_new)
+{
   TURN_MUTEX_LOCK(&o_to_realm_mutex);
   ur_string_map_free(&o_to_realm);
   o_to_realm = o_to_realm_new;
   TURN_MUTEX_UNLOCK(&o_to_realm_mutex);
 }
 
-void create_default_realm(void) {
-  if (default_realm_params_ptr) {
+void create_default_realm(void)
+{
+  if (default_realm_params_ptr)
+  {
     return;
   }
 
@@ -136,15 +141,18 @@ void create_default_realm(void) {
   unlock_realms();
 }
 
-void get_default_realm_options(realm_options_t *ro) {
-  if (ro) {
+void get_default_realm_options(realm_options_t *ro)
+{
+  if (ro)
+  {
     lock_realms();
     memcpy(ro, &(default_realm_params_ptr->options), sizeof(realm_options_t));
     unlock_realms();
   }
 }
 
-void set_default_realm_name(char *realm) {
+void set_default_realm_name(char *realm)
+{
   lock_realms();
   ur_string_map_value_type value = (ur_string_map_value_type)default_realm_params_ptr;
   STRCPY(default_realm_params_ptr->options.name, realm);
@@ -153,15 +161,20 @@ void set_default_realm_name(char *realm) {
   unlock_realms();
 }
 
-realm_params_t *get_realm(char *name) {
-  if (name && name[0]) {
+realm_params_t *get_realm(char *name)
+{
+  if (name && name[0])
+  {
     lock_realms();
     ur_string_map_value_type value = 0;
     ur_string_map_key_type key = (ur_string_map_key_type)name;
-    if (ur_string_map_get(realms, key, &value)) {
+    if (ur_string_map_get(realms, key, &value))
+    {
       unlock_realms();
       return (realm_params_t *)value;
-    } else {
+    }
+    else
+    {
       realm_params_t *ret = (realm_params_t *)malloc(sizeof(realm_params_t));
       memcpy(ret, default_realm_params_ptr, sizeof(realm_params_t));
       STRCPY(ret->options.name, name);
@@ -177,17 +190,20 @@ realm_params_t *get_realm(char *name) {
   return default_realm_params_ptr;
 }
 
-int get_realm_data(char *name, realm_params_t *rp) {
+int get_realm_data(char *name, realm_params_t *rp)
+{
   lock_realms();
   memcpy(rp, get_realm(name), sizeof(realm_params_t));
   unlock_realms();
   return 0;
 }
 
-int get_realm_options_by_origin(char *origin, realm_options_t *ro) {
+int get_realm_options_by_origin(char *origin, realm_options_t *ro)
+{
   ur_string_map_value_type value = 0;
   TURN_MUTEX_LOCK(&o_to_realm_mutex);
-  if (ur_string_map_get(o_to_realm, (ur_string_map_key_type)origin, &value) && value) {
+  if (ur_string_map_get(o_to_realm, (ur_string_map_key_type)origin, &value) && value)
+  {
     char *realm = strdup((char *)value);
     TURN_MUTEX_UNLOCK(&o_to_realm_mutex);
     realm_params_t rp;
@@ -195,20 +211,24 @@ int get_realm_options_by_origin(char *origin, realm_options_t *ro) {
     memcpy(ro, &(rp.options), sizeof(realm_options_t));
     free(realm);
     return 1;
-  } else {
+  }
+  else
+  {
     TURN_MUTEX_UNLOCK(&o_to_realm_mutex);
     get_default_realm_options(ro);
     return 0;
   }
 }
 
-void get_realm_options_by_name(char *realm, realm_options_t *ro) {
+void get_realm_options_by_name(char *realm, realm_options_t *ro)
+{
   realm_params_t rp;
   get_realm_data(realm, &rp);
   memcpy(ro, &(rp.options), sizeof(realm_options_t));
 }
 
-int change_total_quota(char *realm, int value) {
+int change_total_quota(char *realm, int value)
+{
   int ret = value;
   lock_realms();
   realm_params_t *rp = get_realm(realm);
@@ -217,7 +237,8 @@ int change_total_quota(char *realm, int value) {
   return ret;
 }
 
-int change_user_quota(char *realm, int value) {
+int change_user_quota(char *realm, int value)
+{
   int ret = value;
   lock_realms();
   realm_params_t *rp = get_realm(realm);
@@ -226,33 +247,41 @@ int change_user_quota(char *realm, int value) {
   return ret;
 }
 
-static void must_set_admin_realm(void *realm0) {
+static void must_set_admin_realm(void *realm0)
+{
   char *realm = (char *)realm0;
-  if (!realm || !realm[0]) {
+  if (!realm || !realm[0])
+  {
     fprintf(stderr, "The operation cannot be completed: the realm must be set.\n");
     exit(-1);
   }
 }
 
-static void must_set_admin_user(void *user0) {
+static void must_set_admin_user(void *user0)
+{
   char *user = (char *)user0;
-  if (!user || !user[0]) {
+  if (!user || !user[0])
+  {
     fprintf(stderr, "The operation cannot be completed: the user must be set.\n");
     exit(-1);
   }
 }
 
-static void must_set_admin_pwd(void *pwd0) {
+static void must_set_admin_pwd(void *pwd0)
+{
   char *pwd = (char *)pwd0;
-  if (!pwd || !pwd[0]) {
+  if (!pwd || !pwd[0])
+  {
     fprintf(stderr, "The operation cannot be completed: the password must be set.\n");
     exit(-1);
   }
 }
 
-static void must_set_admin_origin(void *origin0) {
+static void must_set_admin_origin(void *origin0)
+{
   char *origin = (char *)origin0;
-  if (!origin || !origin[0]) {
+  if (!origin || !origin[0])
+  {
     fprintf(stderr, "The operation cannot be completed: the origin must be set.\n");
     exit(-1);
   }
@@ -260,18 +289,25 @@ static void must_set_admin_origin(void *origin0) {
 
 /////////// SHARED SECRETS /////////////////
 
-void init_secrets_list(secrets_list_t *sl) {
-  if (sl) {
+void init_secrets_list(secrets_list_t *sl)
+{
+  if (sl)
+  {
     memset(sl, 0, sizeof(secrets_list_t));
   }
 }
 
-void clean_secrets_list(secrets_list_t *sl) {
-  if (sl) {
-    if (sl->secrets) {
+void clean_secrets_list(secrets_list_t *sl)
+{
+  if (sl)
+  {
+    if (sl->secrets)
+    {
       size_t i = 0;
-      for (i = 0; i < sl->sz; ++i) {
-        if (sl->secrets[i]) {
+      for (i = 0; i < sl->sz; ++i)
+      {
+        if (sl->secrets[i])
+        {
           free(sl->secrets[i]);
         }
       }
@@ -282,22 +318,28 @@ void clean_secrets_list(secrets_list_t *sl) {
   }
 }
 
-size_t get_secrets_list_size(secrets_list_t *sl) {
-  if (sl && sl->secrets) {
+size_t get_secrets_list_size(secrets_list_t *sl)
+{
+  if (sl && sl->secrets)
+  {
     return sl->sz;
   }
   return 0;
 }
 
-const char *get_secrets_list_elem(secrets_list_t *sl, size_t i) {
-  if (get_secrets_list_size(sl) > i) {
+const char *get_secrets_list_elem(secrets_list_t *sl, size_t i)
+{
+  if (get_secrets_list_size(sl) > i)
+  {
     return sl->secrets[i];
   }
   return NULL;
 }
 
-void add_to_secrets_list(secrets_list_t *sl, const char *elem) {
-  if (sl && elem) {
+void add_to_secrets_list(secrets_list_t *sl, const char *elem)
+{
+  if (sl && elem)
+  {
     sl->secrets = (char **)realloc(sl->secrets, (sizeof(char *) * (sl->sz + 1)));
     sl->secrets[sl->sz] = strdup(elem);
     sl->sz += 1;
@@ -306,21 +348,25 @@ void add_to_secrets_list(secrets_list_t *sl, const char *elem) {
 
 ////////////////////////////////////////////
 
-static int get_auth_secrets(secrets_list_t *sl, uint8_t *realm) {
+static int get_auth_secrets(secrets_list_t *sl, uint8_t *realm)
+{
   int ret = -1;
   const turn_dbdriver_t *dbd = get_dbdriver();
 
   clean_secrets_list(sl);
 
-  if (get_secrets_list_size(&turn_params.default_users_db.ram_db.static_auth_secrets)) {
+  if (get_secrets_list_size(&turn_params.default_users_db.ram_db.static_auth_secrets))
+  {
     size_t i = 0;
-    for (i = 0; i < get_secrets_list_size(&turn_params.default_users_db.ram_db.static_auth_secrets); ++i) {
+    for (i = 0; i < get_secrets_list_size(&turn_params.default_users_db.ram_db.static_auth_secrets); ++i)
+    {
       add_to_secrets_list(sl, get_secrets_list_elem(&turn_params.default_users_db.ram_db.static_auth_secrets, i));
     }
     ret = 0;
   }
 
-  if (dbd && dbd->get_auth_secrets) {
+  if (dbd && dbd->get_auth_secrets)
+  {
     ret = (*dbd->get_auth_secrets)(sl, realm);
   }
 
@@ -330,29 +376,39 @@ static int get_auth_secrets(secrets_list_t *sl, uint8_t *realm) {
 /*
  * Timestamp retrieval
  */
-static turn_time_t get_rest_api_timestamp(char *usname) {
+static turn_time_t get_rest_api_timestamp(char *usname)
+{
   turn_time_t ts = 0;
   int ts_set = 0;
 
   char *col = strchr(usname, turn_params.rest_api_separator);
 
-  if (col) {
-    if (col == usname) {
+  if (col)
+  {
+    if (col == usname)
+    {
       usname += 1;
-    } else {
+    }
+    else
+    {
       char *ptr = usname;
       int found_non_figure = 0;
-      while (ptr < col) {
-        if (!(ptr[0] >= '0' && ptr[0] <= '9')) {
+      while (ptr < col)
+      {
+        if (!(ptr[0] >= '0' && ptr[0] <= '9'))
+        {
           found_non_figure = 1;
           break;
         }
         ++ptr;
       }
-      if (found_non_figure) {
+      if (found_non_figure)
+      {
         ts = (turn_time_t)atol(col + 1);
         ts_set = 1;
-      } else {
+      }
+      else
+      {
         *col = 0;
         ts = (turn_time_t)atol(usname);
         ts_set = 1;
@@ -361,32 +417,44 @@ static turn_time_t get_rest_api_timestamp(char *usname) {
     }
   }
 
-  if (!ts_set) {
+  if (!ts_set)
+  {
     ts = (turn_time_t)atol(usname);
   }
 
   return ts;
 }
 
-static char *get_real_username(char *usname) {
-  if (usname[0] && turn_params.use_auth_secret_with_timestamp) {
+static char *get_real_username(char *usname)
+{
+  if (usname[0] && turn_params.use_auth_secret_with_timestamp)
+  {
     char *col = strchr(usname, turn_params.rest_api_separator);
-    if (col) {
-      if (col == usname) {
+    if (col)
+    {
+      if (col == usname)
+      {
         usname += 1;
-      } else {
+      }
+      else
+      {
         char *ptr = usname;
         int found_non_figure = 0;
-        while (ptr < col) {
-          if (!(ptr[0] >= '0' && ptr[0] <= '9')) {
+        while (ptr < col)
+        {
+          if (!(ptr[0] >= '0' && ptr[0] <= '9'))
+          {
             found_non_figure = 1;
             break;
           }
           ++ptr;
         }
-        if (!found_non_figure) {
+        if (!found_non_figure)
+        {
           usname = col + 1;
-        } else {
+        }
+        else
+        {
           *col = 0;
           usname = strdup(usname);
           *col = turn_params.rest_api_separator;
@@ -403,44 +471,54 @@ static char *get_real_username(char *usname) {
  * Password retrieval
  */
 int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *usname, uint8_t *realm, hmackey_t key,
-                 ioa_network_buffer_handle nbh) {
+                 ioa_network_buffer_handle nbh)
+{
   int ret = -1;
 
-  if (max_session_time) {
+  if (max_session_time)
+  {
     *max_session_time = 0;
   }
 
-  if (in_oauth && out_oauth && usname && usname[0]) {
+  if (in_oauth && out_oauth && usname && usname[0])
+  {
 
     stun_attr_ref sar = stun_attr_get_first_by_type_str(ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh),
                                                         STUN_ATTRIBUTE_OAUTH_ACCESS_TOKEN);
-    if (sar) {
+    if (sar)
+    {
 
       int len = stun_attr_get_len(sar);
       const uint8_t *value = stun_attr_get_value(sar);
 
       *out_oauth = 1;
 
-      if (len > 0 && value) {
+      if (len > 0 && value)
+      {
 
         const turn_dbdriver_t *dbd = get_dbdriver();
 
-        if (dbd && dbd->get_oauth_key) {
+        if (dbd && dbd->get_oauth_key)
+        {
 
           oauth_key_data_raw rawKey;
           memset(&rawKey, 0, sizeof(rawKey));
 
           int gres = (*(dbd->get_oauth_key))(usname, &rawKey);
-          if (gres < 0) {
+          if (gres < 0)
+          {
             return ret;
           }
 
-          if (!rawKey.kid[0]) {
+          if (!rawKey.kid[0])
+          {
             return ret;
           }
 
-          if (rawKey.lifetime) {
-            if (!turn_time_before(turn_time(), (turn_time_t)(rawKey.timestamp + rawKey.lifetime + OAUTH_TIME_DELTA))) {
+          if (rawKey.lifetime)
+          {
+            if (!turn_time_before(turn_time(), (turn_time_t)(rawKey.timestamp + rawKey.lifetime + OAUTH_TIME_DELTA)))
+            {
               return ret;
             }
           }
@@ -456,7 +534,8 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
           oauth_key okey;
           memset(&okey, 0, sizeof(okey));
 
-          if (!convert_oauth_key_data(&okd, &okey, err_msg, err_msg_size)) {
+          if (!convert_oauth_key_data(&okd, &okey, err_msg, err_msg_size))
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s\n", err_msg);
             return -1;
           }
@@ -467,7 +546,8 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
           encoded_oauth_token etoken;
           memset(&etoken, 0, sizeof(etoken));
 
-          if ((size_t)len > sizeof(etoken.token)) {
+          if ((size_t)len > sizeof(etoken.token))
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Encoded oAuth token is too large\n");
             return -1;
           }
@@ -475,20 +555,24 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
           etoken.size = (size_t)len;
 
           const char *server_name = (char *)turn_params.oauth_server_name;
-          if (!(server_name && server_name[0])) {
+          if (!(server_name && server_name[0]))
+          {
             server_name = (char *)realm;
-            if (!(server_name && server_name[0])) {
+            if (!(server_name && server_name[0]))
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot determine oAuth server name");
               return -1;
             }
           }
 
-          if (!decode_oauth_token((const uint8_t *)server_name, &etoken, &okey, &dot)) {
+          if (!decode_oauth_token((const uint8_t *)server_name, &etoken, &okey, &dot))
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot decode oauth token\n");
             return -1;
           }
 
-          switch (dot.enc_block.key_length) {
+          switch (dot.enc_block.key_length)
+          {
           case SHA1SIZEBYTES:
             break;
           case SHA256SIZEBYTES:
@@ -503,25 +587,30 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
           password_t pwdtmp;
           if (stun_check_message_integrity_by_key_str(TURN_CREDENTIALS_LONG_TERM, ioa_network_buffer_data(nbh),
                                                       ioa_network_buffer_get_size(nbh), dot.enc_block.mac_key, pwdtmp,
-                                                      SHATYPE_DEFAULT) > 0) {
+                                                      SHATYPE_DEFAULT) > 0)
+          {
 
             turn_time_t lifetime = (turn_time_t)(dot.enc_block.lifetime);
-            if (lifetime) {
+            if (lifetime)
+            {
               turn_time_t ts = (turn_time_t)(dot.enc_block.timestamp >> 16);
               turn_time_t to = ts + lifetime + OAUTH_TIME_DELTA;
               turn_time_t ct = turn_time();
-              if (!turn_time_before(ct, to)) {
+              if (!turn_time_before(ct, to))
+              {
                 TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "oAuth token is too old\n");
                 return -1;
               }
-              if (max_session_time) {
+              if (max_session_time)
+              {
                 *max_session_time = to - ct;
               }
             }
 
             memcpy(key, dot.enc_block.mac_key, dot.enc_block.key_length);
 
-            if (rawKey.realm[0]) {
+            if (rawKey.realm[0])
+            {
               memcpy(realm, rawKey.realm, sizeof(rawKey.realm));
             }
 
@@ -532,11 +621,13 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
     }
   }
 
-  if (out_oauth && *out_oauth) {
+  if (out_oauth && *out_oauth)
+  {
     return ret;
   }
 
-  if (turn_params.use_auth_secret_with_timestamp) {
+  if (turn_params.use_auth_secret_with_timestamp)
+  {
 
     turn_time_t ctime = (turn_time_t)time(NULL);
     turn_time_t ts = 0;
@@ -545,13 +636,15 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 
     init_secrets_list(&sl);
 
-    if (get_auth_secrets(&sl, realm) < 0) {
+    if (get_auth_secrets(&sl, realm) < 0)
+    {
       return ret;
     }
 
     ts = get_rest_api_timestamp((char *)usname);
 
-    if (!turn_time_before(ts, ctime)) {
+    if (!turn_time_before(ts, ctime))
+    {
 
       uint8_t hmac[MAXSHASIZE];
       unsigned int hmac_len;
@@ -561,12 +654,14 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 
       stun_attr_ref sar = stun_attr_get_first_by_type_str(
           ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh), STUN_ATTRIBUTE_MESSAGE_INTEGRITY);
-      if (!sar) {
+      if (!sar)
+      {
         return -1;
       }
 
       int sarlen = stun_attr_get_len(sar);
-      switch (sarlen) {
+      switch (sarlen)
+      {
       case SHA1SIZEBYTES:
         hmac_len = SHA1SIZEBYTES;
         break;
@@ -577,31 +672,41 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
         return -1;
       };
 
-      for (sll = 0; sll < get_secrets_list_size(&sl); ++sll) {
+      for (sll = 0; sll < get_secrets_list_size(&sl); ++sll)
+      {
 
         const char *secret = get_secrets_list_elem(&sl, sll);
 
-        if (secret) {
+        if (secret)
+        {
           if (stun_calculate_hmac(usname, strlen((char *)usname), (const uint8_t *)secret, strlen(secret), hmac,
-                                  &hmac_len, SHATYPE_DEFAULT)) {
+                                  &hmac_len, SHATYPE_DEFAULT))
+          {
             size_t pwd_length = 0;
             char *pwd = base64_encode(hmac, hmac_len, &pwd_length);
 
-            if (pwd) {
-              if (pwd_length < 1) {
+            if (pwd)
+            {
+              if (pwd_length < 1)
+              {
                 free(pwd);
-              } else {
-                if (stun_produce_integrity_key_str((uint8_t *)usname, realm, (uint8_t *)pwd, key, SHATYPE_DEFAULT)) {
+              }
+              else
+              {
+                if (stun_produce_integrity_key_str((uint8_t *)usname, realm, (uint8_t *)pwd, key, SHATYPE_DEFAULT))
+                {
                   if (stun_check_message_integrity_by_key_str(TURN_CREDENTIALS_LONG_TERM, ioa_network_buffer_data(nbh),
                                                               ioa_network_buffer_get_size(nbh), key, pwdtmp,
-                                                              SHATYPE_DEFAULT) > 0) {
+                                                              SHATYPE_DEFAULT) > 0)
+                  {
 
                     ret = 0;
                   }
                 }
                 free(pwd);
 
-                if (ret == 0) {
+                if (ret == 0)
+                {
                   break;
                 }
               }
@@ -618,19 +723,22 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 
   ur_string_map_value_type ukey = NULL;
   ur_string_map_lock(turn_params.default_users_db.ram_db.static_accounts);
-  if (ur_string_map_get(turn_params.default_users_db.ram_db.static_accounts, (ur_string_map_key_type)usname, &ukey)) {
+  if (ur_string_map_get(turn_params.default_users_db.ram_db.static_accounts, (ur_string_map_key_type)usname, &ukey))
+  {
     ret = 0;
   }
   ur_string_map_unlock(turn_params.default_users_db.ram_db.static_accounts);
 
-  if (ret == 0) {
+  if (ret == 0)
+  {
     size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
     memcpy(key, ukey, sz);
     return 0;
   }
 
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->get_user_key) {
+  if (dbd && dbd->get_user_key)
+  {
     ret = (*(dbd->get_user_key))(usname, realm, key);
   }
 
@@ -639,7 +747,8 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 
 uint8_t *start_user_check(turnserver_id id, turn_credential_type ct, int in_oauth, int *out_oauth, uint8_t *usname,
                           uint8_t *realm, get_username_resume_cb resume, ioa_net_data *in_buffer, uint64_t ctxkey,
-                          int *postpone_reply) {
+                          int *postpone_reply)
+{
   *postpone_reply = 1;
 
   struct auth_message am;
@@ -660,31 +769,44 @@ uint8_t *start_user_check(turnserver_id id, turn_credential_type ct, int in_oaut
   return NULL;
 }
 
-int check_new_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
+int check_new_allocation_quota(uint8_t *user, int oauth, uint8_t *realm)
+{
   int ret = 0;
-  if (user || oauth) {
+  if (user || oauth)
+  {
     uint8_t *username = oauth ? (uint8_t *)strdup("") : (uint8_t *)get_real_username((char *)user);
     realm_params_t *rp = get_realm((char *)realm);
     ur_string_map_lock(rp->status.alloc_counters);
     if (rp->options.perf_options.total_quota &&
-        (rp->status.total_current_allocs >= rp->options.perf_options.total_quota)) {
+        (rp->status.total_current_allocs >= rp->options.perf_options.total_quota))
+    {
       ret = -1;
-    } else if (username[0]) {
+    }
+    else if (username[0])
+    {
       ur_string_map_value_type value = 0;
-      if (!ur_string_map_get(rp->status.alloc_counters, (ur_string_map_key_type)username, &value)) {
+      if (!ur_string_map_get(rp->status.alloc_counters, (ur_string_map_key_type)username, &value))
+      {
         value = (ur_string_map_value_type)1;
         ur_string_map_put(rp->status.alloc_counters, (ur_string_map_key_type)username, value);
         ++(rp->status.total_current_allocs);
-      } else {
-        if ((rp->options.perf_options.user_quota) && ((size_t)value >= (size_t)(rp->options.perf_options.user_quota))) {
+      }
+      else
+      {
+        if ((rp->options.perf_options.user_quota) && ((size_t)value >= (size_t)(rp->options.perf_options.user_quota)))
+        {
           ret = -1;
-        } else {
+        }
+        else
+        {
           value = (ur_string_map_value_type)(((size_t)value) + 1);
           ur_string_map_put(rp->status.alloc_counters, (ur_string_map_key_type)username, value);
           ++(rp->status.total_current_allocs);
         }
       }
-    } else {
+    }
+    else
+    {
       ++(rp->status.total_current_allocs);
     }
     free(username);
@@ -696,31 +818,40 @@ int check_new_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
 #else
   size_t cur_count = (size_t)InterlockedIncrement((volatile LONG *)&global_allocation_count);
 #endif
-  if (turn_params.verbose > TURN_VERBOSE_NONE) {
+  if (turn_params.verbose > TURN_VERBOSE_NONE)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "Global turn allocation count incremented, now %ld\n", cur_count);
   }
 
   return ret;
 }
 
-void release_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
-  if (user) {
+void release_allocation_quota(uint8_t *user, int oauth, uint8_t *realm)
+{
+  if (user)
+  {
     uint8_t *username = oauth ? (uint8_t *)strdup("") : (uint8_t *)get_real_username((char *)user);
     realm_params_t *rp = get_realm((char *)realm);
     ur_string_map_lock(rp->status.alloc_counters);
-    if (username[0]) {
+    if (username[0])
+    {
       ur_string_map_value_type value = 0;
       ur_string_map_get(rp->status.alloc_counters, (ur_string_map_key_type)username, &value);
-      if (value) {
+      if (value)
+      {
         value = (ur_string_map_value_type)(((size_t)value) - 1);
-        if (value == 0) {
+        if (value == 0)
+        {
           ur_string_map_del(rp->status.alloc_counters, (ur_string_map_key_type)username);
-        } else {
+        }
+        else
+        {
           ur_string_map_put(rp->status.alloc_counters, (ur_string_map_key_type)username, value);
         }
       }
     }
-    if (rp->status.total_current_allocs) {
+    if (rp->status.total_current_allocs)
+    {
       --(rp->status.total_current_allocs);
     }
     ur_string_map_unlock(rp->status.alloc_counters);
@@ -728,7 +859,8 @@ void release_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
   }
 
   int log_level = TURN_LOG_LEVEL_DEBUG;
-  if (turn_params.drain_turn_server) {
+  if (turn_params.drain_turn_server)
+  {
     log_level = TURN_LOG_LEVEL_INFO;
   }
 #ifndef _MSC_VER
@@ -736,21 +868,25 @@ void release_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
 #else
   size_t cur_count = (size_t)InterlockedDecrement((volatile LONG *)&global_allocation_count);
 #endif
-  if (turn_params.verbose > TURN_VERBOSE_NONE) {
+  if (turn_params.verbose > TURN_VERBOSE_NONE)
+  {
     TURN_LOG_FUNC(log_level, "Global turn allocation count decremented, now %ld\n", cur_count);
   }
 }
 
 //////////////////////////////////
 
-int add_static_user_account(char *user) {
+int add_static_user_account(char *user)
+{
   /* Realm is either default or empty for users taken from file or command-line */
-  if (!user || turn_params.use_auth_secret_with_timestamp) {
+  if (!user || turn_params.use_auth_secret_with_timestamp)
+  {
     return -1;
   }
 
   char *s = strstr(user, ":");
-  if (!s || (s == user) || (strlen(s) < 2)) {
+  if (!s || (s == user) || (strlen(s) < 2))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong user account: %s\n", user);
     return -1;
   }
@@ -761,14 +897,16 @@ int add_static_user_account(char *user) {
   // are user account names as well? If so, we can avoid allocating
   // and instead use a stack buffer.
   char *usname = (char *)malloc(ulen + 1);
-  if (!usname) {
+  if (!usname)
+  {
     return -1;
   }
 
   strncpy(usname, user, ulen);
   usname[ulen] = 0;
 
-  if (!SASLprep((uint8_t *)usname)) {
+  if (!SASLprep((uint8_t *)usname))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong user name: %s\n", user);
     free(usname);
     return -1;
@@ -776,19 +914,24 @@ int add_static_user_account(char *user) {
   s = skip_blanks(s + 1);
 
   hmackey_t *key = (hmackey_t *)malloc(sizeof(hmackey_t));
-  if (!key) {
+  if (!key)
+  {
     free(usname);
     return -1;
   }
 
-  if (strstr(s, "0x") == s) {
+  if (strstr(s, "0x") == s)
+  {
     char *keysource = s + 2;
     size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
-    if (strlen(keysource) < sz * 2) {
+    if (strlen(keysource) < sz * 2)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format: %s\n", s);
     }
     convert_string_key_to_binary(keysource, *key, sz);
-  } else {
+  }
+  else
+  {
     // this is only for default realm
     stun_produce_integrity_key_str((uint8_t *)usname, (uint8_t *)get_realm(NULL)->options.name, (uint8_t *)s, *key,
                                    SHATYPE_DEFAULT);
@@ -796,7 +939,8 @@ int add_static_user_account(char *user) {
 
   // the ur_string_map functions only fail (well... other than allocation failures, which aren't handled)
   // if the map isn't valid. So we only need to check the result of locking.
-  if (!ur_string_map_lock(turn_params.default_users_db.ram_db.static_accounts)) {
+  if (!ur_string_map_lock(turn_params.default_users_db.ram_db.static_accounts))
+  {
     free(usname);
     free(key);
     return -1;
@@ -816,15 +960,22 @@ int add_static_user_account(char *user) {
 
 ////////////////// Admin /////////////////////////
 
-static int list_users(uint8_t *realm, int is_admin) {
+static int list_users(uint8_t *realm, int is_admin)
+{
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd) {
-    if (is_admin) {
-      if (dbd->list_admin_users) {
+  if (dbd)
+  {
+    if (is_admin)
+    {
+      if (dbd->list_admin_users)
+      {
         (*dbd->list_admin_users)(0);
       }
-    } else {
-      if (dbd->list_users) {
+    }
+    else
+    {
+      if (dbd->list_users)
+      {
         (*dbd->list_users)(realm, NULL, NULL);
       }
     }
@@ -833,30 +984,36 @@ static int list_users(uint8_t *realm, int is_admin) {
   return 0;
 }
 
-static int show_secret(uint8_t *realm) {
+static int show_secret(uint8_t *realm)
+{
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->list_secrets) {
+  if (dbd && dbd->list_secrets)
+  {
     (*dbd->list_secrets)(realm, NULL, NULL);
   }
 
   return 0;
 }
 
-static int del_secret(uint8_t *secret, uint8_t *realm) {
+static int del_secret(uint8_t *secret, uint8_t *realm)
+{
 
   must_set_admin_realm(realm);
 
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->del_secret) {
+  if (dbd && dbd->del_secret)
+  {
     (*dbd->del_secret)(secret, realm);
   }
 
   return 0;
 }
 
-static int set_secret(uint8_t *secret, uint8_t *realm) {
+static int set_secret(uint8_t *secret, uint8_t *realm)
+{
 
-  if (!secret || (secret[0] == 0)) {
+  if (!secret || (secret[0] == 0))
+  {
     return 0;
   }
 
@@ -865,71 +1022,84 @@ static int set_secret(uint8_t *secret, uint8_t *realm) {
   del_secret(secret, realm);
 
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->set_secret) {
+  if (dbd && dbd->set_secret)
+  {
     (*dbd->set_secret)(secret, realm);
   }
 
   return 0;
 }
 
-static int add_origin(uint8_t *origin0, uint8_t *realm) {
+static int add_origin(uint8_t *origin0, uint8_t *realm)
+{
   uint8_t origin[STUN_MAX_ORIGIN_SIZE + 1];
 
   get_canonic_origin((const char *)origin0, (char *)origin, sizeof(origin) - 1);
 
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->add_origin) {
+  if (dbd && dbd->add_origin)
+  {
     (*dbd->add_origin)(origin, realm);
   }
 
   return 0;
 }
 
-static int del_origin(uint8_t *origin0) {
+static int del_origin(uint8_t *origin0)
+{
   uint8_t origin[STUN_MAX_ORIGIN_SIZE + 1];
 
   get_canonic_origin((const char *)origin0, (char *)origin, sizeof(origin) - 1);
 
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->del_origin) {
+  if (dbd && dbd->del_origin)
+  {
     (*dbd->del_origin)(origin);
   }
 
   return 0;
 }
 
-static int list_origins(uint8_t *realm) {
+static int list_origins(uint8_t *realm)
+{
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->list_origins) {
+  if (dbd && dbd->list_origins)
+  {
     (*dbd->list_origins)(realm, NULL, NULL);
   }
 
   return 0;
 }
 
-static int set_realm_option_one(uint8_t *realm, unsigned long value, const char *opt) {
-  if (value == (unsigned long)-1) {
+static int set_realm_option_one(uint8_t *realm, unsigned long value, const char *opt)
+{
+  if (value == (unsigned long)-1)
+  {
     return 0;
   }
 
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->set_realm_option_one) {
+  if (dbd && dbd->set_realm_option_one)
+  {
     (*dbd->set_realm_option_one)(realm, value, opt);
   }
 
   return 0;
 }
 
-static int set_realm_option(uint8_t *realm, perf_options_t *po) {
+static int set_realm_option(uint8_t *realm, perf_options_t *po)
+{
   set_realm_option_one(realm, (unsigned long)po->max_bps, "max-bps");
   set_realm_option_one(realm, (unsigned long)po->user_quota, "user-quota");
   set_realm_option_one(realm, (unsigned long)po->total_quota, "total-quota");
   return 0;
 }
 
-static int list_realm_options(uint8_t *realm) {
+static int list_realm_options(uint8_t *realm)
+{
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->list_realm_options) {
+  if (dbd && dbd->list_realm_options)
+  {
     (*dbd->list_realm_options)(realm);
   }
 
@@ -937,57 +1107,69 @@ static int list_realm_options(uint8_t *realm) {
 }
 
 int adminuser(uint8_t *user, uint8_t *realm, uint8_t *pwd, uint8_t *secret, uint8_t *origin, TURNADMIN_COMMAND_TYPE ct,
-              perf_options_t *po, int is_admin) {
+              perf_options_t *po, int is_admin)
+{
   hmackey_t key;
   char skey[sizeof(hmackey_t) * 2 + 1];
 
-  if (ct == TA_LIST_USERS) {
+  if (ct == TA_LIST_USERS)
+  {
     return list_users(realm, is_admin);
   }
 
-  if (ct == TA_LIST_ORIGINS) {
+  if (ct == TA_LIST_ORIGINS)
+  {
     return list_origins(realm);
   }
 
-  if (ct == TA_SHOW_SECRET) {
+  if (ct == TA_SHOW_SECRET)
+  {
     return show_secret(realm);
   }
 
-  if (ct == TA_SET_SECRET) {
+  if (ct == TA_SET_SECRET)
+  {
     return set_secret(secret, realm);
   }
 
-  if (ct == TA_DEL_SECRET) {
+  if (ct == TA_DEL_SECRET)
+  {
     return del_secret(secret, realm);
   }
 
-  if (ct == TA_ADD_ORIGIN) {
+  if (ct == TA_ADD_ORIGIN)
+  {
     must_set_admin_origin(origin);
     must_set_admin_realm(realm);
     return add_origin(origin, realm);
   }
 
-  if (ct == TA_DEL_ORIGIN) {
+  if (ct == TA_DEL_ORIGIN)
+  {
     must_set_admin_origin(origin);
     return del_origin(origin);
   }
 
-  if (ct == TA_SET_REALM_OPTION) {
+  if (ct == TA_SET_REALM_OPTION)
+  {
     must_set_admin_realm(realm);
-    if (!(po && (po->max_bps != ((band_limit_t)-1) || po->total_quota >= 0 || po->user_quota >= 0))) {
+    if (!(po && (po->max_bps != ((band_limit_t)-1) || po->total_quota >= 0 || po->user_quota >= 0)))
+    {
       fprintf(stderr, "The operation cannot be completed: a realm option must be set.\n");
       exit(-1);
     }
     return set_realm_option(realm, po);
   }
 
-  if (ct == TA_LIST_REALM_OPTIONS) {
+  if (ct == TA_LIST_REALM_OPTIONS)
+  {
     return list_realm_options(realm);
   }
 
   must_set_admin_user(user);
 
-  if (ct != TA_DELETE_USER && !is_admin) {
+  if (ct != TA_DELETE_USER && !is_admin)
+  {
 
     must_set_admin_pwd(pwd);
 
@@ -996,7 +1178,8 @@ int adminuser(uint8_t *user, uint8_t *realm, uint8_t *pwd, uint8_t *secret, uint
       size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
       int maxsz = (int)(sz * 2) + 1;
       char *s = skey;
-      for (size_t i = 0; (i < sz) && (maxsz > 2); i++) {
+      for (size_t i = 0; (i < sz) && (maxsz > 2); i++)
+      {
         snprintf(s, (size_t)(sz * 2), "%02x", (unsigned int)key[i]);
         maxsz -= 2;
         s += 2;
@@ -1007,36 +1190,52 @@ int adminuser(uint8_t *user, uint8_t *realm, uint8_t *pwd, uint8_t *secret, uint
 
   const turn_dbdriver_t *dbd = get_dbdriver();
 
-  if (ct == TA_PRINT_KEY) {
+  if (ct == TA_PRINT_KEY)
+  {
 
     printf("0x%s\n", skey);
+  }
+  else if (dbd)
+  {
 
-  } else if (dbd) {
-
-    if (!is_admin) {
+    if (!is_admin)
+    {
       must_set_admin_realm(realm);
     }
 
-    if (ct == TA_DELETE_USER) {
-      if (is_admin) {
-        if (dbd->del_admin_user) {
+    if (ct == TA_DELETE_USER)
+    {
+      if (is_admin)
+      {
+        if (dbd->del_admin_user)
+        {
           (*dbd->del_admin_user)(user);
         }
-      } else {
-        if (dbd->del_user) {
+      }
+      else
+      {
+        if (dbd->del_user)
+        {
           (*dbd->del_user)(user, realm);
         }
       }
-    } else if (ct == TA_UPDATE_USER) {
-      if (is_admin) {
+    }
+    else if (ct == TA_UPDATE_USER)
+    {
+      if (is_admin)
+      {
         must_set_admin_pwd(pwd);
-        if (dbd->set_admin_user) {
+        if (dbd->set_admin_user)
+        {
           password_t password;
           generate_new_enc_password((char *)pwd, (char *)password);
           (*dbd->set_admin_user)(user, realm, password);
         }
-      } else {
-        if (dbd->set_user_key) {
+      }
+      else
+      {
+        if (dbd->set_user_key)
+        {
           (*dbd->set_user_key)(user, realm, skey);
         }
       }
@@ -1048,9 +1247,11 @@ int adminuser(uint8_t *user, uint8_t *realm, uint8_t *pwd, uint8_t *secret, uint
 
 /////////// PING //////////////
 
-void auth_ping(redis_context_handle rch) {
+void auth_ping(redis_context_handle rch)
+{
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->auth_ping) {
+  if (dbd && dbd->auth_ping)
+  {
     (*dbd->auth_ping)(rch);
   }
 }
@@ -1059,9 +1260,11 @@ void auth_ping(redis_context_handle rch) {
 
 #if defined(DB_TEST)
 
-void run_db_test(void) {
+void run_db_test(void)
+{
   turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd) {
+  if (dbd)
+  {
 
     printf("DB TEST 1:\n");
     dbd->list_oauth_keys();
@@ -1105,9 +1308,12 @@ void run_db_test(void) {
     oauth_key oak;
     char err_msg[1025];
     err_msg[0] = 0;
-    if (!convert_oauth_key_data(&oakd, &oak, err_msg, sizeof(err_msg) - 1)) {
+    if (!convert_oauth_key_data(&oakd, &oak, err_msg, sizeof(err_msg) - 1))
+    {
       printf("  ERROR: %s\n", err_msg);
-    } else {
+    }
+    else
+    {
       printf("  OK!\n");
     }
     printf("DB TEST END\n");
@@ -1129,7 +1335,8 @@ static TURN_MUTEX_DECLARE(blacklist_mutex);
 static ip_range_list_t *ipwhitelist = NULL;
 static ip_range_list_t *ipblacklist = NULL;
 
-void init_dynamic_ip_lists(void) {
+void init_dynamic_ip_lists(void)
+{
 #if !defined(TURN_NO_RWLOCK)
   whitelist_rwlock = (pthread_rwlock_t *)malloc(sizeof(pthread_rwlock_t));
   pthread_rwlock_init(whitelist_rwlock, NULL);
@@ -1142,7 +1349,8 @@ void init_dynamic_ip_lists(void) {
 #endif
 }
 
-void ioa_lock_whitelist(ioa_engine_handle e) {
+void ioa_lock_whitelist(ioa_engine_handle e)
+{
   UNUSED_ARG(e);
 #if !defined(TURN_NO_RWLOCK)
   pthread_rwlock_rdlock(whitelist_rwlock);
@@ -1150,7 +1358,8 @@ void ioa_lock_whitelist(ioa_engine_handle e) {
   TURN_MUTEX_LOCK(&whitelist_mutex);
 #endif
 }
-void ioa_unlock_whitelist(ioa_engine_handle e) {
+void ioa_unlock_whitelist(ioa_engine_handle e)
+{
   UNUSED_ARG(e);
 #if !defined(TURN_NO_RWLOCK)
   pthread_rwlock_unlock(whitelist_rwlock);
@@ -1158,7 +1367,8 @@ void ioa_unlock_whitelist(ioa_engine_handle e) {
   TURN_MUTEX_UNLOCK(&whitelist_mutex);
 #endif
 }
-static void ioa_wrlock_whitelist(ioa_engine_handle e) {
+static void ioa_wrlock_whitelist(ioa_engine_handle e)
+{
   UNUSED_ARG(e);
 #if !defined(TURN_NO_RWLOCK)
   pthread_rwlock_wrlock(whitelist_rwlock);
@@ -1166,12 +1376,14 @@ static void ioa_wrlock_whitelist(ioa_engine_handle e) {
   TURN_MUTEX_LOCK(&whitelist_mutex);
 #endif
 }
-const ip_range_list_t *ioa_get_whitelist(ioa_engine_handle e) {
+const ip_range_list_t *ioa_get_whitelist(ioa_engine_handle e)
+{
   UNUSED_ARG(e);
   return ipwhitelist;
 }
 
-void ioa_lock_blacklist(ioa_engine_handle e) {
+void ioa_lock_blacklist(ioa_engine_handle e)
+{
   UNUSED_ARG(e);
 #if !defined(TURN_NO_RWLOCK)
   pthread_rwlock_rdlock(blacklist_rwlock);
@@ -1179,7 +1391,8 @@ void ioa_lock_blacklist(ioa_engine_handle e) {
   TURN_MUTEX_LOCK(&blacklist_mutex);
 #endif
 }
-void ioa_unlock_blacklist(ioa_engine_handle e) {
+void ioa_unlock_blacklist(ioa_engine_handle e)
+{
   UNUSED_ARG(e);
 #if !defined(TURN_NO_RWLOCK)
   pthread_rwlock_unlock(blacklist_rwlock);
@@ -1187,7 +1400,8 @@ void ioa_unlock_blacklist(ioa_engine_handle e) {
   TURN_MUTEX_UNLOCK(&blacklist_mutex);
 #endif
 }
-static void ioa_wrlock_blacklist(ioa_engine_handle e) {
+static void ioa_wrlock_blacklist(ioa_engine_handle e)
+{
   UNUSED_ARG(e);
 #if !defined(TURN_NO_RWLOCK)
   pthread_rwlock_wrlock(blacklist_rwlock);
@@ -1195,32 +1409,39 @@ static void ioa_wrlock_blacklist(ioa_engine_handle e) {
   TURN_MUTEX_LOCK(&blacklist_mutex);
 #endif
 }
-const ip_range_list_t *ioa_get_blacklist(ioa_engine_handle e) {
+const ip_range_list_t *ioa_get_blacklist(ioa_engine_handle e)
+{
   UNUSED_ARG(e);
   return ipblacklist;
 }
 
-ip_range_list_t *get_ip_list(const char *kind) {
+ip_range_list_t *get_ip_list(const char *kind)
+{
   ip_range_list_t *ret = (ip_range_list_t *)calloc(sizeof(ip_range_list_t), 1);
 
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->get_ip_list && !turn_params.no_dynamic_ip_list) {
+  if (dbd && dbd->get_ip_list && !turn_params.no_dynamic_ip_list)
+  {
     (*dbd->get_ip_list)(kind, ret);
   }
 
   return ret;
 }
 
-void ip_list_free(ip_range_list_t *l) {
-  if (l) {
-    if (l->rs) {
+void ip_list_free(ip_range_list_t *l)
+{
+  if (l)
+  {
+    if (l->rs)
+    {
       free(l->rs);
     }
     free(l);
   }
 }
 
-void update_white_and_black_lists(void) {
+void update_white_and_black_lists(void)
+{
   {
     ip_range_list_t *wl = get_ip_list("allowed");
     ip_range_list_t *owl = NULL;
@@ -1243,44 +1464,55 @@ void update_white_and_black_lists(void) {
 
 /////////////// add ACL record ///////////////////
 
-int add_ip_list_range(const char *range0, const char *realm, ip_range_list_t *list) {
+int add_ip_list_range(const char *range0, const char *realm, ip_range_list_t *list)
+{
   char *range = strdup(range0);
 
   char *separator = strchr(range, '-');
 
-  if (separator) {
+  if (separator)
+  {
     *separator = '\0';
   }
 
   ioa_addr min, max;
 
-  if (make_ioa_addr((const uint8_t *)range, 0, &min) < 0) {
+  if (make_ioa_addr((const uint8_t *)range, 0, &min) < 0)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong address format: %s\n", range);
     free(range);
     return -1;
   }
 
-  if (separator) {
-    if (make_ioa_addr((const uint8_t *)separator + 1, 0, &max) < 0) {
+  if (separator)
+  {
+    if (make_ioa_addr((const uint8_t *)separator + 1, 0, &max) < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong address format: %s\n", separator + 1);
       free(range);
       return -1;
     }
-  } else {
+  }
+  else
+  {
     // Doesn't have a '-' character in it, so assume that this is a single address
     addr_cpy(&max, &min);
   }
 
-  if (separator) {
+  if (separator)
+  {
     *separator = '-';
   }
 
   ++(list->ranges_number);
   list->rs = (ip_range_t *)realloc(list->rs, sizeof(ip_range_t) * list->ranges_number);
   STRCPY(list->rs[list->ranges_number - 1].str, range);
-  if (realm) {
+  if (realm)
+  {
     STRCPY(list->rs[list->ranges_number - 1].realm, realm);
-  } else {
+  }
+  else
+  {
     list->rs[list->ranges_number - 1].realm[0] = 0;
   }
   free(range);
@@ -1289,35 +1521,43 @@ int add_ip_list_range(const char *range0, const char *realm, ip_range_list_t *li
   return 0;
 }
 
-int check_ip_list_range(const char *range0) {
+int check_ip_list_range(const char *range0)
+{
   char *range = strdup(range0);
 
   char *separator = strchr(range, '-');
 
-  if (separator) {
+  if (separator)
+  {
     *separator = '\0';
   }
 
   ioa_addr min, max;
 
-  if (make_ioa_addr((const uint8_t *)range, 0, &min) < 0) {
+  if (make_ioa_addr((const uint8_t *)range, 0, &min) < 0)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong address range format: %s\n", range);
     free(range);
     return -1;
   }
 
-  if (separator) {
-    if (make_ioa_addr((const uint8_t *)separator + 1, 0, &max) < 0) {
+  if (separator)
+  {
+    if (make_ioa_addr((const uint8_t *)separator + 1, 0, &max) < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong address range format: %s\n", separator + 1);
       free(range);
       return -1;
     }
-  } else {
+  }
+  else
+  {
     // Doesn't have a '-' character in it, so assume that this is a single address
     addr_cpy(&max, &min);
   }
 
-  if (separator) {
+  if (separator)
+  {
     *separator = '-';
   }
 
@@ -1328,7 +1568,8 @@ int check_ip_list_range(const char *range0) {
 
 /////////// REALM //////////////
 
-void reread_realms(void) {
+void reread_realms(void)
+{
   {
     realm_params_t *defrp = get_realm(NULL);
     lock_realms();
@@ -1339,7 +1580,8 @@ void reread_realms(void) {
   }
 
   const turn_dbdriver_t *dbd = get_dbdriver();
-  if (dbd && dbd->reread_realms && !turn_params.no_dynamic_realms) {
+  if (dbd && dbd->reread_realms && !turn_params.no_dynamic_realms)
+  {
     (*dbd->reread_realms)(&realms_list);
   }
 }

--- a/src/apps/relay/userdb.h
+++ b/src/apps/relay/userdb.h
@@ -43,7 +43,8 @@
 #include "apputils.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #ifndef _MSC_VER
@@ -62,13 +63,15 @@ typedef struct _realm_status_t realm_status_t;
 struct _realm_params_t;
 typedef struct _realm_params_t realm_params_t;
 
-struct _realm_status_t {
+struct _realm_status_t
+{
 
   vint total_current_allocs;
   ur_string_map *alloc_counters;
 };
 
-struct _realm_params_t {
+struct _realm_params_t
+{
 
   int is_default_realm;
 
@@ -83,7 +86,8 @@ void update_o_to_realm(ur_string_map *o_to_realm_new);
 
 //////////// USER DB //////////////////////////////
 
-struct auth_message {
+struct auth_message
+{
   turnserver_id id;
   turn_credential_type ct;
   int in_oauth;
@@ -99,7 +103,8 @@ struct auth_message {
   int success;
 };
 
-enum _TURN_USERDB_TYPE {
+enum _TURN_USERDB_TYPE
+{
   TURN_USERDB_TYPE_UNKNOWN,
   TURN_USERDB_TYPE_SQLITE,
   TURN_USERDB_TYPE_PQ,
@@ -110,7 +115,8 @@ enum _TURN_USERDB_TYPE {
 
 typedef enum _TURN_USERDB_TYPE TURN_USERDB_TYPE;
 
-enum _TURNADMIN_COMMAND_TYPE {
+enum _TURNADMIN_COMMAND_TYPE
+{
   TA_COMMAND_UNKNOWN,
   TA_PRINT_KEY,
   TA_UPDATE_USER,
@@ -130,7 +136,8 @@ typedef enum _TURNADMIN_COMMAND_TYPE TURNADMIN_COMMAND_TYPE;
 
 /////////// SHARED SECRETS //////////////////
 
-struct _secrets_list {
+struct _secrets_list
+{
   char **secrets;
   size_t sz;
 };
@@ -140,23 +147,27 @@ typedef struct _secrets_list secrets_list_t;
 
 #define TURN_LONG_STRING_SIZE (1025)
 
-typedef struct _redis_stats_db_t {
+typedef struct _redis_stats_db_t
+{
   char connection_string[TURN_LONG_STRING_SIZE];
   char connection_string_sanitized[TURN_LONG_STRING_SIZE];
 } redis_stats_db_t;
 
-typedef struct _ram_users_db_t {
+typedef struct _ram_users_db_t
+{
   size_t users_number;
   ur_string_map *static_accounts;
   secrets_list_t static_auth_secrets;
 } ram_users_db_t;
 
-typedef struct _persistent_users_db_t {
+typedef struct _persistent_users_db_t
+{
   char userdb[TURN_LONG_STRING_SIZE];
   char userdb_sanitized[TURN_LONG_STRING_SIZE];
 } persistent_users_db_t;
 
-typedef struct _default_users_db_t {
+typedef struct _default_users_db_t
+{
   TURN_USERDB_TYPE userdb_type;
 
   persistent_users_db_t persistent_users_db;

--- a/src/apps/rfc5769/rfc5769check.c
+++ b/src/apps/rfc5769/rfc5769check.c
@@ -54,17 +54,20 @@ static const char *encs[] = {
 static int print_extra = 0;
 
 void print_field5769(const char *name, const void *f0, size_t len);
-void print_field5769(const char *name, const void *f0, size_t len) {
+void print_field5769(const char *name, const void *f0, size_t len)
+{
   const unsigned char *f = (const unsigned char *)f0;
   printf("\nfield %s %lu==>>\n", name, (unsigned long)len);
   size_t i;
-  for (i = 0; i < len; ++i) {
+  for (i = 0; i < len; ++i)
+  {
     printf("\\x%02x", (unsigned int)f[i]);
   }
   printf("\n<<==field %s\n", name);
 }
 
-static int check_oauth(void) {
+static int check_oauth(void)
+{
   const char server_name[33] = "blackdow.carleon.gov";
 
   size_t i_encs;
@@ -89,10 +92,12 @@ static int check_oauth(void) {
 
   {
     {
-      for (i_encs = 0; encs[i_encs]; ++i_encs) {
+      for (i_encs = 0; encs[i_encs]; ++i_encs)
+      {
         printf("oauth token %s:", encs[i_encs]);
 
-        if (print_extra) {
+        if (print_extra)
+        {
           printf("\n");
         }
 
@@ -127,14 +132,16 @@ static int check_oauth(void) {
             char err_msg[1025] = "\0";
             size_t err_msg_size = sizeof(err_msg) - 1;
 
-            if (!convert_oauth_key_data(&okd, &key, err_msg, err_msg_size)) {
+            if (!convert_oauth_key_data(&okd, &key, err_msg, err_msg_size))
+            {
               fprintf(stderr, "%s\n", err_msg);
               goto err;
             }
           }
         }
 
-        if (print_extra) {
+        if (print_extra)
+        {
           print_field5769("AS-RS", key.as_rs_key, key.as_rs_key_size);
           print_field5769("AUTH", key.auth_key, key.auth_key_size);
         }
@@ -143,38 +150,45 @@ static int check_oauth(void) {
           encoded_oauth_token etoken;
           memset(&etoken, 0, sizeof(etoken));
 
-          if (!encode_oauth_token((const uint8_t *)server_name, &etoken, &key, &ot, (const uint8_t *)gcm_nonce)) {
+          if (!encode_oauth_token((const uint8_t *)server_name, &etoken, &key, &ot, (const uint8_t *)gcm_nonce))
+          {
             fprintf(stderr, "%s: cannot encode oauth token\n", __FUNCTION__);
             goto err;
           }
 
-          if (print_extra) {
+          if (print_extra)
+          {
             print_field5769("encoded token", etoken.token, etoken.size);
           }
 
-          if (!decode_oauth_token((const uint8_t *)server_name, &etoken, &key, &dot)) {
+          if (!decode_oauth_token((const uint8_t *)server_name, &etoken, &key, &dot))
+          {
             fprintf(stderr, "%s: cannot decode oauth token\n", __FUNCTION__);
             goto err;
           }
         }
 
-        if (strcmp((char *)ot.enc_block.mac_key, (char *)dot.enc_block.mac_key)) {
+        if (strcmp((char *)ot.enc_block.mac_key, (char *)dot.enc_block.mac_key))
+        {
           fprintf(stderr, "%s: wrong mac key: %s, must be %s\n", __FUNCTION__, (char *)dot.enc_block.mac_key,
                   (char *)ot.enc_block.mac_key);
           goto err;
         }
 
-        if (ot.enc_block.key_length != dot.enc_block.key_length) {
+        if (ot.enc_block.key_length != dot.enc_block.key_length)
+        {
           fprintf(stderr, "%s: wrong key length: %d, must be %d\n", __FUNCTION__, (int)dot.enc_block.key_length,
                   (int)ot.enc_block.key_length);
           goto err;
         }
-        if (ot.enc_block.timestamp != dot.enc_block.timestamp) {
+        if (ot.enc_block.timestamp != dot.enc_block.timestamp)
+        {
           fprintf(stderr, "%s: wrong timestamp: %llu, must be %llu\n", __FUNCTION__,
                   (unsigned long long)dot.enc_block.timestamp, (unsigned long long)ot.enc_block.timestamp);
           goto err;
         }
-        if (ot.enc_block.lifetime != dot.enc_block.lifetime) {
+        if (ot.enc_block.lifetime != dot.enc_block.lifetime)
+        {
           fprintf(stderr, "%s: wrong lifetime: %lu, must be %lu\n", __FUNCTION__, (unsigned long)dot.enc_block.lifetime,
                   (unsigned long)ot.enc_block.lifetime);
           goto err;
@@ -185,13 +199,15 @@ static int check_oauth(void) {
     }
   }
 
-  if (base64encoded_ltp) {
+  if (base64encoded_ltp)
+  {
     free(base64encoded_ltp);
   }
   return 0;
 
 err:
-  if (base64encoded_ltp) {
+  if (base64encoded_ltp)
+  {
     free(base64encoded_ltp);
   }
   return -1;
@@ -201,13 +217,15 @@ err:
 
 static SHATYPE shatype = SHATYPE_SHA1;
 
-int main(int argc, const char **argv) {
+int main(int argc, const char **argv)
+{
   int res = -1;
 
   UNUSED_ARG(argc);
   UNUSED_ARG(argv);
 
-  if (argc > 1) {
+  if (argc > 1)
+  {
     print_extra = 1;
   }
 
@@ -241,9 +259,12 @@ int main(int argc, const char **argv) {
       res = stun_is_command_message_full_check_str(buf, sizeof(reqstc) - 1, 1, NULL);
       printf("RFC 5769 message fingerprint test(0) result: ");
 
-      if (res) {
+      if (res)
+      {
         printf("success\n");
-      } else if (res == 0) {
+      }
+      else if (res == 0)
+      {
         printf("failure on fingerprint(0) check\n");
         exit(-1);
       }
@@ -259,12 +280,17 @@ int main(int argc, const char **argv) {
                                              shatype);
       printf("RFC 5769 simple request short-term credentials and integrity test result: ");
 
-      if (res > 0) {
+      if (res > 0)
+      {
         printf("success\n");
-      } else if (res == 0) {
+      }
+      else if (res == 0)
+      {
         printf("failure on integrity check\n");
         exit(-1);
-      } else {
+      }
+      else
+      {
         printf("failure on message structure check\n");
         exit(-1);
       }
@@ -276,9 +302,12 @@ int main(int argc, const char **argv) {
       res = stun_is_command_message_full_check_str(buf, sizeof(reqstc) - 1, 1, NULL);
       printf("RFC 5769 NEGATIVE fingerprint test(0) result: ");
 
-      if (!res) {
+      if (!res)
+      {
         printf("success\n");
-      } else if (res == 0) {
+      }
+      else if (res == 0)
+      {
         printf("failure on NEGATIVE fingerprint check\n");
         exit(-1);
       }
@@ -324,12 +353,17 @@ int main(int argc, const char **argv) {
 
     printf("RFC 5769 message structure, long-term credentials and integrity test result: ");
 
-    if (res > 0) {
+    if (res > 0)
+    {
       printf("success\n");
-    } else if (res == 0) {
+    }
+    else if (res == 0)
+    {
       printf("failure on integrity check\n");
       exit(-1);
-    } else {
+    }
+    else
+    {
       printf("failure on message structure check\n");
       exit(-1);
     }
@@ -349,19 +383,23 @@ int main(int argc, const char **argv) {
       buf32[1] = nswap32(STUN_MAGIC_COOKIE);
       stun_tid_message_cpy(buf, &tid);
       stun_attr_add_integrity_by_user_str(buf, &len, uname, realm, upwd, nonce, shatype);
-      if (len != (sizeof(reqltc) - 1)) {
+      if (len != (sizeof(reqltc) - 1))
+      {
         printf("failure: length %d, must be %d\n", (int)len, (int)(sizeof(reqltc) - 1));
         exit(-1);
       }
-      if (memcmp(buf, reqltc, len)) {
+      if (memcmp(buf, reqltc, len))
+      {
         printf("failure: wrong message content\n");
         {
           int lines = 29;
           int line = 0;
           int col = 0;
           int cols = 4;
-          for (line = 0; line < lines; line++) {
-            for (col = 0; col < cols; col++) {
+          for (line = 0; line < lines; line++)
+          {
+            for (col = 0; col < cols; col++)
+            {
               uint8_t c = buf[line * 4 + col];
               printf(" %2x", (int)c);
             }
@@ -380,9 +418,12 @@ int main(int argc, const char **argv) {
 
     printf("RFC 5769 NEGATIVE long-term credentials test result: ");
 
-    if (res == 0) {
+    if (res == 0)
+    {
       printf("success\n");
-    } else {
+    }
+    else
+    {
       printf("failure on NEGATIVE long-term credentials check\n");
       exit(-1);
     }
@@ -410,9 +451,12 @@ int main(int argc, const char **argv) {
       res = stun_is_command_message_full_check_str(buf, sizeof(respv4) - 1, 1, NULL);
       printf("RFC 5769 message fingerprint test(1) result: ");
 
-      if (res) {
+      if (res)
+      {
         printf("success\n");
-      } else if (res == 0) {
+      }
+      else if (res == 0)
+      {
         printf("failure on fingerprint(1) check\n");
         exit(-1);
       }
@@ -428,12 +472,17 @@ int main(int argc, const char **argv) {
                                              shatype);
       printf("RFC 5769 IPv4 response short-term credentials and integrity test result: ");
 
-      if (res > 0) {
+      if (res > 0)
+      {
         printf("success\n");
-      } else if (res == 0) {
+      }
+      else if (res == 0)
+      {
         printf("failure on integrity check\n");
         exit(-1);
-      } else {
+      }
+      else
+      {
         printf("failure on message structure check\n");
         exit(-1);
       }
@@ -445,9 +494,12 @@ int main(int argc, const char **argv) {
       res = stun_is_command_message_full_check_str(buf, sizeof(respv4) - 1, 1, NULL);
       printf("RFC 5769 NEGATIVE fingerprint test(1) result: ");
 
-      if (!res) {
+      if (!res)
+      {
         printf("success\n");
-      } else if (res == 0) {
+      }
+      else if (res == 0)
+      {
         printf("failure on NEGATIVE fingerprint check\n");
         exit(-1);
       }
@@ -459,15 +511,19 @@ int main(int argc, const char **argv) {
 
       printf("RFC 5769 IPv4 encoding result: ");
 
-      if (!stun_attr_get_first_addr_str(buf, sizeof(respv4) - 1, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, &addr4, NULL)) {
+      if (!stun_attr_get_first_addr_str(buf, sizeof(respv4) - 1, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, &addr4, NULL))
+      {
         printf("failure on message structure check\n");
         exit(-1);
       }
 
       make_ioa_addr((const uint8_t *)"192.0.2.1", 32853, &addr4_test);
-      if (addr_eq(&addr4, &addr4_test)) {
+      if (addr_eq(&addr4, &addr4_test))
+      {
         printf("success\n");
-      } else {
+      }
+      else
+      {
         printf("failure on IPv4 deconding check\n");
         exit(-1);
       }
@@ -498,9 +554,12 @@ int main(int argc, const char **argv) {
       res = stun_is_command_message_full_check_str(buf, sizeof(respv6) - 1, 1, NULL);
       printf("RFC 5769 message fingerprint test(2) result: ");
 
-      if (res) {
+      if (res)
+      {
         printf("success\n");
-      } else if (res == 0) {
+      }
+      else if (res == 0)
+      {
         printf("failure on fingerprint(2) check\n");
         exit(-1);
       }
@@ -516,12 +575,17 @@ int main(int argc, const char **argv) {
                                              shatype);
       printf("RFC 5769 IPv6 response short-term credentials and integrity test result: ");
 
-      if (res > 0) {
+      if (res > 0)
+      {
         printf("success\n");
-      } else if (res == 0) {
+      }
+      else if (res == 0)
+      {
         printf("failure on integrity check\n");
         exit(-1);
-      } else {
+      }
+      else
+      {
         printf("failure on message structure check\n");
         exit(-1);
       }
@@ -533,9 +597,12 @@ int main(int argc, const char **argv) {
       res = stun_is_command_message_full_check_str(buf, sizeof(respv6) - 1, 1, NULL);
       printf("RFC 5769 NEGATIVE fingerprint test(2) result: ");
 
-      if (!res) {
+      if (!res)
+      {
         printf("success\n");
-      } else if (res == 0) {
+      }
+      else if (res == 0)
+      {
         printf("failure on NEGATIVE fingerprint check\n");
         exit(-1);
       }
@@ -547,15 +614,19 @@ int main(int argc, const char **argv) {
 
       printf("RFC 5769 IPv6 encoding result: ");
 
-      if (!stun_attr_get_first_addr_str(buf, sizeof(respv6) - 1, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, &addr6, NULL)) {
+      if (!stun_attr_get_first_addr_str(buf, sizeof(respv6) - 1, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, &addr6, NULL))
+      {
         printf("failure on message structure check\n");
         exit(-1);
       }
 
       make_ioa_addr((const uint8_t *)"2001:db8:1234:5678:11:2233:4455:6677", 32853, &addr6_test);
-      if (addr_eq(&addr6, &addr6_test)) {
+      if (addr_eq(&addr6, &addr6_test))
+      {
         printf("success\n");
-      } else {
+      }
+      else
+      {
         printf("failure on IPv6 deconding check\n");
         exit(-1);
       }
@@ -563,7 +634,8 @@ int main(int argc, const char **argv) {
   }
 
   {
-    if (check_oauth() < 0) {
+    if (check_oauth() < 0)
+    {
       exit(-1);
     }
   }

--- a/src/apps/stunclient/stunclient.c
+++ b/src/apps/stunclient/stunclient.c
@@ -59,39 +59,48 @@ static int counter = 0;
 #ifdef __cplusplus
 
 static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, int response_port, bool change_ip,
-                          bool change_port, int padding) {
+                          bool change_port, int padding)
+{
 
   ioa_addr remote_addr;
   int new_udp_fd = -1;
 
   memset((void *)&remote_addr, 0, sizeof(ioa_addr));
-  if (make_ioa_addr((const uint8_t *)rip, rport, &remote_addr) < 0) {
+  if (make_ioa_addr((const uint8_t *)rip, rport, &remote_addr) < 0)
+  {
     err(-1, NULL);
   }
 
-  if (udp_fd < 0) {
+  if (udp_fd < 0)
+  {
     udp_fd = socket(remote_addr.ss.sa_family, SOCK_DGRAM, 0);
-    if (udp_fd < 0) {
+    if (udp_fd < 0)
+    {
       err(-1, NULL);
     }
 
-    if (!addr_any(&real_local_addr)) {
-      if (addr_bind(udp_fd, &real_local_addr, 0, 1, UDP_SOCKET) < 0) {
+    if (!addr_any(&real_local_addr))
+    {
+      if (addr_bind(udp_fd, &real_local_addr, 0, 1, UDP_SOCKET) < 0)
+      {
         err(-1, NULL);
       }
     }
   }
 
-  if (response_port >= 0) {
+  if (response_port >= 0)
+  {
 
     new_udp_fd = socket(remote_addr.ss.sa_family, SOCK_DGRAM, 0);
-    if (new_udp_fd < 0) {
+    if (new_udp_fd < 0)
+    {
       err(-1, NULL);
     }
 
     addr_set_port(&real_local_addr, response_port);
 
-    if (addr_bind(new_udp_fd, &real_local_addr, 0, 1, UDP_SOCKET) < 0) {
+    if (addr_bind(new_udp_fd, &real_local_addr, 0, 1, UDP_SOCKET) < 0)
+    {
       err(-1, NULL);
     }
   }
@@ -100,51 +109,75 @@ static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, 
 
   req.constructBindingRequest();
 
-  if (response_port >= 0) {
+  if (response_port >= 0)
+  {
     turn::StunAttrResponsePort rpa;
     rpa.setResponsePort((uint16_t)response_port);
-    try {
+    try
+    {
       req.addAttr(rpa);
-    } catch (turn::WrongStunAttrFormatException &ex1) {
+    }
+    catch (turn::WrongStunAttrFormatException &ex1)
+    {
       printf("Wrong rp attr format\n");
       exit(-1);
-    } catch (turn::WrongStunBufferFormatException &ex2) {
+    }
+    catch (turn::WrongStunBufferFormatException &ex2)
+    {
       printf("Wrong stun buffer format (1)\n");
       exit(-1);
-    } catch (...) {
+    }
+    catch (...)
+    {
       printf("Wrong something (1)\n");
       exit(-1);
     }
   }
-  if (change_ip || change_port) {
+  if (change_ip || change_port)
+  {
     turn::StunAttrChangeRequest cra;
     cra.setChangeIp(change_ip);
     cra.setChangePort(change_port);
-    try {
+    try
+    {
       req.addAttr(cra);
-    } catch (turn::WrongStunAttrFormatException &ex1) {
+    }
+    catch (turn::WrongStunAttrFormatException &ex1)
+    {
       printf("Wrong cr attr format\n");
       exit(-1);
-    } catch (turn::WrongStunBufferFormatException &ex2) {
+    }
+    catch (turn::WrongStunBufferFormatException &ex2)
+    {
       printf("Wrong stun buffer format (2)\n");
       exit(-1);
-    } catch (...) {
+    }
+    catch (...)
+    {
       printf("Wrong something (2)\n");
       exit(-1);
     }
   }
-  if (padding) {
+  if (padding)
+  {
     turn::StunAttrPadding pa;
     pa.setPadding(1500);
-    try {
+    try
+    {
       req.addAttr(pa);
-    } catch (turn::WrongStunAttrFormatException &ex1) {
+    }
+    catch (turn::WrongStunAttrFormatException &ex1)
+    {
       printf("Wrong p attr format\n");
       exit(-1);
-    } catch (turn::WrongStunBufferFormatException &ex2) {
+    }
+    catch (turn::WrongStunBufferFormatException &ex2)
+    {
       printf("Wrong stun buffer format (3)\n");
       exit(-1);
-    } catch (...) {
+    }
+    catch (...)
+    {
       printf("Wrong something (3)\n");
       exit(-1);
     }
@@ -154,23 +187,29 @@ static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, 
     int len = 0;
     int slen = get_ioa_addr_len(&remote_addr);
 
-    do {
+    do
+    {
       len = sendto(udp_fd, req.getRawBuffer(), req.getSize(), 0, (struct sockaddr *)&remote_addr, (socklen_t)slen);
     } while (len < 0 && (socket_eintr() || socket_enobufs() || socket_eagain()));
 
-    if (len < 0) {
+    if (len < 0)
+    {
       err(-1, NULL);
     }
   }
 
-  if (addr_get_from_sock(udp_fd, &real_local_addr) < 0) {
+  if (addr_get_from_sock(udp_fd, &real_local_addr) < 0)
+  {
     printf("%s: Cannot get address from local socket\n", __FUNCTION__);
-  } else {
+  }
+  else
+  {
     *port = addr_get_port(&real_local_addr);
   }
 
   {
-    if (new_udp_fd >= 0) {
+    if (new_udp_fd >= 0)
+    {
       socket_closesocket(udp_fd);
       udp_fd = new_udp_fd;
       new_udp_fd = -1;
@@ -184,39 +223,48 @@ static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, 
     int recvd = 0;
     const int to_recv = sizeof(buf.buf);
 
-    do {
+    do
+    {
       len = recv(udp_fd, ptr, to_recv - recvd, 0);
-      if (len > 0) {
+      if (len > 0)
+      {
         recvd += len;
         ptr += len;
         break;
       }
     } while (len < 0 && socket_eintr());
 
-    if (recvd > 0) {
+    if (recvd > 0)
+    {
       len = recvd;
     }
     buf.len = len;
 
-    try {
+    try
+    {
       turn::StunMsgResponse res(buf.buf, sizeof(buf.buf), (size_t)buf.len, true);
 
-      if (res.isCommand()) {
+      if (res.isCommand())
+      {
 
-        if (res.isSuccess()) {
+        if (res.isSuccess())
+        {
 
-          if (res.isBindingResponse()) {
+          if (res.isBindingResponse())
+          {
 
             ioa_addr reflexive_addr;
             addr_set_any(&reflexive_addr);
             turn::StunAttrIterator iter(res, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS);
-            if (!iter.eof()) {
+            if (!iter.eof())
+            {
 
               turn::StunAttrAddr addr(iter);
               addr.getAddr(reflexive_addr);
 
               turn::StunAttrIterator iter1(res, STUN_ATTRIBUTE_OTHER_ADDRESS);
-              if (!iter1.eof()) {
+              if (!iter1.eof())
+              {
                 *rfc5780 = 1;
                 printf("\n========================================\n");
                 printf("RFC 5780 response %d\n", ++counter);
@@ -224,7 +272,8 @@ static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, 
                 turn::StunAttrAddr addr1(iter1);
                 addr1.getAddr(other_addr);
                 turn::StunAttrIterator iter2(res, STUN_ATTRIBUTE_RESPONSE_ORIGIN);
-                if (!iter2.eof()) {
+                if (!iter2.eof())
+                {
                   ioa_addr response_origin;
                   turn::StunAttrAddr addr2(iter2);
                   addr2.getAddr(response_origin);
@@ -233,23 +282,32 @@ static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, 
                 addr_debug_print(1, &other_addr, "Other addr: ");
               }
               addr_debug_print(1, &reflexive_addr, "UDP reflexive addr");
-
-            } else {
+            }
+            else
+            {
               printf("Cannot read the response\n");
             }
-          } else {
+          }
+          else
+          {
             printf("Wrong type of response\n");
           }
-        } else {
+        }
+        else
+        {
           int err_code = res.getError();
           std::string reason = res.getReason();
 
           printf("The response is an error %d (%s)\n", err_code, reason.c_str());
         }
-      } else {
+      }
+      else
+      {
         printf("The response is not a response message\n");
       }
-    } catch (...) {
+    }
+    catch (...)
+    {
       printf("The response is not a well formed STUN message\n");
     }
   }
@@ -260,54 +318,67 @@ static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, 
 #else
 
 static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, int response_port, bool change_ip,
-                          bool change_port, int padding) {
+                          bool change_port, int padding)
+{
 
   ioa_addr remote_addr;
   int new_udp_fd = -1;
   stun_buffer buf;
 
   memset(&remote_addr, 0, sizeof(remote_addr));
-  if (make_ioa_addr((const uint8_t *)rip, rport, &remote_addr) < 0) {
+  if (make_ioa_addr((const uint8_t *)rip, rport, &remote_addr) < 0)
+  {
     err(-1, NULL);
   }
 
-  if (udp_fd < 0) {
+  if (udp_fd < 0)
+  {
     udp_fd = socket(remote_addr.ss.sa_family, CLIENT_DGRAM_SOCKET_TYPE, CLIENT_DGRAM_SOCKET_PROTOCOL);
-    if (udp_fd < 0) {
+    if (udp_fd < 0)
+    {
       err(-1, NULL);
     }
 
-    if (!addr_any(&real_local_addr)) {
-      if (addr_bind(udp_fd, &real_local_addr, 0, 1, UDP_SOCKET) < 0) {
+    if (!addr_any(&real_local_addr))
+    {
+      if (addr_bind(udp_fd, &real_local_addr, 0, 1, UDP_SOCKET) < 0)
+      {
         err(-1, NULL);
       }
     }
   }
 
-  if (response_port >= 0) {
+  if (response_port >= 0)
+  {
 
     new_udp_fd = socket(remote_addr.ss.sa_family, CLIENT_DGRAM_SOCKET_TYPE, CLIENT_DGRAM_SOCKET_PROTOCOL);
-    if (new_udp_fd < 0) {
+    if (new_udp_fd < 0)
+    {
       err(-1, NULL);
     }
 
     addr_set_port(&real_local_addr, response_port);
 
-    if (addr_bind(new_udp_fd, &real_local_addr, 0, 1, UDP_SOCKET) < 0) {
+    if (addr_bind(new_udp_fd, &real_local_addr, 0, 1, UDP_SOCKET) < 0)
+    {
       err(-1, NULL);
     }
   }
 
   stun_prepare_binding_request(&buf);
 
-  if (response_port >= 0) {
+  if (response_port >= 0)
+  {
     stun_attr_add_response_port_str((uint8_t *)(buf.buf), (size_t *)&(buf.len), (uint16_t)response_port);
   }
-  if (change_ip || change_port) {
+  if (change_ip || change_port)
+  {
     stun_attr_add_change_request_str((uint8_t *)buf.buf, (size_t *)&(buf.len), change_ip, change_port);
   }
-  if (padding) {
-    if (!stun_attr_add_padding_str((uint8_t *)buf.buf, (size_t *)&(buf.len), 1500)) {
+  if (padding)
+  {
+    if (!stun_attr_add_padding_str((uint8_t *)buf.buf, (size_t *)&(buf.len), 1500))
+    {
       printf("%s: ERROR: Cannot add padding\n", __FUNCTION__);
     }
   }
@@ -316,23 +387,29 @@ static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, 
     int len = 0;
     int slen = get_ioa_addr_len(&remote_addr);
 
-    do {
+    do
+    {
       len = sendto(udp_fd, buf.buf, buf.len, 0, (struct sockaddr *)&remote_addr, (socklen_t)slen);
     } while (len < 0 && (socket_eintr() || socket_enobufs() || socket_eagain()));
 
-    if (len < 0) {
+    if (len < 0)
+    {
       err(-1, NULL);
     }
   }
 
-  if (addr_get_from_sock(udp_fd, &real_local_addr) < 0) {
+  if (addr_get_from_sock(udp_fd, &real_local_addr) < 0)
+  {
     printf("%s: Cannot get address from local socket\n", __FUNCTION__);
-  } else {
+  }
+  else
+  {
     *port = addr_get_port(&real_local_addr);
   }
 
   {
-    if (new_udp_fd >= 0) {
+    if (new_udp_fd >= 0)
+    {
       socket_closesocket(udp_fd);
       udp_fd = new_udp_fd;
       new_udp_fd = -1;
@@ -345,41 +422,51 @@ static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, 
     int recvd = 0;
     const int to_recv = sizeof(buf.buf);
 
-    do {
+    do
+    {
       len = recv(udp_fd, ptr, to_recv - recvd, 0);
-      if (len > 0) {
+      if (len > 0)
+      {
         recvd += len;
         ptr += len;
         break;
       }
     } while (len < 0 && (socket_eintr() || socket_eagain()));
 
-    if (recvd > 0) {
+    if (recvd > 0)
+    {
       len = recvd;
     }
     buf.len = len;
 
-    if (stun_is_command_message(&buf)) {
+    if (stun_is_command_message(&buf))
+    {
 
-      if (stun_is_response(&buf)) {
+      if (stun_is_response(&buf))
+      {
 
-        if (stun_is_success_response(&buf)) {
+        if (stun_is_success_response(&buf))
+        {
 
-          if (stun_is_binding_response(&buf)) {
+          if (stun_is_binding_response(&buf))
+          {
 
             ioa_addr reflexive_addr;
             addr_set_any(&reflexive_addr);
-            if (stun_attr_get_first_addr(&buf, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, &reflexive_addr, NULL)) {
+            if (stun_attr_get_first_addr(&buf, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, &reflexive_addr, NULL))
+            {
 
               stun_attr_ref sar = stun_attr_get_first_by_type_str(buf.buf, buf.len, STUN_ATTRIBUTE_OTHER_ADDRESS);
-              if (sar) {
+              if (sar)
+              {
                 *rfc5780 = 1;
                 printf("\n========================================\n");
                 printf("RFC 5780 response %d\n", ++counter);
                 ioa_addr other_addr;
                 stun_attr_get_addr_str((uint8_t *)buf.buf, (size_t)buf.len, sar, &other_addr, NULL);
                 sar = stun_attr_get_first_by_type_str(buf.buf, buf.len, STUN_ATTRIBUTE_RESPONSE_ORIGIN);
-                if (sar) {
+                if (sar)
+                {
                   ioa_addr response_origin;
                   stun_attr_get_addr_str((uint8_t *)buf.buf, (size_t)buf.len, sar, &response_origin, NULL);
                   addr_debug_print(1, &response_origin, "Response origin: ");
@@ -387,27 +474,39 @@ static int run_stunclient(const char *rip, int rport, int *port, bool *rfc5780, 
                 addr_debug_print(1, &other_addr, "Other addr: ");
               }
               addr_debug_print(1, &reflexive_addr, "UDP reflexive addr");
-
-            } else {
+            }
+            else
+            {
               printf("Cannot read the response\n");
             }
-          } else {
+          }
+          else
+          {
             printf("Wrong type of response\n");
           }
-        } else {
+        }
+        else
+        {
           int err_code = 0;
           uint8_t err_msg[1025] = "\0";
           size_t err_msg_size = sizeof(err_msg);
-          if (stun_is_error_response(&buf, &err_code, err_msg, err_msg_size)) {
+          if (stun_is_error_response(&buf, &err_code, err_msg, err_msg_size))
+          {
             printf("The response is an error %d (%s)\n", err_code, (char *)err_msg);
-          } else {
+          }
+          else
+          {
             printf("The response is an unrecognized error\n");
           }
         }
-      } else {
+      }
+      else
+      {
         printf("The response is not a response message\n");
       }
-    } else {
+    }
+    else
+    {
       printf("The response is not a STUN message\n");
     }
   }
@@ -426,13 +525,15 @@ static char Usage[] = "Usage: stunclient [options] address\n"
 
 //////////////////////////////////////////////////
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
   int port = DEFAULT_STUN_PORT;
   char local_addr[256] = "\0";
   int c = 0;
   bool forceRfc5780 = false;
 
-  if (socket_init()) {
+  if (socket_init())
+  {
     return -1;
   }
 
@@ -442,8 +543,10 @@ int main(int argc, char **argv) {
 
   memset(local_addr, 0, sizeof(local_addr));
 
-  while ((c = getopt(argc, argv, "p:L:f")) != -1) {
-    switch (c) {
+  while ((c = getopt(argc, argv, "p:L:f")) != -1)
+  {
+    switch (c)
+    {
     case 'f':
       forceRfc5780 = 1;
       break;
@@ -459,15 +562,18 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (optind >= argc) {
+  if (optind >= argc)
+  {
     fprintf(stderr, "%s\n", Usage);
     exit(-1);
   }
 
   addr_set_any(&real_local_addr);
 
-  if (local_addr[0]) {
-    if (make_ioa_addr((const uint8_t *)local_addr, 0, &real_local_addr) < 0) {
+  if (local_addr[0])
+  {
+    if (make_ioa_addr((const uint8_t *)local_addr, 0, &real_local_addr) < 0)
+    {
       err(-1, NULL);
     }
   }
@@ -477,7 +583,8 @@ int main(int argc, char **argv) {
 
   run_stunclient(argv[optind], port, &local_port, &rfc5780, -1, 0, 0, 0);
 
-  if (rfc5780 || forceRfc5780) {
+  if (rfc5780 || forceRfc5780)
+  {
     run_stunclient(argv[optind], port, &local_port, &rfc5780, local_port + 1, 1, 1, 0);
     run_stunclient(argv[optind], port, &local_port, &rfc5780, -1, 1, 1, 1);
   }

--- a/src/apps/uclient/mainuclient.c
+++ b/src/apps/uclient/mainuclient.c
@@ -157,7 +157,8 @@ static char Usage[] =
 
 //////////////////////////////////////////////////
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
   int port = 0;
   int messagenumber = 5;
   char local_addr[256];
@@ -179,7 +180,8 @@ int main(int argc, char **argv) {
   wVersionRequested = MAKEWORD(2, 2);
 
   err = WSAStartup(wVersionRequested, &wsaData);
-  if (err != 0) {
+  if (err != 0)
+  {
     /* Tell the user that we could not find a usable */
     /* Winsock DLL.                                  */
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "WSAStartup failed with error: %d\n", err);
@@ -196,9 +198,12 @@ int main(int argc, char **argv) {
 
   memset(local_addr, 0, sizeof(local_addr));
 
-  while ((c = getopt(argc, argv, "a:d:p:l:n:L:m:e:r:u:w:i:k:z:W:C:E:F:o:bZvsyhcxXgtTSAPDNOUMRIGBJ")) != -1) {
-    switch (c) {
-    case 'J': {
+  while ((c = getopt(argc, argv, "a:d:p:l:n:L:m:e:r:u:w:i:k:z:W:C:E:F:o:bZvsyhcxXgtTSAPDNOUMRIGBJ")) != -1)
+  {
+    switch (c)
+    {
+    case 'J':
+    {
 
       oauth = 1;
 
@@ -210,21 +215,25 @@ int main(int argc, char **argv) {
       char err_msg[1025] = "\0";
       size_t err_msg_size = sizeof(err_msg) - 1;
 
-      if (!convert_oauth_key_data(&okd_array[0], &okey_array[0], err_msg, err_msg_size)) {
+      if (!convert_oauth_key_data(&okd_array[0], &okey_array[0], err_msg, err_msg_size))
+      {
         fprintf(stderr, "%s\n", err_msg);
         exit(-1);
       }
 
-      if (!convert_oauth_key_data(&okd_array[1], &okey_array[1], err_msg, err_msg_size)) {
+      if (!convert_oauth_key_data(&okd_array[1], &okey_array[1], err_msg, err_msg_size))
+      {
         fprintf(stderr, "%s\n", err_msg);
         exit(-1);
       }
 
-      if (!convert_oauth_key_data(&okd_array[2], &okey_array[2], err_msg, err_msg_size)) {
+      if (!convert_oauth_key_data(&okd_array[2], &okey_array[2], err_msg, err_msg_size))
+      {
         fprintf(stderr, "%s\n", err_msg);
         exit(-1);
       }
-    } break;
+    }
+    break;
     case 'a':
       bps = (band_limit_t)strtoul(optarg, NULL, 10);
       break;
@@ -246,14 +255,17 @@ int main(int argc, char **argv) {
     case 'M':
       mobility = true;
       break;
-    case 'E': {
+    case 'E':
+    {
       char *fn = find_config_file(optarg);
-      if (!fn) {
+      if (!fn)
+      {
         fprintf(stderr, "ERROR: file %s not found\n", optarg);
         exit(-1);
       }
       STRCPY(ca_cert_file, fn);
-    } break;
+    }
+    break;
     case 'O':
       dos = true;
       break;
@@ -356,43 +368,54 @@ int main(int argc, char **argv) {
       g_use_auth_secret_with_timestamp = true;
       STRCPY(g_auth_secret, optarg);
       break;
-    case 'i': {
+    case 'i':
+    {
       char *fn = find_config_file(optarg);
-      if (!fn) {
+      if (!fn)
+      {
         fprintf(stderr, "ERROR: file %s not found\n", optarg);
         exit(-1);
       }
       STRCPY(cert_file, fn);
       free(fn);
-    } break;
-    case 'k': {
+    }
+    break;
+    case 'k':
+    {
       char *fn = find_config_file(optarg);
-      if (!fn) {
+      if (!fn)
+      {
         fprintf(stderr, "ERROR: file %s not found\n", optarg);
         exit(-1);
       }
       STRCPY(pkey_file, fn);
       free(fn);
-    } break;
+    }
+    break;
     default:
       fprintf(stderr, "%s\n", Usage);
       exit(1);
     }
   }
 
-  if (dual_allocation) {
+  if (dual_allocation)
+  {
     no_rtcp = true;
   }
 
-  if (g_use_auth_secret_with_timestamp) {
+  if (g_use_auth_secret_with_timestamp)
+  {
 
     {
       char new_uname[1025];
       const unsigned long exp_time = 3600 * 24; /* one day */
-      if (g_uname[0]) {
+      if (g_uname[0])
+      {
         snprintf(new_uname, sizeof(new_uname), "%lu%c%s", (unsigned long)time(NULL) + exp_time, rest_api_separator,
                  (char *)g_uname);
-      } else {
+      }
+      else
+      {
         snprintf(new_uname, sizeof(new_uname), "%lu", (unsigned long)time(NULL) + exp_time);
       }
       STRCPY(g_uname, new_uname);
@@ -401,7 +424,8 @@ int main(int argc, char **argv) {
       uint8_t hmac[MAXSHASIZE];
       unsigned int hmac_len;
 
-      switch (shatype) {
+      switch (shatype)
+      {
       case SHATYPE_SHA256:
         hmac_len = SHA256SIZEBYTES;
         break;
@@ -418,12 +442,15 @@ int main(int argc, char **argv) {
       hmac[0] = 0;
 
       if (stun_calculate_hmac(g_uname, strlen((char *)g_uname), (uint8_t *)g_auth_secret, strlen(g_auth_secret), hmac,
-                              &hmac_len, shatype)) {
+                              &hmac_len, shatype))
+      {
         size_t pwd_length = 0;
         char *pwd = base64_encode(hmac, hmac_len, &pwd_length);
 
-        if (pwd) {
-          if (pwd_length > 0) {
+        if (pwd)
+        {
+          if (pwd_length > 0)
+          {
             memcpy(g_upwd, pwd, pwd_length);
             g_upwd[pwd_length] = 0;
           }
@@ -433,7 +460,8 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (is_TCP_relay()) {
+  if (is_TCP_relay())
+  {
     dont_fragment = false;
     no_rtcp = true;
     c2c = true;
@@ -441,65 +469,85 @@ int main(int argc, char **argv) {
     do_not_use_channel = true;
   }
 
-  if (port == 0) {
-    if (use_secure) {
+  if (port == 0)
+  {
+    if (use_secure)
+    {
       port = DEFAULT_STUN_TLS_PORT;
-    } else {
+    }
+    else
+    {
       port = DEFAULT_STUN_PORT;
     }
   }
 
-  if (clmessage_length < (int)sizeof(message_info)) {
+  if (clmessage_length < (int)sizeof(message_info))
+  {
     clmessage_length = (int)sizeof(message_info);
   }
 
   const int max_header = 100;
-  if (clmessage_length > (int)(STUN_BUFFER_SIZE - max_header)) {
+  if (clmessage_length > (int)(STUN_BUFFER_SIZE - max_header))
+  {
     fprintf(stderr, "Message length was corrected to %d\n", (STUN_BUFFER_SIZE - max_header));
     clmessage_length = (int)(STUN_BUFFER_SIZE - max_header);
   }
 
-  if (optind >= argc) {
+  if (optind >= argc)
+  {
     fprintf(stderr, "%s\n", Usage);
     exit(-1);
   }
 
-  if (!c2c) {
-    if (!peer_address[0]) {
+  if (!c2c)
+  {
+    if (!peer_address[0])
+    {
       fprintf(stderr, "Either -e peer_address or -y must be specified\n");
       return -1;
     }
 
-    if (make_ioa_addr((const uint8_t *)peer_address, peer_port, &peer_addr) < 0) {
+    if (make_ioa_addr((const uint8_t *)peer_address, peer_port, &peer_addr) < 0)
+    {
       return -1;
     }
 
-    if (peer_addr.ss.sa_family == AF_INET6) {
+    if (peer_addr.ss.sa_family == AF_INET6)
+    {
       default_address_family = STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6;
-    } else if (peer_addr.ss.sa_family == AF_INET) {
+    }
+    else if (peer_addr.ss.sa_family == AF_INET)
+    {
       default_address_family = STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4;
     }
   }
 
   /* SSL Init ==>> */
 
-  if (use_secure) {
+  if (use_secure)
+  {
 
     SSL_load_error_strings();
     OpenSSL_add_ssl_algorithms();
 
     const char *csuite = "ALL"; //"AES256-SHA" "DH"
-    if (use_null_cipher) {
+    if (use_null_cipher)
+    {
       csuite = "eNULL";
-    } else if (cipher_suite[0]) {
+    }
+    else if (cipher_suite[0])
+    {
       csuite = cipher_suite;
     }
 
-    if (use_tcp) {
+    if (use_tcp)
+    {
       root_tls_ctx[root_tls_ctx_num] = SSL_CTX_new(TLS_client_method());
       SSL_CTX_set_cipher_list(root_tls_ctx[root_tls_ctx_num], csuite);
       root_tls_ctx_num++;
-    } else {
+    }
+    else
+    {
 #if !DTLS_SUPPORTED
       fprintf(stderr, "ERROR: DTLS is not supported.\n");
       exit(-1);
@@ -513,33 +561,42 @@ int main(int argc, char **argv) {
 
   int use_cert = 0;
   int use_ca_cert = 0;
-  if (cert_file[0] && pkey_file[0]) {
+  if (cert_file[0] && pkey_file[0])
+  {
     use_cert = 1;
   }
-  if (ca_cert_file[0]) {
+  if (ca_cert_file[0])
+  {
     use_ca_cert = 1;
   }
 
-  if (use_cert) {
+  if (use_cert)
+  {
     int sslind = 0;
-    for (sslind = 0; sslind < root_tls_ctx_num; sslind++) {
-      if (!SSL_CTX_use_certificate_chain_file(root_tls_ctx[sslind], cert_file)) {
+    for (sslind = 0; sslind < root_tls_ctx_num; sslind++)
+    {
+      if (!SSL_CTX_use_certificate_chain_file(root_tls_ctx[sslind], cert_file))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "\nERROR: could not load certificate chain file!\n");
         exit(-1);
       }
 
-      if (!SSL_CTX_use_PrivateKey_file(root_tls_ctx[sslind], pkey_file, SSL_FILETYPE_PEM)) {
+      if (!SSL_CTX_use_PrivateKey_file(root_tls_ctx[sslind], pkey_file, SSL_FILETYPE_PEM))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "\nERROR: could not load private key file!\n");
         exit(-1);
       }
 
-      if (!SSL_CTX_check_private_key(root_tls_ctx[sslind])) {
+      if (!SSL_CTX_check_private_key(root_tls_ctx[sslind]))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "\nERROR: invalid private key!\n");
         exit(-1);
       }
 
-      if (use_ca_cert) {
-        if (!SSL_CTX_load_verify_locations(root_tls_ctx[sslind], ca_cert_file, NULL)) {
+      if (use_ca_cert)
+      {
+        if (!SSL_CTX_load_verify_locations(root_tls_ctx[sslind], ca_cert_file, NULL))
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "ERROR: cannot load CA from file: %s\n", ca_cert_file);
           exit(-1);
         }
@@ -549,7 +606,9 @@ int main(int argc, char **argv) {
 
         /* Set the verification depth to 9 */
         SSL_CTX_set_verify_depth(root_tls_ctx[sslind], 9);
-      } else {
+      }
+      else
+      {
         SSL_CTX_set_verify(root_tls_ctx[sslind], SSL_VERIFY_NONE, NULL);
       }
     }

--- a/src/apps/uclient/session.h
+++ b/src/apps/uclient/session.h
@@ -42,16 +42,23 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ///////// types ////////////
 
-typedef enum { UR_STATE_UNKNOWN = 0, UR_STATE_READY, UR_STATE_DONE } UR_STATE;
+typedef enum
+{
+  UR_STATE_UNKNOWN = 0,
+  UR_STATE_READY,
+  UR_STATE_DONE
+} UR_STATE;
 
 //////////////// session info //////////////////////
 
-typedef struct {
+typedef struct
+{
   /* RFC 6062 */
   uint32_t cid; // https://datatracker.ietf.org/doc/html/rfc6062#section-6.2.1
   ioa_addr tcp_data_local_addr;
@@ -60,7 +67,8 @@ typedef struct {
   bool tcp_data_bound;
 } app_tcp_conn_info;
 
-typedef struct {
+typedef struct
+{
   ioa_addr local_addr;
   char lsaddr[129];
   ioa_addr remote_addr;
@@ -86,7 +94,8 @@ typedef struct {
   char s_mobile_id[33];
 } app_ur_conn_info;
 
-typedef struct {
+typedef struct
+{
   app_ur_conn_info pinfo;
   UR_STATE state;
   unsigned int ctime; // assigned to from a uint64_t variable "current time" likely should be a time_t or similar.
@@ -115,7 +124,8 @@ typedef struct {
 
 ///////////////////////////////////////////////////////
 
-typedef struct {
+typedef struct
+{
   int msgnum;
   uint64_t mstime;
 } message_info;

--- a/src/apps/uclient/startuclient.h
+++ b/src/apps/uclient/startuclient.h
@@ -36,7 +36,8 @@
 #include "stun_buffer.h" // for stun_buffer
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 /////////////////////////////////////////////////////////

--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -95,7 +95,8 @@ static bool show_statistics = false;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-static void __turn_getMSTime(void) {
+static void __turn_getMSTime(void)
+{
   static uint64_t start_sec = 0;
   struct timespec tp = {0, 0};
 #if defined(CLOCK_REALTIME)
@@ -103,10 +104,12 @@ static void __turn_getMSTime(void) {
 #else
   tp.tv_sec = time(NULL);
 #endif
-  if (!start_sec) {
+  if (!start_sec)
+  {
     start_sec = tp.tv_sec;
   }
-  if (current_time != (uint64_t)((uint64_t)(tp.tv_sec) - start_sec)) {
+  if (current_time != (uint64_t)((uint64_t)(tp.tv_sec) - start_sec))
+  {
     show_statistics = true;
   }
   current_time = (uint64_t)((uint64_t)(tp.tv_sec) - start_sec);
@@ -119,35 +122,47 @@ static int refresh_channel(app_ur_session *elem, uint16_t method, uint32_t lt);
 
 //////////////////////// SS ////////////////////////////////////////
 
-static app_ur_session *init_app_session(app_ur_session *ss) {
-  if (ss) {
+static app_ur_session *init_app_session(app_ur_session *ss)
+{
+  if (ss)
+  {
     memset(ss, 0, sizeof(app_ur_session));
     ss->pinfo.fd = -1;
   }
   return ss;
 }
 
-static app_ur_session *create_new_ss(void) {
+static app_ur_session *create_new_ss(void)
+{
   ++current_clients_number;
   return init_app_session((app_ur_session *)malloc(sizeof(app_ur_session)));
 }
 
-static void uc_delete_session_elem_data(app_ur_session *cdi) {
-  if (cdi) {
+static void uc_delete_session_elem_data(app_ur_session *cdi)
+{
+  if (cdi)
+  {
     EVENT_DEL(cdi->input_ev);
     EVENT_DEL(cdi->input_tcp_data_ev);
-    if (cdi->pinfo.tcp_conn) {
-      for (int i = 0; i < (int)(cdi->pinfo.tcp_conn_number); ++i) {
-        if (cdi->pinfo.tcp_conn[i]) {
-          if (cdi->pinfo.tcp_conn[i]->tcp_data_ssl && !(cdi->pinfo.broken)) {
-            if (!(SSL_get_shutdown(cdi->pinfo.tcp_conn[i]->tcp_data_ssl) & SSL_SENT_SHUTDOWN)) {
+    if (cdi->pinfo.tcp_conn)
+    {
+      for (int i = 0; i < (int)(cdi->pinfo.tcp_conn_number); ++i)
+      {
+        if (cdi->pinfo.tcp_conn[i])
+        {
+          if (cdi->pinfo.tcp_conn[i]->tcp_data_ssl && !(cdi->pinfo.broken))
+          {
+            if (!(SSL_get_shutdown(cdi->pinfo.tcp_conn[i]->tcp_data_ssl) & SSL_SENT_SHUTDOWN))
+            {
               SSL_set_shutdown(cdi->pinfo.tcp_conn[i]->tcp_data_ssl, SSL_RECEIVED_SHUTDOWN);
               SSL_shutdown(cdi->pinfo.tcp_conn[i]->tcp_data_ssl);
             }
-            if (cdi->pinfo.tcp_conn[i]->tcp_data_ssl) {
+            if (cdi->pinfo.tcp_conn[i]->tcp_data_ssl)
+            {
               SSL_free(cdi->pinfo.tcp_conn[i]->tcp_data_ssl);
             }
-            if (cdi->pinfo.tcp_conn[i]->tcp_data_fd >= 0) {
+            if (cdi->pinfo.tcp_conn[i]->tcp_data_fd >= 0)
+            {
               socket_closesocket(cdi->pinfo.tcp_conn[i]->tcp_data_fd);
               cdi->pinfo.tcp_conn[i]->tcp_data_fd = -1;
             }
@@ -157,29 +172,36 @@ static void uc_delete_session_elem_data(app_ur_session *cdi) {
         }
       }
       cdi->pinfo.tcp_conn_number = 0;
-      if (cdi->pinfo.tcp_conn) {
+      if (cdi->pinfo.tcp_conn)
+      {
         free(cdi->pinfo.tcp_conn);
         cdi->pinfo.tcp_conn = NULL;
       }
     }
-    if (cdi->pinfo.ssl && !(cdi->pinfo.broken)) {
-      if (!(SSL_get_shutdown(cdi->pinfo.ssl) & SSL_SENT_SHUTDOWN)) {
+    if (cdi->pinfo.ssl && !(cdi->pinfo.broken))
+    {
+      if (!(SSL_get_shutdown(cdi->pinfo.ssl) & SSL_SENT_SHUTDOWN))
+      {
         SSL_set_shutdown(cdi->pinfo.ssl, SSL_RECEIVED_SHUTDOWN);
         SSL_shutdown(cdi->pinfo.ssl);
       }
     }
-    if (cdi->pinfo.ssl) {
+    if (cdi->pinfo.ssl)
+    {
       SSL_free(cdi->pinfo.ssl);
     }
-    if (cdi->pinfo.fd >= 0) {
+    if (cdi->pinfo.fd >= 0)
+    {
       socket_closesocket(cdi->pinfo.fd);
     }
     cdi->pinfo.fd = -1;
   }
 }
 
-static int remove_all_from_ss(app_ur_session *ss) {
-  if (ss) {
+static int remove_all_from_ss(app_ur_session *ss)
+{
+  if (ss)
+  {
     uc_delete_session_elem_data(ss);
 
     --current_clients_number;
@@ -190,17 +212,21 @@ static int remove_all_from_ss(app_ur_session *ss) {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-int send_buffer(app_ur_conn_info *clnet_info, stun_buffer *message, bool data_connection, app_tcp_conn_info *atc) {
+int send_buffer(app_ur_conn_info *clnet_info, stun_buffer *message, bool data_connection, app_tcp_conn_info *atc)
+{
 
   int rc = 0;
   int ret = -1;
 
   char *buffer = (char *)(message->buf);
 
-  if (negative_protocol_test && (message->len > 0)) {
-    if (turn_random() % 10 == 0) {
+  if (negative_protocol_test && (message->len > 0))
+  {
+    if (turn_random() % 10 == 0)
+    {
       int np = (int)((unsigned long)turn_random() % 10);
-      while (np-- > 0) {
+      while (np-- > 0)
+      {
         int pos = (int)((unsigned long)turn_random() % (unsigned long)message->len);
         int val = (int)((unsigned long)turn_random() % 256);
         message->buf[pos] = (uint8_t)val;
@@ -211,40 +237,53 @@ int send_buffer(app_ur_conn_info *clnet_info, stun_buffer *message, bool data_co
   SSL *ssl = clnet_info->ssl;
   ioa_socket_raw fd = clnet_info->fd;
 
-  if (data_connection) {
-    if (atc) {
+  if (data_connection)
+  {
+    if (atc)
+    {
       ssl = atc->tcp_data_ssl;
       fd = atc->tcp_data_fd;
-    } else if (is_TCP_relay()) {
+    }
+    else if (is_TCP_relay())
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "trying to send tcp data buffer over unready connection: size=%d\n",
                     (int)(message->len));
       return -1;
     }
   }
 
-  if (ssl) {
+  if (ssl)
+  {
 
     bool message_sent = false;
-    while (!message_sent) {
+    while (!message_sent)
+    {
 
-      if (SSL_get_shutdown(ssl)) {
+      if (SSL_get_shutdown(ssl))
+      {
         return -1;
       }
 
       int len = 0;
-      do {
+      do
+      {
         len = SSL_write(ssl, buffer, (int)message->len);
       } while (len < 0 && (socket_eintr() || socket_enobufs()));
 
-      if (len == (int)message->len) {
-        if (clnet_verbose) {
+      if (len == (int)message->len)
+      {
+        if (clnet_verbose)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "buffer sent: size=%d\n", len);
         }
 
         message_sent = true;
         ret = len;
-      } else {
-        switch (SSL_get_error(ssl, len)) {
+      }
+      else
+      {
+        switch (SSL_get_error(ssl, len))
+        {
         case SSL_ERROR_NONE:
           /* Try again ? */
           break;
@@ -259,11 +298,13 @@ int send_buffer(app_ur_conn_info *clnet_info, stun_buffer *message, bool data_co
           break;
         case SSL_ERROR_SYSCALL:
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Socket write error 111.666: \n");
-          if (handle_socket_error()) {
+          if (handle_socket_error())
+          {
             break;
           }
           /* Falls through. */
-        case SSL_ERROR_SSL: {
+        case SSL_ERROR_SSL:
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "SSL write error: \n");
           char buf[1024];
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s (%d)\n", ERR_error_string(ERR_get_error(), buf),
@@ -277,25 +318,32 @@ int send_buffer(app_ur_conn_info *clnet_info, stun_buffer *message, bool data_co
         }
       }
     }
-
-  } else if (fd >= 0) {
+  }
+  else if (fd >= 0)
+  {
 
     size_t left = message->len;
 
-    while (left > 0) {
-      do {
+    while (left > 0)
+    {
+      do
+      {
         rc = send(fd, buffer, left, 0);
       } while (rc <= 0 && (socket_eintr() || socket_enobufs() || socket_eagain()));
-      if (rc > 0) {
+      if (rc > 0)
+      {
         left -= (size_t)rc;
         buffer += rc;
-      } else {
+      }
+      else
+      {
         tot_send_dropped += 1;
         break;
       }
     }
 
-    if (left > 0) {
+    if (left > 0)
+    {
       return -1;
     }
 
@@ -305,16 +353,21 @@ int send_buffer(app_ur_conn_info *clnet_info, stun_buffer *message, bool data_co
   return ret;
 }
 
-static int wait_fd(int fd, unsigned int cycle) {
+static int wait_fd(int fd, unsigned int cycle)
+{
 
-  if (fd >= (int)FD_SETSIZE) {
+  if (fd >= (int)FD_SETSIZE)
+  {
     return 1;
-  } else {
+  }
+  else
+  {
     fd_set fds;
     FD_ZERO(&fds);
     FD_SET(fd, &fds);
 
-    if (dos && cycle == 0) {
+    if (dos && cycle == 0)
+    {
       return 0;
     }
 
@@ -327,29 +380,41 @@ static int wait_fd(int fd, unsigned int cycle) {
 
     int rc = 0;
 
-    do {
+    do
+    {
       struct timeval timeout = {0, 0};
-      if (cycle == 0) {
+      if (cycle == 0)
+      {
         timeout.tv_usec = 500000;
-      } else {
+      }
+      else
+      {
 
         timeout.tv_sec = 1;
-        while (--cycle) {
+        while (--cycle)
+        {
           timeout.tv_sec = timeout.tv_sec + timeout.tv_sec;
         }
 
-        if (ctime.tv_sec > start_time.tv_sec) {
-          if (ctime.tv_sec >= start_time.tv_sec + timeout.tv_sec) {
+        if (ctime.tv_sec > start_time.tv_sec)
+        {
+          if (ctime.tv_sec >= start_time.tv_sec + timeout.tv_sec)
+          {
             break;
-          } else {
+          }
+          else
+          {
             timeout.tv_sec -= (ctime.tv_sec - start_time.tv_sec);
           }
         }
       }
       rc = select(fd + 1, &fds, NULL, NULL, &timeout);
-      if ((rc < 0) && socket_eintr()) {
+      if ((rc < 0) && socket_eintr())
+      {
         gettimeofday(&ctime, NULL);
-      } else {
+      }
+      else
+      {
         break;
       }
     } while (1);
@@ -359,95 +424,116 @@ static int wait_fd(int fd, unsigned int cycle) {
 }
 
 int recv_buffer(app_ur_conn_info *clnet_info, stun_buffer *message, bool sync, bool data_connection,
-                app_tcp_conn_info *atc, stun_buffer *request_message) {
+                app_tcp_conn_info *atc, stun_buffer *request_message)
+{
 
   int rc = 0;
 
   stun_tid tid;
   uint16_t method = 0;
 
-  if (request_message) {
+  if (request_message)
+  {
     stun_tid_from_message(request_message, &tid);
     method = stun_get_method(request_message);
   }
 
   ioa_socket_raw fd = clnet_info->fd;
-  if (atc) {
+  if (atc)
+  {
     fd = atc->tcp_data_fd;
   }
 
   SSL *ssl = clnet_info->ssl;
-  if (atc) {
+  if (atc)
+  {
     ssl = atc->tcp_data_ssl;
   }
 
 recv_again:
 
-  if (!use_tcp && sync && request_message && (fd >= 0)) {
+  if (!use_tcp && sync && request_message && (fd >= 0))
+  {
 
     unsigned int cycle = 0;
-    while (cycle < MAX_LISTENING_CYCLE_NUMBER) {
+    while (cycle < MAX_LISTENING_CYCLE_NUMBER)
+    {
       int serc = wait_fd(fd, cycle);
-      if (serc > 0) {
+      if (serc > 0)
+      {
         break;
       }
-      if (serc < 0) {
+      if (serc < 0)
+      {
         return -1;
       }
-      if (send_buffer(clnet_info, request_message, data_connection, atc) <= 0) {
+      if (send_buffer(clnet_info, request_message, data_connection, atc) <= 0)
+      {
         return -1;
       }
       ++cycle;
     }
   }
 
-  if (!use_secure && !use_tcp && fd >= 0) {
+  if (!use_secure && !use_tcp && fd >= 0)
+  {
 
     /* Plain UDP */
 
-    do {
+    do
+    {
       rc = recv(fd, message->buf, sizeof(message->buf) - 1, 0);
     } while (rc < 0 && (socket_eintr() || (socket_eagain() && sync)));
 
-    if (rc < 0) {
+    if (rc < 0)
+    {
       return -1;
     }
 
     message->len = rc;
-
-  } else if (use_secure && !use_tcp && ssl && !(clnet_info->broken)) {
+  }
+  else if (use_secure && !use_tcp && ssl && !(clnet_info->broken))
+  {
 
     /* DTLS */
 
     int message_received = 0;
     int cycle = 0;
-    while (!message_received && cycle++ < 100) {
+    while (!message_received && cycle++ < 100)
+    {
 
-      if (SSL_get_shutdown(ssl)) {
+      if (SSL_get_shutdown(ssl))
+      {
         return -1;
       }
 
       rc = 0;
-      do {
+      do
+      {
         rc = SSL_read(ssl, message->buf, sizeof(message->buf) - 1);
-        if (rc < 0 && socket_eagain() && sync) {
+        if (rc < 0 && socket_eagain() && sync)
+        {
           continue;
         }
       } while (rc < 0 && socket_eintr());
 
-      if (rc > 0) {
+      if (rc > 0)
+      {
 
-        if (clnet_verbose) {
+        if (clnet_verbose)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "response received: size=%d\n", rc);
         }
         message->len = rc;
         message_received = 1;
-
-      } else {
+      }
+      else
+      {
 
         int sslerr = SSL_get_error(ssl, rc);
 
-        switch (sslerr) {
+        switch (sslerr)
+        {
         case SSL_ERROR_NONE:
           /* Try again ? */
           break;
@@ -462,11 +548,13 @@ recv_again:
           break;
         case SSL_ERROR_SYSCALL:
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Socket read error 111.999: \n");
-          if (handle_socket_error()) {
+          if (handle_socket_error())
+          {
             break;
           }
           /* Falls through. */
-        case SSL_ERROR_SSL: {
+        case SSL_ERROR_SSL:
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "SSL write error: \n");
           char buf[1024];
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s (%d)\n", ERR_error_string(ERR_get_error(), buf),
@@ -479,44 +567,54 @@ recv_again:
           return -1;
         }
 
-        if (!sync) {
+        if (!sync)
+        {
           break;
         }
       }
     }
-
-  } else if (use_secure && use_tcp && ssl && !(clnet_info->broken)) {
+  }
+  else if (use_secure && use_tcp && ssl && !(clnet_info->broken))
+  {
 
     /* TLS*/
 
     bool message_received = false;
     int cycle = 0;
-    while (!message_received && cycle++ < 100) {
+    while (!message_received && cycle++ < 100)
+    {
 
-      if (SSL_get_shutdown(ssl)) {
+      if (SSL_get_shutdown(ssl))
+      {
         return -1;
       }
       rc = 0;
-      do {
+      do
+      {
         rc = SSL_read(ssl, message->buf, sizeof(message->buf) - 1);
-        if (rc < 0 && socket_eagain() && sync) {
+        if (rc < 0 && socket_eagain() && sync)
+        {
           continue;
         }
       } while (rc < 0 && socket_eintr());
 
-      if (rc > 0) {
+      if (rc > 0)
+      {
 
-        if (clnet_verbose) {
+        if (clnet_verbose)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "response received: size=%d\n", rc);
         }
         message->len = rc;
         message_received = true;
-
-      } else {
+      }
+      else
+      {
 
         int sslerr = SSL_get_error(ssl, rc);
 
-        switch (sslerr) {
+        switch (sslerr)
+        {
         case SSL_ERROR_NONE:
           /* Try again ? */
           break;
@@ -531,11 +629,13 @@ recv_again:
           break;
         case SSL_ERROR_SYSCALL:
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Socket read error 111.999: \n");
-          if (handle_socket_error()) {
+          if (handle_socket_error())
+          {
             break;
           }
           /* Falls through. */
-        case SSL_ERROR_SSL: {
+        case SSL_ERROR_SSL:
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "SSL write error: \n");
           char buf[1024];
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s (%d)\n", ERR_error_string(ERR_get_error(), buf),
@@ -548,58 +648,74 @@ recv_again:
           return -1;
         }
 
-        if (!sync) {
+        if (!sync)
+        {
           break;
         }
       }
     }
-
-  } else if (!use_secure && use_tcp && fd >= 0) {
+  }
+  else if (!use_secure && use_tcp && fd >= 0)
+  {
 
     /* Plain TCP */
 
-    do {
+    do
+    {
       rc = recv(fd, message->buf, sizeof(message->buf) - 1, MSG_PEEK);
     } while (rc < 0 && (socket_eintr() || (socket_eagain() && sync)));
 
-    if (rc > 0) {
+    if (rc > 0)
+    {
       int mlen = rc;
       size_t app_msg_len = (size_t)rc;
-      if (!atc) {
+      if (!atc)
+      {
         mlen = stun_get_message_len_str(message->buf, rc, 1, &app_msg_len);
-      } else {
-        if (!sync) {
+      }
+      else
+      {
+        if (!sync)
+        {
           mlen = clmessage_length;
         }
 
-        if (mlen > clmessage_length) {
+        if (mlen > clmessage_length)
+        {
           mlen = clmessage_length;
         }
 
         app_msg_len = (size_t)mlen;
       }
 
-      if (mlen > 0) {
+      if (mlen > 0)
+      {
 
         int rcr = 0;
         int rsf = 0;
         int cycle = 0;
-        while (rsf < mlen && cycle++ < 128) {
-          do {
+        while (rsf < mlen && cycle++ < 128)
+        {
+          do
+          {
             rcr = recv(fd, message->buf + rsf, (size_t)mlen - (size_t)rsf, 0);
           } while (rcr < 0 && (socket_eintr() || (socket_eagain() && sync)));
 
-          if (rcr > 0) {
+          if (rcr > 0)
+          {
             rsf += rcr;
           }
         }
 
-        if (rsf < 1) {
+        if (rsf < 1)
+        {
           return -1;
         }
 
-        if (rsf < (int)app_msg_len) {
-          if ((size_t)(app_msg_len / (size_t)rsf) * ((size_t)(rsf)) != app_msg_len) {
+        if (rsf < (int)app_msg_len)
+        {
+          if ((size_t)(app_msg_len / (size_t)rsf) * ((size_t)(rsf)) != app_msg_len)
+          {
             return -1;
           }
         }
@@ -607,15 +723,18 @@ recv_again:
         message->len = app_msg_len;
 
         rc = app_msg_len;
-
-      } else {
+      }
+      else
+      {
         rc = 0;
       }
     }
   }
 
-  if (rc > 0) {
-    if (request_message) {
+  if (rc > 0)
+  {
+    if (request_message)
+    {
 
       stun_tid recv_tid;
       uint16_t recv_method = 0;
@@ -623,13 +742,15 @@ recv_again:
       stun_tid_from_message(message, &recv_tid);
       recv_method = stun_get_method(message);
 
-      if (method != recv_method) {
+      if (method != recv_method)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Received wrong response method: 0x%x, expected 0x%x; trying again...\n",
                       (unsigned int)recv_method, (unsigned int)method);
         goto recv_again;
       }
 
-      if (memcmp(tid.tsx_id, recv_tid.tsx_id, STUN_TID_SIZE)) {
+      if (memcmp(tid.tsx_id, recv_tid.tsx_id, STUN_TID_SIZE))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Received wrong response tid; trying again...\n");
         goto recv_again;
       }
@@ -639,13 +760,16 @@ recv_again:
   return rc;
 }
 
-static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info *atc) {
+static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info *atc)
+{
 
-  if (!elem) {
+  if (!elem)
+  {
     return -1;
   }
 
-  if (elem->state != UR_STATE_READY) {
+  if (elem->state != UR_STATE_READY)
+  {
     return -1;
   }
 
@@ -657,17 +781,20 @@ static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info 
   int rc = 0;
   int applen = 0;
 
-  if (clnet_verbose && verbose_packets) {
+  if (clnet_verbose && verbose_packets)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "before read ...\n");
   }
 
   rc = recv_buffer(clnet_info, &(elem->in_buffer), 0, is_tcp_data, atc, NULL);
 
-  if (clnet_verbose && verbose_packets) {
+  if (clnet_verbose && verbose_packets)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "read %d bytes\n", (int)rc);
   }
 
-  if (rc > 0) {
+  if (rc > 0)
+  {
 
     elem->in_buffer.len = rc;
 
@@ -677,50 +804,68 @@ static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info 
     bool miset = false;
     size_t buffers = 1;
 
-    if (is_tcp_data) {
-      if ((int)elem->in_buffer.len == clmessage_length) {
+    if (is_tcp_data)
+    {
+      if ((int)elem->in_buffer.len == clmessage_length)
+      {
         memcpy(&mi, (elem->in_buffer.buf), sizeof(message_info));
         miset = true;
-      } else {
+      }
+      else
+      {
         /* TODO: make a more clean fix */
         buffers = (int)elem->in_buffer.len / clmessage_length;
       }
-    } else if (stun_is_indication(&(elem->in_buffer))) {
+    }
+    else if (stun_is_indication(&(elem->in_buffer)))
+    {
 
       uint16_t method = stun_get_method(&elem->in_buffer);
 
-      if ((method == STUN_METHOD_CONNECTION_ATTEMPT) && is_TCP_relay()) {
+      if ((method == STUN_METHOD_CONNECTION_ATTEMPT) && is_TCP_relay())
+      {
         stun_attr_ref sar = stun_attr_get_first(&(elem->in_buffer));
         uint32_t cid = 0;
-        while (sar) {
+        while (sar)
+        {
           int attr_type = stun_attr_get_type(sar);
-          if (attr_type == STUN_ATTRIBUTE_CONNECTION_ID) {
+          if (attr_type == STUN_ATTRIBUTE_CONNECTION_ID)
+          {
             cid = *((const uint32_t *)stun_attr_get_value(sar));
             break;
           }
           sar = stun_attr_get_next_str(elem->in_buffer.buf, elem->in_buffer.len, sar);
         }
-        if (negative_test) {
+        if (negative_test)
+        {
           tcp_data_connect(elem, (uint64_t)turn_random());
-        } else {
+        }
+        else
+        {
           /* positive test */
           tcp_data_connect(elem, cid);
         }
         return rc;
-      } else if (method != STUN_METHOD_DATA) {
+      }
+      else if (method != STUN_METHOD_DATA)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "ERROR: received indication message has wrong method: 0x%x\n", (int)method);
         return rc;
-      } else {
+      }
+      else
+      {
 
         stun_attr_ref sar = stun_attr_get_first_by_type(&(elem->in_buffer), STUN_ATTRIBUTE_DATA);
-        if (!sar) {
+        if (!sar)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "ERROR: received DATA message has no data, size=%d\n", rc);
           return rc;
         }
 
         int rlen = stun_attr_get_len(sar);
         applen = rlen;
-        if (rlen != clmessage_length) {
+        if (rlen != clmessage_length)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "ERROR: received DATA message has wrong len: %d, must be %d\n", rlen,
                         clmessage_length);
           tot_recv_bytes += applen;
@@ -732,21 +877,27 @@ static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info 
         memcpy(&mi, data, sizeof(message_info));
         miset = true;
       }
+    }
+    else if (stun_is_success_response(&(elem->in_buffer)))
+    {
 
-    } else if (stun_is_success_response(&(elem->in_buffer))) {
-
-      if (elem->pinfo.nonce[0]) {
-        if (check_integrity(&(elem->pinfo), &(elem->in_buffer)) < 0) {
+      if (elem->pinfo.nonce[0])
+      {
+        if (check_integrity(&(elem->pinfo), &(elem->in_buffer)) < 0)
+        {
           return -1;
         }
       }
 
-      if (is_TCP_relay() && (stun_get_method(&(elem->in_buffer)) == STUN_METHOD_CONNECT)) {
+      if (is_TCP_relay() && (stun_get_method(&(elem->in_buffer)) == STUN_METHOD_CONNECT))
+      {
         stun_attr_ref sar = stun_attr_get_first(&(elem->in_buffer));
         uint32_t cid = 0;
-        while (sar) {
+        while (sar)
+        {
           int attr_type = stun_attr_get_type(sar);
-          if (attr_type == STUN_ATTRIBUTE_CONNECTION_ID) {
+          if (attr_type == STUN_ATTRIBUTE_CONNECTION_ID)
+          {
             cid = *((const uint32_t *)stun_attr_get_value(sar));
             break;
           }
@@ -756,26 +907,38 @@ static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info 
       }
 
       return rc;
-    } else if (stun_is_challenge_response_str(elem->in_buffer.buf, elem->in_buffer.len, &err_code, err_msg,
-                                              sizeof(err_msg), clnet_info->realm, clnet_info->nonce,
-                                              clnet_info->server_name, &(clnet_info->oauth))) {
-      if (is_TCP_relay() && (stun_get_method(&(elem->in_buffer)) == STUN_METHOD_CONNECT)) {
+    }
+    else if (stun_is_challenge_response_str(elem->in_buffer.buf, elem->in_buffer.len, &err_code, err_msg,
+                                            sizeof(err_msg), clnet_info->realm, clnet_info->nonce,
+                                            clnet_info->server_name, &(clnet_info->oauth)))
+    {
+      if (is_TCP_relay() && (stun_get_method(&(elem->in_buffer)) == STUN_METHOD_CONNECT))
+      {
         turn_tcp_connect(clnet_verbose, &(elem->pinfo), &(elem->pinfo.peer_addr));
-      } else if (stun_get_method(&(elem->in_buffer)) == STUN_METHOD_REFRESH) {
+      }
+      else if (stun_get_method(&(elem->in_buffer)) == STUN_METHOD_REFRESH)
+      {
         refresh_channel(elem, stun_get_method(&elem->in_buffer), 600);
       }
       return rc;
-    } else if (stun_is_error_response(&(elem->in_buffer), NULL, NULL, 0)) {
+    }
+    else if (stun_is_error_response(&(elem->in_buffer), NULL, NULL, 0))
+    {
       return rc;
-    } else if (stun_is_channel_message(&(elem->in_buffer), &chnumber, use_tcp)) {
-      if (elem->chnum != chnumber) {
+    }
+    else if (stun_is_channel_message(&(elem->in_buffer), &chnumber, use_tcp))
+    {
+      if (elem->chnum != chnumber)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "ERROR: received message has wrong channel: %d\n", (int)chnumber);
         return rc;
       }
 
-      if (elem->in_buffer.len >= 4) {
+      if (elem->in_buffer.len >= 4)
+      {
         if (((int)(elem->in_buffer.len - 4) < clmessage_length) ||
-            ((int)(elem->in_buffer.len - 4) > clmessage_length + 3)) {
+            ((int)(elem->in_buffer.len - 4) > clmessage_length + 3))
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "ERROR: received buffer have wrong length: %d, must be %d, len=%d\n", rc,
                         clmessage_length + 4, (int)elem->in_buffer.len);
           return rc;
@@ -785,34 +948,45 @@ static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info 
         miset = true;
         applen = elem->in_buffer.len - 4;
       }
-    } else {
+    }
+    else
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "ERROR: Unknown message received of size: %d\n", (int)(elem->in_buffer.len));
       return rc;
     }
 
-    if (miset) {
+    if (miset)
+    {
       /*
       printf("%s: 111.111: msgnum=%d, rmsgnum=%d, sent=%lu, recv=%lu\n",__FUNCTION__,
               mi->msgnum,elem->recvmsgnum,(unsigned long)mi->mstime,(unsigned long)current_mstime);
               */
-      if (mi.msgnum != elem->recvmsgnum + 1) {
+      if (mi.msgnum != elem->recvmsgnum + 1)
+      {
         ++(elem->loss);
-      } else {
+      }
+      else
+      {
         uint64_t clatency = (uint64_t)time_minus(current_mstime, mi.mstime);
-        if (clatency > max_latency) {
+        if (clatency > max_latency)
+        {
           max_latency = clatency;
         }
-        if (clatency < min_latency) {
+        if (clatency < min_latency)
+        {
           min_latency = clatency;
         }
         elem->latency += clatency;
-        if (elem->rmsgnum > 0) {
+        if (elem->rmsgnum > 0)
+        {
           uint64_t cjitter = abs((int)(current_mstime - elem->recvtimems) - RTP_PACKET_INTERVAL);
 
-          if (cjitter > max_jitter) {
+          if (cjitter > max_jitter)
+          {
             max_jitter = cjitter;
           }
-          if (cjitter < min_jitter) {
+          if (cjitter < min_jitter)
+          {
             min_jitter = cjitter;
           }
 
@@ -825,26 +999,34 @@ static int client_read(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info 
 
     elem->rmsgnum += buffers;
     tot_recv_messages += buffers;
-    if (applen > 0) {
+    if (applen > 0)
+    {
       tot_recv_bytes += applen;
-    } else {
+    }
+    else
+    {
       tot_recv_bytes += elem->in_buffer.len;
     }
     elem->recvtimems = current_mstime;
     elem->wait_cycles = 0;
-
-  } else if (rc == 0) {
+  }
+  else if (rc == 0)
+  {
     return 0;
-  } else {
+  }
+  else
+  {
     return -1;
   }
 
   return rc;
 }
 
-static int client_shutdown(app_ur_session *elem) {
+static int client_shutdown(app_ur_session *elem)
+{
 
-  if (!elem) {
+  if (!elem)
+  {
     return -1;
   }
 
@@ -854,20 +1036,24 @@ static int client_shutdown(app_ur_session *elem) {
 
   remove_all_from_ss(elem);
 
-  if (clnet_verbose) {
+  if (clnet_verbose)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "done, connection %p closed.\n", elem);
   }
 
   return 0;
 }
 
-static int client_write(app_ur_session *elem) {
+static int client_write(app_ur_session *elem)
+{
 
-  if (!elem) {
+  if (!elem)
+  {
     return -1;
   }
 
-  if (elem->state != UR_STATE_READY) {
+  if (elem->state != UR_STATE_READY)
+  {
     return -1;
   }
 
@@ -878,13 +1064,16 @@ static int client_write(app_ur_session *elem) {
   mi->mstime = current_mstime;
   app_tcp_conn_info *atc = NULL;
 
-  if (is_TCP_relay()) {
+  if (is_TCP_relay())
+  {
 
     memcpy(elem->out_buffer.buf, buffer_to_send, clmessage_length);
     elem->out_buffer.len = clmessage_length;
 
-    if (elem->pinfo.is_peer) {
-      if (send(elem->pinfo.fd, elem->out_buffer.buf, clmessage_length, 0) >= 0) {
+    if (elem->pinfo.is_peer)
+    {
+      if (send(elem->pinfo.fd, elem->out_buffer.buf, clmessage_length, 0) >= 0)
+      {
         ++elem->wmsgnum;
         elem->to_send_timems += RTP_PACKET_INTERVAL;
         tot_send_messages++;
@@ -893,35 +1082,45 @@ static int client_write(app_ur_session *elem) {
       return 0;
     }
 
-    if (!(elem->pinfo.tcp_conn) || !(elem->pinfo.tcp_conn_number)) {
+    if (!(elem->pinfo.tcp_conn) || !(elem->pinfo.tcp_conn_number))
+    {
       return -1;
     }
     int i = (unsigned int)(turn_random()) % elem->pinfo.tcp_conn_number;
     atc = elem->pinfo.tcp_conn[i];
-    if (!atc->tcp_data_bound) {
+    if (!atc->tcp_data_bound)
+    {
       printf("%s: Uninitialized atc: i=%d, atc=%p\n", __FUNCTION__, i, atc);
       return -1;
     }
-  } else if (!do_not_use_channel) {
+  }
+  else if (!do_not_use_channel)
+  {
     /* Let's always do padding: */
     stun_init_channel_message(elem->chnum, &(elem->out_buffer), clmessage_length, mandatory_channel_padding || use_tcp);
     memcpy(elem->out_buffer.buf + 4, buffer_to_send, clmessage_length);
-  } else {
+  }
+  else
+  {
     stun_init_indication(STUN_METHOD_SEND, &(elem->out_buffer));
     stun_attr_add(&(elem->out_buffer), STUN_ATTRIBUTE_DATA, buffer_to_send, clmessage_length);
     stun_attr_add_addr(&(elem->out_buffer), STUN_ATTRIBUTE_XOR_PEER_ADDRESS, &(elem->pinfo.peer_addr));
-    if (dont_fragment) {
+    if (dont_fragment)
+    {
       stun_attr_add(&(elem->out_buffer), STUN_ATTRIBUTE_DONT_FRAGMENT, NULL, 0);
     }
 
-    if (use_fingerprints) {
+    if (use_fingerprints)
+    {
       stun_attr_add_fingerprint_str(elem->out_buffer.buf, (size_t *)&(elem->out_buffer.len));
     }
   }
 
-  if (elem->out_buffer.len > 0) {
+  if (elem->out_buffer.len > 0)
+  {
 
-    if (clnet_verbose && verbose_packets) {
+    if (clnet_verbose && verbose_packets)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "before write ...\n");
     }
 
@@ -930,13 +1129,17 @@ static int client_write(app_ur_session *elem) {
     ++elem->wmsgnum;
     elem->to_send_timems += RTP_PACKET_INTERVAL;
 
-    if (rc >= 0) {
-      if (clnet_verbose && verbose_packets) {
+    if (rc >= 0)
+    {
+      if (clnet_verbose && verbose_packets)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "wrote %d bytes\n", (int)rc);
       }
       tot_send_messages++;
       tot_send_bytes += clmessage_length;
-    } else {
+    }
+    else
+    {
       return -1;
     }
   }
@@ -944,29 +1147,38 @@ static int client_write(app_ur_session *elem) {
   return 0;
 }
 
-void client_input_handler(evutil_socket_t fd, short what, void *arg) {
+void client_input_handler(evutil_socket_t fd, short what, void *arg)
+{
 
-  if (!(what & EV_READ) || !arg) {
+  if (!(what & EV_READ) || !arg)
+  {
     return;
   }
 
   UNUSED_ARG(fd);
 
   app_ur_session *elem = (app_ur_session *)arg;
-  if (!elem) {
+  if (!elem)
+  {
     return;
   }
 
-  switch (elem->state) {
+  switch (elem->state)
+  {
   case UR_STATE_READY:
-    do {
+    do
+    {
       app_tcp_conn_info *atc = NULL;
       int is_tcp_data = 0;
-      if (elem->pinfo.tcp_conn) {
+      if (elem->pinfo.tcp_conn)
+      {
         int i = 0;
-        for (i = 0; i < (int)(elem->pinfo.tcp_conn_number); ++i) {
-          if (elem->pinfo.tcp_conn[i]) {
-            if ((fd == elem->pinfo.tcp_conn[i]->tcp_data_fd) && (elem->pinfo.tcp_conn[i]->tcp_data_bound)) {
+        for (i = 0; i < (int)(elem->pinfo.tcp_conn_number); ++i)
+        {
+          if (elem->pinfo.tcp_conn[i])
+          {
+            if ((fd == elem->pinfo.tcp_conn[i]->tcp_data_fd) && (elem->pinfo.tcp_conn[i]->tcp_data_bound))
+            {
               is_tcp_data = 1;
               atc = elem->pinfo.tcp_conn[i];
               break;
@@ -975,7 +1187,8 @@ void client_input_handler(evutil_socket_t fd, short what, void *arg) {
         }
       }
       int rc = client_read(elem, is_tcp_data, atc);
-      if (rc <= 0) {
+      if (rc <= 0)
+      {
         break;
       }
     } while (1);
@@ -985,13 +1198,17 @@ void client_input_handler(evutil_socket_t fd, short what, void *arg) {
   }
 }
 
-static void run_events(int short_burst) {
+static void run_events(int short_burst)
+{
   struct timeval timeout;
 
-  if (!short_burst) {
+  if (!short_burst)
+  {
     timeout.tv_sec = 1;
     timeout.tv_usec = 0;
-  } else {
+  }
+  else
+  {
     timeout.tv_sec = 0;
     timeout.tv_usec = 100000;
   }
@@ -1004,12 +1221,14 @@ static void run_events(int short_burst) {
 ////////////////////// main method /////////////////
 
 static int start_client(const char *remote_address, int port, const unsigned char *ifname, const char *local_address,
-                        int messagenumber, int i) {
+                        int messagenumber, int i)
+{
 
   app_ur_session *ss = create_new_ss();
   app_ur_session *ss_rtcp = NULL;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     ss_rtcp = create_new_ss();
   }
 
@@ -1020,7 +1239,8 @@ static int start_client(const char *remote_address, int port, const unsigned cha
   app_ur_conn_info *clnet_info = &(ss->pinfo);
   app_ur_conn_info *clnet_info_rtcp = NULL;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     clnet_info_rtcp = &(ss_rtcp->pinfo);
   }
 
@@ -1030,17 +1250,21 @@ static int start_client(const char *remote_address, int port, const unsigned cha
   start_connection(port, remote_address, ifname, local_address, clnet_verbose, &clnet_info_probe, clnet_info, &chnum,
                    clnet_info_rtcp, &chnum_rtcp);
 
-  if (clnet_info_probe.ssl) {
+  if (clnet_info_probe.ssl)
+  {
     SSL_free(clnet_info_probe.ssl);
     clnet_info_probe.fd = -1;
-  } else if (clnet_info_probe.fd != -1) {
+  }
+  else if (clnet_info_probe.fd != -1)
+  {
     socket_closesocket(clnet_info_probe.fd);
     clnet_info_probe.fd = -1;
   }
 
   socket_set_nonblocking(clnet_info->fd);
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     socket_set_nonblocking(clnet_info_rtcp->fd);
   }
 
@@ -1050,7 +1274,8 @@ static int start_client(const char *remote_address, int port, const unsigned cha
 
   struct event *ev_rtcp = NULL;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     ev_rtcp = event_new(client_event_base, clnet_info_rtcp->fd, EV_READ | EV_PERSIST, client_input_handler, ss_rtcp);
 
     event_add(ev_rtcp, NULL);
@@ -1063,13 +1288,15 @@ static int start_client(const char *remote_address, int port, const unsigned cha
   ss->recvmsgnum = -1;
   ss->chnum = chnum;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
 
     ss_rtcp->state = UR_STATE_READY;
 
     ss_rtcp->input_ev = ev_rtcp;
     ss_rtcp->tot_msgnum = ss->tot_msgnum;
-    if (ss_rtcp->tot_msgnum < 1) {
+    if (ss_rtcp->tot_msgnum < 1)
+    {
       ss_rtcp->tot_msgnum = 1;
     }
     ss_rtcp->recvmsgnum = -1;
@@ -1080,7 +1307,8 @@ static int start_client(const char *remote_address, int port, const unsigned cha
 
   refresh_channel(ss, 0, 600);
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     elems[i + 1] = ss_rtcp;
   }
 
@@ -1088,19 +1316,22 @@ static int start_client(const char *remote_address, int port, const unsigned cha
 }
 
 static int start_c2c(const char *remote_address, int port, const unsigned char *ifname, const char *local_address,
-                     int messagenumber, int i) {
+                     int messagenumber, int i)
+{
 
   app_ur_session *ss1 = create_new_ss();
   app_ur_session *ss1_rtcp = NULL;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     ss1_rtcp = create_new_ss();
   }
 
   app_ur_session *ss2 = create_new_ss();
   app_ur_session *ss2_rtcp = NULL;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     ss2_rtcp = create_new_ss();
   }
 
@@ -1111,14 +1342,16 @@ static int start_c2c(const char *remote_address, int port, const unsigned char *
   app_ur_conn_info *clnet_info1 = &(ss1->pinfo);
   app_ur_conn_info *clnet_info1_rtcp = NULL;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     clnet_info1_rtcp = &(ss1_rtcp->pinfo);
   }
 
   app_ur_conn_info *clnet_info2 = &(ss2->pinfo);
   app_ur_conn_info *clnet_info2_rtcp = NULL;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     clnet_info2_rtcp = &(ss2_rtcp->pinfo);
   }
 
@@ -1130,23 +1363,28 @@ static int start_c2c(const char *remote_address, int port, const unsigned char *
   start_c2c_connection(port, remote_address, ifname, local_address, clnet_verbose, &clnet_info_probe, clnet_info1,
                        &chnum1, clnet_info1_rtcp, &chnum1_rtcp, clnet_info2, &chnum2, clnet_info2_rtcp, &chnum2_rtcp);
 
-  if (clnet_info_probe.ssl) {
+  if (clnet_info_probe.ssl)
+  {
     SSL_free(clnet_info_probe.ssl);
     clnet_info_probe.fd = -1;
-  } else if (clnet_info_probe.fd != -1) {
+  }
+  else if (clnet_info_probe.fd != -1)
+  {
     socket_closesocket(clnet_info_probe.fd);
     clnet_info_probe.fd = -1;
   }
 
   socket_set_nonblocking(clnet_info1->fd);
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     socket_set_nonblocking(clnet_info1_rtcp->fd);
   }
 
   socket_set_nonblocking(clnet_info2->fd);
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     socket_set_nonblocking(clnet_info2_rtcp->fd);
   }
 
@@ -1156,7 +1394,8 @@ static int start_c2c(const char *remote_address, int port, const unsigned char *
 
   struct event *ev1_rtcp = NULL;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     ev1_rtcp = event_new(client_event_base, clnet_info1_rtcp->fd, EV_READ | EV_PERSIST, client_input_handler, ss1_rtcp);
 
     event_add(ev1_rtcp, NULL);
@@ -1168,7 +1407,8 @@ static int start_c2c(const char *remote_address, int port, const unsigned char *
 
   struct event *ev2_rtcp = NULL;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     ev2_rtcp = event_new(client_event_base, clnet_info2_rtcp->fd, EV_READ | EV_PERSIST, client_input_handler, ss2_rtcp);
 
     event_add(ev2_rtcp, NULL);
@@ -1181,13 +1421,15 @@ static int start_c2c(const char *remote_address, int port, const unsigned char *
   ss1->recvmsgnum = -1;
   ss1->chnum = chnum1;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
 
     ss1_rtcp->state = UR_STATE_READY;
 
     ss1_rtcp->input_ev = ev1_rtcp;
     ss1_rtcp->tot_msgnum = ss1->tot_msgnum;
-    if (ss1_rtcp->tot_msgnum < 1) {
+    if (ss1_rtcp->tot_msgnum < 1)
+    {
       ss1_rtcp->tot_msgnum = 1;
     }
     ss1_rtcp->recvmsgnum = -1;
@@ -1201,7 +1443,8 @@ static int start_c2c(const char *remote_address, int port, const unsigned char *
   ss2->recvmsgnum = -1;
   ss2->chnum = chnum2;
 
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     ss2_rtcp->state = UR_STATE_READY;
 
     ss2_rtcp->input_ev = ev2_rtcp;
@@ -1211,34 +1454,41 @@ static int start_c2c(const char *remote_address, int port, const unsigned char *
   }
 
   elems[i++] = ss1;
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     elems[i++] = ss1_rtcp;
   }
   elems[i++] = ss2;
-  if (!no_rtcp) {
+  if (!no_rtcp)
+  {
     elems[i++] = ss2_rtcp;
   }
 
   return 0;
 }
 
-static int refresh_channel(app_ur_session *elem, uint16_t method, uint32_t lt) {
+static int refresh_channel(app_ur_session *elem, uint16_t method, uint32_t lt)
+{
 
   stun_buffer message;
   app_ur_conn_info *clnet_info = &(elem->pinfo);
 
-  if (clnet_info->is_peer) {
+  if (clnet_info->is_peer)
+  {
     return 0;
   }
 
-  if (!method || (method == STUN_METHOD_REFRESH)) {
+  if (!method || (method == STUN_METHOD_REFRESH))
+  {
     stun_init_request(STUN_METHOD_REFRESH, &message);
     lt = htonl(lt);
     stun_attr_add(&message, STUN_ATTRIBUTE_LIFETIME, (const char *)&lt, 4);
 
-    if (dual_allocation && !mobility) {
+    if (dual_allocation && !mobility)
+    {
       int t = ((uint8_t)turn_random()) % 3;
-      if (t) {
+      if (t)
+      {
         uint8_t field[4];
         field[0] = (t == 1) ? (uint8_t)STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4
                             : (uint8_t)STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6;
@@ -1250,40 +1500,51 @@ static int refresh_channel(app_ur_session *elem, uint16_t method, uint32_t lt) {
     }
 
     add_origin(&message);
-    if (add_integrity(clnet_info, &message) < 0) {
+    if (add_integrity(clnet_info, &message) < 0)
+    {
       return -1;
     }
-    if (use_fingerprints) {
+    if (use_fingerprints)
+    {
       stun_attr_add_fingerprint_str(message.buf, (size_t *)&(message.len));
     }
     send_buffer(clnet_info, &message, 0, 0);
   }
 
-  if (lt && !addr_any(&(elem->pinfo.peer_addr))) {
+  if (lt && !addr_any(&(elem->pinfo.peer_addr)))
+  {
 
-    if (!no_permissions) {
-      if (!method || (method == STUN_METHOD_CREATE_PERMISSION)) {
+    if (!no_permissions)
+    {
+      if (!method || (method == STUN_METHOD_CREATE_PERMISSION))
+      {
         stun_init_request(STUN_METHOD_CREATE_PERMISSION, &message);
         stun_attr_add_addr(&message, STUN_ATTRIBUTE_XOR_PEER_ADDRESS, &(elem->pinfo.peer_addr));
         add_origin(&message);
-        if (add_integrity(clnet_info, &message) < 0) {
+        if (add_integrity(clnet_info, &message) < 0)
+        {
           return -1;
         }
-        if (use_fingerprints) {
+        if (use_fingerprints)
+        {
           stun_attr_add_fingerprint_str(message.buf, (size_t *)&(message.len));
         }
         send_buffer(&(elem->pinfo), &message, 0, 0);
       }
     }
 
-    if (!method || (method == STUN_METHOD_CHANNEL_BIND)) {
-      if (STUN_VALID_CHANNEL(elem->chnum)) {
+    if (!method || (method == STUN_METHOD_CHANNEL_BIND))
+    {
+      if (STUN_VALID_CHANNEL(elem->chnum))
+      {
         stun_set_channel_bind_request(&message, &(elem->pinfo.peer_addr), elem->chnum);
         add_origin(&message);
-        if (add_integrity(clnet_info, &message) < 0) {
+        if (add_integrity(clnet_info, &message) < 0)
+        {
           return -1;
         }
-        if (use_fingerprints) {
+        if (use_fingerprints)
+        {
           stun_attr_add_fingerprint_str(message.buf, (size_t *)&(message.len));
         }
         send_buffer(&(elem->pinfo), &message, 1, 0);
@@ -1296,25 +1557,33 @@ static int refresh_channel(app_ur_session *elem, uint16_t method, uint32_t lt) {
   return 0;
 }
 
-static inline int client_timer_handler(app_ur_session *elem, int *done) {
-  if (elem) {
-    if (!turn_time_before(current_mstime, elem->refresh_time)) {
+static inline int client_timer_handler(app_ur_session *elem, int *done)
+{
+  if (elem)
+  {
+    if (!turn_time_before(current_mstime, elem->refresh_time))
+    {
       refresh_channel(elem, 0, 600);
     }
 
-    if (hang_on && elem->completed) {
+    if (hang_on && elem->completed)
+    {
       return 0;
     }
 
     int max_num = 50;
     int cur_num = 0;
 
-    while (!turn_time_before(current_mstime, elem->to_send_timems)) {
-      if (cur_num++ >= max_num) {
+    while (!turn_time_before(current_mstime, elem->to_send_timems))
+    {
+      if (cur_num++ >= max_num)
+      {
         break;
       }
-      if (elem->wmsgnum >= elem->tot_msgnum) {
-        if (!turn_time_before(current_mstime, elem->finished_time) || (tot_recv_messages >= tot_messages)) {
+      if (elem->wmsgnum >= elem->tot_msgnum)
+      {
+        if (!turn_time_before(current_mstime, elem->finished_time) || (tot_recv_messages >= tot_messages))
+        {
           /*
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"%s: elem=0x%x: 111.111: c=%d, t=%d, r=%d,
           w=%d\n",__FUNCTION__,(int)elem,elem->wait_cycles,elem->tot_msgnum,elem->rmsgnum,elem->wmsgnum);
@@ -1332,15 +1601,20 @@ static inline int client_timer_handler(app_ur_session *elem, int *done) {
           total_jitter += elem->jitter;
           elem->jitter = 0;
           elem->completed = 1;
-          if (!hang_on) {
+          if (!hang_on)
+          {
             refresh_channel(elem, 0, 0);
             client_shutdown(elem);
             return 1;
-          } else {
+          }
+          else
+          {
             return 0;
           }
         }
-      } else {
+      }
+      else
+      {
         *done += 1;
         client_write(elem);
         elem->finished_time = current_mstime + STOPPING_TIME * 1000;
@@ -1351,26 +1625,34 @@ static inline int client_timer_handler(app_ur_session *elem, int *done) {
   return 0;
 }
 
-static void timer_handler(evutil_socket_t fd, short event, void *arg) {
+static void timer_handler(evutil_socket_t fd, short event, void *arg)
+{
   UNUSED_ARG(fd);
   UNUSED_ARG(event);
   UNUSED_ARG(arg);
 
   __turn_getMSTime();
 
-  if (start_full_timer) {
+  if (start_full_timer)
+  {
     int done = 0;
-    for (int i = 0; i < total_clients; ++i) {
-      if (elems[i]) {
+    for (int i = 0; i < total_clients; ++i)
+    {
+      if (elems[i])
+      {
         int finished = client_timer_handler(elems[i], &done);
-        if (finished) {
+        if (finished)
+        {
           elems[i] = NULL;
         }
       }
     }
-    if (done > 5 && (dos || random_disconnect)) {
-      for (int i = 0; i < total_clients; ++i) {
-        if (elems[i]) {
+    if (done > 5 && (dos || random_disconnect))
+    {
+      for (int i = 0; i < total_clients; ++i)
+      {
+        if (elems[i])
+        {
           socket_closesocket(elems[i]->pinfo.fd);
           elems[i]->pinfo.fd = -1;
         }
@@ -1380,24 +1662,34 @@ static void timer_handler(evutil_socket_t fd, short event, void *arg) {
 }
 
 void start_mclient(const char *remote_address, int port, const unsigned char *ifname, const char *local_address,
-                   int messagenumber, int mclient) {
+                   int messagenumber, int mclient)
+{
 
-  if (mclient < 1) {
+  if (mclient < 1)
+  {
     mclient = 1;
   }
 
   total_clients = mclient;
 
-  if (c2c) {
+  if (c2c)
+  {
     // mclient must be a multiple of 4:
-    if (!no_rtcp) {
+    if (!no_rtcp)
+    {
       mclient += ((4 - (mclient & 0x00000003)) & 0x00000003);
-    } else if (mclient & 0x1) {
+    }
+    else if (mclient & 0x1)
+    {
       ++mclient;
     }
-  } else {
-    if (!no_rtcp) {
-      if (mclient & 0x1) {
+  }
+  else
+  {
+    if (!no_rtcp)
+    {
+      if (mclient & 0x1)
+      {
         ++mclient;
       }
     }
@@ -1414,45 +1706,66 @@ void start_mclient(const char *remote_address, int port, const unsigned char *if
 
   int tot_clients = 0;
 
-  if (c2c) {
-    if (!no_rtcp) {
-      for (int i = 0; i < (mclient >> 2); i++) {
-        if (!dos) {
+  if (c2c)
+  {
+    if (!no_rtcp)
+    {
+      for (int i = 0; i < (mclient >> 2); i++)
+      {
+        if (!dos)
+        {
           usleep(SLEEP_INTERVAL);
         }
-        if (start_c2c(remote_address, port, ifname, local_address, messagenumber, i << 2) < 0) {
+        if (start_c2c(remote_address, port, ifname, local_address, messagenumber, i << 2) < 0)
+        {
           exit(-1);
         }
         tot_clients += 4;
       }
-    } else {
-      for (int i = 0; i < (mclient >> 1); i++) {
-        if (!dos) {
+    }
+    else
+    {
+      for (int i = 0; i < (mclient >> 1); i++)
+      {
+        if (!dos)
+        {
           usleep(SLEEP_INTERVAL);
         }
-        if (start_c2c(remote_address, port, ifname, local_address, messagenumber, i << 1) < 0) {
+        if (start_c2c(remote_address, port, ifname, local_address, messagenumber, i << 1) < 0)
+        {
           exit(-1);
         }
         tot_clients += 2;
       }
     }
-  } else {
-    if (!no_rtcp) {
-      for (int i = 0; i < (mclient >> 1); i++) {
-        if (!dos) {
+  }
+  else
+  {
+    if (!no_rtcp)
+    {
+      for (int i = 0; i < (mclient >> 1); i++)
+      {
+        if (!dos)
+        {
           usleep(SLEEP_INTERVAL);
         }
-        if (start_client(remote_address, port, ifname, local_address, messagenumber, i << 1) < 0) {
+        if (start_client(remote_address, port, ifname, local_address, messagenumber, i << 1) < 0)
+        {
           exit(-1);
         }
         tot_clients += 2;
       }
-    } else {
-      for (int i = 0; i < mclient; i++) {
-        if (!dos) {
+    }
+    else
+    {
+      for (int i = 0; i < mclient; i++)
+      {
+        if (!dos)
+        {
           usleep(SLEEP_INTERVAL);
         }
-        if (start_client(remote_address, port, ifname, local_address, messagenumber, i) < 0) {
+        if (start_client(remote_address, port, ifname, local_address, messagenumber, i) < 0)
+        {
           exit(-1);
         }
         tot_clients++;
@@ -1460,7 +1773,8 @@ void start_mclient(const char *remote_address, int port, const unsigned char *if
     }
   }
 
-  if (dos) {
+  if (dos)
+  {
     _exit(0);
   }
 
@@ -1476,17 +1790,25 @@ void start_mclient(const char *remote_address, int port, const unsigned char *if
 
   evtimer_add(ev, &tv);
 
-  for (int i = 0; i < total_clients; i++) {
+  for (int i = 0; i < total_clients; i++)
+  {
 
-    if (is_TCP_relay()) {
-      if (passive_tcp) {
-        if (elems[i]->pinfo.is_peer) {
+    if (is_TCP_relay())
+    {
+      if (passive_tcp)
+      {
+        if (elems[i]->pinfo.is_peer)
+        {
           int connect_err = 0;
           socket_connect(elems[i]->pinfo.fd, &(elems[i]->pinfo.remote_addr), &connect_err);
         }
-      } else {
-        for (int j = i + 1; j < total_clients; j++) {
-          if (turn_tcp_connect(clnet_verbose, &(elems[i]->pinfo), &(elems[j]->pinfo.relay_addr)) < 0) {
+      }
+      else
+      {
+        for (int j = i + 1; j < total_clients; j++)
+        {
+          if (turn_tcp_connect(clnet_verbose, &(elems[i]->pinfo), &(elems[j]->pinfo.relay_addr)) < 0)
+          {
             exit(-1);
           }
         }
@@ -1501,36 +1823,51 @@ void start_mclient(const char *remote_address, int port, const unsigned char *if
 
   stime = current_time;
 
-  if (is_TCP_relay()) {
+  if (is_TCP_relay())
+  {
     uint64_t connect_wait_start_time = current_time;
-    while (1) {
+    while (1)
+    {
       int completed = 0;
-      if (passive_tcp) {
-        for (int i = 0; i < total_clients; ++i) {
-          if (elems[i]->pinfo.is_peer) {
+      if (passive_tcp)
+      {
+        for (int i = 0; i < total_clients; ++i)
+        {
+          if (elems[i]->pinfo.is_peer)
+          {
             completed += 1;
-          } else if (elems[i]->pinfo.tcp_conn_number > 0 && elems[i]->pinfo.tcp_conn[0]->tcp_data_bound) {
+          }
+          else if (elems[i]->pinfo.tcp_conn_number > 0 && elems[i]->pinfo.tcp_conn[0]->tcp_data_bound)
+          {
             completed += elems[i]->pinfo.tcp_conn_number;
           }
         }
-        if (completed >= total_clients) {
+        if (completed >= total_clients)
+        {
           break;
         }
-      } else {
-        for (int i = 0; i < total_clients; ++i) {
-          for (int j = 0; j < (int)elems[i]->pinfo.tcp_conn_number; j++) {
-            if (elems[i]->pinfo.tcp_conn[j]->tcp_data_bound) {
+      }
+      else
+      {
+        for (int i = 0; i < total_clients; ++i)
+        {
+          for (int j = 0; j < (int)elems[i]->pinfo.tcp_conn_number; j++)
+          {
+            if (elems[i]->pinfo.tcp_conn[j]->tcp_data_bound)
+            {
               completed++;
             }
           }
         }
-        if (completed >= total_clients * (total_clients - 1)) {
+        if (completed >= total_clients * (total_clients - 1))
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%d connections are completed\n", (int)(completed));
           break;
         }
       }
       run_events(0);
-      if (current_time > connect_wait_start_time + STARTING_TCP_RELAY_TIME + total_clients) {
+      if (current_time > connect_wait_start_time + STARTING_TCP_RELAY_TIME + total_clients)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "WARNING: %d connections are completed, not enough\n", (int)(completed));
         break;
       }
@@ -1540,7 +1877,8 @@ void start_mclient(const char *remote_address, int port, const unsigned char *if
   __turn_getMSTime();
   stime = current_time;
 
-  for (int i = 0; i < total_clients; i++) {
+  for (int i = 0; i < total_clients; i++)
+  {
     elems[i]->to_send_timems = current_mstime + 1000 + ((uint32_t)turn_random()) % 5000;
   }
 
@@ -1548,16 +1886,19 @@ void start_mclient(const char *remote_address, int port, const unsigned char *if
 
   start_full_timer = true;
 
-  while (true) {
+  while (true)
+  {
 
     run_events(1);
 
     int msz = (int)current_clients_number;
-    if (msz < 1) {
+    if (msz < 1)
+    {
       break;
     }
 
-    if (show_statistics) {
+    if (show_statistics)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
                     "%s: msz=%d, tot_send_msgs=%lu, tot_recv_msgs=%lu, tot_send_bytes ~ %llu, tot_recv_bytes ~ %llu\n",
                     __FUNCTION__, msz, (unsigned long)tot_send_messages, (unsigned long)tot_recv_messages,
@@ -1572,11 +1913,13 @@ void start_mclient(const char *remote_address, int port, const unsigned char *if
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: tot_send_bytes ~ %lu, tot_recv_bytes ~ %lu\n", __FUNCTION__,
                 (unsigned long)tot_send_bytes, (unsigned long)tot_recv_bytes);
 
-  if (client_event_base) {
+  if (client_event_base)
+  {
     event_base_free(client_event_base);
   }
 
-  if (tot_send_messages < tot_recv_messages) {
+  if (tot_send_messages < tot_recv_messages)
+  {
     tot_recv_messages = tot_send_messages;
   }
 
@@ -1601,16 +1944,20 @@ void start_mclient(const char *remote_address, int port, const unsigned char *if
 
 turn_credential_type get_turn_credentials_type(void) { return TURN_CREDENTIALS_LONG_TERM; }
 
-int add_integrity(app_ur_conn_info *clnet_info, stun_buffer *message) {
-  if (clnet_info->nonce[0]) {
+int add_integrity(app_ur_conn_info *clnet_info, stun_buffer *message)
+{
+  if (clnet_info->nonce[0])
+  {
 
-    if (oauth && clnet_info->oauth) {
+    if (oauth && clnet_info->oauth)
+    {
 
       uint16_t method = stun_get_method_str(message->buf, message->len);
 
       int cok = clnet_info->cok;
 
-      if (((method == STUN_METHOD_ALLOCATE) || (method == STUN_METHOD_REFRESH)) || !(clnet_info->key_set)) {
+      if (((method == STUN_METHOD_ALLOCATE) || (method == STUN_METHOD_REFRESH)) || !(clnet_info->key_set))
+      {
 
         cok = ((unsigned short)turn_random()) % 3;
         clnet_info->cok = cok;
@@ -1620,26 +1967,36 @@ int add_integrity(app_ur_conn_info *clnet_info, stun_buffer *message) {
         RAND_bytes((unsigned char *)nonce, 12);
         long halflifetime = OAUTH_SESSION_LIFETIME / 2;
         long random_lifetime = 0;
-        while (!random_lifetime) {
+        while (!random_lifetime)
+        {
           random_lifetime = turn_random();
         }
-        if (random_lifetime < 0) {
+        if (random_lifetime < 0)
+        {
           random_lifetime = -random_lifetime;
         }
         random_lifetime = random_lifetime % halflifetime;
         otoken.enc_block.lifetime = (uint32_t)(halflifetime + random_lifetime);
         otoken.enc_block.timestamp = ((uint64_t)turn_time()) << 16;
-        if (shatype == SHATYPE_SHA256) {
+        if (shatype == SHATYPE_SHA256)
+        {
           otoken.enc_block.key_length = 32;
-        } else if (shatype == SHATYPE_SHA384) {
+        }
+        else if (shatype == SHATYPE_SHA384)
+        {
           otoken.enc_block.key_length = 48;
-        } else if (shatype == SHATYPE_SHA512) {
+        }
+        else if (shatype == SHATYPE_SHA512)
+        {
           otoken.enc_block.key_length = 64;
-        } else {
+        }
+        else
+        {
           otoken.enc_block.key_length = 20;
         }
         RAND_bytes((unsigned char *)(otoken.enc_block.mac_key), otoken.enc_block.key_length);
-        if (!encode_oauth_token(clnet_info->server_name, &etoken, &(okey_array[cok]), &otoken, nonce)) {
+        if (!encode_oauth_token(clnet_info->server_name, &etoken, &(okey_array[cok]), &otoken, nonce))
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, " Cannot encode token\n");
           return -1;
         }
@@ -1651,7 +2008,8 @@ int add_integrity(app_ur_conn_info *clnet_info, stun_buffer *message) {
       }
 
       if (!stun_attr_add_integrity_by_key_str(message->buf, &(message->len), (uint8_t *)okey_array[cok].kid,
-                                              clnet_info->realm, clnet_info->key, clnet_info->nonce, shatype)) {
+                                              clnet_info->realm, clnet_info->key, clnet_info->nonce, shatype))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, " Cannot add integrity to the message\n");
         return -1;
       }
@@ -1660,14 +2018,18 @@ int add_integrity(app_ur_conn_info *clnet_info, stun_buffer *message) {
       {
         password_t pwd;
         if (stun_check_message_integrity_by_key_str(get_turn_credentials_type(), message->buf, message->len,
-                                                    clnet_info->key, pwd, shatype) < 1) {
+                                                    clnet_info->key, pwd, shatype) < 1)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, " Self-test of integrity does not comple correctly !\n");
           return -1;
         }
       }
-    } else {
+    }
+    else
+    {
       if (!stun_attr_add_integrity_by_user_str(message->buf, (size_t *)&(message->len), g_uname, clnet_info->realm,
-                                               g_upwd, clnet_info->nonce, shatype)) {
+                                               g_upwd, clnet_info->nonce, shatype))
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, " Cannot add integrity to the message\n");
         return -1;
       }
@@ -1677,20 +2039,24 @@ int add_integrity(app_ur_conn_info *clnet_info, stun_buffer *message) {
   return 0;
 }
 
-int check_integrity(app_ur_conn_info *clnet_info, stun_buffer *message) {
+int check_integrity(app_ur_conn_info *clnet_info, stun_buffer *message)
+{
   SHATYPE sht = shatype;
 
-  if (oauth && clnet_info->oauth) {
+  if (oauth && clnet_info->oauth)
+  {
 
     password_t pwd;
 
     return stun_check_message_integrity_by_key_str(get_turn_credentials_type(), message->buf, (size_t)(message->len),
                                                    clnet_info->key, pwd, sht);
-
-  } else {
+  }
+  else
+  {
 
     if (stun_check_message_integrity_str(get_turn_credentials_type(), message->buf, (size_t)(message->len), g_uname,
-                                         clnet_info->realm, g_upwd, sht) < 1) {
+                                         clnet_info->realm, g_upwd, sht) < 1)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Wrong integrity in a message received from server\n");
       return -1;
     }
@@ -1699,23 +2065,38 @@ int check_integrity(app_ur_conn_info *clnet_info, stun_buffer *message) {
   return 0;
 }
 
-SOCKET_TYPE get_socket_type(void) {
-  if (use_sctp) {
-    if (use_secure) {
+SOCKET_TYPE get_socket_type(void)
+{
+  if (use_sctp)
+  {
+    if (use_secure)
+    {
       return TLS_SCTP_SOCKET;
-    } else {
+    }
+    else
+    {
       return SCTP_SOCKET;
     }
-  } else if (use_tcp) {
-    if (use_secure) {
+  }
+  else if (use_tcp)
+  {
+    if (use_secure)
+    {
       return TLS_SOCKET;
-    } else {
+    }
+    else
+    {
       return TCP_SOCKET;
     }
-  } else {
-    if (use_secure) {
+  }
+  else
+  {
+    if (use_secure)
+    {
       return DTLS_SOCKET;
-    } else {
+    }
+    else
+    {
       return UDP_SOCKET;
     }
   }

--- a/src/apps/uclient/uclient.h
+++ b/src/apps/uclient/uclient.h
@@ -35,7 +35,8 @@
 #include "stun_buffer.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////////////////////////////////////////

--- a/src/client++/TurnMsgLib.h
+++ b/src/client++/TurnMsgLib.h
@@ -36,14 +36,16 @@
 
 #include <string>
 
-namespace turn {
+namespace turn
+{
 
 class StunAttr;
 
 /**
  * Exception "end of buffer"
  */
-class EndOfStunMsgException {
+class EndOfStunMsgException
+{
 public:
   EndOfStunMsgException() {}
   virtual ~EndOfStunMsgException() {}
@@ -52,7 +54,8 @@ public:
 /**
  * Exception "wrong format of StunAttr"
  */
-class WrongStunAttrFormatException {
+class WrongStunAttrFormatException
+{
 public:
   WrongStunAttrFormatException() {}
   virtual ~WrongStunAttrFormatException() {}
@@ -61,7 +64,8 @@ public:
 /**
  * Exception "wrong format of StunBuffer"
  */
-class WrongStunBufferFormatException {
+class WrongStunBufferFormatException
+{
 public:
   WrongStunBufferFormatException() {}
   virtual ~WrongStunBufferFormatException() {}
@@ -70,13 +74,16 @@ public:
 /**
  * Iterator class for attributes
  */
-class StunAttrIterator {
+class StunAttrIterator
+{
 public:
   /**
    * Iterator constructor: creates iterator on raw messagebuffer.
    */
-  StunAttrIterator(uint8_t *buf, size_t sz) : _buf(buf), _sz(sz) {
-    if (!stun_is_command_message_str(_buf, _sz)) {
+  StunAttrIterator(uint8_t *buf, size_t sz) : _buf(buf), _sz(sz)
+  {
+    if (!stun_is_command_message_str(_buf, _sz))
+    {
       throw WrongStunBufferFormatException();
     }
     _sar = stun_attr_get_first_str(_buf, _sz);
@@ -85,8 +92,10 @@ public:
   /**
    * Iterator constructor: create iterator over message.
    */
-  template <class T> StunAttrIterator(T &msg) : _buf(msg.getRawBuffer()), _sz(msg.getSize()) {
-    if (!stun_is_command_message_str(_buf, _sz)) {
+  template <class T> StunAttrIterator(T &msg) : _buf(msg.getRawBuffer()), _sz(msg.getSize())
+  {
+    if (!stun_is_command_message_str(_buf, _sz))
+    {
       throw WrongStunBufferFormatException();
     }
     _sar = stun_attr_get_first_str(_buf, _sz);
@@ -96,8 +105,10 @@ public:
    * Iterator constructor: creates iterator over raw buffer, starting from first
    * location of an attribute of particular type.
    */
-  StunAttrIterator(uint8_t *buf, size_t sz, uint16_t attr_type) : _buf(buf), _sz(sz) {
-    if (!stun_is_command_message_str(_buf, _sz)) {
+  StunAttrIterator(uint8_t *buf, size_t sz, uint16_t attr_type) : _buf(buf), _sz(sz)
+  {
+    if (!stun_is_command_message_str(_buf, _sz))
+    {
       throw WrongStunBufferFormatException();
     }
     _sar = stun_attr_get_first_by_type_str(_buf, _sz, attr_type);
@@ -107,8 +118,10 @@ public:
    * Iterator constructor: creates iterator over message, starting from first
    * location of an attribute of particular type.
    */
-  template <class T> StunAttrIterator(T &msg, uint16_t attr_type) : _buf(msg.getRawBuffer()), _sz(msg.getSize()) {
-    if (!stun_is_command_message_str(_buf, _sz)) {
+  template <class T> StunAttrIterator(T &msg, uint16_t attr_type) : _buf(msg.getRawBuffer()), _sz(msg.getSize())
+  {
+    if (!stun_is_command_message_str(_buf, _sz))
+    {
       throw WrongStunBufferFormatException();
     }
     _sar = stun_attr_get_first_by_type_str(_buf, _sz, attr_type);
@@ -117,8 +130,10 @@ public:
   /**
    * Moves iterator to next attribute location
    */
-  void next() {
-    if (!_sar) {
+  void next()
+  {
+    if (!_sar)
+    {
       throw EndOfStunMsgException();
     }
     _sar = stun_attr_get_next_str(_buf, _sz, _sar);
@@ -153,9 +168,11 @@ public:
    * Return raw memroy field of the attribute value.
    * If the attribute value length is zero (0), then return NULL.
    */
-  const uint8_t *getRawBuffer(size_t &sz) const {
+  const uint8_t *getRawBuffer(size_t &sz) const
+  {
     int len = stun_attr_get_len(_sar);
-    if (len < 0) {
+    if (len < 0)
+    {
       throw WrongStunAttrFormatException();
     }
     sz = (size_t)len;
@@ -174,7 +191,8 @@ private:
  * Root class of all STUN attributes.
  * Can be also used for a generic attribute object.
  */
-class StunAttr {
+class StunAttr
+{
 public:
   /**
    * Empty constructor
@@ -184,23 +202,28 @@ public:
   /**
    * Constructs attribute from iterator
    */
-  StunAttr(const StunAttrIterator &iter) {
-    if (iter.eof()) {
+  StunAttr(const StunAttrIterator &iter)
+  {
+    if (iter.eof())
+    {
       throw EndOfStunMsgException();
     }
     size_t sz = 0;
     const uint8_t *ptr = iter.getRawBuffer(sz);
-    if (sz >= 0xFFFF) {
+    if (sz >= 0xFFFF)
+    {
       throw WrongStunAttrFormatException();
     }
     int at = iter.getType();
-    if (at < 0) {
+    if (at < 0)
+    {
       throw WrongStunAttrFormatException();
     }
     _attr_type = (uint16_t)at;
     _sz = sz;
     _value = (uint8_t *)malloc(_sz);
-    if (ptr) {
+    if (ptr)
+    {
       memcpy(_value, ptr, _sz);
     }
   }
@@ -208,8 +231,10 @@ public:
   /**
    * Destructor
    */
-  virtual ~StunAttr() {
-    if (_value) {
+  virtual ~StunAttr()
+  {
+    if (_value)
+    {
       free(_value);
     }
   }
@@ -217,7 +242,8 @@ public:
   /**
    * Return raw data representation of the attribute
    */
-  const uint8_t *getRawValue(size_t &sz) const {
+  const uint8_t *getRawValue(size_t &sz) const
+  {
     sz = _sz;
     return _value;
   }
@@ -225,16 +251,20 @@ public:
   /**
    * Set raw data value
    */
-  void setRawValue(uint8_t *value, size_t sz) {
-    if (sz > 0xFFFF) {
+  void setRawValue(uint8_t *value, size_t sz)
+  {
+    if (sz > 0xFFFF)
+    {
       throw WrongStunAttrFormatException();
     }
-    if (_value) {
+    if (_value)
+    {
       free(_value);
     }
     _sz = sz;
     _value = (uint8_t *)malloc(_sz);
-    if (value) {
+    if (value)
+    {
       memcpy(_value, value, _sz);
     }
   }
@@ -252,14 +282,18 @@ public:
   /**
    * Add attribute to a message
    */
-  template <class T> int addToMsg(T &msg) {
-    if (!_attr_type) {
+  template <class T> int addToMsg(T &msg)
+  {
+    if (!_attr_type)
+    {
       throw WrongStunAttrFormatException();
     }
     uint8_t *buffer = msg.getRawBuffer();
-    if (buffer) {
+    if (buffer)
+    {
       size_t sz = msg.getSize();
-      if (addToBuffer(buffer, sz) < 0) {
+      if (addToBuffer(buffer, sz) < 0)
+      {
         throw WrongStunBufferFormatException();
       }
       msg.setSize(sz);
@@ -272,12 +306,16 @@ protected:
   /**
    * Virtual function member to add attribute to a raw buffer
    */
-  virtual int addToBuffer(uint8_t *buffer, size_t &sz) {
-    if (buffer) {
-      if (!_value) {
+  virtual int addToBuffer(uint8_t *buffer, size_t &sz)
+  {
+    if (buffer)
+    {
+      if (!_value)
+      {
         throw WrongStunAttrFormatException();
       }
-      if (!stun_attr_add_str(buffer, &sz, _attr_type, _value, _sz)) {
+      if (!stun_attr_add_str(buffer, &sz, _attr_type, _value, _sz))
+      {
         throw WrongStunBufferFormatException();
       }
       return 0;
@@ -299,16 +337,20 @@ private:
 /**
  * Channel number attribute class
  */
-class StunAttrChannelNumber : public StunAttr {
+class StunAttrChannelNumber : public StunAttr
+{
 public:
   StunAttrChannelNumber() : _cn(0) { setType(STUN_ATTRIBUTE_CHANNEL_NUMBER); }
-  StunAttrChannelNumber(const StunAttrIterator &iter) : StunAttr(iter) {
+  StunAttrChannelNumber(const StunAttrIterator &iter) : StunAttr(iter)
+  {
 
-    if (iter.eof()) {
+    if (iter.eof())
+    {
       throw EndOfStunMsgException();
     }
     _cn = stun_attr_get_channel_number(getSar(iter));
-    if (!_cn) {
+    if (!_cn)
+    {
       throw WrongStunAttrFormatException();
     }
   }
@@ -326,12 +368,15 @@ private:
 /**
  * Even port attribute class
  */
-class StunAttrEvenPort : public StunAttr {
+class StunAttrEvenPort : public StunAttr
+{
 public:
   StunAttrEvenPort() : _ep(0) { setType(STUN_ATTRIBUTE_EVEN_PORT); }
-  StunAttrEvenPort(const StunAttrIterator &iter) : StunAttr(iter) {
+  StunAttrEvenPort(const StunAttrIterator &iter) : StunAttr(iter)
+  {
 
-    if (iter.eof()) {
+    if (iter.eof())
+    {
       throw EndOfStunMsgException();
     }
     _ep = stun_attr_get_even_port(getSar(iter));
@@ -341,7 +386,8 @@ public:
   void setEvenPort(uint8_t ep) { _ep = ep; }
 
 protected:
-  virtual bool addToBuffer(uint8_t *buffer, size_t &sz) {
+  virtual bool addToBuffer(uint8_t *buffer, size_t &sz)
+  {
     return stun_attr_add_str(buffer, &sz, STUN_ATTRIBUTE_EVEN_PORT, &_ep, 1);
   }
 
@@ -352,12 +398,15 @@ private:
 /**
  * Reservation token attribute class
  */
-class StunAttrReservationToken : public StunAttr {
+class StunAttrReservationToken : public StunAttr
+{
 public:
   StunAttrReservationToken() : _rt(0) { setType(STUN_ATTRIBUTE_RESERVATION_TOKEN); }
-  StunAttrReservationToken(const StunAttrIterator &iter) : StunAttr(iter) {
+  StunAttrReservationToken(const StunAttrIterator &iter) : StunAttr(iter)
+  {
 
-    if (iter.eof()) {
+    if (iter.eof())
+    {
       throw EndOfStunMsgException();
     }
     _rt = stun_attr_get_reservation_token_value(getSar(iter));
@@ -367,7 +416,8 @@ public:
   void setReservationToken(uint64_t rt) { _rt = rt; }
 
 protected:
-  virtual bool addToBuffer(uint8_t *buffer, size_t &sz) {
+  virtual bool addToBuffer(uint8_t *buffer, size_t &sz)
+  {
     uint64_t reservation_token = ioa_ntoh64(_rt);
     return stun_attr_add_str(buffer, &sz, STUN_ATTRIBUTE_RESERVATION_TOKEN, (uint8_t *)(&reservation_token), 8);
   }
@@ -379,20 +429,25 @@ private:
 /**
  * This attribute class is used for all address attributes
  */
-class StunAttrAddr : public StunAttr {
+class StunAttrAddr : public StunAttr
+{
 public:
-  StunAttrAddr(uint16_t attr_type = 0) {
+  StunAttrAddr(uint16_t attr_type = 0)
+  {
     addr_set_any(&_addr);
     setType(attr_type);
   }
-  StunAttrAddr(const StunAttrIterator &iter) : StunAttr(iter) {
+  StunAttrAddr(const StunAttrIterator &iter) : StunAttr(iter)
+  {
 
-    if (iter.eof()) {
+    if (iter.eof())
+    {
       throw EndOfStunMsgException();
     }
     size_t sz = 0;
     const uint8_t *buf = iter.getRawBuffer(sz);
-    if (!stun_attr_get_addr_str(buf, sz, getSar(iter), &_addr, NULL)) {
+    if (!stun_attr_get_addr_str(buf, sz, getSar(iter), &_addr, NULL))
+    {
       throw WrongStunAttrFormatException();
     }
   }
@@ -401,7 +456,8 @@ public:
   void setAddr(ioa_addr &addr) { addr_cpy(&_addr, &addr); }
 
 protected:
-  virtual bool addToBuffer(uint8_t *buffer, size_t &sz) {
+  virtual bool addToBuffer(uint8_t *buffer, size_t &sz)
+  {
     return stun_attr_add_addr_str(buffer, &sz, getType(), &_addr);
   }
 
@@ -412,16 +468,20 @@ private:
 /**
  * Change Request attribute class
  */
-class StunAttrChangeRequest : public StunAttr {
+class StunAttrChangeRequest : public StunAttr
+{
 public:
   StunAttrChangeRequest() : _changeIp(false), _changePort(false) { setType(STUN_ATTRIBUTE_CHANGE_REQUEST); }
-  StunAttrChangeRequest(const StunAttrIterator &iter) : StunAttr(iter) {
+  StunAttrChangeRequest(const StunAttrIterator &iter) : StunAttr(iter)
+  {
 
-    if (iter.eof()) {
+    if (iter.eof())
+    {
       throw EndOfStunMsgException();
     }
 
-    if (!stun_attr_get_change_request_str(getSar(iter), &_changeIp, &_changePort)) {
+    if (!stun_attr_get_change_request_str(getSar(iter), &_changeIp, &_changePort))
+    {
       throw WrongStunAttrFormatException();
     }
   }
@@ -432,7 +492,8 @@ public:
   void setChangePort(bool cp) { _changePort = cp; }
 
 protected:
-  virtual bool addToBuffer(uint8_t *buffer, size_t &sz) {
+  virtual bool addToBuffer(uint8_t *buffer, size_t &sz)
+  {
     return stun_attr_add_change_request_str(buffer, &sz, _changeIp, _changePort);
   }
 
@@ -444,17 +505,21 @@ private:
 /**
  * Change Request attribute class
  */
-class StunAttrResponsePort : public StunAttr {
+class StunAttrResponsePort : public StunAttr
+{
 public:
   StunAttrResponsePort() : _rp(0) { setType(STUN_ATTRIBUTE_RESPONSE_PORT); }
-  StunAttrResponsePort(const StunAttrIterator &iter) : StunAttr(iter) {
+  StunAttrResponsePort(const StunAttrIterator &iter) : StunAttr(iter)
+  {
 
-    if (iter.eof()) {
+    if (iter.eof())
+    {
       throw EndOfStunMsgException();
     }
 
     int rp = stun_attr_get_response_port_str(getSar(iter));
-    if (rp < 0) {
+    if (rp < 0)
+    {
       throw WrongStunAttrFormatException();
     }
     _rp = (uint16_t)rp;
@@ -473,17 +538,21 @@ private:
 /**
  * Padding attribute class
  */
-class StunAttrPadding : public StunAttr {
+class StunAttrPadding : public StunAttr
+{
 public:
   StunAttrPadding() : _p(0) { setType(STUN_ATTRIBUTE_PADDING); }
-  StunAttrPadding(const StunAttrIterator &iter) : StunAttr(iter) {
+  StunAttrPadding(const StunAttrIterator &iter) : StunAttr(iter)
+  {
 
-    if (iter.eof()) {
+    if (iter.eof())
+    {
       throw EndOfStunMsgException();
     }
 
     int p = stun_attr_get_padding_len_str(getSar(iter));
-    if (p < 0) {
+    if (p < 0)
+    {
       throw WrongStunAttrFormatException();
     }
     _p = (uint16_t)p;
@@ -505,12 +574,14 @@ private:
 /**
  * Generic "STUN Message" class, base class for all messages
  */
-class StunMsg {
+class StunMsg
+{
 public:
   /**
    * Empty constructor
    */
-  StunMsg() {
+  StunMsg()
+  {
     _allocated_sz = 0xFFFF;
     _buffer = (uint8_t *)malloc(_allocated_sz);
     _deallocate = true;
@@ -523,13 +594,17 @@ public:
    * Parameter "construct" is true if the buffer is initialized.
    */
   StunMsg(uint8_t *buffer, size_t total_sz, size_t sz, bool constructed)
-      : _buffer(buffer), _deallocate(false), _allocated_sz(total_sz), _sz(sz), _constructed(constructed) {}
+      : _buffer(buffer), _deallocate(false), _allocated_sz(total_sz), _sz(sz), _constructed(constructed)
+  {
+  }
 
   /**
    * Destructor
    */
-  virtual ~StunMsg() {
-    if (_deallocate && _buffer) {
+  virtual ~StunMsg()
+  {
+    if (_deallocate && _buffer)
+    {
       free(_buffer);
     }
   }
@@ -557,8 +632,10 @@ public:
   /**
    * Set message size
    */
-  void setSize(size_t sz) {
-    if (sz > _allocated_sz) {
+  void setSize(size_t sz)
+  {
+    if (sz > _allocated_sz)
+    {
       throw WrongStunBufferFormatException();
     }
     _sz = sz;
@@ -580,7 +657,8 @@ public:
 
   static bool isSuccessResponse(uint8_t *buffer, size_t sz) { return stun_is_success_response_str(buffer, sz); }
 
-  static bool isErrorResponse(uint8_t *buffer, size_t sz, int &err_code, uint8_t *err_msg, size_t err_msg_size) {
+  static bool isErrorResponse(uint8_t *buffer, size_t sz, int &err_code, uint8_t *err_msg, size_t err_msg_size)
+  {
     return stun_is_error_response_str(buffer, sz, &err_code, err_msg, err_msg_size);
   }
 
@@ -588,7 +666,8 @@ public:
    * Check if the raw buffer is a challenge response (the one with 401 error and realm and nonce values).
    */
   static bool isChallengeResponse(const uint8_t *buf, size_t sz, int &err_code, uint8_t *err_msg, size_t err_msg_size,
-                                  uint8_t *realm, uint8_t *nonce, uint8_t *server_name, bool *oauth) {
+                                  uint8_t *realm, uint8_t *nonce, uint8_t *server_name, bool *oauth)
+  {
     return stun_is_challenge_response_str(buf, sz, &err_code, err_msg, err_msg_size, realm, nonce, server_name, oauth);
   }
 
@@ -600,12 +679,15 @@ public:
   /**
    * Check if the fingerprint is present.
    */
-  static bool isFingerprintPresent(uint8_t *buffer, size_t sz) {
-    if (!stun_is_command_message_str(buffer, sz)) {
+  static bool isFingerprintPresent(uint8_t *buffer, size_t sz)
+  {
+    if (!stun_is_command_message_str(buffer, sz))
+    {
       return false;
     }
     stun_attr_ref sar = stun_attr_get_first_by_type_str(buffer, sz, STUN_ATTRIBUTE_FINGERPRINT);
-    if (!sar) {
+    if (!sar)
+    {
       return false;
     }
 
@@ -615,7 +697,8 @@ public:
   /**
    * Check the fingerprint
    */
-  static bool checkFingerprint(uint8_t *buffer, size_t sz) {
+  static bool checkFingerprint(uint8_t *buffer, size_t sz)
+  {
     return stun_is_command_message_full_check_str(buffer, sz, 1, NULL);
   }
 
@@ -627,8 +710,10 @@ public:
   /**
    * Get transaction ID
    */
-  virtual stun_tid getTid() const {
-    if (!_constructed || !isCommand()) {
+  virtual stun_tid getTid() const
+  {
+    if (!_constructed || !isCommand())
+    {
       throw WrongStunBufferFormatException();
     }
     stun_tid tid;
@@ -639,8 +724,10 @@ public:
   /**
    * Set transaction ID
    */
-  virtual void setTid(stun_tid &tid) {
-    if (!_constructed || !isCommand()) {
+  virtual void setTid(stun_tid &tid)
+  {
+    if (!_constructed || !isCommand())
+    {
       throw WrongStunBufferFormatException();
     }
     stun_tid_message_cpy(_buffer, &tid);
@@ -649,8 +736,10 @@ public:
   /**
    * Add fingerprint to the message
    */
-  void addFingerprint() {
-    if (!_constructed || !isCommand()) {
+  void addFingerprint()
+  {
+    if (!_constructed || !isCommand())
+    {
       throw WrongStunBufferFormatException();
     }
     stun_attr_add_fingerprint_str(_buffer, &_sz);
@@ -659,8 +748,10 @@ public:
   /**
    * Check message integrity, in secure communications.
    */
-  bool checkMessageIntegrity(turn_credential_type ct, std::string &uname, std::string &realm, std::string &upwd) const {
-    if (!_constructed || !isCommand()) {
+  bool checkMessageIntegrity(turn_credential_type ct, std::string &uname, std::string &realm, std::string &upwd) const
+  {
+    if (!_constructed || !isCommand())
+    {
       throw WrongStunBufferFormatException();
     }
     uint8_t *suname = (uint8_t *)strdup(uname.c_str());
@@ -677,9 +768,11 @@ public:
   /**
    * Adds long-term message integrity data to the message.
    */
-  void addLTMessageIntegrity(std::string &uname, std::string &realm, std::string &upwd, std::string &nonce) {
+  void addLTMessageIntegrity(std::string &uname, std::string &realm, std::string &upwd, std::string &nonce)
+  {
 
-    if (!_constructed || !isCommand()) {
+    if (!_constructed || !isCommand())
+    {
       throw WrongStunBufferFormatException();
     }
 
@@ -699,9 +792,11 @@ public:
   /**
    * Adds short-term message integrity data to the message.
    */
-  void addSTMessageIntegrity(std::string &uname, std::string &upwd) {
+  void addSTMessageIntegrity(std::string &uname, std::string &upwd)
+  {
 
-    if (!_constructed || !isCommand()) {
+    if (!_constructed || !isCommand())
+    {
       throw WrongStunBufferFormatException();
     }
 
@@ -729,14 +824,18 @@ protected:
 /**
  * Class that represents the "request" flavor of STUN/TURN messages.
  */
-class StunMsgRequest : public StunMsg {
+class StunMsgRequest : public StunMsg
+{
 public:
-  StunMsgRequest(uint16_t method) : _method(method){};
+  StunMsgRequest(uint16_t method) : _method(method) {};
   StunMsgRequest(uint8_t *buffer, size_t total_sz, size_t sz, bool constructed)
-      : StunMsg(buffer, total_sz, sz, constructed), _method(0) {
+      : StunMsg(buffer, total_sz, sz, constructed), _method(0)
+  {
 
-    if (constructed) {
-      if (!stun_is_request_str(buffer, sz)) {
+    if (constructed)
+    {
+      if (!stun_is_request_str(buffer, sz))
+      {
         throw WrongStunBufferFormatException();
       }
       _method = stun_get_method_str(buffer, sz);
@@ -765,31 +864,38 @@ public:
    * Construct allocate request
    */
   void constructAllocateRequest(uint32_t lifetime, int af4, int af6, uint8_t transport, int mobile, const char *rt,
-                                int ep) {
+                                int ep)
+  {
     stun_set_allocate_request_str(_buffer, &_sz, lifetime, af4, af6, transport, mobile, rt, ep);
   }
 
   /**
    * Construct channel bind request
    */
-  void constructChannelBindRequest(const ioa_addr &peer_addr, uint16_t channel_number) {
+  void constructChannelBindRequest(const ioa_addr &peer_addr, uint16_t channel_number)
+  {
     stun_set_channel_bind_request_str(_buffer, &_sz, &peer_addr, channel_number);
   }
 
 protected:
-  virtual void constructBuffer() {
+  virtual void constructBuffer()
+  {
     stun_init_request_str(_method, _buffer, &_sz);
     _constructed = true;
   }
 
-  virtual bool check() {
-    if (!_constructed) {
+  virtual bool check()
+  {
+    if (!_constructed)
+    {
       return false;
     }
-    if (!stun_is_request_str(_buffer, _sz)) {
+    if (!stun_is_request_str(_buffer, _sz))
+    {
       return false;
     }
-    if (_method != stun_get_method_str(_buffer, _sz)) {
+    if (_method != stun_get_method_str(_buffer, _sz))
+    {
       return false;
     }
     return true;
@@ -802,20 +908,25 @@ private:
 /**
  * Class for STUN/TURN responses
  */
-class StunMsgResponse : public StunMsg {
+class StunMsgResponse : public StunMsg
+{
 public:
-  StunMsgResponse(uint16_t method, stun_tid &tid) : _method(method), _err(0), _reason(""), _tid(tid){};
+  StunMsgResponse(uint16_t method, stun_tid &tid) : _method(method), _err(0), _reason(""), _tid(tid) {};
   StunMsgResponse(uint16_t method, int error_code, std::string reason, stun_tid &tid)
-      : _method(method), _err(error_code), _reason(reason), _tid(tid){
+      : _method(method), _err(error_code), _reason(reason), _tid(tid) {
 
-                                                            };
+        };
   StunMsgResponse(uint8_t *buffer, size_t total_sz, size_t sz, bool constructed)
-      : StunMsg(buffer, total_sz, sz, constructed), _method(0), _err(0), _reason("") {
+      : StunMsg(buffer, total_sz, sz, constructed), _method(0), _err(0), _reason("")
+  {
 
-    if (constructed) {
-      if (!stun_is_success_response_str(buffer, sz)) {
+    if (constructed)
+    {
+      if (!stun_is_success_response_str(buffer, sz))
+      {
         uint8_t errtxt[0xFFFF];
-        if (!stun_is_error_response_str(buffer, sz, &_err, errtxt, sizeof(errtxt))) {
+        if (!stun_is_error_response_str(buffer, sz, &_err, errtxt, sizeof(errtxt)))
+        {
           throw WrongStunBufferFormatException();
         }
         _reason = (char *)errtxt;
@@ -862,16 +973,19 @@ public:
   /**
    * Check if this is a challenge response, and return realm and nonce
    */
-  bool isChallenge(std::string &realm, std::string &nonce) const {
+  bool isChallenge(std::string &realm, std::string &nonce) const
+  {
     bool ret = false;
-    if (_constructed) {
+    if (_constructed)
+    {
       int err_code;
       uint8_t err_msg[1025];
       size_t err_msg_size = sizeof(err_msg);
       uint8_t srealm[0xFFFF];
       uint8_t snonce[0xFFFF];
       ret = stun_is_challenge_response_str(_buffer, _sz, &err_code, err_msg, err_msg_size, srealm, snonce, NULL, NULL);
-      if (ret) {
+      if (ret)
+      {
         realm = (char *)srealm;
         nonce = (char *)snonce;
       }
@@ -879,7 +993,8 @@ public:
     return ret;
   }
 
-  bool isChallenge() const {
+  bool isChallenge() const
+  {
     std::string realm, nonce;
     return isChallenge(realm, nonce);
   }
@@ -892,7 +1007,8 @@ public:
   /**
    * Construct binding response
    */
-  void constructBindingResponse(stun_tid &tid, const ioa_addr &reflexive_addr, int error_code, const uint8_t *reason) {
+  void constructBindingResponse(stun_tid &tid, const ioa_addr &reflexive_addr, int error_code, const uint8_t *reason)
+  {
 
     stun_set_binding_response_str(_buffer, &_sz, &tid, &reflexive_addr, error_code, reason, 0, false, true);
   }
@@ -904,7 +1020,8 @@ public:
    */
   void constructAllocateResponse(stun_tid &tid, const ioa_addr &relayed_addr1, const ioa_addr &relayed_addr2,
                                  const ioa_addr &reflexive_addr, uint32_t lifetime, int error_code,
-                                 const uint8_t *reason, uint64_t reservation_token, char *mobile_id) {
+                                 const uint8_t *reason, uint64_t reservation_token, char *mobile_id)
+  {
 
     stun_set_allocate_response_str(_buffer, &_sz, &tid, &relayed_addr1, &relayed_addr2, &reflexive_addr, lifetime,
                                    STUN_DEFAULT_MAX_ALLOCATE_LIFETIME, error_code, reason, reservation_token,
@@ -914,35 +1031,46 @@ public:
   /**
    * Construct channel bind response
    */
-  void constructChannelBindResponse(stun_tid &tid, int error_code, const uint8_t *reason) {
+  void constructChannelBindResponse(stun_tid &tid, int error_code, const uint8_t *reason)
+  {
     stun_set_channel_bind_response_str(_buffer, &_sz, &tid, error_code, reason);
   }
 
 protected:
-  virtual void constructBuffer() {
-    if (_err) {
+  virtual void constructBuffer()
+  {
+    if (_err)
+    {
       stun_init_error_response_str(_method, _buffer, &_sz, _err, (const uint8_t *)_reason.c_str(), &_tid);
-    } else {
+    }
+    else
+    {
       stun_init_success_response_str(_method, _buffer, &_sz, &_tid);
     }
     _constructed = true;
   }
 
-  virtual bool check() {
-    if (!_constructed) {
+  virtual bool check()
+  {
+    if (!_constructed)
+    {
       return false;
     }
-    if (!stun_is_success_response_str(_buffer, _sz)) {
+    if (!stun_is_success_response_str(_buffer, _sz))
+    {
       uint8_t errtxt[0xFFFF];
       int cerr = 0;
-      if (!stun_is_error_response_str(_buffer, _sz, &cerr, errtxt, sizeof(errtxt))) {
+      if (!stun_is_error_response_str(_buffer, _sz, &cerr, errtxt, sizeof(errtxt)))
+      {
         throw WrongStunBufferFormatException();
       }
-      if (cerr != _err) {
+      if (cerr != _err)
+      {
         throw WrongStunBufferFormatException();
       }
     }
-    if (_method != stun_get_method_str(_buffer, _sz)) {
+    if (_method != stun_get_method_str(_buffer, _sz))
+    {
       return false;
     }
     return true;
@@ -958,14 +1086,18 @@ private:
 /**
  * Class for STUN/TURN indications
  */
-class StunMsgIndication : public StunMsg {
+class StunMsgIndication : public StunMsg
+{
 public:
-  StunMsgIndication(uint16_t method) : _method(method){};
+  StunMsgIndication(uint16_t method) : _method(method) {};
   StunMsgIndication(uint8_t *buffer, size_t total_sz, size_t sz, bool constructed)
-      : StunMsg(buffer, total_sz, sz, constructed), _method(0) {
+      : StunMsg(buffer, total_sz, sz, constructed), _method(0)
+  {
 
-    if (constructed) {
-      if (!stun_is_indication_str(buffer, sz)) {
+    if (constructed)
+    {
+      if (!stun_is_indication_str(buffer, sz))
+      {
         throw WrongStunBufferFormatException();
       }
       _method = stun_get_method_str(buffer, sz);
@@ -978,19 +1110,24 @@ public:
   void setMethod(uint16_t method) { _method = method; }
 
 protected:
-  virtual void constructBuffer() {
+  virtual void constructBuffer()
+  {
     stun_init_indication_str(_method, _buffer, &_sz);
     _constructed = true;
   }
 
-  virtual bool check() {
-    if (!_constructed) {
+  virtual bool check()
+  {
+    if (!_constructed)
+    {
       return false;
     }
-    if (!stun_is_indication_str(_buffer, _sz)) {
+    if (!stun_is_indication_str(_buffer, _sz))
+    {
       return false;
     }
-    if (_method != stun_get_method_str(_buffer, _sz)) {
+    if (_method != stun_get_method_str(_buffer, _sz))
+    {
       return false;
     }
     return true;
@@ -1003,23 +1140,31 @@ private:
 /**
  * Channel message
  */
-class StunMsgChannel : public StunMsg {
+class StunMsgChannel : public StunMsg
+{
 public:
-  StunMsgChannel(uint16_t cn, int length) : _cn(cn), _len(length){};
+  StunMsgChannel(uint16_t cn, int length) : _cn(cn), _len(length) {};
   StunMsgChannel(uint8_t *buffer, size_t total_sz, size_t sz, bool constructed)
-      : StunMsg(buffer, total_sz, sz, constructed), _cn(0) {
+      : StunMsg(buffer, total_sz, sz, constructed), _cn(0)
+  {
 
-    if (constructed) {
-      if (!stun_is_channel_message_str(buffer, &_sz, &_cn, false)) {
+    if (constructed)
+    {
+      if (!stun_is_channel_message_str(buffer, &_sz, &_cn, false))
+      {
         throw WrongStunBufferFormatException();
       }
-      if (_sz > 0xFFFF || _sz < 4) {
+      if (_sz > 0xFFFF || _sz < 4)
+      {
         throw WrongStunBufferFormatException();
       }
 
       _len = _sz - 4;
-    } else {
-      if (total_sz > 0xFFFF || total_sz < 4) {
+    }
+    else
+    {
+      if (total_sz > 0xFFFF || total_sz < 4)
+      {
         throw WrongStunBufferFormatException();
       }
 
@@ -1043,20 +1188,25 @@ public:
   void setLength(size_t len) { _len = len; }
 
 protected:
-  virtual void constructBuffer() {
+  virtual void constructBuffer()
+  {
     stun_init_channel_message_str(_cn, _buffer, &_sz, (int)_len, 0);
     _constructed = true;
   }
 
-  virtual bool check() {
-    if (!_constructed) {
+  virtual bool check()
+  {
+    if (!_constructed)
+    {
       return false;
     }
     uint16_t cn = 0;
-    if (!stun_is_channel_message_str(_buffer, &_sz, &cn, false)) {
+    if (!stun_is_channel_message_str(_buffer, &_sz, &cn, false))
+    {
       return false;
     }
-    if (_cn != cn) {
+    if (_cn != cn)
+    {
       return false;
     }
     return true;

--- a/src/client/ns_turn_ioaddr.c
+++ b/src/client/ns_turn_ioaddr.c
@@ -42,10 +42,14 @@
 
 //////////////////////////////////////////////////////////////
 
-uint32_t get_ioa_addr_len(const ioa_addr *addr) {
-  if (addr->ss.sa_family == AF_INET) {
+uint32_t get_ioa_addr_len(const ioa_addr *addr)
+{
+  if (addr->ss.sa_family == AF_INET)
+  {
     return sizeof(struct sockaddr_in);
-  } else if (addr->ss.sa_family == AF_INET6) {
+  }
+  else if (addr->ss.sa_family == AF_INET6)
+  {
     return sizeof(struct sockaddr_in6);
   }
   return 0;
@@ -53,27 +57,39 @@ uint32_t get_ioa_addr_len(const ioa_addr *addr) {
 
 ///////////////////////////////////////////////////////////////
 
-void addr_set_any(ioa_addr *addr) {
-  if (addr) {
+void addr_set_any(ioa_addr *addr)
+{
+  if (addr)
+  {
     memset(addr, 0, sizeof(ioa_addr));
   }
 }
 
-int addr_any(const ioa_addr *addr) {
+int addr_any(const ioa_addr *addr)
+{
 
-  if (!addr) {
+  if (!addr)
+  {
     return 1;
   }
 
-  if (addr->ss.sa_family == AF_INET) {
+  if (addr->ss.sa_family == AF_INET)
+  {
     return ((addr->s4.sin_addr.s_addr == 0) && (addr->s4.sin_port == 0));
-  } else if (addr->ss.sa_family == AF_INET6) {
-    if (addr->s6.sin6_port != 0) {
+  }
+  else if (addr->ss.sa_family == AF_INET6)
+  {
+    if (addr->s6.sin6_port != 0)
+    {
       return 0;
-    } else {
+    }
+    else
+    {
       size_t i;
-      for (i = 0; i < sizeof(addr->s6.sin6_addr); i++) {
-        if (((const char *)&(addr->s6.sin6_addr))[i]) {
+      for (i = 0; i < sizeof(addr->s6.sin6_addr); i++)
+      {
+        if (((const char *)&(addr->s6.sin6_addr))[i])
+        {
           return 0;
         }
       }
@@ -83,17 +99,24 @@ int addr_any(const ioa_addr *addr) {
   return 1;
 }
 
-int addr_any_no_port(const ioa_addr *addr) {
-  if (!addr) {
+int addr_any_no_port(const ioa_addr *addr)
+{
+  if (!addr)
+  {
     return 1;
   }
 
-  if (addr->ss.sa_family == AF_INET) {
+  if (addr->ss.sa_family == AF_INET)
+  {
     return (addr->s4.sin_addr.s_addr == 0);
-  } else if (addr->ss.sa_family == AF_INET6) {
+  }
+  else if (addr->ss.sa_family == AF_INET6)
+  {
     size_t i;
-    for (i = 0; i < sizeof(addr->s6.sin6_addr); i++) {
-      if (((const char *)(&(addr->s6.sin6_addr)))[i]) {
+    for (i = 0; i < sizeof(addr->s6.sin6_addr); i++)
+    {
+      if (((const char *)(&(addr->s6.sin6_addr)))[i])
+      {
         return 0;
       }
     }
@@ -102,29 +125,36 @@ int addr_any_no_port(const ioa_addr *addr) {
   return 1;
 }
 
-uint32_t hash_int32(uint32_t a) {
+uint32_t hash_int32(uint32_t a)
+{
   a = a ^ (a >> 4);
   a = (a ^ 0xdeadbeef) + (a << 5);
   a = a ^ (a >> 11);
   return a;
 }
 
-uint64_t hash_int64(uint64_t a) {
+uint64_t hash_int64(uint64_t a)
+{
   a = a ^ (a >> 4);
   a = (a ^ 0xdeadbeefdeadbeefLL) + (a << 5);
   a = a ^ (a >> 11);
   return a;
 }
 
-uint32_t addr_hash(const ioa_addr *addr) {
-  if (!addr) {
+uint32_t addr_hash(const ioa_addr *addr)
+{
+  if (!addr)
+  {
     return 0;
   }
 
   uint32_t ret = 0;
-  if (addr->ss.sa_family == AF_INET) {
+  if (addr->ss.sa_family == AF_INET)
+  {
     ret = hash_int32(addr->s4.sin_addr.s_addr + addr->s4.sin_port);
-  } else {
+  }
+  else
+  {
     uint64_t a[2];
     memcpy(&a, &(addr->s6.sin6_addr), sizeof(a));
     ret = (uint32_t)((hash_int64(a[0]) << 3) + (hash_int64(a[1] + addr->s6.sin6_port)));
@@ -132,15 +162,20 @@ uint32_t addr_hash(const ioa_addr *addr) {
   return ret;
 }
 
-uint32_t addr_hash_no_port(const ioa_addr *addr) {
-  if (!addr) {
+uint32_t addr_hash_no_port(const ioa_addr *addr)
+{
+  if (!addr)
+  {
     return 0;
   }
 
   uint32_t ret = 0;
-  if (addr->ss.sa_family == AF_INET) {
+  if (addr->ss.sa_family == AF_INET)
+  {
     ret = hash_int32(addr->s4.sin_addr.s_addr);
-  } else {
+  }
+  else
+  {
     uint64_t a[2];
     memcpy(&a, &(addr->s6.sin6_addr), sizeof(a));
     ret = (uint32_t)((hash_int64(a[0]) << 3) + (hash_int64(a[1])));
@@ -148,39 +183,55 @@ uint32_t addr_hash_no_port(const ioa_addr *addr) {
   return ret;
 }
 
-void addr_cpy(ioa_addr *dst, const ioa_addr *src) {
-  if (dst && src) {
+void addr_cpy(ioa_addr *dst, const ioa_addr *src)
+{
+  if (dst && src)
+  {
     memcpy(dst, src, sizeof(ioa_addr));
   }
 }
 
-void addr_cpy4(ioa_addr *dst, const struct sockaddr_in *src) {
-  if (src && dst) {
+void addr_cpy4(ioa_addr *dst, const struct sockaddr_in *src)
+{
+  if (src && dst)
+  {
     memcpy(dst, src, sizeof(struct sockaddr_in));
   }
 }
 
-void addr_cpy6(ioa_addr *dst, const struct sockaddr_in6 *src) {
-  if (src && dst) {
+void addr_cpy6(ioa_addr *dst, const struct sockaddr_in6 *src)
+{
+  if (src && dst)
+  {
     memcpy(dst, src, sizeof(struct sockaddr_in6));
   }
 }
 
-int addr_eq(const ioa_addr *a1, const ioa_addr *a2) {
+int addr_eq(const ioa_addr *a1, const ioa_addr *a2)
+{
 
-  if (!a1) {
+  if (!a1)
+  {
     return (!a2);
-  } else if (!a2) {
+  }
+  else if (!a2)
+  {
     return (!a1);
   }
 
-  if (a1->ss.sa_family == a2->ss.sa_family) {
-    if (a1->ss.sa_family == AF_INET && a1->s4.sin_port == a2->s4.sin_port) {
-      if ((int)a1->s4.sin_addr.s_addr == (int)a2->s4.sin_addr.s_addr) {
+  if (a1->ss.sa_family == a2->ss.sa_family)
+  {
+    if (a1->ss.sa_family == AF_INET && a1->s4.sin_port == a2->s4.sin_port)
+    {
+      if ((int)a1->s4.sin_addr.s_addr == (int)a2->s4.sin_addr.s_addr)
+      {
         return 1;
       }
-    } else if (a1->ss.sa_family == AF_INET6 && a1->s6.sin6_port == a2->s6.sin6_port) {
-      if (memcmp(&(a1->s6.sin6_addr), &(a2->s6.sin6_addr), sizeof(struct in6_addr)) == 0) {
+    }
+    else if (a1->ss.sa_family == AF_INET6 && a1->s6.sin6_port == a2->s6.sin6_port)
+    {
+      if (memcmp(&(a1->s6.sin6_addr), &(a2->s6.sin6_addr), sizeof(struct in6_addr)) == 0)
+      {
         return 1;
       }
     }
@@ -189,21 +240,31 @@ int addr_eq(const ioa_addr *a1, const ioa_addr *a2) {
   return 0;
 }
 
-int addr_eq_no_port(const ioa_addr *a1, const ioa_addr *a2) {
+int addr_eq_no_port(const ioa_addr *a1, const ioa_addr *a2)
+{
 
-  if (!a1) {
+  if (!a1)
+  {
     return (!a2);
-  } else if (!a2) {
+  }
+  else if (!a2)
+  {
     return (!a1);
   }
 
-  if (a1->ss.sa_family == a2->ss.sa_family) {
-    if (a1->ss.sa_family == AF_INET) {
-      if ((int)a1->s4.sin_addr.s_addr == (int)a2->s4.sin_addr.s_addr) {
+  if (a1->ss.sa_family == a2->ss.sa_family)
+  {
+    if (a1->ss.sa_family == AF_INET)
+    {
+      if ((int)a1->s4.sin_addr.s_addr == (int)a2->s4.sin_addr.s_addr)
+      {
         return 1;
       }
-    } else if (a1->ss.sa_family == AF_INET6) {
-      if (memcmp(&(a1->s6.sin6_addr), &(a2->s6.sin6_addr), sizeof(struct in6_addr)) == 0) {
+    }
+    else if (a1->ss.sa_family == AF_INET6)
+    {
+      if (memcmp(&(a1->s6.sin6_addr), &(a2->s6.sin6_addr), sizeof(struct in6_addr)) == 0)
+      {
         return 1;
       }
     }
@@ -211,9 +272,11 @@ int addr_eq_no_port(const ioa_addr *a1, const ioa_addr *a2) {
   return 0;
 }
 
-int make_ioa_addr(const uint8_t *saddr0, int port, ioa_addr *addr) {
+int make_ioa_addr(const uint8_t *saddr0, int port, ioa_addr *addr)
+{
 
-  if (!saddr0 || !addr) {
+  if (!saddr0 || !addr)
+  {
     return -1;
   }
 
@@ -221,34 +284,44 @@ int make_ioa_addr(const uint8_t *saddr0, int port, ioa_addr *addr) {
   STRCPY(ssaddr, saddr0);
 
   char *saddr = ssaddr;
-  while (*saddr == ' ') {
+  while (*saddr == ' ')
+  {
     ++saddr;
   }
 
   size_t len = strlen(saddr);
-  while (len > 0) {
-    if (saddr[len - 1] == ' ') {
+  while (len > 0)
+  {
+    if (saddr[len - 1] == ' ')
+    {
       saddr[len - 1] = 0;
       --len;
-    } else {
+    }
+    else
+    {
       break;
     }
   }
 
   memset(addr, 0, sizeof(ioa_addr));
-  if ((len == 0) || (inet_pton(AF_INET, saddr, &addr->s4.sin_addr) == 1)) {
+  if ((len == 0) || (inet_pton(AF_INET, saddr, &addr->s4.sin_addr) == 1))
+  {
     addr->s4.sin_family = AF_INET;
 #if defined(TURN_HAS_SIN_LEN) /* tested when configured */
     addr->s4.sin_len = sizeof(struct sockaddr_in);
 #endif
     addr->s4.sin_port = nswap16(port);
-  } else if (inet_pton(AF_INET6, saddr, &addr->s6.sin6_addr) == 1) {
+  }
+  else if (inet_pton(AF_INET6, saddr, &addr->s6.sin6_addr) == 1)
+  {
     addr->s6.sin6_family = AF_INET6;
 #if defined(SIN6_LEN) /* this define is required by IPv6 if used */
     addr->s6.sin6_len = sizeof(struct sockaddr_in6);
 #endif
     addr->s6.sin6_port = nswap16(port);
-  } else {
+  }
+  else
+  {
     struct addrinfo addr_hints;
     struct addrinfo *addr_result = NULL;
     int err;
@@ -263,7 +336,8 @@ int make_ioa_addr(const uint8_t *saddr0, int port, ioa_addr *addr) {
     addr_hints.ai_next = NULL;
 
     err = getaddrinfo(saddr, NULL, &addr_hints, &addr_result);
-    if ((err != 0) || (!addr_result)) {
+    if ((err != 0) || (!addr_result))
+    {
       fprintf(stderr, "error resolving '%s' hostname: %s\n", saddr, gai_strerror(err));
       return -1;
     }
@@ -272,12 +346,15 @@ int make_ioa_addr(const uint8_t *saddr0, int port, ioa_addr *addr) {
     struct addrinfo *addr_result_orig = addr_result;
     int found = 0;
 
-  beg_af:
+beg_af:
 
-    while (addr_result) {
+    while (addr_result)
+    {
 
-      if (addr_result->ai_family == family) {
-        if (addr_result->ai_family == AF_INET) {
+      if (addr_result->ai_family == family)
+      {
+        if (addr_result->ai_family == AF_INET)
+        {
           memcpy(addr, addr_result->ai_addr, addr_result->ai_addrlen);
           addr->s4.sin_port = nswap16(port);
 #if defined(TURN_HAS_SIN_LEN) /* tested when configured */
@@ -285,7 +362,9 @@ int make_ioa_addr(const uint8_t *saddr0, int port, ioa_addr *addr) {
 #endif
           found = 1;
           break;
-        } else if (addr_result->ai_family == AF_INET6) {
+        }
+        else if (addr_result->ai_family == AF_INET6)
+        {
           memcpy(addr, addr_result->ai_addr, addr_result->ai_addrlen);
           addr->s6.sin6_port = nswap16(port);
 #if defined(SIN6_LEN) /* this define is required by IPv6 if used */
@@ -299,7 +378,8 @@ int make_ioa_addr(const uint8_t *saddr0, int port, ioa_addr *addr) {
       addr_result = addr_result->ai_next;
     }
 
-    if (!found && family == AF_INET) {
+    if (!found && family == AF_INET)
+    {
       family = AF_INET6;
       addr_result = addr_result_orig;
       goto beg_af;
@@ -311,37 +391,50 @@ int make_ioa_addr(const uint8_t *saddr0, int port, ioa_addr *addr) {
   return 0;
 }
 
-static char *get_addr_string_and_port(char *s0, int *port) {
+static char *get_addr_string_and_port(char *s0, int *port)
+{
   char *s = s0;
-  while (*s && (*s == ' ')) {
+  while (*s && (*s == ' '))
+  {
     ++s;
   }
-  if (*s == '[') {
+  if (*s == '[')
+  {
     ++s;
     char *tail = strstr(s, "]");
-    if (tail) {
+    if (tail)
+    {
       *tail = 0;
       ++tail;
-      while (*tail && (*tail == ' ')) {
+      while (*tail && (*tail == ' '))
+      {
         ++tail;
       }
-      if (*tail == ':') {
+      if (*tail == ':')
+      {
         ++tail;
         *port = atoi(tail);
         return s;
-      } else if (*tail == 0) {
+      }
+      else if (*tail == 0)
+      {
         *port = 0;
         return s;
       }
     }
-  } else {
+  }
+  else
+  {
     char *tail = strstr(s, ":");
-    if (tail) {
+    if (tail)
+    {
       *tail = 0;
       ++tail;
       *port = atoi(tail);
       return s;
-    } else {
+    }
+    else
+    {
       *port = 0;
       return s;
     }
@@ -349,8 +442,10 @@ static char *get_addr_string_and_port(char *s0, int *port) {
   return NULL;
 }
 
-int make_ioa_addr_from_full_string(const uint8_t *saddr, int default_port, ioa_addr *addr) {
-  if (!addr) {
+int make_ioa_addr_from_full_string(const uint8_t *saddr, int default_port, ioa_addr *addr)
+{
+  if (!addr)
+  {
     return -1;
   }
 
@@ -358,8 +453,10 @@ int make_ioa_addr_from_full_string(const uint8_t *saddr, int default_port, ioa_a
   int port = 0;
   char *s = strdup((const char *)saddr);
   char *sa = get_addr_string_and_port(s, &port);
-  if (sa) {
-    if (port < 1) {
+  if (sa)
+  {
+    if (port < 1)
+    {
       port = default_port;
     }
     ret = make_ioa_addr((uint8_t *)sa, port, addr);
@@ -368,27 +465,40 @@ int make_ioa_addr_from_full_string(const uint8_t *saddr, int default_port, ioa_a
   return ret;
 }
 
-int addr_to_string(const ioa_addr *addr, uint8_t *saddr) {
+int addr_to_string(const ioa_addr *addr, uint8_t *saddr)
+{
 
-  if (addr && saddr) {
+  if (addr && saddr)
+  {
 
     char addrtmp[INET6_ADDRSTRLEN];
 
-    if (addr->ss.sa_family == AF_INET) {
+    if (addr->ss.sa_family == AF_INET)
+    {
       inet_ntop(AF_INET, &addr->s4.sin_addr, addrtmp, INET_ADDRSTRLEN);
-      if (addr_get_port(addr) > 0) {
+      if (addr_get_port(addr) > 0)
+      {
         snprintf((char *)saddr, MAX_IOA_ADDR_STRING, "%s:%d", addrtmp, addr_get_port(addr));
-      } else {
+      }
+      else
+      {
         strncpy((char *)saddr, addrtmp, MAX_IOA_ADDR_STRING);
       }
-    } else if (addr->ss.sa_family == AF_INET6) {
+    }
+    else if (addr->ss.sa_family == AF_INET6)
+    {
       inet_ntop(AF_INET6, &addr->s6.sin6_addr, addrtmp, INET6_ADDRSTRLEN);
-      if (addr_get_port(addr) > 0) {
+      if (addr_get_port(addr) > 0)
+      {
         snprintf((char *)saddr, MAX_IOA_ADDR_STRING, "[%s]:%d", addrtmp, addr_get_port(addr));
-      } else {
+      }
+      else
+      {
         strncpy((char *)saddr, addrtmp, MAX_IOA_ADDR_STRING);
       }
-    } else {
+    }
+    else
+    {
       return -1;
     }
 
@@ -398,19 +508,26 @@ int addr_to_string(const ioa_addr *addr, uint8_t *saddr) {
   return -1;
 }
 
-int addr_to_string_no_port(const ioa_addr *addr, uint8_t *saddr) {
+int addr_to_string_no_port(const ioa_addr *addr, uint8_t *saddr)
+{
 
-  if (addr && saddr) {
+  if (addr && saddr)
+  {
 
     char addrtmp[MAX_IOA_ADDR_STRING];
 
-    if (addr->ss.sa_family == AF_INET) {
+    if (addr->ss.sa_family == AF_INET)
+    {
       inet_ntop(AF_INET, &addr->s4.sin_addr, addrtmp, INET_ADDRSTRLEN);
       strncpy((char *)saddr, addrtmp, MAX_IOA_ADDR_STRING);
-    } else if (addr->ss.sa_family == AF_INET6) {
+    }
+    else if (addr->ss.sa_family == AF_INET6)
+    {
       inet_ntop(AF_INET6, &addr->s6.sin6_addr, addrtmp, INET6_ADDRSTRLEN);
       strncpy((char *)saddr, addrtmp, MAX_IOA_ADDR_STRING);
-    } else {
+    }
+    else
+    {
       return -1;
     }
 
@@ -420,24 +537,34 @@ int addr_to_string_no_port(const ioa_addr *addr, uint8_t *saddr) {
   return -1;
 }
 
-void addr_set_port(ioa_addr *addr, int port) {
-  if (addr) {
-    if (addr->s4.sin_family == AF_INET) {
+void addr_set_port(ioa_addr *addr, int port)
+{
+  if (addr)
+  {
+    if (addr->s4.sin_family == AF_INET)
+    {
       addr->s4.sin_port = nswap16(port);
-    } else if (addr->s6.sin6_family == AF_INET6) {
+    }
+    else if (addr->s6.sin6_family == AF_INET6)
+    {
       addr->s6.sin6_port = nswap16(port);
     }
   }
 }
 
-int addr_get_port(const ioa_addr *addr) {
-  if (!addr) {
+int addr_get_port(const ioa_addr *addr)
+{
+  if (!addr)
+  {
     return 0;
   }
 
-  if (addr->s4.sin_family == AF_INET) {
+  if (addr->s4.sin_family == AF_INET)
+  {
     return nswap16(addr->s4.sin_port);
-  } else if (addr->s6.sin6_family == AF_INET6) {
+  }
+  else if (addr->s6.sin6_family == AF_INET6)
+  {
     return nswap16(addr->s6.sin6_port);
   }
   return 0;
@@ -445,54 +572,82 @@ int addr_get_port(const ioa_addr *addr) {
 
 /////////////////////////////////////////////////////////////////////////////
 
-void ioa_addr_range_set(ioa_addr_range *range, const ioa_addr *addr_min, const ioa_addr *addr_max) {
-  if (range) {
-    if (addr_min) {
+void ioa_addr_range_set(ioa_addr_range *range, const ioa_addr *addr_min, const ioa_addr *addr_max)
+{
+  if (range)
+  {
+    if (addr_min)
+    {
       addr_cpy(&(range->min), addr_min);
-    } else {
+    }
+    else
+    {
       addr_set_any(&(range->min));
     }
-    if (addr_max) {
+    if (addr_max)
+    {
       addr_cpy(&(range->max), addr_max);
-    } else {
+    }
+    else
+    {
       addr_set_any(&(range->max));
     }
   }
 }
 
-int addr_less_eq(const ioa_addr *addr1, const ioa_addr *addr2) {
+int addr_less_eq(const ioa_addr *addr1, const ioa_addr *addr2)
+{
 
-  if (!addr1) {
+  if (!addr1)
+  {
     return 1;
-  } else if (!addr2) {
+  }
+  else if (!addr2)
+  {
     return 0;
-  } else {
-    if (addr1->ss.sa_family != addr2->ss.sa_family) {
+  }
+  else
+  {
+    if (addr1->ss.sa_family != addr2->ss.sa_family)
+    {
       return (addr1->ss.sa_family < addr2->ss.sa_family);
-    } else if (addr1->ss.sa_family == AF_INET) {
+    }
+    else if (addr1->ss.sa_family == AF_INET)
+    {
       return ((uint32_t)nswap32(addr1->s4.sin_addr.s_addr) <= (uint32_t)nswap32(addr2->s4.sin_addr.s_addr));
-    } else if (addr1->ss.sa_family == AF_INET6) {
+    }
+    else if (addr1->ss.sa_family == AF_INET6)
+    {
       int i;
-      for (i = 0; i < 16; i++) {
-        if ((uint8_t)(((const char *)&(addr1->s6.sin6_addr))[i]) >
-            (uint8_t)(((const char *)&(addr2->s6.sin6_addr))[i])) {
+      for (i = 0; i < 16; i++)
+      {
+        if ((uint8_t)(((const char *)&(addr1->s6.sin6_addr))[i]) > (uint8_t)(((const char *)&(addr2->s6.sin6_addr))[i]))
+        {
           return 0;
         }
       }
       return 1;
-    } else {
+    }
+    else
+    {
       return 1;
     }
   }
 }
 
-int ioa_addr_in_range(const ioa_addr_range *range, const ioa_addr *addr) {
+int ioa_addr_in_range(const ioa_addr_range *range, const ioa_addr *addr)
+{
 
-  if (range && addr) {
-    if (addr_any(&(range->min)) || addr_less_eq(&(range->min), addr)) {
-      if (addr_any(&(range->max))) {
+  if (range && addr)
+  {
+    if (addr_any(&(range->min)) || addr_less_eq(&(range->min), addr))
+    {
+      if (addr_any(&(range->max)))
+      {
         return 1;
-      } else {
+      }
+      else
+      {
         return addr_less_eq(addr, &(range->max));
       }
     }
@@ -501,8 +656,10 @@ int ioa_addr_in_range(const ioa_addr_range *range, const ioa_addr *addr) {
   return 0;
 }
 
-void ioa_addr_range_cpy(ioa_addr_range *dest, const ioa_addr_range *src) {
-  if (dest && src) {
+void ioa_addr_range_cpy(ioa_addr_range *dest, const ioa_addr_range *src)
+{
+  if (dest && src)
+  {
     addr_cpy(&(dest->min), &(src->min));
     addr_cpy(&(dest->max), &(src->max));
   }
@@ -510,12 +667,17 @@ void ioa_addr_range_cpy(ioa_addr_range *dest, const ioa_addr_range *src) {
 
 /////// Check whether this is a good address //////////////
 
-int ioa_addr_is_multicast(ioa_addr *addr) {
-  if (addr) {
-    if (addr->ss.sa_family == AF_INET) {
+int ioa_addr_is_multicast(ioa_addr *addr)
+{
+  if (addr)
+  {
+    if (addr->ss.sa_family == AF_INET)
+    {
       const uint8_t *u = ((const uint8_t *)&(addr->s4.sin_addr));
       return (u[0] > 223);
-    } else if (addr->ss.sa_family == AF_INET6) {
+    }
+    else if (addr->ss.sa_family == AF_INET6)
+    {
       uint8_t u = ((const uint8_t *)&(addr->s6.sin6_addr))[0];
       return (u == 255);
     }
@@ -523,17 +685,25 @@ int ioa_addr_is_multicast(ioa_addr *addr) {
   return 0;
 }
 
-int ioa_addr_is_loopback(ioa_addr *addr) {
-  if (addr) {
-    if (addr->ss.sa_family == AF_INET) {
+int ioa_addr_is_loopback(ioa_addr *addr)
+{
+  if (addr)
+  {
+    if (addr->ss.sa_family == AF_INET)
+    {
       const uint8_t *u = ((const uint8_t *)&(addr->s4.sin_addr));
       return (u[0] == 127);
-    } else if (addr->ss.sa_family == AF_INET6) {
+    }
+    else if (addr->ss.sa_family == AF_INET6)
+    {
       const uint8_t *u = ((const uint8_t *)&(addr->s6.sin6_addr));
-      if (u[15] == 1) {
+      if (u[15] == 1)
+      {
         int i;
-        for (i = 0; i < 15; ++i) {
-          if (u[i]) {
+        for (i = 0; i < 15; ++i)
+        {
+          if (u[i])
+          {
             return 0;
           }
         }
@@ -550,16 +720,23 @@ Source from (INADDR_ANY) 0.0.0.0/32 and (in6addr_any) ::/128 routed to loopback 
 compatibility. https://github.com/torvalds/linux/blob/a2f5ea9e314ba6778f885c805c921e9362ec0420/net/ipv6/tcp_ipv6.c#L182
 To avoid any trouble we match the whole 0.0.0.0/8 that defined in RFC6890 as local network "this".
 */
-int ioa_addr_is_zero(ioa_addr *addr) {
-  if (addr) {
-    if (addr->ss.sa_family == AF_INET) {
+int ioa_addr_is_zero(ioa_addr *addr)
+{
+  if (addr)
+  {
+    if (addr->ss.sa_family == AF_INET)
+    {
       const uint8_t *u = ((const uint8_t *)&(addr->s4.sin_addr));
       return (u[0] == 0);
-    } else if (addr->ss.sa_family == AF_INET6) {
+    }
+    else if (addr->ss.sa_family == AF_INET6)
+    {
       const uint8_t *u = ((const uint8_t *)&(addr->s6.sin6_addr));
       int i;
-      for (i = 0; i <= 15; ++i) {
-        if (u[i]) {
+      for (i = 0; i <= 15; ++i)
+      {
+        if (u[i])
+        {
           return 0;
         }
       }
@@ -579,7 +756,8 @@ static ioa_addr **private_addrs = NULL;
 static size_t mcount = 0;
 static size_t msz = 0;
 
-void ioa_addr_add_mapping(ioa_addr *apub, ioa_addr *apriv) {
+void ioa_addr_add_mapping(ioa_addr *apub, ioa_addr *apriv)
+{
   size_t new_size = msz + sizeof(ioa_addr *);
   public_addrs = (ioa_addr **)realloc(public_addrs, new_size);
   private_addrs = (ioa_addr **)realloc(private_addrs, new_size);
@@ -591,10 +769,13 @@ void ioa_addr_add_mapping(ioa_addr *apub, ioa_addr *apriv) {
   msz += sizeof(ioa_addr *);
 }
 
-void map_addr_from_public_to_private(const ioa_addr *public_addr, ioa_addr *private_addr) {
+void map_addr_from_public_to_private(const ioa_addr *public_addr, ioa_addr *private_addr)
+{
   size_t i;
-  for (i = 0; i < mcount; ++i) {
-    if (addr_eq_no_port(public_addr, public_addrs[i])) {
+  for (i = 0; i < mcount; ++i)
+  {
+    if (addr_eq_no_port(public_addr, public_addrs[i]))
+    {
       addr_cpy(private_addr, private_addrs[i]);
       addr_set_port(private_addr, addr_get_port(public_addr));
       return;
@@ -603,10 +784,13 @@ void map_addr_from_public_to_private(const ioa_addr *public_addr, ioa_addr *priv
   addr_cpy(private_addr, public_addr);
 }
 
-void map_addr_from_private_to_public(const ioa_addr *private_addr, ioa_addr *public_addr) {
+void map_addr_from_private_to_public(const ioa_addr *private_addr, ioa_addr *public_addr)
+{
   size_t i;
-  for (i = 0; i < mcount; ++i) {
-    if (addr_eq_no_port(private_addr, private_addrs[i])) {
+  for (i = 0; i < mcount; ++i)
+  {
+    if (addr_eq_no_port(private_addr, private_addrs[i]))
+    {
       addr_cpy(public_addr, public_addrs[i]);
       addr_set_port(public_addr, addr_get_port(private_addr));
       return;

--- a/src/client/ns_turn_ioaddr.h
+++ b/src/client/ns_turn_ioaddr.h
@@ -34,20 +34,23 @@
 #include "ns_turn_defs.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 /////////////////////////////////////////////////////
 
 #define MAX_IOA_ADDR_STRING (65)
 
-typedef union {
+typedef union
+{
   struct sockaddr ss;
   struct sockaddr_in s4;
   struct sockaddr_in6 s6;
 } ioa_addr;
 
-typedef struct {
+typedef struct
+{
   ioa_addr min;
   ioa_addr max;
 } ioa_addr_range;

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -50,12 +50,14 @@
 
 ///////////
 
-int stun_method_str(uint16_t method, char *smethod) {
+int stun_method_str(uint16_t method, char *smethod)
+{
   int ret = 0;
 
   const char *s = "UNKNOWN";
 
-  switch (method) {
+  switch (method)
+  {
   case STUN_METHOD_BINDING:
     s = "BINDING";
     break;
@@ -90,14 +92,16 @@ int stun_method_str(uint16_t method, char *smethod) {
     ret = -1;
   };
 
-  if (smethod) {
+  if (smethod)
+  {
     strcpy(smethod, s);
   }
 
   return ret;
 }
 
-long turn_random_number(void) {
+long turn_random_number(void)
+{
   long ret = 0;
   if (!RAND_bytes((unsigned char *)&ret, sizeof(ret)))
 #if defined(WINDOWS)
@@ -108,56 +112,73 @@ long turn_random_number(void) {
   return ret;
 }
 
-static void generate_random_nonce(unsigned char *nonce, size_t sz) {
-  if (!RAND_bytes(nonce, (int)sz)) {
-    for (size_t i = 0; i < sz; ++i) {
+static void generate_random_nonce(unsigned char *nonce, size_t sz)
+{
+  if (!RAND_bytes(nonce, (int)sz))
+  {
+    for (size_t i = 0; i < sz; ++i)
+    {
       nonce[i] = (unsigned char)turn_random_number();
     }
   }
 }
 
-static void turn_random_tid_size(void *id) {
+static void turn_random_tid_size(void *id)
+{
   uint32_t *ar = (uint32_t *)id;
-  if (!RAND_bytes((unsigned char *)ar, 12)) {
-    for (size_t i = 0; i < 3; ++i) {
+  if (!RAND_bytes((unsigned char *)ar, 12))
+  {
+    for (size_t i = 0; i < 3; ++i)
+    {
       ar[i] = (uint32_t)turn_random_number();
     }
   }
 }
 
 bool stun_calculate_hmac(const uint8_t *buf, size_t len, const uint8_t *key, size_t keylen, uint8_t *hmac,
-                         unsigned int *hmac_len, SHATYPE shatype) {
+                         unsigned int *hmac_len, SHATYPE shatype)
+{
   ERR_clear_error();
   UNUSED_ARG(shatype);
 
-  if (shatype == SHATYPE_SHA256) {
+  if (shatype == SHATYPE_SHA256)
+  {
 #if !defined(OPENSSL_NO_SHA256) && defined(SHA256_DIGEST_LENGTH)
-    if (!HMAC(EVP_sha256(), key, (int)keylen, buf, len, hmac, hmac_len)) {
+    if (!HMAC(EVP_sha256(), key, (int)keylen, buf, len, hmac, hmac_len))
+    {
       return false;
     }
 #else
     fprintf(stderr, "SHA256 is not supported\n");
     return false;
 #endif
-  } else if (shatype == SHATYPE_SHA384) {
+  }
+  else if (shatype == SHATYPE_SHA384)
+  {
 #if !defined(OPENSSL_NO_SHA384) && defined(SHA384_DIGEST_LENGTH)
-    if (!HMAC(EVP_sha384(), key, (int)keylen, buf, len, hmac, hmac_len)) {
+    if (!HMAC(EVP_sha384(), key, (int)keylen, buf, len, hmac, hmac_len))
+    {
       return false;
     }
 #else
     fprintf(stderr, "SHA384 is not supported\n");
     return false;
 #endif
-  } else if (shatype == SHATYPE_SHA512) {
+  }
+  else if (shatype == SHATYPE_SHA512)
+  {
 #if !defined(OPENSSL_NO_SHA512) && defined(SHA512_DIGEST_LENGTH)
-    if (!HMAC(EVP_sha512(), key, (int)keylen, buf, len, hmac, hmac_len)) {
+    if (!HMAC(EVP_sha512(), key, (int)keylen, buf, len, hmac, hmac_len))
+    {
       return false;
     }
 #else
     fprintf(stderr, "SHA512 is not supported\n");
     return false;
 #endif
-  } else if (!HMAC(EVP_sha1(), key, (int)keylen, buf, len, hmac, hmac_len)) {
+  }
+  else if (!HMAC(EVP_sha1(), key, (int)keylen, buf, len, hmac, hmac_len))
+  {
     return false;
   }
 
@@ -165,7 +186,8 @@ bool stun_calculate_hmac(const uint8_t *buf, size_t len, const uint8_t *key, siz
 }
 
 bool stun_produce_integrity_key_str(const uint8_t *uname, const uint8_t *realm, const uint8_t *upwd, hmackey_t key,
-                                    SHATYPE shatype) {
+                                    SHATYPE shatype)
+{
   bool ret;
 
   ERR_clear_error();
@@ -185,7 +207,8 @@ bool stun_produce_integrity_key_str(const uint8_t *uname, const uint8_t *realm, 
   strncpy((char *)str + ulen + 1 + rlen + 1, (const char *)upwd, sz - ulen - 1 - rlen - 1);
   str[strl] = 0;
 
-  if (shatype == SHATYPE_SHA256) {
+  if (shatype == SHATYPE_SHA256)
+  {
 #if !defined(OPENSSL_NO_SHA256) && defined(SHA256_DIGEST_LENGTH)
     unsigned int keylen = 0;
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
@@ -198,7 +221,9 @@ bool stun_produce_integrity_key_str(const uint8_t *uname, const uint8_t *realm, 
     fprintf(stderr, "SHA256 is not supported\n");
     ret = false;
 #endif
-  } else if (shatype == SHATYPE_SHA384) {
+  }
+  else if (shatype == SHATYPE_SHA384)
+  {
 #if !defined(OPENSSL_NO_SHA384) && defined(SHA384_DIGEST_LENGTH)
     unsigned int keylen = 0;
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
@@ -211,7 +236,9 @@ bool stun_produce_integrity_key_str(const uint8_t *uname, const uint8_t *realm, 
     fprintf(stderr, "SHA384 is not supported\n");
     ret = false;
 #endif
-  } else if (shatype == SHATYPE_SHA512) {
+  }
+  else if (shatype == SHATYPE_SHA512)
+  {
 #if !defined(OPENSSL_NO_SHA512) && defined(SHA512_DIGEST_LENGTH)
     unsigned int keylen = 0;
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
@@ -224,11 +251,14 @@ bool stun_produce_integrity_key_str(const uint8_t *uname, const uint8_t *realm, 
     fprintf(stderr, "SHA512 is not supported\n");
     ret = false;
 #endif
-  } else {
+  }
+  else
+  {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     unsigned int keylen = 0;
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-    if (EVP_default_properties_is_fips_enabled(NULL)) {
+    if (EVP_default_properties_is_fips_enabled(NULL))
+    {
       EVP_default_properties_enable_fips(NULL, 0);
     }
     EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
@@ -239,7 +269,8 @@ bool stun_produce_integrity_key_str(const uint8_t *uname, const uint8_t *realm, 
     unsigned int keylen = 0;
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 #if defined EVP_MD_CTX_FLAG_NON_FIPS_ALLOW && !defined(LIBRESSL_VERSION_NUMBER)
-    if (FIPS_mode()) {
+    if (FIPS_mode())
+    {
       EVP_MD_CTX_set_flags(ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
     }
 #endif
@@ -258,19 +289,25 @@ bool stun_produce_integrity_key_str(const uint8_t *uname, const uint8_t *realm, 
 
 #define PWD_SALT_SIZE (8)
 
-static void readable_string(unsigned char *orig, unsigned char *out, size_t sz) {
+static void readable_string(unsigned char *orig, unsigned char *out, size_t sz)
+{
   out[0] = '\0';
-  for (size_t i = 0; i < sz; ++i) {
+  for (size_t i = 0; i < sz; ++i)
+  {
     snprintf((char *)(out + (i * 2)), 3, "%02x", (unsigned int)orig[i]);
   }
   out[sz * 2] = 0;
 }
 
-static void generate_enc_password(const char *pwd, char *result, const unsigned char *orig_salt) {
+static void generate_enc_password(const char *pwd, char *result, const unsigned char *orig_salt)
+{
   unsigned char salt[PWD_SALT_SIZE + 1];
-  if (!orig_salt) {
+  if (!orig_salt)
+  {
     generate_random_nonce(salt, PWD_SALT_SIZE);
-  } else {
+  }
+  else
+  {
     memcpy(salt, orig_salt, PWD_SALT_SIZE);
     salt[PWD_SALT_SIZE] = 0;
   }
@@ -303,11 +340,15 @@ static void generate_enc_password(const char *pwd, char *result, const unsigned 
 
 void generate_new_enc_password(const char *pwd, char *result) { generate_enc_password(pwd, result, NULL); }
 
-static bool encrypted_password(const char *pin, unsigned char *salt) {
+static bool encrypted_password(const char *pin, unsigned char *salt)
+{
   static const size_t min_len = 3 + PWD_SALT_SIZE + PWD_SALT_SIZE + 1 + 32;
-  if (strlen(pin) >= min_len) {
-    if ((pin[0] == '$') && (pin[1] == '5') && (pin[2] == '$') && (pin[3 + PWD_SALT_SIZE + PWD_SALT_SIZE] == '$')) {
-      for (size_t i = 0; i < PWD_SALT_SIZE; ++i) {
+  if (strlen(pin) >= min_len)
+  {
+    if ((pin[0] == '$') && (pin[1] == '5') && (pin[2] == '$') && (pin[3 + PWD_SALT_SIZE + PWD_SALT_SIZE] == '$'))
+    {
+      for (size_t i = 0; i < PWD_SALT_SIZE; ++i)
+      {
         const char *c = pin + 3 + i + i;
         char sc[3];
         sc[0] = c[0];
@@ -321,9 +362,11 @@ static bool encrypted_password(const char *pin, unsigned char *salt) {
   return false;
 }
 
-bool check_password_equal(const char *pin, const char *pwd) {
+bool check_password_equal(const char *pin, const char *pwd)
+{
   unsigned char salt[PWD_SALT_SIZE];
-  if (!encrypted_password(pwd, salt)) {
+  if (!encrypted_password(pwd, salt))
+  {
     return 0 == strcmp(pin, pwd);
   }
   char enc_pin[257];
@@ -337,22 +380,27 @@ static uint32_t ns_crc32(const uint8_t *buffer, uint32_t len);
 
 /////////////////////////////////////////////////////////////////
 
-int stun_get_command_message_len_str(const uint8_t *buf, size_t len) {
-  if (len < STUN_HEADER_LENGTH) {
+int stun_get_command_message_len_str(const uint8_t *buf, size_t len)
+{
+  if (len < STUN_HEADER_LENGTH)
+  {
     return -1;
   }
 
   /* Validate the size the buffer claims to be */
   size_t bufLen = (size_t)(nswap16(((const uint16_t *)(buf))[1]) + STUN_HEADER_LENGTH);
-  if (bufLen > len) {
+  if (bufLen > len)
+  {
     return -1;
   }
 
   return bufLen;
 }
 
-static bool stun_set_command_message_len_str(uint8_t *buf, int len) {
-  if (len < STUN_HEADER_LENGTH) {
+static bool stun_set_command_message_len_str(uint8_t *buf, int len)
+{
+  if (len < STUN_HEADER_LENGTH)
+  {
     return false;
   }
   ((uint16_t *)buf)[1] = nswap16((uint16_t)(len - STUN_HEADER_LENGTH));
@@ -361,13 +409,16 @@ static bool stun_set_command_message_len_str(uint8_t *buf, int len) {
 
 ///////////  Low-level binary //////////////////////////////////////////////
 
-uint16_t stun_make_type(uint16_t method) {
+uint16_t stun_make_type(uint16_t method)
+{
   method = method & 0x0FFF;
   return ((method & 0x000F) | ((method & 0x0070) << 1) | ((method & 0x0380) << 2) | ((method & 0x0C00) << 2));
 }
 
-uint16_t stun_get_method_str(const uint8_t *buf, size_t len) {
-  if (!buf || len < 2) {
+uint16_t stun_get_method_str(const uint8_t *buf, size_t len)
+{
+  if (!buf || len < 2)
+  {
     return (uint16_t)-1;
   }
 
@@ -376,27 +427,37 @@ uint16_t stun_get_method_str(const uint8_t *buf, size_t len) {
   return (tt & 0x000F) | ((tt & 0x00E0) >> 1) | ((tt & 0x0E00) >> 2) | ((tt & 0x3000) >> 2);
 }
 
-uint16_t stun_get_msg_type_str(const uint8_t *buf, size_t len) {
-  if (!buf || len < 2) {
+uint16_t stun_get_msg_type_str(const uint8_t *buf, size_t len)
+{
+  if (!buf || len < 2)
+  {
     return (uint16_t)-1;
   }
   return ((nswap16(((const uint16_t *)buf)[0])) & 0x3FFF);
 }
 
-bool is_channel_msg_str(const uint8_t *buf, size_t blen) {
+bool is_channel_msg_str(const uint8_t *buf, size_t blen)
+{
   return (buf && blen >= 4 && STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0])));
 }
 
 /////////////// message types /////////////////////////////////
 
-bool stun_is_command_message_str(const uint8_t *buf, size_t blen) {
-  if (buf && blen >= STUN_HEADER_LENGTH) {
-    if (!STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0]))) {
-      if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0) {
-        if (nswap32(((const uint32_t *)(buf))[1]) == STUN_MAGIC_COOKIE) {
+bool stun_is_command_message_str(const uint8_t *buf, size_t blen)
+{
+  if (buf && blen >= STUN_HEADER_LENGTH)
+  {
+    if (!STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0])))
+    {
+      if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0)
+      {
+        if (nswap32(((const uint32_t *)(buf))[1]) == STUN_MAGIC_COOKIE)
+        {
           uint16_t len = nswap16(((const uint16_t *)(buf))[1]);
-          if ((len & 0x0003) == 0) {
-            if ((size_t)(len + STUN_HEADER_LENGTH) == blen) {
+          if ((len & 0x0003) == 0)
+          {
+            if ((size_t)(len + STUN_HEADER_LENGTH) == blen)
+            {
               return true;
             }
           }
@@ -407,14 +468,21 @@ bool stun_is_command_message_str(const uint8_t *buf, size_t blen) {
   return false;
 }
 
-bool old_stun_is_command_message_str(const uint8_t *buf, size_t blen, uint32_t *cookie) {
-  if (buf && blen >= STUN_HEADER_LENGTH) {
-    if (!STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0]))) {
-      if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0) {
-        if (nswap32(((const uint32_t *)(buf))[1]) != STUN_MAGIC_COOKIE) {
+bool old_stun_is_command_message_str(const uint8_t *buf, size_t blen, uint32_t *cookie)
+{
+  if (buf && blen >= STUN_HEADER_LENGTH)
+  {
+    if (!STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0])))
+    {
+      if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0)
+      {
+        if (nswap32(((const uint32_t *)(buf))[1]) != STUN_MAGIC_COOKIE)
+        {
           uint16_t len = nswap16(((const uint16_t *)(buf))[1]);
-          if ((len & 0x0003) == 0) {
-            if ((size_t)(len + STUN_HEADER_LENGTH) == blen) {
+          if ((len & 0x0003) == 0)
+          {
+            if ((size_t)(len + STUN_HEADER_LENGTH) == blen)
+            {
               *cookie = nswap32(((const uint32_t *)(buf))[1]);
               return true;
             }
@@ -427,65 +495,86 @@ bool old_stun_is_command_message_str(const uint8_t *buf, size_t blen, uint32_t *
 }
 
 bool stun_is_command_message_full_check_str(const uint8_t *buf, size_t blen, int must_check_fingerprint,
-                                            int *fingerprint_present) {
-  if (!stun_is_command_message_str(buf, blen)) {
+                                            int *fingerprint_present)
+{
+  if (!stun_is_command_message_str(buf, blen))
+  {
     return false;
   }
   stun_attr_ref sar = stun_attr_get_first_by_type_str(buf, blen, STUN_ATTRIBUTE_FINGERPRINT);
-  if (!sar) {
-    if (fingerprint_present) {
+  if (!sar)
+  {
+    if (fingerprint_present)
+    {
       *fingerprint_present = 0;
     }
-    if (stun_get_method_str(buf, blen) == STUN_METHOD_BINDING) {
+    if (stun_get_method_str(buf, blen) == STUN_METHOD_BINDING)
+    {
       return true;
     }
     return !must_check_fingerprint;
   }
-  if (stun_attr_get_len(sar) != 4) {
+  if (stun_attr_get_len(sar) != 4)
+  {
     return false;
   }
   const uint32_t *fingerprint = (const uint32_t *)stun_attr_get_value(sar);
-  if (!fingerprint) {
+  if (!fingerprint)
+  {
     return !must_check_fingerprint;
   }
   uint32_t crc32len = (uint32_t)((((const uint8_t *)fingerprint) - buf) - 4);
   bool ret = (*fingerprint == nswap32(ns_crc32(buf, crc32len) ^ ((uint32_t)FINGERPRINT_XOR)));
-  if (ret && fingerprint_present) {
+  if (ret && fingerprint_present)
+  {
     *fingerprint_present = ret;
   }
   return ret;
 }
 
-bool stun_is_request_str(const uint8_t *buf, size_t len) {
-  if (is_channel_msg_str(buf, len)) {
+bool stun_is_request_str(const uint8_t *buf, size_t len)
+{
+  if (is_channel_msg_str(buf, len))
+  {
     return false;
   }
   return IS_STUN_REQUEST(stun_get_msg_type_str(buf, len));
 }
 
-bool stun_is_success_response_str(const uint8_t *buf, size_t len) {
-  if (is_channel_msg_str(buf, len)) {
+bool stun_is_success_response_str(const uint8_t *buf, size_t len)
+{
+  if (is_channel_msg_str(buf, len))
+  {
     return false;
   }
   return IS_STUN_SUCCESS_RESP(stun_get_msg_type_str(buf, len));
 }
 
-bool stun_is_error_response_str(const uint8_t *buf, size_t len, int *err_code, uint8_t *err_msg, size_t err_msg_size) {
-  if (is_channel_msg_str(buf, len)) {
+bool stun_is_error_response_str(const uint8_t *buf, size_t len, int *err_code, uint8_t *err_msg, size_t err_msg_size)
+{
+  if (is_channel_msg_str(buf, len))
+  {
     return false;
   }
-  if (IS_STUN_ERR_RESP(stun_get_msg_type_str(buf, len))) {
-    if (err_code) {
+  if (IS_STUN_ERR_RESP(stun_get_msg_type_str(buf, len)))
+  {
+    if (err_code)
+    {
       stun_attr_ref sar = stun_attr_get_first_by_type_str(buf, len, STUN_ATTRIBUTE_ERROR_CODE);
-      if (sar) {
-        if (stun_attr_get_len(sar) >= 4) {
+      if (sar)
+      {
+        if (stun_attr_get_len(sar) >= 4)
+        {
           const uint8_t *val = (const uint8_t *)stun_attr_get_value(sar);
           *err_code = (int)(val[2] * 100 + val[3]);
-          if (err_msg && err_msg_size > 0) {
+          if (err_msg && err_msg_size > 0)
+          {
             err_msg[0] = 0;
-            if (stun_attr_get_len(sar) > 4) {
+            if (stun_attr_get_len(sar) > 4)
+            {
               size_t msg_len = stun_attr_get_len(sar) - 4;
-              if (msg_len > (err_msg_size - 1)) {
+              if (msg_len > (err_msg_size - 1))
+              {
                 msg_len = err_msg_size - 1;
               }
               memcpy(err_msg, val + 4, msg_len);
@@ -502,29 +591,37 @@ bool stun_is_error_response_str(const uint8_t *buf, size_t len, int *err_code, u
 
 bool stun_is_challenge_response_str(const uint8_t *buf, size_t len, int *err_code, uint8_t *err_msg,
                                     size_t err_msg_size, uint8_t *realm, uint8_t *nonce, uint8_t *server_name,
-                                    bool *oauth) {
+                                    bool *oauth)
+{
   bool ret = stun_is_error_response_str(buf, len, err_code, err_msg, err_msg_size);
 
-  if (ret && (((*err_code) == 401) || ((*err_code) == 438))) {
+  if (ret && (((*err_code) == 401) || ((*err_code) == 438)))
+  {
     stun_attr_ref sar = stun_attr_get_first_by_type_str(buf, len, STUN_ATTRIBUTE_REALM);
-    if (sar) {
+    if (sar)
+    {
       bool found_oauth = false;
 
       const uint8_t *value = stun_attr_get_value(sar);
-      if (value) {
+      if (value)
+      {
         size_t vlen = (size_t)stun_attr_get_len(sar);
         vlen = min(vlen, (size_t)STUN_MAX_REALM_SIZE);
         memcpy(realm, value, vlen);
         realm[vlen] = 0;
         {
           sar = stun_attr_get_first_by_type_str(buf, len, STUN_ATTRIBUTE_THIRD_PARTY_AUTHORIZATION);
-          if (sar) {
+          if (sar)
+          {
             value = stun_attr_get_value(sar);
-            if (value) {
+            if (value)
+            {
               vlen = (size_t)stun_attr_get_len(sar);
               vlen = min(vlen, (size_t)STUN_MAX_SERVER_NAME_SIZE);
-              if (vlen > 0) {
-                if (server_name) {
+              if (vlen > 0)
+              {
+                if (server_name)
+                {
                   memcpy(server_name, value, vlen);
                 }
                 found_oauth = true;
@@ -534,14 +631,17 @@ bool stun_is_challenge_response_str(const uint8_t *buf, size_t len, int *err_cod
         }
 
         sar = stun_attr_get_first_by_type_str(buf, len, STUN_ATTRIBUTE_NONCE);
-        if (sar) {
+        if (sar)
+        {
           value = stun_attr_get_value(sar);
-          if (value) {
+          if (value)
+          {
             vlen = (size_t)stun_attr_get_len(sar);
             vlen = min(vlen, (size_t)STUN_MAX_NONCE_SIZE);
             memcpy(nonce, value, vlen);
             nonce[vlen] = 0;
-            if (oauth) {
+            if (oauth)
+            {
               *oauth = found_oauth;
             }
             return true;
@@ -554,21 +654,27 @@ bool stun_is_challenge_response_str(const uint8_t *buf, size_t len, int *err_cod
   return false;
 }
 
-bool stun_is_response_str(const uint8_t *buf, size_t len) {
-  if (is_channel_msg_str(buf, len)) {
+bool stun_is_response_str(const uint8_t *buf, size_t len)
+{
+  if (is_channel_msg_str(buf, len))
+  {
     return false;
   }
-  if (IS_STUN_SUCCESS_RESP(stun_get_msg_type_str(buf, len))) {
+  if (IS_STUN_SUCCESS_RESP(stun_get_msg_type_str(buf, len)))
+  {
     return true;
   }
-  if (IS_STUN_ERR_RESP(stun_get_msg_type_str(buf, len))) {
+  if (IS_STUN_ERR_RESP(stun_get_msg_type_str(buf, len)))
+  {
     return true;
   }
   return false;
 }
 
-bool stun_is_indication_str(const uint8_t *buf, size_t len) {
-  if (is_channel_msg_str(buf, len)) {
+bool stun_is_indication_str(const uint8_t *buf, size_t len)
+{
+  if (is_channel_msg_str(buf, len))
+  {
     return false;
   }
   return IS_STUN_INDICATION(stun_get_msg_type_str(buf, len));
@@ -584,12 +690,14 @@ uint16_t stun_make_error_response(uint16_t method) { return GET_STUN_ERR_RESP(st
 
 //////////////// INIT ////////////////////////////////////////////
 
-void stun_init_buffer_str(uint8_t *buf, size_t *len) {
+void stun_init_buffer_str(uint8_t *buf, size_t *len)
+{
   *len = STUN_HEADER_LENGTH;
   memset(buf, 0, *len);
 }
 
-void stun_init_command_str(uint16_t message_type, uint8_t *buf, size_t *len) {
+void stun_init_command_str(uint16_t message_type, uint8_t *buf, size_t *len)
+{
   stun_init_buffer_str(buf, len);
   message_type &= (uint16_t)(0x3FFF);
   ((uint16_t *)buf)[0] = nswap16(message_type);
@@ -598,7 +706,8 @@ void stun_init_command_str(uint16_t message_type, uint8_t *buf, size_t *len) {
   stun_tid_generate_in_message_str(buf, NULL);
 }
 
-void old_stun_init_command_str(uint16_t message_type, uint8_t *buf, size_t *len, uint32_t cookie) {
+void old_stun_init_command_str(uint16_t message_type, uint8_t *buf, size_t *len, uint32_t cookie)
+{
   stun_init_buffer_str(buf, len);
   message_type &= (uint16_t)(0x3FFF);
   ((uint16_t *)buf)[0] = nswap16(message_type);
@@ -607,32 +716,40 @@ void old_stun_init_command_str(uint16_t message_type, uint8_t *buf, size_t *len,
   stun_tid_generate_in_message_str(buf, NULL);
 }
 
-void stun_init_request_str(uint16_t method, uint8_t *buf, size_t *len) {
+void stun_init_request_str(uint16_t method, uint8_t *buf, size_t *len)
+{
   stun_init_command_str(stun_make_request(method), buf, len);
 }
 
-void stun_init_indication_str(uint16_t method, uint8_t *buf, size_t *len) {
+void stun_init_indication_str(uint16_t method, uint8_t *buf, size_t *len)
+{
   stun_init_command_str(stun_make_indication(method), buf, len);
 }
 
-void stun_init_success_response_str(uint16_t method, uint8_t *buf, size_t *len, stun_tid *id) {
+void stun_init_success_response_str(uint16_t method, uint8_t *buf, size_t *len, stun_tid *id)
+{
   stun_init_command_str(stun_make_success_response(method), buf, len);
-  if (id) {
+  if (id)
+  {
     stun_tid_message_cpy(buf, id);
   }
 }
 
-void old_stun_init_success_response_str(uint16_t method, uint8_t *buf, size_t *len, stun_tid *id, uint32_t cookie) {
+void old_stun_init_success_response_str(uint16_t method, uint8_t *buf, size_t *len, stun_tid *id, uint32_t cookie)
+{
   old_stun_init_command_str(stun_make_success_response(method), buf, len, cookie);
-  if (id) {
+  if (id)
+  {
     stun_tid_message_cpy(buf, id);
   }
 }
 
-const uint8_t *get_default_reason(int error_code) {
+const uint8_t *get_default_reason(int error_code)
+{
   const char *reason = "Unknown error";
 
-  switch (error_code) {
+  switch (error_code)
+  {
   case 300:
     reason = "Try Alternate";
     break;
@@ -694,9 +811,11 @@ const uint8_t *get_default_reason(int error_code) {
 }
 
 static void stun_init_error_response_common_str(uint8_t *buf, size_t *len, uint16_t error_code, const uint8_t *reason,
-                                                stun_tid *id) {
+                                                stun_tid *id)
+{
 
-  if (!reason || !strcmp((const char *)reason, "Unknown error")) {
+  if (!reason || !strcmp((const char *)reason, "Unknown error"))
+  {
     reason = get_default_reason(error_code);
   }
 
@@ -712,19 +831,22 @@ static void stun_init_error_response_common_str(uint8_t *buf, size_t *len, uint1
   //"Manual" padding for compatibility with classic old stun:
   {
     int rem = alen % 4;
-    if (rem) {
+    if (rem)
+    {
       alen += (4 - rem);
     }
   }
 
   stun_attr_add_str(buf, len, STUN_ATTRIBUTE_ERROR_CODE, (uint8_t *)avalue, alen);
-  if (id) {
+  if (id)
+  {
     stun_tid_message_cpy(buf, id);
   }
 }
 
 void old_stun_init_error_response_str(uint16_t method, uint8_t *buf, size_t *len, uint16_t error_code,
-                                      const uint8_t *reason, stun_tid *id, uint32_t cookie) {
+                                      const uint8_t *reason, stun_tid *id, uint32_t cookie)
+{
 
   old_stun_init_command_str(stun_make_error_response(method), buf, len, cookie);
 
@@ -732,7 +854,8 @@ void old_stun_init_error_response_str(uint16_t method, uint8_t *buf, size_t *len
 }
 
 void stun_init_error_response_str(uint16_t method, uint8_t *buf, size_t *len, uint16_t error_code,
-                                  const uint8_t *reason, stun_tid *id) {
+                                  const uint8_t *reason, stun_tid *id)
+{
 
   stun_init_command_str(stun_make_error_response(method), buf, len);
 
@@ -741,16 +864,19 @@ void stun_init_error_response_str(uint16_t method, uint8_t *buf, size_t *len, ui
 
 /////////// CHANNEL ////////////////////////////////////////////////
 
-bool stun_init_channel_message_str(uint16_t chnumber, uint8_t *buf, size_t *len, int length, bool do_padding) {
+bool stun_init_channel_message_str(uint16_t chnumber, uint8_t *buf, size_t *len, int length, bool do_padding)
+{
   uint16_t rlen = (uint16_t)length;
 
-  if (length < 0 || (MAX_STUN_MESSAGE_SIZE < (4 + length))) {
+  if (length < 0 || (MAX_STUN_MESSAGE_SIZE < (4 + length)))
+  {
     return false;
   }
   ((uint16_t *)(buf))[0] = nswap16(chnumber);
   ((uint16_t *)(buf))[1] = nswap16((uint16_t)length);
 
-  if (do_padding && (rlen & 0x0003)) {
+  if (do_padding && (rlen & 0x0003))
+  {
     rlen = ((rlen >> 2) + 1) << 2;
   }
 
@@ -759,20 +885,24 @@ bool stun_init_channel_message_str(uint16_t chnumber, uint8_t *buf, size_t *len,
   return true;
 }
 
-bool stun_is_channel_message_str(const uint8_t *buf, size_t *blen, uint16_t *chnumber, bool mandatory_padding) {
+bool stun_is_channel_message_str(const uint8_t *buf, size_t *blen, uint16_t *chnumber, bool mandatory_padding)
+{
   uint16_t datalen_header;
   uint16_t datalen_actual;
 
-  if (!blen || (*blen < 4)) {
+  if (!blen || (*blen < 4))
+  {
     return false;
   }
 
   uint16_t chn = nswap16(((const uint16_t *)(buf))[0]);
-  if (!STUN_VALID_CHANNEL(chn)) {
+  if (!STUN_VALID_CHANNEL(chn))
+  {
     return false;
   }
 
-  if (*blen > (uint16_t)-1) {
+  if (*blen > (uint16_t)-1)
+  {
     *blen = (uint16_t)-1;
   }
 
@@ -780,23 +910,32 @@ bool stun_is_channel_message_str(const uint8_t *buf, size_t *blen, uint16_t *chn
   datalen_header = ((const uint16_t *)buf)[1];
   datalen_header = nswap16(datalen_header);
 
-  if (datalen_header > datalen_actual) {
+  if (datalen_header > datalen_actual)
+  {
     return false;
   }
 
-  if (datalen_header != datalen_actual) {
+  if (datalen_header != datalen_actual)
+  {
 
     /* maybe there are padding bytes for 32-bit alignment. Mandatory for TCP. Optional for UDP */
 
-    if (datalen_actual & 0x0003) {
+    if (datalen_actual & 0x0003)
+    {
 
-      if (mandatory_padding) {
+      if (mandatory_padding)
+      {
         return false;
-      } else if (datalen_header == 0) {
+      }
+      else if (datalen_header == 0)
+      {
         return false;
-      } else {
+      }
+      else
+      {
         uint16_t diff = datalen_actual - datalen_header;
-        if (diff > 3) {
+        if (diff > 3)
+        {
           return false;
         }
       }
@@ -805,7 +944,8 @@ bool stun_is_channel_message_str(const uint8_t *buf, size_t *blen, uint16_t *chn
 
   *blen = datalen_header + 4;
 
-  if (chnumber) {
+  if (chnumber)
+  {
     *chnumber = chn;
   }
 
@@ -814,12 +954,18 @@ bool stun_is_channel_message_str(const uint8_t *buf, size_t *blen, uint16_t *chn
 
 ////////// STUN message ///////////////////////////////
 
-static inline bool sheadof(const char *head, const char *full, bool ignore_case) {
-  while (*head) {
-    if (*head != *full) {
-      if (ignore_case && (tolower((int)*head) == tolower((int)*full))) {
+static inline bool sheadof(const char *head, const char *full, bool ignore_case)
+{
+  while (*head)
+  {
+    if (*head != *full)
+    {
+      if (ignore_case && (tolower((int)*head) == tolower((int)*full)))
+      {
         // OK
-      } else {
+      }
+      else
+      {
         return false;
       }
     }
@@ -829,16 +975,21 @@ static inline bool sheadof(const char *head, const char *full, bool ignore_case)
   return true;
 }
 
-static inline const char *findstr(const char *hay, size_t slen, const char *needle, bool ignore_case) {
+static inline const char *findstr(const char *hay, size_t slen, const char *needle, bool ignore_case)
+{
   const char *ret = NULL;
 
-  if (hay && slen && needle) {
+  if (hay && slen && needle)
+  {
     size_t nlen = strlen(needle);
-    if (nlen <= slen) {
+    if (nlen <= slen)
+    {
       size_t smax = slen - nlen + 1;
       const char *sp = hay;
-      for (size_t i = 0; i < smax; ++i) {
-        if (sheadof(needle, sp + i, ignore_case)) {
+      for (size_t i = 0; i < smax; ++i)
+      {
+        if (sheadof(needle, sp + i, ignore_case))
+        {
           ret = sp + i;
           break;
         }
@@ -849,23 +1000,31 @@ static inline const char *findstr(const char *hay, size_t slen, const char *need
   return ret;
 }
 
-int is_http(const char *s, size_t blen) {
-  if (s && blen >= 12) {
+int is_http(const char *s, size_t blen)
+{
+  if (s && blen >= 12)
+  {
     if ((strstr(s, "GET ") == s) || (strstr(s, "POST ") == s) || (strstr(s, "DELETE ") == s) ||
-        (strstr(s, "PUT ") == s)) {
+        (strstr(s, "PUT ") == s))
+    {
       const char *sp = findstr(s + 4, blen - 4, " HTTP/", false);
-      if (sp) {
+      if (sp)
+      {
         sp += 6;
         size_t diff_blen = sp - s;
-        if (diff_blen + 4 <= blen) {
+        if (diff_blen + 4 <= blen)
+        {
           sp = findstr(sp, blen - diff_blen, "\r\n\r\n", false);
-          if (sp) {
+          if (sp)
+          {
             int ret_len = (int)(sp - s + 4);
             const char *clheader = "content-length: ";
             const char *cl = findstr(s, sp - s, clheader, true);
-            if (cl) {
+            if (cl)
+            {
               unsigned long clen = strtoul(cl + strlen(clheader), NULL, 10);
-              if (clen > 0 && clen < (0x0FFFFFFF)) {
+              if (clen > 0 && clen < (0x0FFFFFFF))
+              {
                 ret_len += (int)clen;
               }
             }
@@ -878,17 +1037,25 @@ int is_http(const char *s, size_t blen) {
   return 0;
 }
 
-int stun_get_message_len_str(uint8_t *buf, size_t blen, int padding, size_t *app_len) {
-  if (buf && blen) {
+int stun_get_message_len_str(uint8_t *buf, size_t blen, int padding, size_t *app_len)
+{
+  if (buf && blen)
+  {
     /* STUN request/response ? */
-    if (buf && blen >= STUN_HEADER_LENGTH) {
-      if (!STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0]))) {
-        if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0) {
-          if (nswap32(((const uint32_t *)(buf))[1]) == STUN_MAGIC_COOKIE) {
+    if (buf && blen >= STUN_HEADER_LENGTH)
+    {
+      if (!STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0])))
+      {
+        if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0)
+        {
+          if (nswap32(((const uint32_t *)(buf))[1]) == STUN_MAGIC_COOKIE)
+          {
             uint16_t len = nswap16(((const uint16_t *)(buf))[1]);
-            if ((len & 0x0003) == 0) {
+            if ((len & 0x0003) == 0)
+            {
               len += STUN_HEADER_LENGTH;
-              if ((size_t)len <= blen) {
+              if ((size_t)len <= blen)
+              {
                 *app_len = (size_t)len;
                 return (int)len;
               }
@@ -901,26 +1068,31 @@ int stun_get_message_len_str(uint8_t *buf, size_t blen, int padding, size_t *app
     // HTTP request ?
     {
       int http_len = is_http(((char *)buf), blen);
-      if ((http_len > 0) && ((size_t)http_len <= blen)) {
+      if ((http_len > 0) && ((size_t)http_len <= blen))
+      {
         *app_len = (size_t)http_len;
         return http_len;
       }
     }
 
     /* STUN channel ? */
-    if (blen >= 4) {
+    if (blen >= 4)
+    {
       uint16_t chn = nswap16(((const uint16_t *)(buf))[0]);
-      if (STUN_VALID_CHANNEL(chn)) {
+      if (STUN_VALID_CHANNEL(chn))
+      {
 
         uint16_t bret = (4 + (nswap16(((const uint16_t *)(buf))[1])));
 
         *app_len = bret;
 
-        if (padding && (bret & 0x0003)) {
+        if (padding && (bret & 0x0003))
+        {
           bret = ((bret >> 2) + 1) << 2;
         }
 
-        if (bret <= blen) {
+        if (bret <= blen)
+        {
           return bret;
         }
       }
@@ -933,7 +1105,8 @@ int stun_get_message_len_str(uint8_t *buf, size_t blen, int padding, size_t *app
 ////////// ALLOCATE ///////////////////////////////////
 
 bool stun_set_allocate_request_str(uint8_t *buf, size_t *len, uint32_t lifetime, bool af4, bool af6, uint8_t transport,
-                                   bool mobile, const char *rt, int ep) {
+                                   bool mobile, const char *rt, int ep)
+{
 
   stun_init_request_str(STUN_METHOD_ALLOCATE, buf, len);
 
@@ -944,73 +1117,88 @@ bool stun_set_allocate_request_str(uint8_t *buf, size_t *len, uint32_t lifetime,
     field[1] = 0;
     field[2] = 0;
     field[3] = 0;
-    if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_REQUESTED_TRANSPORT, field, sizeof(field))) {
+    if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_REQUESTED_TRANSPORT, field, sizeof(field)))
+    {
       return false;
     }
   }
 
   // LIFETIME
   {
-    if (lifetime < 1) {
+    if (lifetime < 1)
+    {
       lifetime = STUN_DEFAULT_ALLOCATE_LIFETIME;
     }
     uint32_t field = nswap32(lifetime);
-    if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_LIFETIME, (uint8_t *)(&field), sizeof(field))) {
+    if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_LIFETIME, (uint8_t *)(&field), sizeof(field)))
+    {
       return false;
     }
   }
 
   // MICE
-  if (mobile) {
-    if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_MOBILITY_TICKET, (const uint8_t *)"", 0)) {
+  if (mobile)
+  {
+    if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_MOBILITY_TICKET, (const uint8_t *)"", 0))
+    {
       return false;
     }
   }
 
-  if (ep > -1) {
+  if (ep > -1)
+  {
     uint8_t value = ep ? 0x80 : 0x00;
-    if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_EVEN_PORT, (const uint8_t *)&value, 1)) {
+    if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_EVEN_PORT, (const uint8_t *)&value, 1))
+    {
       return false;
     }
   }
 
   // RESERVATION-TOKEN, EVEN-PORT and DUAL-ALLOCATION are mutually exclusive:
-  if (rt) {
+  if (rt)
+  {
 
     stun_attr_add_str(buf, len, STUN_ATTRIBUTE_RESERVATION_TOKEN, (const uint8_t *)rt, 8);
-
-  } else {
+  }
+  else
+  {
 
     // ADRESS-FAMILY
-    if (af4 && !af6) {
+    if (af4 && !af6)
+    {
       uint8_t field[4];
       field[0] = (uint8_t)STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4;
       field[1] = 0;
       field[2] = 0;
       field[3] = 0;
-      if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY, field, sizeof(field))) {
+      if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY, field, sizeof(field)))
+      {
         return false;
       }
     }
 
-    if (af6 && !af4) {
+    if (af6 && !af4)
+    {
       uint8_t field[4];
       field[0] = (uint8_t)STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6;
       field[1] = 0;
       field[2] = 0;
       field[3] = 0;
-      if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY, field, sizeof(field))) {
+      if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY, field, sizeof(field)))
+      {
         return false;
       }
     }
 
-    if (af4 && af6) {
+    if (af4 && af6)
+    {
       uint8_t field[4];
       field[0] = (uint8_t)STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6;
       field[1] = 0;
       field[2] = 0;
       field[3] = 0;
-      if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY, field, sizeof(field))) {
+      if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY, field, sizeof(field)))
+      {
         return false;
       }
     }
@@ -1022,55 +1210,71 @@ bool stun_set_allocate_request_str(uint8_t *buf, size_t *len, uint32_t lifetime,
 bool stun_set_allocate_response_str(uint8_t *buf, size_t *len, stun_tid *tid, const ioa_addr *relayed_addr1,
                                     const ioa_addr *relayed_addr2, const ioa_addr *reflexive_addr, uint32_t lifetime,
                                     uint32_t max_lifetime, int error_code, const uint8_t *reason,
-                                    uint64_t reservation_token, char *mobile_id) {
+                                    uint64_t reservation_token, char *mobile_id)
+{
 
-  if (!error_code) {
+  if (!error_code)
+  {
 
     stun_init_success_response_str(STUN_METHOD_ALLOCATE, buf, len, tid);
 
-    if (relayed_addr1) {
-      if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_RELAYED_ADDRESS, relayed_addr1)) {
+    if (relayed_addr1)
+    {
+      if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_RELAYED_ADDRESS, relayed_addr1))
+      {
         return false;
       }
     }
 
-    if (relayed_addr2) {
-      if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_RELAYED_ADDRESS, relayed_addr2)) {
+    if (relayed_addr2)
+    {
+      if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_RELAYED_ADDRESS, relayed_addr2))
+      {
         return false;
       }
     }
 
-    if (reflexive_addr) {
-      if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, reflexive_addr)) {
+    if (reflexive_addr)
+    {
+      if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, reflexive_addr))
+      {
         return false;
       }
     }
 
-    if (reservation_token) {
+    if (reservation_token)
+    {
       reservation_token = nswap64(reservation_token);
       stun_attr_add_str(buf, len, STUN_ATTRIBUTE_RESERVATION_TOKEN, (uint8_t *)(&reservation_token), 8);
     }
 
     {
-      if (lifetime < 1) {
+      if (lifetime < 1)
+      {
         lifetime = STUN_DEFAULT_ALLOCATE_LIFETIME;
-      } else if (lifetime > max_lifetime) {
+      }
+      else if (lifetime > max_lifetime)
+      {
         lifetime = max_lifetime;
       }
 
       uint32_t field = nswap32(lifetime);
-      if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_LIFETIME, (uint8_t *)(&field), sizeof(field))) {
+      if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_LIFETIME, (uint8_t *)(&field), sizeof(field)))
+      {
         return false;
       }
     }
 
-    if (mobile_id && *mobile_id) {
-      if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_MOBILITY_TICKET, (uint8_t *)mobile_id, (int)strlen(mobile_id))) {
+    if (mobile_id && *mobile_id)
+    {
+      if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_MOBILITY_TICKET, (uint8_t *)mobile_id, (int)strlen(mobile_id)))
+      {
         return false;
       }
     }
-
-  } else {
+  }
+  else
+  {
     stun_init_error_response_str(STUN_METHOD_ALLOCATE, buf, len, error_code, reason, tid);
   }
 
@@ -1080,27 +1284,35 @@ bool stun_set_allocate_response_str(uint8_t *buf, size_t *len, stun_tid *tid, co
 /////////////// CHANNEL BIND ///////////////////////////////////////
 
 uint16_t stun_set_channel_bind_request_str(uint8_t *buf, size_t *len, const ioa_addr *peer_addr,
-                                           uint16_t channel_number) {
+                                           uint16_t channel_number)
+{
 
-  if (!STUN_VALID_CHANNEL(channel_number)) {
+  if (!STUN_VALID_CHANNEL(channel_number))
+  {
     channel_number = 0x4000 + ((uint16_t)(((uint32_t)turn_random_number()) % (0x7FFF - 0x4000 + 1)));
   }
 
   stun_init_request_str(STUN_METHOD_CHANNEL_BIND, buf, len);
 
-  if (!stun_attr_add_channel_number_str(buf, len, channel_number)) {
+  if (!stun_attr_add_channel_number_str(buf, len, channel_number))
+  {
     return 0;
   }
 
-  if (!peer_addr) {
+  if (!peer_addr)
+  {
     ioa_addr ca;
     memset(&ca, 0, sizeof(ioa_addr));
 
-    if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_PEER_ADDRESS, &ca)) {
+    if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_PEER_ADDRESS, &ca))
+    {
       return 0;
     }
-  } else {
-    if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_PEER_ADDRESS, peer_addr)) {
+  }
+  else
+  {
+    if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_PEER_ADDRESS, peer_addr))
+    {
       return 0;
     }
   }
@@ -1108,11 +1320,14 @@ uint16_t stun_set_channel_bind_request_str(uint8_t *buf, size_t *len, const ioa_
   return channel_number;
 }
 
-void stun_set_channel_bind_response_str(uint8_t *buf, size_t *len, stun_tid *tid, int error_code,
-                                        const uint8_t *reason) {
-  if (!error_code) {
+void stun_set_channel_bind_response_str(uint8_t *buf, size_t *len, stun_tid *tid, int error_code, const uint8_t *reason)
+{
+  if (!error_code)
+  {
     stun_init_success_response_str(STUN_METHOD_CHANNEL_BIND, buf, len, tid);
-  } else {
+  }
+  else
+  {
     stun_init_error_response_str(STUN_METHOD_CHANNEL_BIND, buf, len, error_code, reason, tid);
   }
 }
@@ -1126,38 +1341,54 @@ bool stun_set_binding_response_str(uint8_t *buf, size_t *len, stun_tid *tid, con
                                    bool no_stun_backward_compatibility)
 
 {
-  if (!error_code) {
-    if (!old_stun) {
+  if (!error_code)
+  {
+    if (!old_stun)
+    {
       stun_init_success_response_str(STUN_METHOD_BINDING, buf, len, tid);
-    } else {
+    }
+    else
+    {
       old_stun_init_success_response_str(STUN_METHOD_BINDING, buf, len, tid, cookie);
     }
-    if (!old_stun && reflexive_addr) {
-      if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, reflexive_addr)) {
+    if (!old_stun && reflexive_addr)
+    {
+      if (!stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, reflexive_addr))
+      {
         return false;
       }
     }
-    if (reflexive_addr) {
+    if (reflexive_addr)
+    {
       if (!no_stun_backward_compatibility &&
-          !stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_MAPPED_ADDRESS, reflexive_addr)) {
+          !stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_MAPPED_ADDRESS, reflexive_addr))
+      {
         return false;
       }
     }
-  } else if (!old_stun) {
+  }
+  else if (!old_stun)
+  {
     stun_init_error_response_str(STUN_METHOD_BINDING, buf, len, error_code, reason, tid);
-  } else {
+  }
+  else
+  {
     old_stun_init_error_response_str(STUN_METHOD_BINDING, buf, len, error_code, reason, tid, cookie);
   }
 
   return true;
 }
 
-bool stun_is_binding_request_str(const uint8_t *buf, size_t len, size_t offset) {
-  if (offset < len) {
+bool stun_is_binding_request_str(const uint8_t *buf, size_t len, size_t offset)
+{
+  if (offset < len)
+  {
     buf += offset;
     len -= offset;
-    if (stun_is_command_message_str(buf, len)) {
-      if (stun_is_request_str(buf, len) && (stun_get_method_str(buf, len) == STUN_METHOD_BINDING)) {
+    if (stun_is_command_message_str(buf, len))
+    {
+      if (stun_is_request_str(buf, len) && (stun_get_method_str(buf, len) == STUN_METHOD_BINDING))
+      {
         return true;
       }
     }
@@ -1165,9 +1396,12 @@ bool stun_is_binding_request_str(const uint8_t *buf, size_t len, size_t offset) 
   return false;
 }
 
-bool stun_is_binding_response_str(const uint8_t *buf, size_t len) {
-  if (stun_is_command_message_str(buf, len) && (stun_get_method_str(buf, len) == STUN_METHOD_BINDING)) {
-    if (stun_is_response_str(buf, len)) {
+bool stun_is_binding_response_str(const uint8_t *buf, size_t len)
+{
+  if (stun_is_command_message_str(buf, len) && (stun_get_method_str(buf, len) == STUN_METHOD_BINDING))
+  {
+    if (stun_is_response_str(buf, len))
+    {
       return true;
     }
   }
@@ -1176,60 +1410,78 @@ bool stun_is_binding_response_str(const uint8_t *buf, size_t len) {
 
 /////////////////////////////// TID ///////////////////////////////
 
-bool stun_tid_equals(const stun_tid *id1, const stun_tid *id2) {
-  if (!id1 || !id2) {
+bool stun_tid_equals(const stun_tid *id1, const stun_tid *id2)
+{
+  if (!id1 || !id2)
+  {
     return false;
   }
-  if (id1 == id2) {
+  if (id1 == id2)
+  {
     return true;
   }
-  for (size_t i = 0; i < STUN_TID_SIZE; ++i) {
-    if (id1->tsx_id[i] != id2->tsx_id[i]) {
+  for (size_t i = 0; i < STUN_TID_SIZE; ++i)
+  {
+    if (id1->tsx_id[i] != id2->tsx_id[i])
+    {
       return false;
     }
   }
   return true;
 }
 
-void stun_tid_cpy(stun_tid *id1, const stun_tid *id2) {
-  if (!id1 || !id2) {
+void stun_tid_cpy(stun_tid *id1, const stun_tid *id2)
+{
+  if (!id1 || !id2)
+  {
     return;
   }
   memcpy(id1->tsx_id, id2->tsx_id, STUN_TID_SIZE);
 }
 
-static void stun_tid_string_cpy(uint8_t *s, const stun_tid *id) {
-  if (s && id) {
+static void stun_tid_string_cpy(uint8_t *s, const stun_tid *id)
+{
+  if (s && id)
+  {
     memcpy(s, id->tsx_id, STUN_TID_SIZE);
   }
 }
 
-static void stun_tid_from_string(const uint8_t *s, stun_tid *id) {
-  if (s && id) {
+static void stun_tid_from_string(const uint8_t *s, stun_tid *id)
+{
+  if (s && id)
+  {
     memcpy(id->tsx_id, s, STUN_TID_SIZE);
   }
 }
 
-void stun_tid_from_message_str(const uint8_t *buf, size_t len, stun_tid *id) {
+void stun_tid_from_message_str(const uint8_t *buf, size_t len, stun_tid *id)
+{
   UNUSED_ARG(len);
   stun_tid_from_string(buf + 8, id);
 }
 
-void stun_tid_message_cpy(uint8_t *buf, const stun_tid *id) {
-  if (buf && id) {
+void stun_tid_message_cpy(uint8_t *buf, const stun_tid *id)
+{
+  if (buf && id)
+  {
     stun_tid_string_cpy(buf + 8, id);
   }
 }
 
-void stun_tid_generate(stun_tid *id) {
-  if (id) {
+void stun_tid_generate(stun_tid *id)
+{
+  if (id)
+  {
     turn_random_tid_size(id->tsx_id);
   }
 }
 
-void stun_tid_generate_in_message_str(uint8_t *buf, stun_tid *id) {
+void stun_tid_generate_in_message_str(uint8_t *buf, stun_tid *id)
+{
   stun_tid tmp;
-  if (!id) {
+  if (!id)
+  {
     id = &tmp;
   }
   stun_tid_generate(id);
@@ -1239,17 +1491,24 @@ void stun_tid_generate_in_message_str(uint8_t *buf, stun_tid *id) {
 /////////////////// TIME ////////////////////////////////////////////////////////
 
 turn_time_t stun_adjust_allocate_lifetime(turn_time_t lifetime, turn_time_t max_allowed_lifetime,
-                                          turn_time_t max_lifetime) {
+                                          turn_time_t max_lifetime)
+{
 
-  if (!lifetime) {
+  if (!lifetime)
+  {
     lifetime = STUN_DEFAULT_ALLOCATE_LIFETIME;
-  } else if (lifetime < STUN_MIN_ALLOCATE_LIFETIME) {
+  }
+  else if (lifetime < STUN_MIN_ALLOCATE_LIFETIME)
+  {
     lifetime = STUN_MIN_ALLOCATE_LIFETIME;
-  } else if (lifetime > max_allowed_lifetime) {
+  }
+  else if (lifetime > max_allowed_lifetime)
+  {
     lifetime = max_allowed_lifetime;
   }
 
-  if (max_lifetime && (max_lifetime < lifetime)) {
+  if (max_lifetime && (max_lifetime < lifetime))
+  {
     lifetime = max_lifetime;
   }
 
@@ -1258,24 +1517,31 @@ turn_time_t stun_adjust_allocate_lifetime(turn_time_t lifetime, turn_time_t max_
 
 ////////////// ATTR /////////////////////////////////////////////////////////////
 
-int stun_attr_get_type(stun_attr_ref attr) {
-  if (attr) {
+int stun_attr_get_type(stun_attr_ref attr)
+{
+  if (attr)
+  {
     return (int)(nswap16(((const uint16_t *)attr)[0]));
   }
   return -1;
 }
 
-int stun_attr_get_len(stun_attr_ref attr) {
-  if (attr) {
+int stun_attr_get_len(stun_attr_ref attr)
+{
+  if (attr)
+  {
     return (int)(nswap16(((const uint16_t *)attr)[1]));
   }
   return -1;
 }
 
-const uint8_t *stun_attr_get_value(stun_attr_ref attr) {
-  if (attr) {
+const uint8_t *stun_attr_get_value(stun_attr_ref attr)
+{
+  if (attr)
+  {
     int len = (int)(nswap16(((const uint16_t *)attr)[1]));
-    if (len < 1) {
+    if (len < 1)
+    {
       return NULL;
     }
     return ((const uint8_t *)attr) + 4;
@@ -1283,14 +1549,18 @@ const uint8_t *stun_attr_get_value(stun_attr_ref attr) {
   return NULL;
 }
 
-int stun_get_requested_address_family(stun_attr_ref attr) {
-  if (attr) {
+int stun_get_requested_address_family(stun_attr_ref attr)
+{
+  if (attr)
+  {
     int len = (int)(nswap16(((const uint16_t *)attr)[1]));
-    if (len != 4) {
+    if (len != 4)
+    {
       return STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_INVALID;
     }
     int val = ((const uint8_t *)attr)[4];
-    switch (val) {
+    switch (val)
+    {
     case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4:
     case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6:
       return val;
@@ -1301,12 +1571,16 @@ int stun_get_requested_address_family(stun_attr_ref attr) {
   return STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_DEFAULT;
 }
 
-uint16_t stun_attr_get_channel_number(stun_attr_ref attr) {
-  if (attr) {
+uint16_t stun_attr_get_channel_number(stun_attr_ref attr)
+{
+  if (attr)
+  {
     const uint8_t *value = stun_attr_get_value(attr);
-    if (value && (stun_attr_get_len(attr) >= 2)) {
+    if (value && (stun_attr_get_len(attr) >= 2))
+    {
       uint16_t cn = nswap16(((const uint16_t *)value)[0]);
-      if (STUN_VALID_CHANNEL(cn)) {
+      if (STUN_VALID_CHANNEL(cn))
+      {
         return cn;
       }
     }
@@ -1314,10 +1588,13 @@ uint16_t stun_attr_get_channel_number(stun_attr_ref attr) {
   return 0;
 }
 
-band_limit_t stun_attr_get_bandwidth(stun_attr_ref attr) {
-  if (attr) {
+band_limit_t stun_attr_get_bandwidth(stun_attr_ref attr)
+{
+  if (attr)
+  {
     const uint8_t *value = stun_attr_get_value(attr);
-    if (value && (stun_attr_get_len(attr) >= 4)) {
+    if (value && (stun_attr_get_len(attr) >= 4))
+    {
       uint32_t bps = nswap32(((const uint32_t *)value)[0]);
       return (band_limit_t)(bps << 7);
     }
@@ -1325,10 +1602,13 @@ band_limit_t stun_attr_get_bandwidth(stun_attr_ref attr) {
   return 0;
 }
 
-uint64_t stun_attr_get_reservation_token_value(stun_attr_ref attr) {
-  if (attr) {
+uint64_t stun_attr_get_reservation_token_value(stun_attr_ref attr)
+{
+  if (attr)
+  {
     const uint8_t *value = stun_attr_get_value(attr);
-    if (value && (stun_attr_get_len(attr) == 8)) {
+    if (value && (stun_attr_get_len(attr) == 8))
+    {
       uint64_t token;
       memcpy(&token, value, sizeof(uint64_t));
       return nswap64(token);
@@ -1337,10 +1617,13 @@ uint64_t stun_attr_get_reservation_token_value(stun_attr_ref attr) {
   return 0;
 }
 
-bool stun_attr_is_addr(stun_attr_ref attr) {
+bool stun_attr_is_addr(stun_attr_ref attr)
+{
 
-  if (attr) {
-    switch (stun_attr_get_type(attr)) {
+  if (attr)
+  {
+    switch (stun_attr_get_type(attr))
+    {
     case STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS:
     case STUN_ATTRIBUTE_XOR_PEER_ADDRESS:
     case STUN_ATTRIBUTE_XOR_RELAYED_ADDRESS:
@@ -1360,11 +1643,15 @@ bool stun_attr_is_addr(stun_attr_ref attr) {
   return false;
 }
 
-uint8_t stun_attr_get_even_port(stun_attr_ref attr) {
-  if (attr) {
+uint8_t stun_attr_get_even_port(stun_attr_ref attr)
+{
+  if (attr)
+  {
     const uint8_t *value = stun_attr_get_value(attr);
-    if (value) {
-      if ((uint8_t)(value[0]) > 0x7F) {
+    if (value)
+    {
+      if ((uint8_t)(value[0]) > 0x7F)
+      {
         return 1;
       }
     }
@@ -1372,10 +1659,13 @@ uint8_t stun_attr_get_even_port(stun_attr_ref attr) {
   return 0;
 }
 
-stun_attr_ref stun_attr_get_first_by_type_str(const uint8_t *buf, size_t len, uint16_t attr_type) {
+stun_attr_ref stun_attr_get_first_by_type_str(const uint8_t *buf, size_t len, uint16_t attr_type)
+{
   stun_attr_ref attr = stun_attr_get_first_str(buf, len);
-  while (attr) {
-    if (stun_attr_get_type(attr) == attr_type) {
+  while (attr)
+  {
+    if (stun_attr_get_type(attr) == attr_type)
+    {
       return attr;
     }
     attr = stun_attr_get_next_str(buf, len, attr);
@@ -1384,20 +1674,24 @@ stun_attr_ref stun_attr_get_first_by_type_str(const uint8_t *buf, size_t len, ui
   return NULL;
 }
 
-static stun_attr_ref stun_attr_check_valid(stun_attr_ref attr, size_t remaining) {
-  if (remaining >= 4) {
+static stun_attr_ref stun_attr_check_valid(stun_attr_ref attr, size_t remaining)
+{
+  if (remaining >= 4)
+  {
     /* Read the size of the attribute */
     size_t attrlen = stun_attr_get_len(attr);
     remaining -= 4;
 
     /* Round to boundary */
     uint16_t rem4 = ((uint16_t)attrlen) & 0x0003;
-    if (rem4) {
+    if (rem4)
+    {
       attrlen = attrlen + 4 - (int)rem4;
     }
 
     /* Check that there's enough space remaining */
-    if (attrlen <= remaining) {
+    if (attrlen <= remaining)
+    {
       return attr;
     }
   }
@@ -1405,9 +1699,11 @@ static stun_attr_ref stun_attr_check_valid(stun_attr_ref attr, size_t remaining)
   return NULL;
 }
 
-stun_attr_ref stun_attr_get_first_str(const uint8_t *buf, size_t len) {
+stun_attr_ref stun_attr_get_first_str(const uint8_t *buf, size_t len)
+{
   int bufLen = stun_get_command_message_len_str(buf, len);
-  if (bufLen > STUN_HEADER_LENGTH) {
+  if (bufLen > STUN_HEADER_LENGTH)
+  {
     stun_attr_ref attr = (stun_attr_ref)(buf + STUN_HEADER_LENGTH);
     return stun_attr_check_valid(attr, bufLen - STUN_HEADER_LENGTH);
   }
@@ -1415,18 +1711,24 @@ stun_attr_ref stun_attr_get_first_str(const uint8_t *buf, size_t len) {
   return NULL;
 }
 
-stun_attr_ref stun_attr_get_next_str(const uint8_t *buf, size_t len, stun_attr_ref prev) {
-  if (!prev) {
+stun_attr_ref stun_attr_get_next_str(const uint8_t *buf, size_t len, stun_attr_ref prev)
+{
+  if (!prev)
+  {
     return stun_attr_get_first_str(buf, len);
-  } else {
+  }
+  else
+  {
     const uint8_t *end = buf + stun_get_command_message_len_str(buf, len);
     int attrlen = stun_attr_get_len(prev);
     uint16_t rem4 = ((uint16_t)attrlen) & 0x0003;
-    if (rem4) {
+    if (rem4)
+    {
       attrlen = attrlen + 4 - (int)rem4;
     }
     /* Note the order here: operations on attrlen are untrusted as they may overflow */
-    if (attrlen < end - (const uint8_t *)prev - 4) {
+    if (attrlen < end - (const uint8_t *)prev - 4)
+    {
       const uint8_t *attr_end = (const uint8_t *)prev + 4 + attrlen;
       return stun_attr_check_valid(attr_end, end - attr_end);
     }
@@ -1434,12 +1736,15 @@ stun_attr_ref stun_attr_get_next_str(const uint8_t *buf, size_t len, stun_attr_r
   }
 }
 
-bool stun_attr_add_str(uint8_t *buf, size_t *len, uint16_t attr, const uint8_t *avalue, int alen) {
-  if (alen < 0) {
+bool stun_attr_add_str(uint8_t *buf, size_t *len, uint16_t attr, const uint8_t *avalue, int alen)
+{
+  if (alen < 0)
+  {
     alen = 0;
   }
   uint8_t tmp[1];
-  if (!avalue) {
+  if (!avalue)
+  {
     alen = 0;
     avalue = tmp;
   }
@@ -1447,12 +1752,14 @@ bool stun_attr_add_str(uint8_t *buf, size_t *len, uint16_t attr, const uint8_t *
   int newlen = clen + 4 + alen;
   int newlenrem4 = newlen & 0x00000003;
   int paddinglen = 0;
-  if (newlenrem4) {
+  if (newlenrem4)
+  {
     paddinglen = 4 - newlenrem4;
     newlen = newlen + paddinglen;
   }
 
-  if (newlen >= MAX_STUN_MESSAGE_SIZE) {
+  if (newlen >= MAX_STUN_MESSAGE_SIZE)
+  {
     return false;
   }
 
@@ -1465,7 +1772,8 @@ bool stun_attr_add_str(uint8_t *buf, size_t *len, uint16_t attr, const uint8_t *
 
   attr_start_16t[0] = nswap16(attr);
   attr_start_16t[1] = nswap16(alen);
-  if (alen > 0) {
+  if (alen > 0)
+  {
     memcpy(attr_start + 4, avalue, alen);
   }
 
@@ -1475,13 +1783,15 @@ bool stun_attr_add_str(uint8_t *buf, size_t *len, uint16_t attr, const uint8_t *
   return true;
 }
 
-bool stun_attr_add_addr_str(uint8_t *buf, size_t *len, uint16_t attr_type, const ioa_addr *ca) {
+bool stun_attr_add_addr_str(uint8_t *buf, size_t *len, uint16_t attr_type, const ioa_addr *ca)
+{
 
   stun_tid tid;
   stun_tid_from_message_str(buf, *len, &tid);
 
   int xor_ed = 0;
-  switch (attr_type) {
+  switch (attr_type)
+  {
   case STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS:
   case STUN_ATTRIBUTE_XOR_PEER_ADDRESS:
   case STUN_ATTRIBUTE_XOR_RELAYED_ADDRESS:
@@ -1495,11 +1805,13 @@ bool stun_attr_add_addr_str(uint8_t *buf, size_t *len, uint16_t attr_type, const
 
   uint8_t cfield[64];
   int clen = 0;
-  if (stun_addr_encode(&public_addr, cfield, &clen, xor_ed, STUN_MAGIC_COOKIE, tid.tsx_id) < 0) {
+  if (stun_addr_encode(&public_addr, cfield, &clen, xor_ed, STUN_MAGIC_COOKIE, tid.tsx_id) < 0)
+  {
     return false;
   }
 
-  if (!stun_attr_add_str(buf, len, attr_type, (uint8_t *)(&cfield), clen)) {
+  if (!stun_attr_add_str(buf, len, attr_type, (uint8_t *)(&cfield), clen))
+  {
     return false;
   }
 
@@ -1507,7 +1819,8 @@ bool stun_attr_add_addr_str(uint8_t *buf, size_t *len, uint16_t attr_type, const
 }
 
 bool stun_attr_get_addr_str(const uint8_t *buf, size_t len, stun_attr_ref attr, ioa_addr *ca,
-                            const ioa_addr *default_addr) {
+                            const ioa_addr *default_addr)
+{
   stun_tid tid;
   stun_tid_from_message_str(buf, len, &tid);
   ioa_addr public_addr;
@@ -1516,12 +1829,14 @@ bool stun_attr_get_addr_str(const uint8_t *buf, size_t len, stun_attr_ref attr, 
   addr_set_any(&public_addr);
 
   int attr_type = stun_attr_get_type(attr);
-  if (attr_type < 0) {
+  if (attr_type < 0)
+  {
     return false;
   }
 
   int xor_ed = 0;
-  switch (attr_type) {
+  switch (attr_type)
+  {
   case STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS:
   case STUN_ATTRIBUTE_XOR_PEER_ADDRESS:
   case STUN_ATTRIBUTE_XOR_RELAYED_ADDRESS:
@@ -1531,17 +1846,20 @@ bool stun_attr_get_addr_str(const uint8_t *buf, size_t len, stun_attr_ref attr, 
   };
 
   const uint8_t *cfield = stun_attr_get_value(attr);
-  if (!cfield) {
+  if (!cfield)
+  {
     return false;
   }
 
-  if (stun_addr_decode(&public_addr, cfield, stun_attr_get_len(attr), xor_ed, STUN_MAGIC_COOKIE, tid.tsx_id) < 0) {
+  if (stun_addr_decode(&public_addr, cfield, stun_attr_get_len(attr), xor_ed, STUN_MAGIC_COOKIE, tid.tsx_id) < 0)
+  {
     return false;
   }
 
   map_addr_from_public_to_private(&public_addr, ca);
 
-  if (default_addr && addr_any_no_port(ca) && !addr_any_no_port(default_addr)) {
+  if (default_addr && addr_any_no_port(ca) && !addr_any_no_port(default_addr))
+  {
     int port = addr_get_port(ca);
     addr_cpy(ca, default_addr);
     addr_set_port(ca, port);
@@ -1551,12 +1869,16 @@ bool stun_attr_get_addr_str(const uint8_t *buf, size_t len, stun_attr_ref attr, 
 }
 
 bool stun_attr_get_first_addr_str(const uint8_t *buf, size_t len, uint16_t attr_type, ioa_addr *ca,
-                                  const ioa_addr *default_addr) {
+                                  const ioa_addr *default_addr)
+{
   stun_attr_ref attr = stun_attr_get_first_str(buf, len);
 
-  while (attr) {
-    if (stun_attr_is_addr(attr) && (attr_type == stun_attr_get_type(attr))) {
-      if (stun_attr_get_addr_str(buf, len, attr, ca, default_addr)) {
+  while (attr)
+  {
+    if (stun_attr_is_addr(attr) && (attr_type == stun_attr_get_type(attr)))
+    {
+      if (stun_attr_get_addr_str(buf, len, attr, ca, default_addr))
+      {
         return true;
       }
     }
@@ -1566,7 +1888,8 @@ bool stun_attr_get_first_addr_str(const uint8_t *buf, size_t len, uint16_t attr_
   return false;
 }
 
-bool stun_attr_add_channel_number_str(uint8_t *buf, size_t *len, uint16_t chnumber) {
+bool stun_attr_add_channel_number_str(uint8_t *buf, size_t *len, uint16_t chnumber)
+{
 
   uint16_t field[2];
   field[0] = nswap16(chnumber);
@@ -1575,7 +1898,8 @@ bool stun_attr_add_channel_number_str(uint8_t *buf, size_t *len, uint16_t chnumb
   return stun_attr_add_str(buf, len, STUN_ATTRIBUTE_CHANNEL_NUMBER, (uint8_t *)(field), sizeof(field));
 }
 
-bool stun_attr_add_bandwidth_str(uint8_t *buf, size_t *len, band_limit_t bps0) {
+bool stun_attr_add_bandwidth_str(uint8_t *buf, size_t *len, band_limit_t bps0)
+{
 
   uint32_t bps = (uint32_t)(band_limit_t)(bps0 >> 7);
 
@@ -1584,7 +1908,8 @@ bool stun_attr_add_bandwidth_str(uint8_t *buf, size_t *len, band_limit_t bps0) {
   return stun_attr_add_str(buf, len, STUN_ATTRIBUTE_NEW_BANDWIDTH, (uint8_t *)(&field), sizeof(field));
 }
 
-bool stun_attr_add_address_error_code(uint8_t *buf, size_t *len, int requested_address_family, int error_code) {
+bool stun_attr_add_address_error_code(uint8_t *buf, size_t *len, int requested_address_family, int error_code)
+{
   const uint8_t *reason = get_default_reason(error_code);
 
   uint8_t avalue[513];
@@ -1599,7 +1924,8 @@ bool stun_attr_add_address_error_code(uint8_t *buf, size_t *len, int requested_a
   //"Manual" padding for compatibility with classic old stun:
   {
     int rem = alen % 4;
-    if (rem) {
+    if (rem)
+    {
       alen += (4 - rem);
     }
   }
@@ -1607,13 +1933,17 @@ bool stun_attr_add_address_error_code(uint8_t *buf, size_t *len, int requested_a
   return stun_attr_add_str(buf, len, STUN_ATTRIBUTE_ADDRESS_ERROR_CODE, (uint8_t *)avalue, alen);
 }
 
-uint16_t stun_attr_get_first_channel_number_str(const uint8_t *buf, size_t len) {
+uint16_t stun_attr_get_first_channel_number_str(const uint8_t *buf, size_t len)
+{
 
   stun_attr_ref attr = stun_attr_get_first_str(buf, len);
-  while (attr) {
-    if (stun_attr_get_type(attr) == STUN_ATTRIBUTE_CHANNEL_NUMBER) {
+  while (attr)
+  {
+    if (stun_attr_get_type(attr) == STUN_ATTRIBUTE_CHANNEL_NUMBER)
+    {
       uint16_t ret = stun_attr_get_channel_number(attr);
-      if (STUN_VALID_CHANNEL(ret)) {
+      if (STUN_VALID_CHANNEL(ret))
+      {
         return ret;
       }
     }
@@ -1625,9 +1955,11 @@ uint16_t stun_attr_get_first_channel_number_str(const uint8_t *buf, size_t len) 
 
 ////////////// FINGERPRINT ////////////////////////////
 
-bool stun_attr_add_fingerprint_str(uint8_t *buf, size_t *len) {
+bool stun_attr_add_fingerprint_str(uint8_t *buf, size_t *len)
+{
   uint32_t crc32 = 0;
-  if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_FINGERPRINT, (uint8_t *)&crc32, 4)) {
+  if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_FINGERPRINT, (uint8_t *)&crc32, 4))
+  {
     return false;
   }
   crc32 = ns_crc32(buf, (int)*len - 8);
@@ -1672,9 +2004,11 @@ static const uint32_t crctable[256] = {
     0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d,
 };
 
-static uint32_t ns_crc32(const uint8_t *buffer, uint32_t len) {
+static uint32_t ns_crc32(const uint8_t *buffer, uint32_t len)
+{
   uint32_t crc = CRC_MASK;
-  while (len--) {
+  while (len--)
+  {
     UPDATE_CRC(crc, *buffer++);
   }
   return (~crc);
@@ -1684,18 +2018,23 @@ static uint32_t ns_crc32(const uint8_t *buffer, uint32_t len) {
 
 /* We support only basic ASCII table */
 
-bool SASLprep(uint8_t *s) {
-  if (s) {
+bool SASLprep(uint8_t *s)
+{
+  if (s)
+  {
     uint8_t *strin = s;
     uint8_t *strout = s;
-    for (;;) {
+    for (;;)
+    {
       uint8_t c = *strin;
-      if (!c) {
+      if (!c)
+      {
         *strout = 0;
         break;
       }
 
-      switch (c) {
+      switch (c)
+      {
       case 0xAD:
         ++strin;
         break;
@@ -1708,10 +2047,12 @@ bool SASLprep(uint8_t *s) {
       case 0x7F:
         return false;
       default:
-        if (c < 0x1F) {
+        if (c < 0x1F)
+        {
           return false;
         }
-        if (c >= 0x80 && c <= 0x9F) {
+        if (c >= 0x80 && c <= 0x9F)
+        {
           return false;
         }
         *strout = c;
@@ -1726,34 +2067,42 @@ bool SASLprep(uint8_t *s) {
 
 //////////////// Message Integrity ////////////////////////////
 
-size_t get_hmackey_size(SHATYPE shatype) {
-  if (shatype == SHATYPE_SHA256) {
+size_t get_hmackey_size(SHATYPE shatype)
+{
+  if (shatype == SHATYPE_SHA256)
+  {
     return 32;
   }
-  if (shatype == SHATYPE_SHA384) {
+  if (shatype == SHATYPE_SHA384)
+  {
     return 48;
   }
-  if (shatype == SHATYPE_SHA512) {
+  if (shatype == SHATYPE_SHA512)
+  {
     return 64;
   }
   return 16;
 }
 
-void print_bin_func(const char *name, size_t len, const void *s, const char *func) {
+void print_bin_func(const char *name, size_t len, const void *s, const char *func)
+{
   printf("<%s>:<%s>:len=%d:[", func, name, (int)len);
-  for (size_t i = 0; i < len; i++) {
+  for (size_t i = 0; i < len; i++)
+  {
     printf("%02x", (int)((const uint8_t *)s)[i]);
   }
   printf("]\n");
 }
 
 bool stun_attr_add_integrity_str(turn_credential_type ct, uint8_t *buf, size_t *len, hmackey_t key, password_t pwd,
-                                 SHATYPE shatype) {
+                                 SHATYPE shatype)
+{
   uint8_t hmac[MAXSHASIZE];
 
   unsigned int shasize;
 
-  switch (shatype) {
+  switch (shatype)
+  {
   case SHATYPE_SHA256:
     shasize = SHA256SIZEBYTES;
     break;
@@ -1767,30 +2116,38 @@ bool stun_attr_add_integrity_str(turn_credential_type ct, uint8_t *buf, size_t *
     shasize = SHA1SIZEBYTES;
   };
 
-  if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_MESSAGE_INTEGRITY, hmac, shasize)) {
+  if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_MESSAGE_INTEGRITY, hmac, shasize))
+  {
     return false;
   }
 
-  if (ct == TURN_CREDENTIALS_SHORT_TERM) {
+  if (ct == TURN_CREDENTIALS_SHORT_TERM)
+  {
     return stun_calculate_hmac(buf, *len - 4 - shasize, pwd, strlen((char *)pwd), buf + *len - shasize, &shasize,
                                shatype);
-  } else {
+  }
+  else
+  {
     return stun_calculate_hmac(buf, *len - 4 - shasize, key, get_hmackey_size(shatype), buf + *len - shasize, &shasize,
                                shatype);
   }
 }
 
 bool stun_attr_add_integrity_by_key_str(uint8_t *buf, size_t *len, const uint8_t *uname, const uint8_t *realm,
-                                        hmackey_t key, const uint8_t *nonce, SHATYPE shatype) {
-  if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_USERNAME, uname, (int)strlen((const char *)uname))) {
+                                        hmackey_t key, const uint8_t *nonce, SHATYPE shatype)
+{
+  if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_USERNAME, uname, (int)strlen((const char *)uname)))
+  {
     return false;
   }
 
-  if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_NONCE, nonce, (int)strlen((const char *)nonce))) {
+  if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_NONCE, nonce, (int)strlen((const char *)nonce)))
+  {
     return false;
   }
 
-  if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_REALM, realm, (int)strlen((const char *)realm))) {
+  if (!stun_attr_add_str(buf, len, STUN_ATTRIBUTE_REALM, realm, (int)strlen((const char *)realm)))
+  {
     return false;
   }
 
@@ -1799,10 +2156,12 @@ bool stun_attr_add_integrity_by_key_str(uint8_t *buf, size_t *len, const uint8_t
 }
 
 bool stun_attr_add_integrity_by_user_str(uint8_t *buf, size_t *len, const uint8_t *uname, const uint8_t *realm,
-                                         const uint8_t *upwd, const uint8_t *nonce, SHATYPE shatype) {
+                                         const uint8_t *upwd, const uint8_t *nonce, SHATYPE shatype)
+{
   hmackey_t key;
 
-  if (!stun_produce_integrity_key_str(uname, realm, upwd, key, shatype)) {
+  if (!stun_produce_integrity_key_str(uname, realm, upwd, key, shatype))
+  {
     return false;
   }
 
@@ -1810,8 +2169,10 @@ bool stun_attr_add_integrity_by_user_str(uint8_t *buf, size_t *len, const uint8_
 }
 
 bool stun_attr_add_integrity_by_user_short_term_str(uint8_t *buf, size_t *len, const uint8_t *uname, password_t pwd,
-                                                    SHATYPE shatype) {
-  if (stun_attr_add_str(buf, len, STUN_ATTRIBUTE_USERNAME, uname, (int)strlen((const char *)uname))) {
+                                                    SHATYPE shatype)
+{
+  if (stun_attr_add_str(buf, len, STUN_ATTRIBUTE_USERNAME, uname, (int)strlen((const char *)uname)))
+  {
     return false;
   }
 
@@ -1823,35 +2184,42 @@ bool stun_attr_add_integrity_by_user_short_term_str(uint8_t *buf, size_t *len, c
  * Return -1 if failure, 0 if the integrity is not correct, 1 if OK
  */
 int stun_check_message_integrity_by_key_str(turn_credential_type ct, uint8_t *buf, size_t len, hmackey_t key,
-                                            password_t pwd, SHATYPE shatype) {
+                                            password_t pwd, SHATYPE shatype)
+{
   stun_attr_ref sar = stun_attr_get_first_by_type_str(buf, len, STUN_ATTRIBUTE_MESSAGE_INTEGRITY);
-  if (!sar) {
+  if (!sar)
+  {
     return -1;
   }
 
   unsigned int shasize = 0;
-  switch (stun_attr_get_len(sar)) {
+  switch (stun_attr_get_len(sar))
+  {
   case SHA256SIZEBYTES:
     shasize = SHA256SIZEBYTES;
-    if (shatype != SHATYPE_SHA256) {
+    if (shatype != SHATYPE_SHA256)
+    {
       return -1;
     }
     break;
   case SHA384SIZEBYTES:
     shasize = SHA384SIZEBYTES;
-    if (shatype != SHATYPE_SHA384) {
+    if (shatype != SHATYPE_SHA384)
+    {
       return -1;
     }
     break;
   case SHA512SIZEBYTES:
     shasize = SHA512SIZEBYTES;
-    if (shatype != SHATYPE_SHA512) {
+    if (shatype != SHATYPE_SHA512)
+    {
       return -1;
     }
     break;
   case SHA1SIZEBYTES:
     shasize = SHA1SIZEBYTES;
-    if (shatype != SHATYPE_SHA1) {
+    if (shatype != SHATYPE_SHA1)
+    {
       return -1;
     }
     break;
@@ -1860,48 +2228,62 @@ int stun_check_message_integrity_by_key_str(turn_credential_type ct, uint8_t *bu
   };
 
   int orig_len = stun_get_command_message_len_str(buf, len);
-  if (orig_len < 0) {
+  if (orig_len < 0)
+  {
     return -1;
   }
 
   int new_len = (int)((const uint8_t *)sar - buf) + 4 + shasize;
-  if (new_len > orig_len) {
+  if (new_len > orig_len)
+  {
     return -1;
   }
 
-  if (!stun_set_command_message_len_str(buf, new_len)) {
+  if (!stun_set_command_message_len_str(buf, new_len))
+  {
     return -1;
   }
 
   int res = 0;
   uint8_t new_hmac[MAXSHASIZE] = {0};
-  if (ct == TURN_CREDENTIALS_SHORT_TERM) {
-    if (!stun_calculate_hmac(buf, (size_t)new_len - 4 - shasize, pwd, strlen((char *)pwd), new_hmac, &shasize,
-                             shatype)) {
+  if (ct == TURN_CREDENTIALS_SHORT_TERM)
+  {
+    if (!stun_calculate_hmac(buf, (size_t)new_len - 4 - shasize, pwd, strlen((char *)pwd), new_hmac, &shasize, shatype))
+    {
       res = -1;
-    } else {
+    }
+    else
+    {
       res = 0;
     }
-  } else {
+  }
+  else
+  {
     if (!stun_calculate_hmac(buf, (size_t)new_len - 4 - shasize, key, get_hmackey_size(shatype), new_hmac, &shasize,
-                             shatype)) {
+                             shatype))
+    {
       res = -1;
-    } else {
+    }
+    else
+    {
       res = 0;
     }
   }
 
   stun_set_command_message_len_str(buf, orig_len);
-  if (res < 0) {
+  if (res < 0)
+  {
     return -1;
   }
 
   const uint8_t *old_hmac = stun_attr_get_value(sar);
-  if (!old_hmac) {
+  if (!old_hmac)
+  {
     return -1;
   }
 
-  if (0 != memcmp(old_hmac, new_hmac, shasize)) {
+  if (0 != memcmp(old_hmac, new_hmac, shasize))
+  {
     return 0;
   }
 
@@ -1912,14 +2294,18 @@ int stun_check_message_integrity_by_key_str(turn_credential_type ct, uint8_t *bu
  * Return -1 if failure, 0 if the integrity is not correct, 1 if OK
  */
 int stun_check_message_integrity_str(turn_credential_type ct, uint8_t *buf, size_t len, const uint8_t *uname,
-                                     const uint8_t *realm, const uint8_t *upwd, SHATYPE shatype) {
+                                     const uint8_t *realm, const uint8_t *upwd, SHATYPE shatype)
+{
   hmackey_t key;
   password_t pwd;
 
-  if (ct == TURN_CREDENTIALS_SHORT_TERM) {
+  if (ct == TURN_CREDENTIALS_SHORT_TERM)
+  {
     strncpy((char *)pwd, (const char *)upwd, sizeof(password_t) - 1);
     pwd[sizeof(password_t) - 1] = 0;
-  } else if (!stun_produce_integrity_key_str(uname, realm, upwd, key, shatype)) {
+  }
+  else if (!stun_produce_integrity_key_str(uname, realm, upwd, key, shatype))
+  {
     return -1;
   }
 
@@ -1928,10 +2314,13 @@ int stun_check_message_integrity_str(turn_credential_type ct, uint8_t *buf, size
 
 /* RFC 5780 */
 
-bool stun_attr_get_change_request_str(stun_attr_ref attr, bool *change_ip, bool *change_port) {
-  if (stun_attr_get_len(attr) == 4) {
+bool stun_attr_get_change_request_str(stun_attr_ref attr, bool *change_ip, bool *change_port)
+{
+  if (stun_attr_get_len(attr) == 4)
+  {
     const uint8_t *value = stun_attr_get_value(attr);
-    if (value) {
+    if (value)
+    {
       *change_ip = (value[3] & 0x04);
       *change_port = (value[3] & 0x02);
       return true;
@@ -1940,33 +2329,44 @@ bool stun_attr_get_change_request_str(stun_attr_ref attr, bool *change_ip, bool 
   return false;
 }
 
-bool stun_attr_add_change_request_str(uint8_t *buf, size_t *len, bool change_ip, bool change_port) {
+bool stun_attr_add_change_request_str(uint8_t *buf, size_t *len, bool change_ip, bool change_port)
+{
   uint8_t avalue[4] = {0, 0, 0, 0};
 
-  if (change_ip) {
-    if (change_port) {
+  if (change_ip)
+  {
+    if (change_port)
+    {
       avalue[3] = 0x06;
-    } else {
+    }
+    else
+    {
       avalue[3] = 0x04;
     }
-  } else if (change_port) {
+  }
+  else if (change_port)
+  {
     avalue[3] = 0x02;
   }
 
   return stun_attr_add_str(buf, len, STUN_ATTRIBUTE_CHANGE_REQUEST, avalue, 4);
 }
 
-int stun_attr_get_response_port_str(stun_attr_ref attr) {
-  if (stun_attr_get_len(attr) >= 2) {
+int stun_attr_get_response_port_str(stun_attr_ref attr)
+{
+  if (stun_attr_get_len(attr) >= 2)
+  {
     const uint8_t *value = stun_attr_get_value(attr);
-    if (value) {
+    if (value)
+    {
       return nswap16(((const uint16_t *)value)[0]);
     }
   }
   return -1;
 }
 
-bool stun_attr_add_response_port_str(uint8_t *buf, size_t *len, uint16_t port) {
+bool stun_attr_add_response_port_str(uint8_t *buf, size_t *len, uint16_t port)
+{
   uint8_t avalue[4] = {0, 0, 0, 0};
   uint16_t *port_ptr = (uint16_t *)avalue;
 
@@ -1975,15 +2375,18 @@ bool stun_attr_add_response_port_str(uint8_t *buf, size_t *len, uint16_t port) {
   return stun_attr_add_str(buf, len, STUN_ATTRIBUTE_RESPONSE_PORT, avalue, 4);
 }
 
-int stun_attr_get_padding_len_str(stun_attr_ref attr) {
+int stun_attr_get_padding_len_str(stun_attr_ref attr)
+{
   int len = stun_attr_get_len(attr);
-  if (len < 0) {
+  if (len < 0)
+  {
     return -1;
   }
   return (uint16_t)len;
 }
 
-bool stun_attr_add_padding_str(uint8_t *buf, size_t *len, uint16_t padding_len) {
+bool stun_attr_add_padding_str(uint8_t *buf, size_t *len, uint16_t padding_len)
+{
   uint8_t avalue[0xFFFF];
   memset(avalue, 0, padding_len);
 
@@ -1994,25 +2397,35 @@ bool stun_attr_add_padding_str(uint8_t *buf, size_t *len, uint16_t padding_len) 
 
 #define OAUTH_ERROR(...) fprintf(stderr, __VA_ARGS__)
 
-static void remove_spaces(char *s) {
+static void remove_spaces(char *s)
+{
   char *sfns = s;
-  while (*sfns) {
-    if (*sfns != ' ') {
+  while (*sfns)
+  {
+    if (*sfns != ' ')
+    {
       break;
     }
     ++sfns;
   }
-  if (*sfns) {
-    if (sfns != s) {
-      while (*sfns && (*sfns != ' ')) {
+  if (*sfns)
+  {
+    if (sfns != s)
+    {
+      while (*sfns && (*sfns != ' '))
+      {
         *s = *sfns;
         ++s;
         ++sfns;
       };
       *s = 0;
-    } else {
-      while (*s) {
-        if (*s == ' ') {
+    }
+    else
+    {
+      while (*s)
+      {
+        if (*s == ' ')
+        {
           *s = 0;
           break;
         }
@@ -2022,12 +2435,17 @@ static void remove_spaces(char *s) {
   }
 }
 
-static void normalize_algorithm(char *s) {
+static void normalize_algorithm(char *s)
+{
   char c = *s;
-  while (c) {
-    if (c == '_') {
+  while (c)
+  {
+    if (c == '_')
+    {
       *s = '-';
-    } else if ((c >= 'a') && (c <= 'z')) {
+    }
+    else if ((c >= 'a') && (c <= 'z'))
+    {
       *s = c - 'a' + 'A';
     }
     ++s;
@@ -2036,8 +2454,10 @@ static void normalize_algorithm(char *s) {
 }
 
 size_t calculate_enc_key_length(ENC_ALG a);
-size_t calculate_enc_key_length(ENC_ALG a) {
-  switch (a) {
+size_t calculate_enc_key_length(ENC_ALG a)
+{
+  switch (a)
+  {
 #if !defined(TURN_NO_GCM)
   case A128GCM:
     return 16;
@@ -2050,8 +2470,10 @@ size_t calculate_enc_key_length(ENC_ALG a) {
 }
 
 size_t calculate_auth_key_length(ENC_ALG a);
-size_t calculate_auth_key_length(ENC_ALG a) {
-  switch (a) {
+size_t calculate_auth_key_length(ENC_ALG a)
+{
+  switch (a)
+  {
 #if !defined(TURN_NO_GCM)
   case A256GCM:
   case A128GCM:
@@ -2065,7 +2487,8 @@ size_t calculate_auth_key_length(ENC_ALG a) {
 }
 
 static bool calculate_key(char *key, size_t key_size, char *new_key, size_t new_key_size);
-static bool calculate_key(char *key, size_t key_size, char *new_key, size_t new_key_size) {
+static bool calculate_key(char *key, size_t key_size, char *new_key, size_t new_key_size)
+{
   UNUSED_ARG(key_size);
 
   memcpy(new_key, key, new_key_size);
@@ -2073,15 +2496,19 @@ static bool calculate_key(char *key, size_t key_size, char *new_key, size_t new_
   return true;
 }
 
-bool convert_oauth_key_data(const oauth_key_data *oakd0, oauth_key *key, char *err_msg, size_t err_msg_size) {
-  if (oakd0 && key) {
+bool convert_oauth_key_data(const oauth_key_data *oakd0, oauth_key *key, char *err_msg, size_t err_msg_size)
+{
+  if (oakd0 && key)
+  {
 
     oauth_key_data oakd_obj;
     memcpy(&oakd_obj, oakd0, sizeof(oauth_key_data));
     oauth_key_data *oakd = &oakd_obj;
 
-    if (!(oakd->ikm_key_size)) {
-      if (err_msg) {
+    if (!(oakd->ikm_key_size))
+    {
+      if (err_msg)
+      {
         snprintf(err_msg, err_msg_size, "key is not defined");
       }
     }
@@ -2092,8 +2519,10 @@ bool convert_oauth_key_data(const oauth_key_data *oakd0, oauth_key *key, char *e
 
     normalize_algorithm(oakd->as_rs_alg);
 
-    if (!(oakd->kid[0])) {
-      if (err_msg) {
+    if (!(oakd->kid[0]))
+    {
+      if (err_msg)
+      {
         snprintf(err_msg, err_msg_size, "KID is not defined");
       }
       OAUTH_ERROR("KID is not defined\n");
@@ -2110,28 +2539,35 @@ bool convert_oauth_key_data(const oauth_key_data *oakd0, oauth_key *key, char *e
     key->timestamp = oakd->timestamp;
     key->lifetime = oakd->lifetime;
 
-    if (!(key->timestamp)) {
+    if (!(key->timestamp))
+    {
       key->timestamp = OAUTH_DEFAULT_TIMESTAMP;
     }
-    if (!(key->lifetime)) {
+    if (!(key->lifetime))
+    {
       key->lifetime = OAUTH_DEFAULT_LIFETIME;
     }
 
     key->as_rs_alg = ENC_ALG_ERROR;
 #if !defined(TURN_NO_GCM)
     key->as_rs_alg = ENC_ALG_DEFAULT;
-    if (!strcmp(oakd->as_rs_alg, "A128GCM")) {
+    if (!strcmp(oakd->as_rs_alg, "A128GCM"))
+    {
       key->as_rs_alg = A128GCM;
       key->auth_key_size = 0;
       key->auth_key[0] = 0;
-    } else if (!strcmp(oakd->as_rs_alg, "A256GCM")) {
+    }
+    else if (!strcmp(oakd->as_rs_alg, "A256GCM"))
+    {
       key->as_rs_alg = A256GCM;
       key->auth_key_size = 0;
       key->auth_key[0] = 0;
-    } else
+    }
+    else
 #endif
     {
-      if (err_msg) {
+      if (err_msg)
+      {
         snprintf(err_msg, err_msg_size, "Wrong oAuth token encryption algorithm: %s (2)\n", oakd->as_rs_alg);
       }
       OAUTH_ERROR("Wrong oAuth token encryption algorithm: %s (3)\n", oakd->as_rs_alg);
@@ -2141,14 +2577,17 @@ bool convert_oauth_key_data(const oauth_key_data *oakd0, oauth_key *key, char *e
 #if !defined(TURN_NO_GCM)
 
     key->auth_key_size = calculate_auth_key_length(key->as_rs_alg);
-    if (key->auth_key_size) {
-      if (!calculate_key(key->ikm_key, key->ikm_key_size, key->auth_key, key->auth_key_size)) {
+    if (key->auth_key_size)
+    {
+      if (!calculate_key(key->ikm_key, key->ikm_key_size, key->auth_key, key->auth_key_size))
+      {
         return false;
       }
     }
 
     key->as_rs_key_size = calculate_enc_key_length(key->as_rs_alg);
-    if (!calculate_key(key->ikm_key, key->ikm_key_size, key->as_rs_key, key->as_rs_key_size)) {
+    if (!calculate_key(key->ikm_key, key->ikm_key_size, key->as_rs_key, key->as_rs_key_size))
+    {
       return false;
     }
 #endif
@@ -2158,8 +2597,10 @@ bool convert_oauth_key_data(const oauth_key_data *oakd0, oauth_key *key, char *e
 }
 
 const EVP_CIPHER *get_cipher_type(ENC_ALG enc_alg);
-const EVP_CIPHER *get_cipher_type(ENC_ALG enc_alg) {
-  switch (enc_alg) {
+const EVP_CIPHER *get_cipher_type(ENC_ALG enc_alg)
+{
+  switch (enc_alg)
+  {
 #if !defined(TURN_NO_GCM)
   case A128GCM:
     return EVP_aes_128_gcm();
@@ -2174,18 +2615,22 @@ const EVP_CIPHER *get_cipher_type(ENC_ALG enc_alg) {
 }
 
 int my_EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
-int my_EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) {
+int my_EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl)
+{
   int cycle = 0;
   int out_len = 0;
-  while ((out_len < inl) && (++cycle < 128)) {
+  while ((out_len < inl) && (++cycle < 128))
+  {
     int tmp_outl = 0;
     unsigned char *ptr = NULL;
-    if (out) {
+    if (out)
+    {
       ptr = out + out_len;
     }
     int ret = EVP_EncryptUpdate(ctx, ptr, &tmp_outl, in + out_len, inl - out_len);
     out_len += tmp_outl;
-    if (ret < 1) {
+    if (ret < 1)
+    {
       return ret;
     }
   }
@@ -2194,18 +2639,22 @@ int my_EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, con
 }
 
 int my_EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
-int my_EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl) {
+int my_EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl)
+{
   int cycle = 0;
   int out_len = 0;
-  while ((out_len < inl) && (++cycle < 128)) {
+  while ((out_len < inl) && (++cycle < 128))
+  {
     int tmp_outl = 0;
     unsigned char *ptr = NULL;
-    if (out) {
+    if (out)
+    {
       ptr = out + out_len;
     }
     int ret = EVP_DecryptUpdate(ctx, ptr, &tmp_outl, in + out_len, inl - out_len);
     out_len += tmp_outl;
-    if (ret < 1) {
+    if (ret < 1)
+    {
       return ret;
     }
   }
@@ -2215,16 +2664,21 @@ int my_EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, con
 #if !defined(TURN_NO_GCM)
 
 static bool encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_token *etoken, const oauth_key *key,
-                                   const oauth_token *dtoken, const uint8_t *nonce0) {
-  if (server_name && etoken && key && dtoken && (dtoken->enc_block.key_length <= MAXSHASIZE)) {
+                                   const oauth_token *dtoken, const uint8_t *nonce0)
+{
+  if (server_name && etoken && key && dtoken && (dtoken->enc_block.key_length <= MAXSHASIZE))
+  {
 
     unsigned char orig_field[MAX_ENCODED_OAUTH_TOKEN_SIZE];
     memset(orig_field, 0, sizeof(orig_field));
 
     unsigned char nonce[OAUTH_GCM_NONCE_SIZE];
-    if (nonce0) {
+    if (nonce0)
+    {
       memcpy(nonce, nonce0, sizeof(nonce));
-    } else {
+    }
+    else
+    {
       generate_random_nonce(nonce, sizeof(nonce));
     }
 
@@ -2250,7 +2704,8 @@ static bool encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_tok
     len += 4;
 
     const EVP_CIPHER *cipher = get_cipher_type(key->as_rs_alg);
-    if (!cipher) {
+    if (!cipher)
+    {
       return false;
     }
 
@@ -2258,19 +2713,22 @@ static bool encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_tok
     EVP_CIPHER_CTX_init(ctxp);
 
     /* Initialize the encryption operation. */
-    if (1 != EVP_EncryptInit_ex(ctxp, cipher, NULL, NULL, NULL)) {
+    if (1 != EVP_EncryptInit_ex(ctxp, cipher, NULL, NULL, NULL))
+    {
       return -1;
     }
 
     EVP_CIPHER_CTX_set_padding(ctxp, 1);
 
     /* Set IV length if default 12 bytes (96 bits) is not appropriate */
-    if (1 != EVP_CIPHER_CTX_ctrl(ctxp, EVP_CTRL_GCM_SET_IVLEN, OAUTH_GCM_NONCE_SIZE, NULL)) {
+    if (1 != EVP_CIPHER_CTX_ctrl(ctxp, EVP_CTRL_GCM_SET_IVLEN, OAUTH_GCM_NONCE_SIZE, NULL))
+    {
       return false;
     }
 
     /* Initialize key and IV */
-    if (1 != EVP_EncryptInit_ex(ctxp, NULL, NULL, (const unsigned char *)key->as_rs_key, nonce)) {
+    if (1 != EVP_EncryptInit_ex(ctxp, NULL, NULL, (const unsigned char *)key->as_rs_key, nonce))
+    {
       return false;
     }
 
@@ -2280,7 +2738,8 @@ static bool encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_tok
     /* Provide any AAD data. This can be called zero or more times as
      * required
      */
-    if (1 != my_EVP_EncryptUpdate(ctxp, NULL, &outl, server_name, (int)sn_len)) {
+    if (1 != my_EVP_EncryptUpdate(ctxp, NULL, &outl, server_name, (int)sn_len))
+    {
       return false;
     }
 
@@ -2291,7 +2750,8 @@ static bool encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_tok
     unsigned char *start_field = orig_field + OAUTH_GCM_NONCE_SIZE + 2;
     len -= OAUTH_GCM_NONCE_SIZE + 2;
 
-    if (1 != my_EVP_EncryptUpdate(ctxp, encoded_field, &outl, start_field, (int)len)) {
+    if (1 != my_EVP_EncryptUpdate(ctxp, encoded_field, &outl, start_field, (int)len))
+    {
       return -1;
     }
 
@@ -2312,8 +2772,10 @@ static bool encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_tok
 }
 
 static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oauth_token *etoken, const oauth_key *key,
-                                   oauth_token *dtoken) {
-  if (server_name && etoken && key && dtoken) {
+                                   oauth_token *dtoken)
+{
+  if (server_name && etoken && key && dtoken)
+  {
 
     unsigned char snl[2];
     memcpy(snl, (const unsigned char *)(etoken->token), 2);
@@ -2323,7 +2785,8 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
     dtoken->enc_block.nonce_length = nonce_len;
 
     size_t min_encoded_field_size = 2 + 4 + 8 + nonce_len + 2 + OAUTH_GCM_TAG_SIZE + 1;
-    if (etoken->size < min_encoded_field_size) {
+    if (etoken->size < min_encoded_field_size)
+    {
       OAUTH_ERROR("%s: token size too small: %d\n", __FUNCTION__, (int)etoken->size);
       return false;
     }
@@ -2339,7 +2802,8 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
     unsigned char decoded_field[MAX_ENCODED_OAUTH_TOKEN_SIZE];
 
     const EVP_CIPHER *cipher = get_cipher_type(key->as_rs_alg);
-    if (!cipher) {
+    if (!cipher)
+    {
       OAUTH_ERROR("%s: Cannot find cipher for algorithm: %d\n", __FUNCTION__, (int)key->as_rs_alg);
       return false;
     }
@@ -2347,7 +2811,8 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
     EVP_CIPHER_CTX *ctxp = EVP_CIPHER_CTX_new();
     EVP_CIPHER_CTX_init(ctxp);
     /* Initialize the decryption operation. */
-    if (1 != EVP_DecryptInit_ex(ctxp, cipher, NULL, NULL, NULL)) {
+    if (1 != EVP_DecryptInit_ex(ctxp, cipher, NULL, NULL, NULL))
+    {
       OAUTH_ERROR("%s: Cannot initialize decryption\n", __FUNCTION__);
       return false;
     }
@@ -2355,13 +2820,15 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
     // EVP_CIPHER_CTX_set_padding(&ctx,1);
 
     /* Set IV length if default 12 bytes (96 bits) is not appropriate */
-    if (1 != EVP_CIPHER_CTX_ctrl(ctxp, EVP_CTRL_GCM_SET_IVLEN, nonce_len, NULL)) {
+    if (1 != EVP_CIPHER_CTX_ctrl(ctxp, EVP_CTRL_GCM_SET_IVLEN, nonce_len, NULL))
+    {
       OAUTH_ERROR("%s: Cannot set nonce length\n", __FUNCTION__);
       return false;
     }
 
     /* Initialize key and IV */
-    if (1 != EVP_DecryptInit_ex(ctxp, NULL, NULL, (const unsigned char *)key->as_rs_key, nonce)) {
+    if (1 != EVP_DecryptInit_ex(ctxp, NULL, NULL, (const unsigned char *)key->as_rs_key, nonce))
+    {
       OAUTH_ERROR("%s: Cannot set nonce\n", __FUNCTION__);
       return false;
     }
@@ -2376,17 +2843,20 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
     /* Provide any AAD data. This can be called zero or more times as
      * required
      */
-    if (1 != my_EVP_DecryptUpdate(ctxp, NULL, &outl, server_name, (int)sn_len)) {
+    if (1 != my_EVP_DecryptUpdate(ctxp, NULL, &outl, server_name, (int)sn_len))
+    {
       OAUTH_ERROR("%s: Cannot decrypt update server_name: %s, len=%d\n", __FUNCTION__, server_name, (int)sn_len);
       return false;
     }
-    if (1 != my_EVP_DecryptUpdate(ctxp, decoded_field, &outl, encoded_field, (int)encoded_field_size)) {
+    if (1 != my_EVP_DecryptUpdate(ctxp, decoded_field, &outl, encoded_field, (int)encoded_field_size))
+    {
       OAUTH_ERROR("%s: Cannot decrypt update\n", __FUNCTION__);
       return false;
     }
 
     int tmp_outl = 0;
-    if (EVP_DecryptFinal_ex(ctxp, decoded_field + outl, &tmp_outl) < 1) {
+    if (EVP_DecryptFinal_ex(ctxp, decoded_field + outl, &tmp_outl) < 1)
+    {
       EVP_CIPHER_CTX_free(ctxp);
       OAUTH_ERROR("%s: token integrity check failed\n", __FUNCTION__);
       return false;
@@ -2421,10 +2891,13 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
 #endif
 
 bool encode_oauth_token(const uint8_t *server_name, encoded_oauth_token *etoken, const oauth_key *key,
-                        const oauth_token *dtoken, const uint8_t *nonce) {
+                        const oauth_token *dtoken, const uint8_t *nonce)
+{
   UNUSED_ARG(nonce);
-  if (server_name && etoken && key && dtoken) {
-    switch (key->as_rs_alg) {
+  if (server_name && etoken && key && dtoken)
+  {
+    switch (key->as_rs_alg)
+    {
 #if !defined(TURN_NO_GCM)
     case A256GCM:
     case A128GCM:
@@ -2439,9 +2912,12 @@ bool encode_oauth_token(const uint8_t *server_name, encoded_oauth_token *etoken,
 }
 
 bool decode_oauth_token(const uint8_t *server_name, const encoded_oauth_token *etoken, const oauth_key *key,
-                        oauth_token *dtoken) {
-  if (server_name && etoken && key && dtoken) {
-    switch (key->as_rs_alg) {
+                        oauth_token *dtoken)
+{
+  if (server_name && etoken && key && dtoken)
+  {
+    switch (key->as_rs_alg)
+    {
 #if !defined(TURN_NO_GCM)
     case A256GCM:
     case A128GCM:

--- a/src/client/ns_turn_msg.h
+++ b/src/client/ns_turn_msg.h
@@ -38,7 +38,8 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ///////////////////////////////////
@@ -47,14 +48,16 @@ extern "C" {
  * Structure holding the STUN message Transaction ID
  */
 #define STUN_TID_SIZE (12)
-typedef struct {
+typedef struct
+{
   /**
    * Binary array
    */
   uint8_t tsx_id[STUN_TID_SIZE];
 } stun_tid;
 
-typedef enum {
+typedef enum
+{
   TURN_CREDENTIALS_NONE = 0,
   TURN_CREDENTIALS_LONG_TERM,
   TURN_CREDENTIALS_SHORT_TERM,

--- a/src/client/ns_turn_msg_addr.c
+++ b/src/client/ns_turn_msg_addr.c
@@ -35,13 +35,16 @@
 
 //////////////////////////////////////////////////////////////////////////////
 
-int stun_addr_encode(const ioa_addr *ca, uint8_t *cfield, int *clen, int xor_ed, uint32_t mc, const uint8_t *tsx_id) {
+int stun_addr_encode(const ioa_addr *ca, uint8_t *cfield, int *clen, int xor_ed, uint32_t mc, const uint8_t *tsx_id)
+{
 
-  if (!cfield || !clen || !ca || !tsx_id) {
+  if (!cfield || !clen || !ca || !tsx_id)
+  {
     return -1;
   }
 
-  if (ca->ss.sa_family == AF_INET || ca->ss.sa_family == 0) {
+  if (ca->ss.sa_family == AF_INET || ca->ss.sa_family == 0)
+  {
 
     /* IPv4 address */
 
@@ -50,15 +53,17 @@ int stun_addr_encode(const ioa_addr *ca, uint8_t *cfield, int *clen, int xor_ed,
     cfield[0] = 0;
     cfield[1] = 1; // IPv4 family
 
-    if (xor_ed) {
+    if (xor_ed)
+    {
 
       /* Port */
       ((uint16_t *)cfield)[1] = (ca->s4.sin_port) ^ nswap16(mc >> 16);
 
       /* Address */
       ((uint32_t *)cfield)[1] = (ca->s4.sin_addr.s_addr) ^ nswap32(mc);
-
-    } else {
+    }
+    else
+    {
 
       /* Port */
       ((uint16_t *)cfield)[1] = ca->s4.sin_port;
@@ -66,8 +71,9 @@ int stun_addr_encode(const ioa_addr *ca, uint8_t *cfield, int *clen, int xor_ed,
       /* Address */
       ((uint32_t *)cfield)[1] = ca->s4.sin_addr.s_addr;
     }
-
-  } else if (ca->ss.sa_family == AF_INET6) {
+  }
+  else if (ca->ss.sa_family == AF_INET6)
+  {
 
     /* IPv6 address */
 
@@ -76,7 +82,8 @@ int stun_addr_encode(const ioa_addr *ca, uint8_t *cfield, int *clen, int xor_ed,
     cfield[0] = 0;
     cfield[1] = 2; // IPv6 family
 
-    if (xor_ed) {
+    if (xor_ed)
+    {
 
       unsigned int i;
       uint8_t *dst = ((uint8_t *)cfield) + 4;
@@ -88,14 +95,17 @@ int stun_addr_encode(const ioa_addr *ca, uint8_t *cfield, int *clen, int xor_ed,
 
       /* Address */
 
-      for (i = 0; i < 4; ++i) {
+      for (i = 0; i < 4; ++i)
+      {
         dst[i] = (uint8_t)(src[i] ^ ((const uint8_t *)&magic)[i]);
       }
-      for (i = 0; i < 12; ++i) {
+      for (i = 0; i < 12; ++i)
+      {
         dst[i + 4] = (uint8_t)(src[i + 4] ^ tsx_id[i]);
       }
-
-    } else {
+    }
+    else
+    {
 
       /* Port */
       ((uint16_t *)cfield)[1] = ca->s6.sin6_port;
@@ -103,39 +113,50 @@ int stun_addr_encode(const ioa_addr *ca, uint8_t *cfield, int *clen, int xor_ed,
       /* Address */
       memcpy(((uint8_t *)cfield) + 4, &ca->s6.sin6_addr, 16);
     }
-
-  } else {
+  }
+  else
+  {
     return -1;
   }
 
   return 0;
 }
 
-int stun_addr_decode(ioa_addr *ca, const uint8_t *cfield, int len, int xor_ed, uint32_t mc, const uint8_t *tsx_id) {
+int stun_addr_decode(ioa_addr *ca, const uint8_t *cfield, int len, int xor_ed, uint32_t mc, const uint8_t *tsx_id)
+{
 
-  if (!cfield || !len || !ca || !tsx_id || (len < 8)) {
+  if (!cfield || !len || !ca || !tsx_id || (len < 8))
+  {
     return -1;
   }
 
-  if (cfield[0] != 0) {
+  if (cfield[0] != 0)
+  {
     return -1;
   }
 
   int sa_family;
 
-  if (cfield[1] == 1) {
+  if (cfield[1] == 1)
+  {
     sa_family = AF_INET;
-  } else if (cfield[1] == 2) {
+  }
+  else if (cfield[1] == 2)
+  {
     sa_family = AF_INET6;
-  } else {
+  }
+  else
+  {
     return -1;
   }
 
   ca->ss.sa_family = sa_family;
 
-  if (sa_family == AF_INET) {
+  if (sa_family == AF_INET)
+  {
 
-    if (len != 8) {
+    if (len != 8)
+    {
       return -1;
     }
 
@@ -147,16 +168,19 @@ int stun_addr_decode(ioa_addr *ca, const uint8_t *cfield, int len, int xor_ed, u
     /* Address */
     ca->s4.sin_addr.s_addr = ((const uint32_t *)cfield)[1];
 
-    if (xor_ed) {
+    if (xor_ed)
+    {
       ca->s4.sin_port ^= nswap16(mc >> 16);
       ca->s4.sin_addr.s_addr ^= nswap32(mc);
     }
-
-  } else if (sa_family == AF_INET6) {
+  }
+  else if (sa_family == AF_INET6)
+  {
 
     /* IPv6 address */
 
-    if (len != 20) {
+    if (len != 20)
+    {
       return -1;
     }
 
@@ -166,7 +190,8 @@ int stun_addr_decode(ioa_addr *ca, const uint8_t *cfield, int len, int xor_ed, u
     /* Address */
     memcpy(&ca->s6.sin6_addr, ((const uint8_t *)cfield) + 4, 16);
 
-    if (xor_ed) {
+    if (xor_ed)
+    {
 
       unsigned int i;
       uint8_t *dst;
@@ -179,15 +204,18 @@ int stun_addr_decode(ioa_addr *ca, const uint8_t *cfield, int len, int xor_ed, u
       /* Address */
       src = ((const uint8_t *)cfield) + 4;
       dst = (uint8_t *)&ca->s6.sin6_addr;
-      for (i = 0; i < 4; ++i) {
+      for (i = 0; i < 4; ++i)
+      {
         dst[i] = (uint8_t)(src[i] ^ ((const uint8_t *)&magic)[i]);
       }
-      for (i = 0; i < 12; ++i) {
+      for (i = 0; i < 12; ++i)
+      {
         dst[i + 4] = (uint8_t)(src[i + 4] ^ tsx_id[i]);
       }
     }
-
-  } else {
+  }
+  else
+  {
     return -1;
   }
 

--- a/src/client/ns_turn_msg_addr.h
+++ b/src/client/ns_turn_msg_addr.h
@@ -35,7 +35,8 @@
 #include "ns_turn_ioaddr.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ///////////////////////////////////////////

--- a/src/client/ns_turn_msg_defs.h
+++ b/src/client/ns_turn_msg_defs.h
@@ -51,10 +51,10 @@
 
 #define STUN_MAGIC_COOKIE (0x2112A442)
 
-#define IS_STUN_REQUEST(msg_type) (((msg_type)&0x0110) == 0x0000)
-#define IS_STUN_INDICATION(msg_type) (((msg_type)&0x0110) == 0x0010)
-#define IS_STUN_SUCCESS_RESP(msg_type) (((msg_type)&0x0110) == 0x0100)
-#define IS_STUN_ERR_RESP(msg_type) (((msg_type)&0x0110) == 0x0110)
+#define IS_STUN_REQUEST(msg_type) (((msg_type) & 0x0110) == 0x0000)
+#define IS_STUN_INDICATION(msg_type) (((msg_type) & 0x0110) == 0x0010)
+#define IS_STUN_SUCCESS_RESP(msg_type) (((msg_type) & 0x0110) == 0x0100)
+#define IS_STUN_ERR_RESP(msg_type) (((msg_type) & 0x0110) == 0x0110)
 
 #define GET_STUN_REQUEST(msg_type) (msg_type & 0xFEEF)
 #define GET_STUN_INDICATION(msg_type) ((msg_type & 0xFEEF) | 0x0010)
@@ -159,7 +159,8 @@
 
 #define MAXSHASIZE (128)
 
-enum _SHATYPE {
+enum _SHATYPE
+{
   SHATYPE_ERROR = -1,
   SHATYPE_DEFAULT = 0,
   SHATYPE_SHA1 = SHATYPE_DEFAULT,
@@ -178,7 +179,8 @@ typedef enum _SHATYPE SHATYPE;
 
 /* OAUTH TOKEN ENC ALG ==> */
 
-enum _ENC_ALG {
+enum _ENC_ALG
+{
   ENC_ALG_ERROR = -1,
 #if !defined(TURN_NO_GCM)
   ENC_ALG_DEFAULT = 0,
@@ -213,7 +215,8 @@ typedef enum _ENC_ALG ENC_ALG;
 
 #define OAUTH_TIME_DELTA (5)
 
-struct _oauth_key_data {
+struct _oauth_key_data
+{
   char kid[OAUTH_KID_SIZE + 1];
   char ikm_key[OAUTH_KEY_SIZE + 1];
   size_t ikm_key_size;
@@ -224,7 +227,8 @@ struct _oauth_key_data {
 
 typedef struct _oauth_key_data oauth_key_data;
 
-struct _oauth_key {
+struct _oauth_key
+{
   char kid[OAUTH_KID_SIZE + 1];
   char ikm_key[OAUTH_KEY_SIZE + 1];
   size_t ikm_key_size;
@@ -239,7 +243,8 @@ struct _oauth_key {
 
 typedef struct _oauth_key oauth_key;
 
-struct _oauth_encrypted_block {
+struct _oauth_encrypted_block
+{
   uint16_t nonce_length;
   uint8_t nonce[OAUTH_MAX_NONCE_SIZE];
   uint16_t key_length;
@@ -250,7 +255,8 @@ struct _oauth_encrypted_block {
 
 typedef struct _oauth_encrypted_block oauth_encrypted_block;
 
-struct _oauth_token {
+struct _oauth_token
+{
   oauth_encrypted_block enc_block;
 };
 
@@ -258,7 +264,8 @@ typedef struct _oauth_token oauth_token;
 
 #define MAX_ENCODED_OAUTH_TOKEN_SIZE (1024)
 
-struct _encoded_oauth_token {
+struct _encoded_oauth_token
+{
   char token[MAX_ENCODED_OAUTH_TOKEN_SIZE];
   size_t size;
 };

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -72,18 +72,21 @@
 #include <time.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #define nswap16(s) ntohs(s)
 #define nswap32(ul) ntohl(ul)
 #define nswap64(ull) ioa_ntoh64(ull)
 
-static inline uint64_t _ioa_ntoh64(uint64_t v) {
+static inline uint64_t _ioa_ntoh64(uint64_t v)
+{
 #if BYTE_ORDER == LITTLE_ENDIAN
   uint8_t *src = (uint8_t *)&v;
   uint8_t *dst = src + 7;
-  while (src < dst) {
+  while (src < dst)
+  {
     uint8_t vdst = *dst;
     *(dst--) = *src;
     *(src++) = vdst;
@@ -143,8 +146,10 @@ static inline int socket_emsgsize(void) { return socket_errno() == EMSGSIZE; }
 #endif
 
 #define BUFFEREVENT_FREE(be)                                                                                           \
-  do {                                                                                                                 \
-    if (be) {                                                                                                          \
+  do                                                                                                                   \
+  {                                                                                                                    \
+    if (be)                                                                                                            \
+    {                                                                                                                  \
       bufferevent_flush(be, EV_READ | EV_WRITE, BEV_FLUSH);                                                            \
       bufferevent_disable(be, EV_READ | EV_WRITE);                                                                     \
       bufferevent_free(be);                                                                                            \
@@ -163,7 +168,8 @@ typedef uint32_t turn_time_t;
 
 #if !defined(UNUSED_ARG)
 #define UNUSED_ARG(A)                                                                                                  \
-  do {                                                                                                                 \
+  do                                                                                                                   \
+  {                                                                                                                    \
     A = A;                                                                                                             \
   } while (0)
 #endif
@@ -187,11 +193,14 @@ typedef uint32_t turn_time_t;
 
 // NOLINTBEGIN(clang-diagnostic-string-compare)
 #define STRCPY(dst, src)                                                                                               \
-  do {                                                                                                                 \
-    if ((const char *)(dst) != (const char *)(src)) {                                                                  \
+  do                                                                                                                   \
+  {                                                                                                                    \
+    if ((const char *)(dst) != (const char *)(src))                                                                    \
+    {                                                                                                                  \
       if (sizeof(dst) == sizeof(char *))                                                                               \
         strcpy(((char *)(dst)), (const char *)(src));                                                                  \
-      else {                                                                                                           \
+      else                                                                                                             \
+      {                                                                                                                \
         size_t szdst = sizeof((dst));                                                                                  \
         strncpy((char *)(dst), (const char *)(src), szdst);                                                            \
         ((char *)(dst))[szdst - 1] = 0;                                                                                \

--- a/src/server/ns_turn_allocation.c
+++ b/src/server/ns_turn_allocation.c
@@ -44,8 +44,10 @@ static turn_permission_info *get_from_turn_permission_hashtable(turn_permission_
 
 /////////////// ALLOCATION //////////////////////////////////////
 
-void init_allocation(void *owner, allocation *a, ur_map *tcp_connections) {
-  if (a) {
+void init_allocation(void *owner, allocation *a, ur_map *tcp_connections)
+{
+  if (a)
+  {
     memset(a, 0, sizeof(allocation));
     a->owner = owner;
     a->tcp_connections = tcp_connections;
@@ -53,19 +55,25 @@ void init_allocation(void *owner, allocation *a, ur_map *tcp_connections) {
   }
 }
 
-void clear_allocation(allocation *a, SOCKET_TYPE socket_type) {
-  if (!a) {
+void clear_allocation(allocation *a, SOCKET_TYPE socket_type)
+{
+  if (!a)
+  {
     return;
   }
 
-  if (a->is_valid) {
+  if (a->is_valid)
+  {
     turn_report_allocation_delete(a, socket_type);
   }
 
-  if (a->tcs.elems) {
-    for (size_t i = 0; i < a->tcs.sz; ++i) {
+  if (a->tcs.elems)
+  {
+    for (size_t i = 0; i < a->tcs.sz; ++i)
+    {
       tcp_connection *tc = a->tcs.elems[i];
-      if (tc) {
+      if (tc)
+      {
         delete_tcp_connection(tc);
         a->tcs.elems[i] = NULL;
       }
@@ -75,7 +83,8 @@ void clear_allocation(allocation *a, SOCKET_TYPE socket_type) {
   }
   a->tcs.sz = 0;
 
-  for (size_t i = 0; i < ALLOC_PROTOCOLS_NUMBER; ++i) {
+  for (size_t i = 0; i < ALLOC_PROTOCOLS_NUMBER; ++i)
+  {
     clear_ioa_socket_session_if(a->relay_sessions[i].s, a->owner);
     clear_relay_endpoint_session_data(&(a->relay_sessions[i]));
     IOA_EVENT_DEL(a->relay_sessions[i].lifetime_ev);
@@ -88,45 +97,60 @@ void clear_allocation(allocation *a, SOCKET_TYPE socket_type) {
   a->is_valid = 0;
 }
 
-relay_endpoint_session *get_relay_session(allocation *a, int family) {
-  if (a) {
+relay_endpoint_session *get_relay_session(allocation *a, int family)
+{
+  if (a)
+  {
     return &(a->relay_sessions[ALLOC_INDEX(family)]);
   }
   return NULL;
 }
 
-int get_relay_session_failure(allocation *a, int family) {
-  if (a) {
+int get_relay_session_failure(allocation *a, int family)
+{
+  if (a)
+  {
     return a->relay_sessions_failure[ALLOC_INDEX(family)];
   }
   return 0;
 }
 
-void set_relay_session_failure(allocation *a, int family) {
-  if (a) {
+void set_relay_session_failure(allocation *a, int family)
+{
+  if (a)
+  {
     a->relay_sessions_failure[ALLOC_INDEX(family)] = 1;
   }
 }
 
-ioa_socket_handle get_relay_socket(allocation *a, int family) {
-  if (a) {
+ioa_socket_handle get_relay_socket(allocation *a, int family)
+{
+  if (a)
+  {
     return a->relay_sessions[ALLOC_INDEX(family)].s;
   }
   return NULL;
 }
 
-void set_allocation_family_invalid(allocation *a, int family) {
-  if (!a) {
+void set_allocation_family_invalid(allocation *a, int family)
+{
+  if (!a)
+  {
     return;
   }
 
   const size_t index = ALLOC_INDEX(family);
-  if (a->relay_sessions[index].s) {
-    if (a->tcs.elems) {
-      for (size_t i = 0; i < a->tcs.sz; ++i) {
+  if (a->relay_sessions[index].s)
+  {
+    if (a->tcs.elems)
+    {
+      for (size_t i = 0; i < a->tcs.sz; ++i)
+      {
         tcp_connection *tc = a->tcs.elems[i];
-        if (tc) {
-          if (tc->peer_s && (get_ioa_socket_address_family(tc->peer_s) == family)) {
+        if (tc)
+        {
+          if (tc->peer_s && (get_ioa_socket_address_family(tc->peer_s) == family))
+          {
             delete_tcp_connection(tc);
             a->tcs.elems[i] = NULL;
           }
@@ -140,29 +164,37 @@ void set_allocation_family_invalid(allocation *a, int family) {
   }
 }
 
-void set_allocation_lifetime_ev(allocation *a, turn_time_t exp_time, ioa_timer_handle ev, int family) {
-  if (a) {
+void set_allocation_lifetime_ev(allocation *a, turn_time_t exp_time, ioa_timer_handle ev, int family)
+{
+  if (a)
+  {
     IOA_EVENT_DEL(a->relay_sessions[ALLOC_INDEX(family)].lifetime_ev);
     a->relay_sessions[ALLOC_INDEX(family)].expiration_time = exp_time;
     a->relay_sessions[ALLOC_INDEX(family)].lifetime_ev = ev;
   }
 }
 
-bool is_allocation_valid(const allocation *a) {
-  if (a) {
+bool is_allocation_valid(const allocation *a)
+{
+  if (a)
+  {
     return a->is_valid;
   }
   return false;
 }
 
-void set_allocation_valid(allocation *a, bool value) {
-  if (a) {
+void set_allocation_valid(allocation *a, bool value)
+{
+  if (a)
+  {
     a->is_valid = value;
   }
 }
 
-turn_permission_info *allocation_get_permission(allocation *a, const ioa_addr *addr) {
-  if (a) {
+turn_permission_info *allocation_get_permission(allocation *a, const ioa_addr *addr)
+{
+  if (a)
+  {
     return get_from_turn_permission_hashtable(&(a->addr_to_perm), addr);
   }
   return NULL;
@@ -172,18 +204,22 @@ turn_permission_info *allocation_get_permission(allocation *a, const ioa_addr *a
 
 static bool delete_channel_info_from_allocation_map(ur_map_key_type key, ur_map_value_type value);
 
-void turn_permission_clean(turn_permission_info *tinfo) {
-  if (!tinfo || !tinfo->allocated) {
+void turn_permission_clean(turn_permission_info *tinfo)
+{
+  if (!tinfo || !tinfo->allocated)
+  {
     return;
   }
 
-  if (tinfo->verbose) {
+  if (tinfo->verbose)
+  {
     char s[257] = "\0";
     addr_to_string(&(tinfo->addr), (uint8_t *)s);
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: peer %s deleted\n", tinfo->session_id, s);
   }
 
-  if (!(tinfo->lifetime_ev)) {
+  if (!(tinfo->lifetime_ev))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: strange (1) permission to be cleaned\n", __FUNCTION__);
   }
 
@@ -193,33 +229,44 @@ void turn_permission_clean(turn_permission_info *tinfo) {
   memset(tinfo, 0, sizeof(turn_permission_info));
 }
 
-static void init_turn_permission_hashtable(turn_permission_hashtable *map) {
-  if (map) {
+static void init_turn_permission_hashtable(turn_permission_hashtable *map)
+{
+  if (map)
+  {
     memset(map, 0, sizeof(turn_permission_hashtable));
   }
 }
 
-static void free_turn_permission_hashtable(turn_permission_hashtable *map) {
-  if (!map) {
+static void free_turn_permission_hashtable(turn_permission_hashtable *map)
+{
+  if (!map)
+  {
     return;
   }
 
-  for (size_t i = 0; i < TURN_PERMISSION_HASHTABLE_SIZE; ++i) {
+  for (size_t i = 0; i < TURN_PERMISSION_HASHTABLE_SIZE; ++i)
+  {
 
     turn_permission_array *parray = &(map->table[i]);
 
-    for (size_t j = 0; j < TURN_PERMISSION_ARRAY_SIZE; ++j) {
+    for (size_t j = 0; j < TURN_PERMISSION_ARRAY_SIZE; ++j)
+    {
       turn_permission_slot *slot = &(parray->main_slots[j]);
-      if (slot->info.allocated) {
+      if (slot->info.allocated)
+      {
         turn_permission_clean(&(slot->info));
       }
     }
 
-    if (parray->extra_slots) {
-      for (size_t j = 0; j < parray->extra_sz; ++j) {
+    if (parray->extra_slots)
+    {
+      for (size_t j = 0; j < parray->extra_sz; ++j)
+      {
         turn_permission_slot *slot = parray->extra_slots[j];
-        if (slot) {
-          if (slot->info.allocated) {
+        if (slot)
+        {
+          if (slot->info.allocated)
+          {
             turn_permission_clean(&(slot->info));
           }
           free(slot);
@@ -233,25 +280,32 @@ static void free_turn_permission_hashtable(turn_permission_hashtable *map) {
   }
 }
 
-static turn_permission_info *get_from_turn_permission_hashtable(turn_permission_hashtable *map, const ioa_addr *addr) {
-  if (!addr || !map) {
+static turn_permission_info *get_from_turn_permission_hashtable(turn_permission_hashtable *map, const ioa_addr *addr)
+{
+  if (!addr || !map)
+  {
     return NULL;
   }
 
   uint32_t index = addr_hash_no_port(addr) & (TURN_PERMISSION_HASHTABLE_SIZE - 1);
   turn_permission_array *parray = &(map->table[index]);
 
-  for (size_t i = 0; i < TURN_PERMISSION_ARRAY_SIZE; ++i) {
+  for (size_t i = 0; i < TURN_PERMISSION_ARRAY_SIZE; ++i)
+  {
     turn_permission_slot *slot = &(parray->main_slots[i]);
-    if (slot->info.allocated && addr_eq_no_port(&(slot->info.addr), addr)) {
+    if (slot->info.allocated && addr_eq_no_port(&(slot->info.addr), addr))
+    {
       return &(slot->info);
     }
   }
 
-  if (parray->extra_slots) {
-    for (size_t i = 0; i < parray->extra_sz; ++i) {
+  if (parray->extra_slots)
+  {
+    for (size_t i = 0; i < parray->extra_sz; ++i)
+    {
       turn_permission_slot *slot = parray->extra_slots[i];
-      if (slot->info.allocated && addr_eq_no_port(&(slot->info.addr), addr)) {
+      if (slot->info.allocated && addr_eq_no_port(&(slot->info.addr), addr))
+      {
         return &(slot->info);
       }
     }
@@ -260,9 +314,12 @@ static turn_permission_info *get_from_turn_permission_hashtable(turn_permission_
   return NULL;
 }
 
-static void ch_info_clean(ch_info *c) {
-  if (c) {
-    if (c->kernel_channel) {
+static void ch_info_clean(ch_info *c)
+{
+  if (c)
+  {
+    if (c->kernel_channel)
+    {
       DELETE_TURN_CHANNEL_KERNEL(c->kernel_channel);
       c->kernel_channel = 0;
     }
@@ -271,13 +328,16 @@ static void ch_info_clean(ch_info *c) {
   }
 }
 
-static bool delete_channel_info_from_allocation_map(ur_map_key_type key, ur_map_value_type value) {
+static bool delete_channel_info_from_allocation_map(ur_map_key_type key, ur_map_value_type value)
+{
   UNUSED_ARG(key);
 
-  if (value) {
+  if (value)
+  {
     ch_info *chn = (ch_info *)value;
 
-    if (chn->chnum < 1) {
+    if (chn->chnum < 1)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: strange (0) channel to be cleaned: chnum<1\n", __FUNCTION__);
     }
 
@@ -287,13 +347,16 @@ static bool delete_channel_info_from_allocation_map(ur_map_key_type key, ur_map_
   return false;
 }
 
-void turn_channel_delete(ch_info *chn) {
-  if (!chn) {
+void turn_channel_delete(ch_info *chn)
+{
+  if (!chn)
+  {
     return;
   }
 
   int port = addr_get_port(&(chn->peer_addr));
-  if (port < 1) {
+  if (port < 1)
+  {
     char s[129];
     addr_to_string(&(chn->peer_addr), (uint8_t *)s);
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: strange (1) channel to be cleaned: port is empty: %s\n", __FUNCTION__,
@@ -301,9 +364,12 @@ void turn_channel_delete(ch_info *chn) {
   }
 
   turn_permission_info *tinfo = (turn_permission_info *)chn->owner;
-  if (tinfo) {
+  if (tinfo)
+  {
     lm_map_del(&(tinfo->chns), (ur_map_key_type)port, NULL);
-  } else {
+  }
+  else
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: strange (2) channel to be cleaned: permission is empty\n",
                   __FUNCTION__);
   }
@@ -311,21 +377,26 @@ void turn_channel_delete(ch_info *chn) {
   delete_channel_info_from_allocation_map((ur_map_key_type)port, (ur_map_value_type)chn);
 }
 
-ch_info *allocation_get_new_ch_info(allocation *a, uint16_t chnum, ioa_addr *peer_addr) {
-  if (!a) {
+ch_info *allocation_get_new_ch_info(allocation *a, uint16_t chnum, ioa_addr *peer_addr)
+{
+  if (!a)
+  {
     return NULL;
   }
 
   turn_permission_info *tinfo = get_from_turn_permission_hashtable(&(a->addr_to_perm), peer_addr);
-  if (!tinfo) {
+  if (!tinfo)
+  {
     tinfo = allocation_add_permission(a, peer_addr);
-    if (!tinfo) {
+    if (!tinfo)
+    {
       return NULL;
     }
   }
 
   ch_info *chn = ch_map_get(&(a->chns), chnum, 1);
-  if (!chn) {
+  if (!chn)
+  {
     return NULL;
   }
 
@@ -342,20 +413,26 @@ ch_info *allocation_get_new_ch_info(allocation *a, uint16_t chnum, ioa_addr *pee
 
 ch_info *allocation_get_ch_info(allocation *a, uint16_t chnum) { return ch_map_get(&(a->chns), chnum, 0); }
 
-ch_info *allocation_get_ch_info_by_peer_addr(allocation *a, ioa_addr *peer_addr) {
+ch_info *allocation_get_ch_info_by_peer_addr(allocation *a, ioa_addr *peer_addr)
+{
   turn_permission_info *tinfo = get_from_turn_permission_hashtable(&(a->addr_to_perm), peer_addr);
-  if (tinfo) {
+  if (tinfo)
+  {
     return get_turn_channel(tinfo, peer_addr);
   }
   return NULL;
 }
 
-uint16_t get_turn_channel_number(turn_permission_info *tinfo, ioa_addr *addr) {
-  if (tinfo) {
+uint16_t get_turn_channel_number(turn_permission_info *tinfo, ioa_addr *addr)
+{
+  if (tinfo)
+  {
     ur_map_value_type t = 0;
-    if (lm_map_get(&(tinfo->chns), (ur_map_key_type)addr_get_port(addr), &t) && t) {
+    if (lm_map_get(&(tinfo->chns), (ur_map_key_type)addr_get_port(addr), &t) && t)
+    {
       ch_info *chn = (ch_info *)t;
-      if (STUN_VALID_CHANNEL(chn->chnum)) {
+      if (STUN_VALID_CHANNEL(chn->chnum))
+      {
         return chn->chnum;
       }
     }
@@ -364,12 +441,16 @@ uint16_t get_turn_channel_number(turn_permission_info *tinfo, ioa_addr *addr) {
   return 0;
 }
 
-ch_info *get_turn_channel(turn_permission_info *tinfo, ioa_addr *addr) {
-  if (tinfo) {
+ch_info *get_turn_channel(turn_permission_info *tinfo, ioa_addr *addr)
+{
+  if (tinfo)
+  {
     ur_map_value_type t = 0;
-    if (lm_map_get(&(tinfo->chns), (ur_map_key_type)addr_get_port(addr), &t) && t) {
+    if (lm_map_get(&(tinfo->chns), (ur_map_key_type)addr_get_port(addr), &t) && t)
+    {
       ch_info *chn = (ch_info *)t;
-      if (STUN_VALID_CHANNEL(chn->chnum)) {
+      if (STUN_VALID_CHANNEL(chn->chnum))
+      {
         return chn;
       }
     }
@@ -380,8 +461,10 @@ ch_info *get_turn_channel(turn_permission_info *tinfo, ioa_addr *addr) {
 
 turn_permission_hashtable *allocation_get_turn_permission_hashtable(allocation *a) { return &(a->addr_to_perm); }
 
-turn_permission_info *allocation_add_permission(allocation *a, const ioa_addr *addr) {
-  if (!a || !addr) {
+turn_permission_info *allocation_add_permission(allocation *a, const ioa_addr *addr)
+{
+  if (!a || !addr)
+  {
     return NULL;
   }
 
@@ -393,42 +476,55 @@ turn_permission_info *allocation_add_permission(allocation *a, const ioa_addr *a
 
   turn_permission_slot *slot = NULL;
 
-  for (size_t i = 0; i < TURN_PERMISSION_ARRAY_SIZE; ++i) {
+  for (size_t i = 0; i < TURN_PERMISSION_ARRAY_SIZE; ++i)
+  {
     slot = &(parray->main_slots[i]);
-    if (!(slot->info.allocated)) {
+    if (!(slot->info.allocated))
+    {
       break;
-    } else {
+    }
+    else
+    {
       slot = NULL;
     }
   }
 
-  if (!slot) {
+  if (!slot)
+  {
     size_t old_sz = parray->extra_sz;
     turn_permission_slot **slots = parray->extra_slots;
 
-    if (slots) {
-      for (size_t i = 0; i < old_sz; ++i) {
+    if (slots)
+    {
+      for (size_t i = 0; i < old_sz; ++i)
+      {
         slot = slots[i];
-        if (!(slot->info.allocated)) {
+        if (!(slot->info.allocated))
+        {
           break;
-        } else {
+        }
+        else
+        {
           slot = NULL;
         }
       }
     }
 
-    if (!slot) {
+    if (!slot)
+    {
       size_t old_sz_mem = old_sz * sizeof(turn_permission_slot *);
       turn_permission_slot **new_slots =
           (turn_permission_slot **)realloc(parray->extra_slots, old_sz_mem + sizeof(turn_permission_slot *));
-      if (!new_slots) {
+      if (!new_slots)
+      {
         return NULL;
       }
       parray->extra_slots = new_slots;
       slots = parray->extra_slots;
       parray->extra_sz = old_sz + 1;
       slot = (turn_permission_slot *)malloc(sizeof(turn_permission_slot));
-      if (!slot) {
+      if (!slot)
+      {
         return NULL;
       }
       slots[old_sz] = slot;
@@ -444,50 +540,67 @@ turn_permission_info *allocation_add_permission(allocation *a, const ioa_addr *a
   return elem;
 }
 
-ch_info *ch_map_get(ch_map *const map, const uint16_t chnum, const int new_chn) {
-  if (!map) {
+ch_info *ch_map_get(ch_map *const map, const uint16_t chnum, const int new_chn)
+{
+  if (!map)
+  {
     return NULL;
   }
 
   const size_t index = (size_t)(chnum & (CH_MAP_HASH_SIZE - 1));
   ch_map_array *const a = &(map->table[index]);
 
-  for (size_t i = 0; i < CH_MAP_ARRAY_SIZE; ++i) {
+  for (size_t i = 0; i < CH_MAP_ARRAY_SIZE; ++i)
+  {
     ch_info *const chi = &(a->main_chns[i]);
-    if (chi->allocated) {
-      if (!new_chn && (chi->chnum == chnum)) {
+    if (chi->allocated)
+    {
+      if (!new_chn && (chi->chnum == chnum))
+      {
         return chi;
       }
-    } else if (new_chn) {
+    }
+    else if (new_chn)
+    {
       return chi;
     }
   }
 
   const size_t old_sz = a->extra_sz;
-  if (old_sz && a->extra_chns) {
-    for (size_t i = 0; i < old_sz; ++i) {
+  if (old_sz && a->extra_chns)
+  {
+    for (size_t i = 0; i < old_sz; ++i)
+    {
       ch_info *const chi = a->extra_chns[i];
-      if (chi) {
-        if (chi->allocated) {
-          if (!new_chn && (chi->chnum == chnum)) {
+      if (chi)
+      {
+        if (chi->allocated)
+        {
+          if (!new_chn && (chi->chnum == chnum))
+          {
             return chi;
           }
-        } else if (new_chn) {
+        }
+        else if (new_chn)
+        {
           return chi;
         }
       }
     }
   }
 
-  if (new_chn) {
+  if (new_chn)
+  {
     const size_t old_sz_mem = old_sz * sizeof(ch_info *);
     ch_info **const pTmp = (ch_info **)realloc(a->extra_chns, old_sz_mem + sizeof(ch_info *));
-    if (!pTmp) {
+    if (!pTmp)
+    {
       return NULL;
     }
     a->extra_chns = pTmp;
     a->extra_chns[old_sz] = (ch_info *)calloc(1, sizeof(ch_info));
-    if (!a->extra_chns[old_sz]) {
+    if (!a->extra_chns[old_sz])
+    {
       // if the realloc succeeds, but the calloc fails, we don't attempt to shrink the realloc back down
       // by not recording the change to the size, we allow the next call to this function to realloc the
       // block to presumably the same size it already is, which should be fine and not result in any leaks.
@@ -501,26 +614,35 @@ ch_info *ch_map_get(ch_map *const map, const uint16_t chnum, const int new_chn) 
   return NULL;
 }
 
-void ch_map_clean(ch_map *map) {
-  if (!map) {
+void ch_map_clean(ch_map *map)
+{
+  if (!map)
+  {
     return;
   }
 
-  for (size_t index = 0; index < CH_MAP_HASH_SIZE; ++index) {
+  for (size_t index = 0; index < CH_MAP_HASH_SIZE; ++index)
+  {
     ch_map_array *a = &(map->table[index]);
 
-    for (size_t i = 0; i < CH_MAP_ARRAY_SIZE; ++i) {
+    for (size_t i = 0; i < CH_MAP_ARRAY_SIZE; ++i)
+    {
       ch_info *chi = &(a->main_chns[i]);
-      if (chi->allocated) {
+      if (chi->allocated)
+      {
         ch_info_clean(chi);
       }
     }
 
-    if (a->extra_chns) {
-      for (size_t i = 0; i < a->extra_sz; ++i) {
+    if (a->extra_chns)
+    {
+      for (size_t i = 0; i < a->extra_sz; ++i)
+      {
         ch_info *chi = a->extra_chns[i];
-        if (chi) {
-          if (chi->allocated) {
+        if (chi)
+        {
+          if (chi->allocated)
+          {
             ch_info_clean(chi);
           }
           free(chi);
@@ -536,16 +658,20 @@ void ch_map_clean(ch_map *map) {
 
 ////////////////// TCP connections ///////////////////////////////
 
-static void set_new_tc_id(uint8_t server_id, tcp_connection *tc) {
+static void set_new_tc_id(uint8_t server_id, tcp_connection *tc)
+{
   const uint32_t sid = ((uint32_t)server_id) << 24;
   allocation *const a = (allocation *)(tc->owner);
-  if (!a || !a->tcp_connections) {
+  if (!a || !a->tcp_connections)
+  {
     return;
   }
 
   uint32_t newid = 0;
-  do {
-    do {
+  do
+  {
+    do
+    {
       newid = ((uint32_t)turn_random()) & 0x00FFFFFF;
     } while (!newid);
     newid = newid | sid;
@@ -555,17 +681,23 @@ static void set_new_tc_id(uint8_t server_id, tcp_connection *tc) {
 }
 
 tcp_connection *create_tcp_connection(uint8_t server_id, allocation *a, stun_tid *tid, ioa_addr *peer_addr,
-                                      int *err_code) {
+                                      int *err_code)
+{
   tcp_connection_list *tcl = &(a->tcs);
-  if (!tcl) {
+  if (!tcl)
+  {
     return NULL;
   }
 
-  if (tcl->elems) {
-    for (size_t i = 0; i < tcl->sz; ++i) {
+  if (tcl->elems)
+  {
+    for (size_t i = 0; i < tcl->sz; ++i)
+    {
       tcp_connection *otc = tcl->elems[i];
-      if (otc) {
-        if (addr_eq(&(otc->peer_addr), peer_addr)) {
+      if (otc)
+      {
+        if (addr_eq(&(otc->peer_addr), peer_addr))
+        {
           *err_code = 446;
           return NULL;
         }
@@ -574,20 +706,25 @@ tcp_connection *create_tcp_connection(uint8_t server_id, allocation *a, stun_tid
   }
 
   tcp_connection *tc = (tcp_connection *)calloc(1, sizeof(tcp_connection));
-  if (!tc) {
+  if (!tc)
+  {
     return NULL;
   }
   addr_cpy(&(tc->peer_addr), peer_addr);
-  if (tid) {
+  if (tid)
+  {
     memcpy(&(tc->tid), tid, sizeof(stun_tid));
   }
   tc->owner = a;
 
   bool found = false;
-  if (a->tcs.elems) {
-    for (size_t i = 0; i < tcl->sz; ++i) {
+  if (a->tcs.elems)
+  {
+    for (size_t i = 0; i < tcl->sz; ++i)
+    {
       tcp_connection *otc = tcl->elems[i];
-      if (!otc) {
+      if (!otc)
+      {
         tcl->elems[i] = tc;
         found = true;
         break;
@@ -595,10 +732,12 @@ tcp_connection *create_tcp_connection(uint8_t server_id, allocation *a, stun_tid
     }
   }
 
-  if (!found) {
+  if (!found)
+  {
     size_t old_sz_mem = a->tcs.sz * sizeof(tcp_connection *);
     tcp_connection **new_elems = realloc(a->tcs.elems, old_sz_mem + sizeof(tcp_connection *));
-    if (!new_elems) {
+    if (!new_elems)
+    {
       return NULL;
     }
     a->tcs.elems = new_elems;
@@ -611,12 +750,15 @@ tcp_connection *create_tcp_connection(uint8_t server_id, allocation *a, stun_tid
   return tc;
 }
 
-void delete_tcp_connection(tcp_connection *tc) {
-  if (!tc) {
+void delete_tcp_connection(tcp_connection *tc)
+{
+  if (!tc)
+  {
     return;
   }
 
-  if (tc->done) {
+  if (tc->done)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: check on already closed tcp data connection: %p\n", __FUNCTION__, tc);
     return;
   }
@@ -627,15 +769,20 @@ void delete_tcp_connection(tcp_connection *tc) {
   IOA_EVENT_DEL(tc->peer_conn_timeout);
   IOA_EVENT_DEL(tc->conn_bind_timeout);
   allocation *a = (allocation *)(tc->owner);
-  if (a) {
+  if (a)
+  {
     ur_map *map = a->tcp_connections;
-    if (map) {
+    if (map)
+    {
       ur_map_del(map, (ur_map_key_type)(tc->id), NULL);
     }
     tcp_connection_list *tcl = &(a->tcs);
-    if (tcl->elems) {
-      for (size_t i = 0; i < tcl->sz; ++i) {
-        if (tcl->elems[i] == tc) {
+    if (tcl->elems)
+    {
+      for (size_t i = 0; i < tcl->sz; ++i)
+      {
+        if (tcl->elems[i] == tc)
+        {
           tcl->elems[i] = NULL;
           break;
         }
@@ -647,10 +794,13 @@ void delete_tcp_connection(tcp_connection *tc) {
   free(tc);
 }
 
-tcp_connection *get_and_clean_tcp_connection_by_id(ur_map *map, tcp_connection_id id) {
-  if (map) {
+tcp_connection *get_and_clean_tcp_connection_by_id(ur_map *map, tcp_connection_id id)
+{
+  if (map)
+  {
     ur_map_value_type t = 0;
-    if (ur_map_get(map, (ur_map_key_type)id, &t) && t) {
+    if (ur_map_get(map, (ur_map_key_type)id, &t) && t)
+    {
       ur_map_del(map, (ur_map_key_type)id, NULL);
       return (tcp_connection *)t;
     }
@@ -658,24 +808,33 @@ tcp_connection *get_and_clean_tcp_connection_by_id(ur_map *map, tcp_connection_i
   return NULL;
 }
 
-tcp_connection *get_tcp_connection_by_id(ur_map *map, tcp_connection_id id) {
-  if (map) {
+tcp_connection *get_tcp_connection_by_id(ur_map *map, tcp_connection_id id)
+{
+  if (map)
+  {
     ur_map_value_type t = 0;
-    if (ur_map_get(map, (ur_map_key_type)id, &t) && t) {
+    if (ur_map_get(map, (ur_map_key_type)id, &t) && t)
+    {
       return (tcp_connection *)t;
     }
   }
   return NULL;
 }
 
-tcp_connection *get_tcp_connection_by_peer(allocation *a, ioa_addr *peer_addr) {
-  if (a && peer_addr) {
+tcp_connection *get_tcp_connection_by_peer(allocation *a, ioa_addr *peer_addr)
+{
+  if (a && peer_addr)
+  {
     tcp_connection_list *tcl = &(a->tcs);
-    if (tcl->elems) {
-      for (size_t i = 0; i < tcl->sz; ++i) {
+    if (tcl->elems)
+    {
+      for (size_t i = 0; i < tcl->sz; ++i)
+      {
         tcp_connection *tc = tcl->elems[i];
-        if (tc) {
-          if (addr_eq(&(tc->peer_addr), peer_addr)) {
+        if (tc)
+        {
+          if (addr_eq(&(tc->peer_addr), peer_addr))
+          {
             return tc;
           }
         }
@@ -685,12 +844,15 @@ tcp_connection *get_tcp_connection_by_peer(allocation *a, ioa_addr *peer_addr) {
   return NULL;
 }
 
-bool can_accept_tcp_connection_from_peer(allocation *a, ioa_addr *peer_addr, int server_relay) {
-  if (server_relay) {
+bool can_accept_tcp_connection_from_peer(allocation *a, ioa_addr *peer_addr, int server_relay)
+{
+  if (server_relay)
+  {
     return true;
   }
 
-  if (a && peer_addr) {
+  if (a && peer_addr)
+  {
     return get_from_turn_permission_hashtable(&(a->addr_to_perm), peer_addr) != NULL;
   }
 
@@ -699,12 +861,17 @@ bool can_accept_tcp_connection_from_peer(allocation *a, ioa_addr *peer_addr, int
 
 //////////////// Unsent buffers //////////////////////
 
-void clear_unsent_buffer(unsent_buffer *ub) {
-  if (ub) {
-    if (ub->bufs) {
-      for (size_t sz = 0; sz < ub->sz; sz++) {
+void clear_unsent_buffer(unsent_buffer *ub)
+{
+  if (ub)
+  {
+    if (ub->bufs)
+    {
+      for (size_t sz = 0; sz < ub->sz; sz++)
+      {
         ioa_network_buffer_handle nbh = ub->bufs[sz];
-        if (nbh) {
+        if (nbh)
+        {
           ioa_network_buffer_delete(NULL, nbh);
           ub->bufs[sz] = NULL;
         }
@@ -716,21 +883,29 @@ void clear_unsent_buffer(unsent_buffer *ub) {
   }
 }
 
-void add_unsent_buffer(unsent_buffer *ub, ioa_network_buffer_handle nbh) {
-  if (!ub || (ub->sz >= MAX_UNSENT_BUFFER_SIZE)) {
+void add_unsent_buffer(unsent_buffer *ub, ioa_network_buffer_handle nbh)
+{
+  if (!ub || (ub->sz >= MAX_UNSENT_BUFFER_SIZE))
+  {
     ioa_network_buffer_delete(NULL, nbh);
-  } else {
+  }
+  else
+  {
     ub->bufs = (ioa_network_buffer_handle *)realloc(ub->bufs, sizeof(ioa_network_buffer_handle) * (ub->sz + 1));
     ub->bufs[ub->sz] = nbh;
     ub->sz += 1;
   }
 }
 
-ioa_network_buffer_handle top_unsent_buffer(unsent_buffer *ub) {
+ioa_network_buffer_handle top_unsent_buffer(unsent_buffer *ub)
+{
   ioa_network_buffer_handle ret = NULL;
-  if (ub && ub->bufs && ub->sz) {
-    for (size_t sz = 0; sz < ub->sz; ++sz) {
-      if (ub->bufs[sz]) {
+  if (ub && ub->bufs && ub->sz)
+  {
+    for (size_t sz = 0; sz < ub->sz; ++sz)
+    {
+      if (ub->bufs[sz])
+      {
         ret = ub->bufs[sz];
         break;
       }
@@ -739,10 +914,14 @@ ioa_network_buffer_handle top_unsent_buffer(unsent_buffer *ub) {
   return ret;
 }
 
-void pop_unsent_buffer(unsent_buffer *ub) {
-  if (ub && ub->bufs && ub->sz) {
-    for (size_t sz = 0; sz < ub->sz; ++sz) {
-      if (ub->bufs[sz]) {
+void pop_unsent_buffer(unsent_buffer *ub)
+{
+  if (ub && ub->bufs && ub->sz)
+  {
+    for (size_t sz = 0; sz < ub->sz; ++sz)
+    {
+      if (ub->bufs[sz])
+      {
         ub->bufs[sz] = NULL;
         break;
       }

--- a/src/server/ns_turn_allocation.h
+++ b/src/server/ns_turn_allocation.h
@@ -40,7 +40,8 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ///////// Defines //////////
@@ -50,14 +51,17 @@ extern "C" {
 
 ////////////// Network session ////////////////
 
-typedef struct {
+typedef struct
+{
   ioa_socket_handle s;
   turn_time_t expiration_time;
   ioa_timer_handle lifetime_ev;
 } relay_endpoint_session;
 
-static inline void clear_relay_endpoint_session_data(relay_endpoint_session *cdi) {
-  if (cdi) {
+static inline void clear_relay_endpoint_session_data(relay_endpoint_session *cdi)
+{
+  if (cdi)
+  {
     IOA_CLOSE_SOCKET(cdi->s);
   }
 }
@@ -66,7 +70,8 @@ static inline void clear_relay_endpoint_session_data(relay_endpoint_session *cdi
 
 #define MAX_UNSENT_BUFFER_SIZE (0x10)
 
-enum _TC_STATE {
+enum _TC_STATE
+{
   TC_STATE_UNKNOWN = 0,
   TC_STATE_CLIENT_TO_PEER_CONNECTING,
   TC_STATE_PEER_CONNECTING,
@@ -79,12 +84,14 @@ typedef enum _TC_STATE TC_STATE;
 
 typedef uint32_t tcp_connection_id;
 
-typedef struct {
+typedef struct
+{
   size_t sz;
   ioa_network_buffer_handle *bufs;
 } unsent_buffer;
 
-struct _tcp_connection {
+struct _tcp_connection
+{
   TC_STATE state;
   tcp_connection_id id;
   ioa_addr peer_addr;
@@ -98,7 +105,8 @@ struct _tcp_connection {
   unsent_buffer ub_to_client;
 };
 
-typedef struct _tcp_connection_list {
+typedef struct _tcp_connection_list
+{
   size_t sz;
   tcp_connection **elems;
 } tcp_connection_list;
@@ -108,7 +116,8 @@ typedef struct _tcp_connection_list {
 #define TURN_PERMISSION_HASHTABLE_SIZE (0x8)
 #define TURN_PERMISSION_ARRAY_SIZE (0x3)
 
-typedef struct _ch_info {
+typedef struct _ch_info
+{
   uint16_t chnum;
   bool allocated;
   uint16_t port;
@@ -124,13 +133,15 @@ typedef struct _ch_info {
 #define CH_MAP_HASH_SIZE (0x8)
 #define CH_MAP_ARRAY_SIZE (0x3)
 
-typedef struct _chn_map_array {
+typedef struct _chn_map_array
+{
   ch_info main_chns[CH_MAP_ARRAY_SIZE];
   size_t extra_sz;
   ch_info **extra_chns;
 } ch_map_array;
 
-typedef struct _ch_map {
+typedef struct _ch_map
+{
   ch_map_array table[CH_MAP_HASH_SIZE];
 } ch_map;
 
@@ -139,7 +150,8 @@ void ch_map_clean(ch_map *map);
 
 ////////////////////////////
 
-typedef struct _turn_permission_info {
+typedef struct _turn_permission_info
+{
   bool allocated;
   lm_map chns;
   ioa_addr addr;
@@ -150,17 +162,20 @@ typedef struct _turn_permission_info {
   unsigned long long session_id;
 } turn_permission_info;
 
-typedef struct _turn_permission_slot {
+typedef struct _turn_permission_slot
+{
   turn_permission_info info;
 } turn_permission_slot;
 
-typedef struct _turn_permission_array {
+typedef struct _turn_permission_array
+{
   turn_permission_slot main_slots[TURN_PERMISSION_ARRAY_SIZE];
   size_t extra_sz;
   turn_permission_slot **extra_slots;
 } turn_permission_array;
 
-typedef struct _turn_permission_hashtable {
+typedef struct _turn_permission_hashtable
+{
   turn_permission_array table[TURN_PERMISSION_HASHTABLE_SIZE];
 } turn_permission_hashtable;
 
@@ -172,7 +187,8 @@ typedef struct _turn_permission_hashtable {
 #define ALLOC_INDEX(family) ((((family) == AF_INET6)) ? ALLOC_IPV6_INDEX : ALLOC_IPV4_INDEX)
 #define ALLOC_INDEX_ADDR(addr) ALLOC_INDEX(((addr)->ss).sa_family)
 
-typedef struct _allocation {
+typedef struct _allocation
+{
   bool is_valid;
   stun_tid tid;
   turn_permission_hashtable addr_to_perm;

--- a/src/server/ns_turn_ioalib.h
+++ b/src/server/ns_turn_ioalib.h
@@ -39,7 +39,8 @@
 #include "ns_turn_ioaddr.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ////////////// forward declarations ////////
@@ -74,7 +75,8 @@ typedef SSIZE_T ssize_t;
 
 ////////////// Mutexes /////////////////////
 
-struct _turn_mutex {
+struct _turn_mutex
+{
   uint32_t data;
   void *mutex;
 };
@@ -104,7 +106,8 @@ int turn_mutex_destroy(turn_mutex *mutex);
 #define IOA_EV_SIGNAL 0x08
 #define IOA_EV_CLOSE 0x10
 
-enum _SOCKET_TYPE {
+enum _SOCKET_TYPE
+{
   UNKNOWN_SOCKET = 0,
   TCP_SOCKET = 6,
   UDP_SOCKET = 17,
@@ -119,7 +122,8 @@ enum _SOCKET_TYPE {
 
 typedef enum _SOCKET_TYPE SOCKET_TYPE;
 
-enum _SOCKET_APP_TYPE {
+enum _SOCKET_APP_TYPE
+{
   UNKNOWN_APP_SOCKET,
   CLIENT_SOCKET,
   HTTP_CLIENT_SOCKET,
@@ -146,7 +150,8 @@ typedef void *ioa_timer_handle;
 typedef void *ioa_network_buffer_handle;
 
 /* event data for net event */
-typedef struct _ioa_net_data {
+typedef struct _ioa_net_data
+{
   ioa_addr src_addr;
   ioa_network_buffer_handle nbh;
   int recv_ttl;
@@ -165,7 +170,8 @@ typedef struct _realm_options_t realm_options_t;
 
 //////// IP White/black listing ///////////
 
-struct _ip_range {
+struct _ip_range
+{
   char str[257];
   char realm[513];
   ioa_addr_range enc;
@@ -173,7 +179,8 @@ struct _ip_range {
 
 typedef struct _ip_range ip_range_t;
 
-struct _ip_range_list {
+struct _ip_range_list
+{
   ip_range_t *rs;
   size_t ranges_number;
 };
@@ -208,7 +215,8 @@ void ioa_network_buffer_delete(ioa_engine_handle e, ioa_network_buffer_handle nb
 /*
  * Status reporting functions
  */
-enum _STUN_PROMETHEUS_METRIC_TYPE {
+enum _STUN_PROMETHEUS_METRIC_TYPE
+{
   STUN_PROMETHEUS_METRIC_TYPE_REQUEST,
   STUN_PROMETHEUS_METRIC_TYPE_RESPONSE,
   STUN_PROMETHEUS_METRIC_TYPE_ERROR,
@@ -243,8 +251,10 @@ ioa_timer_handle set_ioa_timer(ioa_engine_handle e, int secs, int ms, ioa_timer_
 void stop_ioa_timer(ioa_timer_handle th);
 void delete_ioa_timer(ioa_timer_handle th);
 #define IOA_EVENT_DEL(E)                                                                                               \
-  do {                                                                                                                 \
-    if (E) {                                                                                                           \
+  do                                                                                                                   \
+  {                                                                                                                    \
+    if (E)                                                                                                             \
+    {                                                                                                                  \
       delete_ioa_timer(E);                                                                                             \
       E = NULL;                                                                                                        \
     }                                                                                                                  \
@@ -296,8 +306,10 @@ int send_data_from_ioa_socket_nbh(ioa_socket_handle s, ioa_addr *dest_addr, ioa_
                                   int tos, int *skip);
 void close_ioa_socket(ioa_socket_handle s);
 #define IOA_CLOSE_SOCKET(S)                                                                                            \
-  do {                                                                                                                 \
-    if (S) {                                                                                                           \
+  do                                                                                                                   \
+  {                                                                                                                    \
+    if (S)                                                                                                             \
+    {                                                                                                                  \
       close_ioa_socket(S);                                                                                             \
       S = NULL;                                                                                                        \
     }                                                                                                                  \

--- a/src/server/ns_turn_khash.h
+++ b/src/server/ns_turn_khash.h
@@ -192,7 +192,8 @@ typedef khint_t khiter_t;
 static const double __ac_HASH_UPPER = 0.77;
 
 #define __KHASH_TYPE(name, khkey_t, khval_t)                                                                           \
-  typedef struct kh_##name##_s {                                                                                       \
+  typedef struct kh_##name##_s                                                                                         \
+  {                                                                                                                    \
     khint_t n_buckets, size, n_occupied, upper_bound;                                                                  \
     khint32_t *flags;                                                                                                  \
     khkey_t *keys;                                                                                                     \
@@ -210,39 +211,47 @@ static const double __ac_HASH_UPPER = 0.77;
 
 #define __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)                              \
   SCOPE kh_##name##_t *kh_init_##name(void) { return (kh_##name##_t *)kcalloc(1, sizeof(kh_##name##_t)); }             \
-  SCOPE void kh_destroy_##name(kh_##name##_t *h) {                                                                     \
-    if (h) {                                                                                                           \
+  SCOPE void kh_destroy_##name(kh_##name##_t *h)                                                                       \
+  {                                                                                                                    \
+    if (h)                                                                                                             \
+    {                                                                                                                  \
       kfree((void *)h->keys);                                                                                          \
       kfree(h->flags);                                                                                                 \
       kfree((void *)h->vals);                                                                                          \
       kfree(h);                                                                                                        \
     }                                                                                                                  \
   }                                                                                                                    \
-  SCOPE void kh_clear_##name(kh_##name##_t *h) {                                                                       \
-    if (h && h->flags) {                                                                                               \
+  SCOPE void kh_clear_##name(kh_##name##_t *h)                                                                         \
+  {                                                                                                                    \
+    if (h && h->flags)                                                                                                 \
+    {                                                                                                                  \
       memset(h->flags, 0xaa, __ac_fsize(h->n_buckets) * sizeof(khint32_t));                                            \
       h->size = h->n_occupied = 0;                                                                                     \
     }                                                                                                                  \
   }                                                                                                                    \
-  SCOPE khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key) {                                                   \
-    if (h->n_buckets) {                                                                                                \
+  SCOPE khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key)                                                     \
+  {                                                                                                                    \
+    if (h->n_buckets)                                                                                                  \
+    {                                                                                                                  \
       khint_t k, i, last, mask, step = 0;                                                                              \
       mask = h->n_buckets - 1;                                                                                         \
       k = __hash_func(key);                                                                                            \
       i = k & mask;                                                                                                    \
       last = i;                                                                                                        \
-      while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) {              \
+      while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key)))                \
+      {                                                                                                                \
         i = (i + (++step)) & mask;                                                                                     \
         if (i == last)                                                                                                 \
           return h->n_buckets;                                                                                         \
       }                                                                                                                \
       return __ac_iseither(h->flags, i) ? h->n_buckets : i;                                                            \
-    } else                                                                                                             \
+    }                                                                                                                  \
+    else                                                                                                               \
       return 0;                                                                                                        \
   }                                                                                                                    \
-  SCOPE int kh_resize_##name(kh_##name##_t *h,                                                                         \
-                             khint_t new_n_buckets) { /* This function uses 0.25*n_buckets bytes of working space      \
-                                                         instead of [sizeof(key_t+val_t)+.25]*n_buckets. */            \
+  SCOPE int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets)                                                  \
+  { /* This function uses 0.25*n_buckets bytes of working space                                                        \
+       instead of [sizeof(key_t+val_t)+.25]*n_buckets. */                                                              \
     khint32_t *new_flags = 0;                                                                                          \
     khint_t j = 1;                                                                                                     \
     {                                                                                                                  \
@@ -251,21 +260,26 @@ static const double __ac_HASH_UPPER = 0.77;
         new_n_buckets = 4;                                                                                             \
       if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5))                                                 \
         j = 0; /* requested size is too small */                                                                       \
-      else {   /* hash table size to be changed (shrink or expand); rehash */                                          \
+      else                                                                                                             \
+      { /* hash table size to be changed (shrink or expand); rehash */                                                 \
         new_flags = (khint32_t *)kmalloc(__ac_fsize(new_n_buckets) * sizeof(khint32_t));                               \
         if (!new_flags)                                                                                                \
           return -1;                                                                                                   \
         memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khint32_t));                                        \
-        if (h->n_buckets < new_n_buckets) { /* expand */                                                               \
+        if (h->n_buckets < new_n_buckets)                                                                              \
+        { /* expand */                                                                                                 \
           khkey_t *new_keys = (khkey_t *)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t));                   \
-          if (!new_keys) {                                                                                             \
+          if (!new_keys)                                                                                               \
+          {                                                                                                            \
             kfree(new_flags);                                                                                          \
             return -1;                                                                                                 \
           }                                                                                                            \
           h->keys = new_keys;                                                                                          \
-          if (kh_is_map) {                                                                                             \
+          if (kh_is_map)                                                                                               \
+          {                                                                                                            \
             khval_t *new_vals = (khval_t *)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t));                 \
-            if (!new_vals) {                                                                                           \
+            if (!new_vals)                                                                                             \
+            {                                                                                                          \
               kfree(new_flags);                                                                                        \
               return -1;                                                                                               \
             }                                                                                                          \
@@ -274,9 +288,12 @@ static const double __ac_HASH_UPPER = 0.77;
         } /* otherwise shrink */                                                                                       \
       }                                                                                                                \
     }                                                                                                                  \
-    if (j) { /* rehashing is needed */                                                                                 \
-      for (j = 0; j != h->n_buckets; ++j) {                                                                            \
-        if (__ac_iseither(h->flags, j) == 0) {                                                                         \
+    if (j)                                                                                                             \
+    { /* rehashing is needed */                                                                                        \
+      for (j = 0; j != h->n_buckets; ++j)                                                                              \
+      {                                                                                                                \
+        if (__ac_iseither(h->flags, j) == 0)                                                                           \
+        {                                                                                                              \
           khkey_t key = h->keys[j];                                                                                    \
           khval_t val;                                                                                                 \
           khint_t new_mask;                                                                                            \
@@ -284,26 +301,31 @@ static const double __ac_HASH_UPPER = 0.77;
           if (kh_is_map)                                                                                               \
             val = h->vals[j];                                                                                          \
           __ac_set_isdel_true(h->flags, j);                                                                            \
-          while (1) { /* kick-out process; sort of like in Cuckoo hashing */                                           \
+          while (1)                                                                                                    \
+          { /* kick-out process; sort of like in Cuckoo hashing */                                                     \
             khint_t k, i, step = 0;                                                                                    \
             k = __hash_func(key);                                                                                      \
             i = k & new_mask;                                                                                          \
             while (!__ac_isempty(new_flags, i))                                                                        \
               i = (i + (++step)) & new_mask;                                                                           \
             __ac_set_isempty_false(new_flags, i);                                                                      \
-            if (i < h->n_buckets && __ac_iseither(h->flags, i) == 0) { /* kick out the existing element */             \
+            if (i < h->n_buckets && __ac_iseither(h->flags, i) == 0)                                                   \
+            { /* kick out the existing element */                                                                      \
               {                                                                                                        \
                 khkey_t tmp = h->keys[i];                                                                              \
                 h->keys[i] = key;                                                                                      \
                 key = tmp;                                                                                             \
               }                                                                                                        \
-              if (kh_is_map) {                                                                                         \
+              if (kh_is_map)                                                                                           \
+              {                                                                                                        \
                 khval_t tmp = h->vals[i];                                                                              \
                 h->vals[i] = val;                                                                                      \
                 val = tmp;                                                                                             \
               }                                                                                                        \
               __ac_set_isdel_true(h->flags, i); /* mark it as deleted in the old hash table */                         \
-            } else {                            /* write the element and jump out of the loop */                       \
+            }                                                                                                          \
+            else                                                                                                       \
+            { /* write the element and jump out of the loop */                                                         \
               h->keys[i] = key;                                                                                        \
               if (kh_is_map)                                                                                           \
                 h->vals[i] = val;                                                                                      \
@@ -312,7 +334,8 @@ static const double __ac_HASH_UPPER = 0.77;
           }                                                                                                            \
         }                                                                                                              \
       }                                                                                                                \
-      if (h->n_buckets > new_n_buckets) { /* shrink the hash table */                                                  \
+      if (h->n_buckets > new_n_buckets)                                                                                \
+      { /* shrink the hash table */                                                                                    \
         h->keys = (khkey_t *)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t));                               \
         if (kh_is_map)                                                                                                 \
           h->vals = (khval_t *)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t));                             \
@@ -325,15 +348,21 @@ static const double __ac_HASH_UPPER = 0.77;
     }                                                                                                                  \
     return 0;                                                                                                          \
   }                                                                                                                    \
-  SCOPE khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret) {                                               \
+  SCOPE khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret)                                                 \
+  {                                                                                                                    \
     khint_t x;                                                                                                         \
-    if (h->n_occupied >= h->upper_bound) { /* update the hash table */                                                 \
-      if (h->n_buckets > (h->size << 1)) {                                                                             \
-        if (kh_resize_##name(h, h->n_buckets - 1) < 0) { /* clear "deleted" elements */                                \
+    if (h->n_occupied >= h->upper_bound)                                                                               \
+    { /* update the hash table */                                                                                      \
+      if (h->n_buckets > (h->size << 1))                                                                               \
+      {                                                                                                                \
+        if (kh_resize_##name(h, h->n_buckets - 1) < 0)                                                                 \
+        { /* clear "deleted" elements */                                                                               \
           *ret = -1;                                                                                                   \
           return h->n_buckets;                                                                                         \
         }                                                                                                              \
-      } else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */                              \
+      }                                                                                                                \
+      else if (kh_resize_##name(h, h->n_buckets + 1) < 0)                                                              \
+      { /* expand the hash table */                                                                                    \
         *ret = -1;                                                                                                     \
         return h->n_buckets;                                                                                           \
       }                                                                                                                \
@@ -345,18 +374,22 @@ static const double __ac_HASH_UPPER = 0.77;
       i = k & mask;                                                                                                    \
       if (__ac_isempty(h->flags, i))                                                                                   \
         x = i; /* for speed up */                                                                                      \
-      else {                                                                                                           \
+      else                                                                                                             \
+      {                                                                                                                \
         last = i;                                                                                                      \
-        while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) {            \
+        while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key)))              \
+        {                                                                                                              \
           if (__ac_isdel(h->flags, i))                                                                                 \
             site = i;                                                                                                  \
           i = (i + (++step)) & mask;                                                                                   \
-          if (i == last) {                                                                                             \
+          if (i == last)                                                                                               \
+          {                                                                                                            \
             x = site;                                                                                                  \
             break;                                                                                                     \
           }                                                                                                            \
         }                                                                                                              \
-        if (x == h->n_buckets) {                                                                                       \
+        if (x == h->n_buckets)                                                                                         \
+        {                                                                                                              \
           if (__ac_isempty(h->flags, i) && site != h->n_buckets)                                                       \
             x = site;                                                                                                  \
           else                                                                                                         \
@@ -364,23 +397,29 @@ static const double __ac_HASH_UPPER = 0.77;
         }                                                                                                              \
       }                                                                                                                \
     }                                                                                                                  \
-    if (__ac_isempty(h->flags, x)) { /* not present at all */                                                          \
+    if (__ac_isempty(h->flags, x))                                                                                     \
+    { /* not present at all */                                                                                         \
       h->keys[x] = key;                                                                                                \
       __ac_set_isboth_false(h->flags, x);                                                                              \
       ++h->size;                                                                                                       \
       ++h->n_occupied;                                                                                                 \
       *ret = 1;                                                                                                        \
-    } else if (__ac_isdel(h->flags, x)) { /* deleted */                                                                \
+    }                                                                                                                  \
+    else if (__ac_isdel(h->flags, x))                                                                                  \
+    { /* deleted */                                                                                                    \
       h->keys[x] = key;                                                                                                \
       __ac_set_isboth_false(h->flags, x);                                                                              \
       ++h->size;                                                                                                       \
       *ret = 2;                                                                                                        \
-    } else                                                                                                             \
+    }                                                                                                                  \
+    else                                                                                                               \
       *ret = 0; /* Don't touch h->keys[x] if present and not deleted */                                                \
     return x;                                                                                                          \
   }                                                                                                                    \
-  SCOPE void kh_del_##name(kh_##name##_t *h, khint_t x) {                                                              \
-    if (x != h->n_buckets && !__ac_iseither(h->flags, x)) {                                                            \
+  SCOPE void kh_del_##name(kh_##name##_t *h, khint_t x)                                                                \
+  {                                                                                                                    \
+    if (x != h->n_buckets && !__ac_iseither(h->flags, x))                                                              \
+    {                                                                                                                  \
       __ac_set_isdel_true(h->flags, x);                                                                                \
       --h->size;                                                                                                       \
     }                                                                                                                  \
@@ -424,10 +463,13 @@ static const double __ac_HASH_UPPER = 0.77;
   @param  s     Pointer to a null terminated string
   @return       The hash value
  */
-static kh_inline khint_t __ac_X31_hash_string(const char *s) {
+static kh_inline khint_t __ac_X31_hash_string(const char *s)
+{
   khint_t h = (khint_t)*s;
-  if (h) {
-    for (++s; *s; ++s) {
+  if (h)
+  {
+    for (++s; *s; ++s)
+    {
       h = (h << 5) - h + (khint_t)*s;
     }
   }
@@ -444,7 +486,8 @@ static kh_inline khint_t __ac_X31_hash_string(const char *s) {
  */
 #define kh_str_hash_equal(a, b) (strcmp(a, b) == 0)
 
-static kh_inline khint_t __ac_Wang_hash(khint_t key) {
+static kh_inline khint_t __ac_Wang_hash(khint_t key)
+{
   key += ~(key << 15);
   key ^= (key >> 10);
   key += (key << 3);
@@ -592,7 +635,8 @@ static kh_inline khint_t __ac_Wang_hash(khint_t key) {
 #define kh_foreach(h, kvar, vvar, code)                                                                                \
   {                                                                                                                    \
     khint_t __i;                                                                                                       \
-    for (__i = kh_begin(h); __i != kh_end(h); ++__i) {                                                                 \
+    for (__i = kh_begin(h); __i != kh_end(h); ++__i)                                                                   \
+    {                                                                                                                  \
       if (!kh_exist(h, __i))                                                                                           \
         continue;                                                                                                      \
       (kvar) = kh_key(h, __i);                                                                                         \
@@ -610,7 +654,8 @@ static kh_inline khint_t __ac_Wang_hash(khint_t key) {
 #define kh_foreach_value(h, vvar, code)                                                                                \
   {                                                                                                                    \
     khint_t __i;                                                                                                       \
-    for (__i = kh_begin(h); __i != kh_end(h); ++__i) {                                                                 \
+    for (__i = kh_begin(h); __i != kh_end(h); ++__i)                                                                   \
+    {                                                                                                                  \
       if (!kh_exist(h, __i))                                                                                           \
         continue;                                                                                                      \
       (vvar) = kh_val(h, __i);                                                                                         \

--- a/src/server/ns_turn_maps.c
+++ b/src/server/ns_turn_maps.c
@@ -41,16 +41,20 @@ KHASH_MAP_INIT_INT64(3, ur_map_value_type)
 
 #define MAGIC_HASH ((uint64_t)(0x90ABCDEFL))
 
-struct _ur_map {
+struct _ur_map
+{
   khash_t(3) * h;
   uint64_t magic;
   TURN_MUTEX_DECLARE(mutex)
 };
 
-static bool ur_map_init(ur_map *map) {
-  if (map) {
+static bool ur_map_init(ur_map *map)
+{
+  if (map)
+  {
     map->h = kh_init(3);
-    if (map->h) {
+    if (map->h)
+    {
       map->magic = MAGIC_HASH;
       TURN_MUTEX_INIT_RECURSIVE(&(map->mutex));
       return true;
@@ -61,29 +65,35 @@ static bool ur_map_init(ur_map *map) {
 
 #define ur_map_valid(map) ((map) && ((map)->h) && ((map)->magic == MAGIC_HASH))
 
-ur_map *ur_map_create(void) {
+ur_map *ur_map_create(void)
+{
   ur_map *map = (ur_map *)malloc(sizeof(ur_map));
-  if (!ur_map_init(map)) {
+  if (!ur_map_init(map))
+  {
     free(map);
     return NULL;
   }
   return map;
 }
 
-bool ur_map_put(ur_map *map, ur_map_key_type key, ur_map_value_type value) {
-  if (!ur_map_valid(map)) {
+bool ur_map_put(ur_map *map, ur_map_key_type key, ur_map_value_type value)
+{
+  if (!ur_map_valid(map))
+  {
     return false;
   }
 
   khiter_t k = kh_get(3, map->h, key);
-  if (k != kh_end(map->h)) {
+  if (k != kh_end(map->h))
+  {
     kh_del(3, map->h, k);
   }
 
   int ret = 0;
   k = kh_put(3, map->h, key, &ret);
 
-  if (!ret) {
+  if (!ret)
+  {
     kh_del(3, map->h, k);
     return false;
   }
@@ -93,14 +103,18 @@ bool ur_map_put(ur_map *map, ur_map_key_type key, ur_map_value_type value) {
   return true;
 }
 
-bool ur_map_get(const ur_map *map, ur_map_key_type key, ur_map_value_type *value) {
-  if (!ur_map_valid(map)) {
+bool ur_map_get(const ur_map *map, ur_map_key_type key, ur_map_value_type *value)
+{
+  if (!ur_map_valid(map))
+  {
     return false;
   }
 
   khiter_t k = kh_get(3, map->h, key);
-  if ((k != kh_end(map->h)) && kh_exist(map->h, k)) {
-    if (value) {
+  if ((k != kh_end(map->h)) && kh_exist(map->h, k))
+  {
+    if (value)
+    {
       *value = kh_value(map->h, k);
     }
     return true;
@@ -109,14 +123,18 @@ bool ur_map_get(const ur_map *map, ur_map_key_type key, ur_map_value_type *value
   return false;
 }
 
-bool ur_map_del(ur_map *map, ur_map_key_type key, ur_map_del_func delfunc) {
-  if (!ur_map_valid(map)) {
+bool ur_map_del(ur_map *map, ur_map_key_type key, ur_map_del_func delfunc)
+{
+  if (!ur_map_valid(map))
+  {
     return false;
   }
 
   khiter_t k = kh_get(3, map->h, key);
-  if ((k != kh_end(map->h)) && kh_exist(map->h, k)) {
-    if (delfunc) {
+  if ((k != kh_end(map->h)) && kh_exist(map->h, k))
+  {
+    if (delfunc)
+    {
       delfunc(kh_value(map->h, k));
     }
     kh_del(3, map->h, k);
@@ -126,24 +144,30 @@ bool ur_map_del(ur_map *map, ur_map_key_type key, ur_map_del_func delfunc) {
   return false;
 }
 
-bool ur_map_exist(const ur_map *map, ur_map_key_type key) {
-  if (!ur_map_valid(map)) {
+bool ur_map_exist(const ur_map *map, ur_map_key_type key)
+{
+  if (!ur_map_valid(map))
+  {
     return false;
   }
 
   khiter_t k = kh_get(3, map->h, key);
-  if ((k != kh_end(map->h)) && kh_exist(map->h, k)) {
+  if ((k != kh_end(map->h)) && kh_exist(map->h, k))
+  {
     return true;
   }
 
   return 0;
 }
 
-void ur_map_free(ur_map **map) {
-  if (map && ur_map_valid(*map)) {
+void ur_map_free(ur_map **map)
+{
+  if (map && ur_map_valid(*map))
+  {
     {
       static int khctest = 0;
-      if (khctest) {
+      if (khctest)
+      {
         kh_clear(3, (*map)->h);
       }
     }
@@ -156,19 +180,28 @@ void ur_map_free(ur_map **map) {
   }
 }
 
-size_t ur_map_size(const ur_map *map) {
-  if (ur_map_valid(map)) {
+size_t ur_map_size(const ur_map *map)
+{
+  if (ur_map_valid(map))
+  {
     return kh_size(map->h);
-  } else {
+  }
+  else
+  {
     return 0;
   }
 }
 
-bool ur_map_foreach(ur_map *map, foreachcb_type func) {
-  if (map && func && ur_map_valid(map)) {
-    for (khiter_t k = kh_begin((*map)->h); k != kh_end(map->h); ++k) {
-      if (kh_exist(map->h, k)) {
-        if (func((ur_map_key_type)(kh_key(map->h, k)), (ur_map_value_type)(kh_value(map->h, k)))) {
+bool ur_map_foreach(ur_map *map, foreachcb_type func)
+{
+  if (map && func && ur_map_valid(map))
+  {
+    for (khiter_t k = kh_begin((*map)->h); k != kh_end(map->h); ++k)
+    {
+      if (kh_exist(map->h, k))
+      {
+        if (func((ur_map_key_type)(kh_key(map->h, k)), (ur_map_value_type)(kh_value(map->h, k))))
+        {
           return true;
         }
       }
@@ -177,11 +210,16 @@ bool ur_map_foreach(ur_map *map, foreachcb_type func) {
   return false;
 }
 
-bool ur_map_foreach_arg(const ur_map *map, foreachcb_arg_type func, void *arg) {
-  if (map && func && ur_map_valid(map)) {
-    for (khiter_t k = kh_begin((*map)->h); k != kh_end(map->h); ++k) {
-      if (kh_exist(map->h, k)) {
-        if (func((ur_map_key_type)(kh_key(map->h, k)), (ur_map_value_type)(kh_value(map->h, k)), arg)) {
+bool ur_map_foreach_arg(const ur_map *map, foreachcb_arg_type func, void *arg)
+{
+  if (map && func && ur_map_valid(map))
+  {
+    for (khiter_t k = kh_begin((*map)->h); k != kh_end(map->h); ++k)
+    {
+      if (kh_exist(map->h, k))
+      {
+        if (func((ur_map_key_type)(kh_key(map->h, k)), (ur_map_value_type)(kh_value(map->h, k)), arg))
+        {
           return true;
         }
       }
@@ -190,16 +228,20 @@ bool ur_map_foreach_arg(const ur_map *map, foreachcb_arg_type func, void *arg) {
   return false;
 }
 
-bool ur_map_lock(const ur_map *map) {
-  if (ur_map_valid(map)) {
+bool ur_map_lock(const ur_map *map)
+{
+  if (ur_map_valid(map))
+  {
     TURN_MUTEX_LOCK((const turn_mutex *)&(map->mutex));
     return true;
   }
   return false;
 }
 
-bool ur_map_unlock(const ur_map *map) {
-  if (ur_map_valid(map)) {
+bool ur_map_unlock(const ur_map *map)
+{
+  if (ur_map_valid(map))
+  {
     TURN_MUTEX_UNLOCK((const turn_mutex *)&(map->mutex));
     return true;
   }
@@ -208,29 +250,36 @@ bool ur_map_unlock(const ur_map *map) {
 
 //////////////////// LOCAL MAPS ////////////////////////////////////
 
-void lm_map_init(lm_map *map) {
-  if (map) {
+void lm_map_init(lm_map *map)
+{
+  if (map)
+  {
     memset(map, 0, sizeof(lm_map));
   }
 }
 
-bool lm_map_put(lm_map *map, ur_map_key_type key, ur_map_value_type value) {
-  if (!map || !key || !value) {
+bool lm_map_put(lm_map *map, ur_map_key_type key, ur_map_value_type value)
+{
+  if (!map || !key || !value)
+  {
     return false;
   }
 
   size_t index = (size_t)(key & (LM_MAP_HASH_SIZE - 1));
   lm_map_array *a = &(map->table[index]);
 
-  for (size_t i = 0; i < LM_MAP_ARRAY_SIZE; ++i) {
+  for (size_t i = 0; i < LM_MAP_ARRAY_SIZE; ++i)
+  {
     ur_map_key_type key0 = a->main_keys[i];
     ur_map_value_type value0 = a->main_values[i];
 
-    if (key0 == key) {
+    if (key0 == key)
+    {
       return value0 == value;
     }
 
-    if (!key0 || !value0) {
+    if (!key0 || !value0)
+    {
       a->main_keys[i] = key;
       a->main_values[i] = value;
       return true;
@@ -238,22 +287,30 @@ bool lm_map_put(lm_map *map, ur_map_key_type key, ur_map_value_type value) {
   }
 
   size_t esz = a->extra_sz;
-  if (esz && a->extra_keys && a->extra_values) {
-    for (size_t i = 0; i < esz; ++i) {
+  if (esz && a->extra_keys && a->extra_values)
+  {
+    for (size_t i = 0; i < esz; ++i)
+    {
       ur_map_key_type *keyp = a->extra_keys[i];
       ur_map_value_type *valuep = a->extra_values[i];
-      if (keyp && valuep) {
-        if (!(*keyp) || !(*valuep)) {
+      if (keyp && valuep)
+      {
+        if (!(*keyp) || !(*valuep))
+        {
           *keyp = key;
           *valuep = value;
           return true;
         }
-      } else {
-        if (!(*keyp)) {
+      }
+      else
+      {
+        if (!(*keyp))
+        {
           a->extra_keys[i] = (ur_map_key_type *)malloc(sizeof(ur_map_key_type));
           keyp = a->extra_keys[i];
         }
-        if (!(*valuep)) {
+        if (!(*valuep))
+        {
           a->extra_values[i] = (ur_map_value_type *)malloc(sizeof(ur_map_value_type));
           valuep = a->extra_values[i];
         }
@@ -280,18 +337,23 @@ bool lm_map_put(lm_map *map, ur_map_key_type key, ur_map_value_type value) {
   return true;
 }
 
-bool lm_map_get(const lm_map *map, ur_map_key_type key, ur_map_value_type *value) {
-  if (!map || !key) {
+bool lm_map_get(const lm_map *map, ur_map_key_type key, ur_map_value_type *value)
+{
+  if (!map || !key)
+  {
     return false;
   }
 
   size_t index = (size_t)(key & (LM_MAP_HASH_SIZE - 1));
   const lm_map_array *a = &(map->table[index]);
 
-  for (size_t i = 0; i < LM_MAP_ARRAY_SIZE; ++i) {
+  for (size_t i = 0; i < LM_MAP_ARRAY_SIZE; ++i)
+  {
     ur_map_key_type key0 = a->main_keys[i];
-    if ((key0 == key) && a->main_values[i]) {
-      if (value) {
+    if ((key0 == key) && a->main_values[i])
+    {
+      if (value)
+      {
         *value = a->main_values[i];
       }
       return true;
@@ -299,13 +361,18 @@ bool lm_map_get(const lm_map *map, ur_map_key_type key, ur_map_value_type *value
   }
 
   size_t esz = a->extra_sz;
-  if (esz && a->extra_keys && a->extra_values) {
-    for (size_t i = 0; i < esz; ++i) {
+  if (esz && a->extra_keys && a->extra_values)
+  {
+    for (size_t i = 0; i < esz; ++i)
+    {
       ur_map_key_type *keyp = a->extra_keys[i];
       ur_map_value_type *valuep = a->extra_values[i];
-      if (keyp && valuep) {
-        if (*keyp == key) {
-          if (value) {
+      if (keyp && valuep)
+      {
+        if (*keyp == key)
+        {
+          if (value)
+          {
             *value = *valuep;
           }
           return true;
@@ -317,19 +384,24 @@ bool lm_map_get(const lm_map *map, ur_map_key_type key, ur_map_value_type *value
   return false;
 }
 
-bool lm_map_del(lm_map *map, ur_map_key_type key, ur_map_del_func delfunc) {
-  if (!map || !key) {
+bool lm_map_del(lm_map *map, ur_map_key_type key, ur_map_del_func delfunc)
+{
+  if (!map || !key)
+  {
     return false;
   }
 
   size_t index = (size_t)(key & (LM_MAP_HASH_SIZE - 1));
   lm_map_array *a = &(map->table[index]);
 
-  for (size_t i = 0; i < LM_MAP_ARRAY_SIZE; ++i) {
+  for (size_t i = 0; i < LM_MAP_ARRAY_SIZE; ++i)
+  {
     ur_map_key_type key0 = a->main_keys[i];
 
-    if ((key0 == key) && a->main_values[i]) {
-      if (delfunc) {
+    if ((key0 == key) && a->main_values[i])
+    {
+      if (delfunc)
+      {
         delfunc(a->main_values[i]);
       }
       a->main_keys[i] = 0;
@@ -339,13 +411,18 @@ bool lm_map_del(lm_map *map, ur_map_key_type key, ur_map_del_func delfunc) {
   }
 
   size_t esz = a->extra_sz;
-  if (esz && a->extra_keys && a->extra_values) {
-    for (size_t i = 0; i < esz; ++i) {
+  if (esz && a->extra_keys && a->extra_values)
+  {
+    for (size_t i = 0; i < esz; ++i)
+    {
       ur_map_key_type *keyp = a->extra_keys[i];
       ur_map_value_type *valuep = a->extra_values[i];
-      if (keyp && valuep) {
-        if (*keyp == key) {
-          if (delfunc) {
+      if (keyp && valuep)
+      {
+        if (*keyp == key)
+        {
+          if (delfunc)
+          {
             delfunc(*valuep);
           }
           *keyp = 0;
@@ -361,16 +438,22 @@ bool lm_map_del(lm_map *map, ur_map_key_type key, ur_map_del_func delfunc) {
 
 bool lm_map_exist(const lm_map *map, ur_map_key_type key) { return lm_map_get(map, key, NULL); }
 
-void lm_map_clean(lm_map *map) {
-  for (size_t j = 0; j < LM_MAP_HASH_SIZE; ++j) {
+void lm_map_clean(lm_map *map)
+{
+  for (size_t j = 0; j < LM_MAP_HASH_SIZE; ++j)
+  {
     lm_map_array *a = &(map->table[j]);
 
     size_t esz = a->extra_sz;
-    if (esz) {
-      if (a->extra_keys) {
-        for (size_t i = 0; i < esz; ++i) {
+    if (esz)
+    {
+      if (a->extra_keys)
+      {
+        for (size_t i = 0; i < esz; ++i)
+        {
           ur_map_key_type *keyp = a->extra_keys[i];
-          if (keyp) {
+          if (keyp)
+          {
             *keyp = 0;
             free(keyp);
           }
@@ -378,10 +461,13 @@ void lm_map_clean(lm_map *map) {
         free(a->extra_keys);
         a->extra_keys = NULL;
       }
-      if (a->extra_values) {
-        for (size_t i = 0; i < esz; ++i) {
+      if (a->extra_values)
+      {
+        for (size_t i = 0; i < esz; ++i)
+        {
           ur_map_value_type *valuep = a->extra_values[i];
-          if (valuep) {
+          if (valuep)
+          {
             *valuep = 0;
             free(valuep);
           }
@@ -395,26 +481,34 @@ void lm_map_clean(lm_map *map) {
   lm_map_init(map);
 }
 
-size_t lm_map_size(const lm_map *map) {
+size_t lm_map_size(const lm_map *map)
+{
 
-  if (!map) {
+  if (!map)
+  {
     return 0;
   }
 
   size_t ret = 0;
-  for (size_t i = 0; i < LM_MAP_HASH_SIZE; ++i) {
+  for (size_t i = 0; i < LM_MAP_HASH_SIZE; ++i)
+  {
     const lm_map_array *a = &(map->table[i]);
 
-    for (size_t j = 0; j < LM_MAP_ARRAY_SIZE; ++j) {
-      if (a->main_keys[j] && a->main_values[j]) {
+    for (size_t j = 0; j < LM_MAP_ARRAY_SIZE; ++j)
+    {
+      if (a->main_keys[j] && a->main_values[j])
+      {
         ++ret;
       }
     }
 
     size_t esz = a->extra_sz;
-    if (esz && a->extra_values && a->extra_keys) {
-      for (size_t j = 0; j < esz; ++j) {
-        if (*(a->extra_keys[j]) && *(a->extra_values[j])) {
+    if (esz && a->extra_values && a->extra_keys)
+    {
+      for (size_t j = 0; j < esz; ++j)
+      {
+        if (*(a->extra_keys[j]) && *(a->extra_values[j]))
+        {
           ++ret;
         }
       }
@@ -424,27 +518,37 @@ size_t lm_map_size(const lm_map *map) {
   return ret;
 }
 
-bool lm_map_foreach(lm_map *map, foreachcb_type func) {
-  if (!map) {
+bool lm_map_foreach(lm_map *map, foreachcb_type func)
+{
+  if (!map)
+  {
     return false;
   }
 
-  for (size_t i = 0; i < LM_MAP_HASH_SIZE; ++i) {
+  for (size_t i = 0; i < LM_MAP_HASH_SIZE; ++i)
+  {
     lm_map_array *a = &(map->table[i]);
 
-    for (size_t j = 0; j < LM_MAP_ARRAY_SIZE; ++j) {
-      if (a->main_keys[j] && a->main_values[j]) {
-        if (func((ur_map_key_type)a->main_keys[j], (ur_map_value_type)a->main_values[j])) {
+    for (size_t j = 0; j < LM_MAP_ARRAY_SIZE; ++j)
+    {
+      if (a->main_keys[j] && a->main_values[j])
+      {
+        if (func((ur_map_key_type)a->main_keys[j], (ur_map_value_type)a->main_values[j]))
+        {
           return true;
         }
       }
     }
 
     size_t esz = a->extra_sz;
-    if (esz && a->extra_values && a->extra_keys) {
-      for (size_t j = 0; j < esz; ++j) {
-        if (*(a->extra_keys[j]) && *(a->extra_values[j])) {
-          if (func((ur_map_key_type) * (a->extra_keys[j]), (ur_map_value_type) * (a->extra_values[j]))) {
+    if (esz && a->extra_values && a->extra_keys)
+    {
+      for (size_t j = 0; j < esz; ++j)
+      {
+        if (*(a->extra_keys[j]) && *(a->extra_values[j]))
+        {
+          if (func((ur_map_key_type) * (a->extra_keys[j]), (ur_map_value_type) * (a->extra_values[j])))
+          {
             return true;
           }
         }
@@ -455,27 +559,37 @@ bool lm_map_foreach(lm_map *map, foreachcb_type func) {
   return false;
 }
 
-bool lm_map_foreach_arg(lm_map *map, foreachcb_arg_type func, void *arg) {
-  if (!map) {
+bool lm_map_foreach_arg(lm_map *map, foreachcb_arg_type func, void *arg)
+{
+  if (!map)
+  {
     return false;
   }
 
-  for (size_t i = 0; i < LM_MAP_HASH_SIZE; ++i) {
+  for (size_t i = 0; i < LM_MAP_HASH_SIZE; ++i)
+  {
     lm_map_array *a = &(map->table[i]);
 
-    for (size_t j = 0; j < LM_MAP_ARRAY_SIZE; ++j) {
-      if (a->main_keys[j] && a->main_values[j]) {
-        if (func((ur_map_key_type)a->main_keys[j], (ur_map_value_type)a->main_values[j], arg)) {
+    for (size_t j = 0; j < LM_MAP_ARRAY_SIZE; ++j)
+    {
+      if (a->main_keys[j] && a->main_values[j])
+      {
+        if (func((ur_map_key_type)a->main_keys[j], (ur_map_value_type)a->main_values[j], arg))
+        {
           return true;
         }
       }
     }
 
     size_t esz = a->extra_sz;
-    if (esz && a->extra_values && a->extra_keys) {
-      for (size_t j = 0; j < esz; ++j) {
-        if (*(a->extra_keys[j]) && *(a->extra_values[j])) {
-          if (func((ur_map_key_type) * (a->extra_keys[j]), (ur_map_value_type) * (a->extra_values[j]), arg)) {
+    if (esz && a->extra_values && a->extra_keys)
+    {
+      for (size_t j = 0; j < esz; ++j)
+      {
+        if (*(a->extra_keys[j]) && *(a->extra_values[j]))
+        {
+          if (func((ur_map_key_type) * (a->extra_keys[j]), (ur_map_value_type) * (a->extra_values[j]), arg))
+          {
             return true;
           }
         }
@@ -488,39 +602,50 @@ bool lm_map_foreach_arg(lm_map *map, foreachcb_arg_type func, void *arg) {
 
 ////////////////////  ADDR LISTS ///////////////////////////////////
 
-static void addr_list_free(addr_list_header *slh) {
-  if (slh) {
-    if (slh->extra_list) {
+static void addr_list_free(addr_list_header *slh)
+{
+  if (slh)
+  {
+    if (slh->extra_list)
+    {
       free(slh->extra_list);
     }
     memset(slh, 0, sizeof(addr_list_header));
   }
 }
 
-static void addr_list_add(addr_list_header *slh, const ioa_addr *key, ur_addr_map_value_type value) {
-  if (!key || !value) {
+static void addr_list_add(addr_list_header *slh, const ioa_addr *key, ur_addr_map_value_type value)
+{
+  if (!key || !value)
+  {
     return;
   }
 
   addr_elem *elem = NULL;
 
-  for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i) {
-    if (!(slh->main_list[i].value)) {
+  for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i)
+  {
+    if (!(slh->main_list[i].value))
+    {
       elem = &(slh->main_list[i]);
       break;
     }
   }
 
-  if (!elem && slh->extra_list) {
-    for (size_t i = 0; i < slh->extra_sz; ++i) {
-      if (!(slh->extra_list[i].value)) {
+  if (!elem && slh->extra_list)
+  {
+    for (size_t i = 0; i < slh->extra_sz; ++i)
+    {
+      if (!(slh->extra_list[i].value))
+      {
         elem = &(slh->extra_list[i]);
         break;
       }
     }
   }
 
-  if (!elem) {
+  if (!elem)
+  {
     size_t old_sz = slh->extra_sz;
     size_t old_sz_mem = old_sz * sizeof(addr_elem);
     slh->extra_list = (addr_elem *)realloc(slh->extra_list, old_sz_mem + sizeof(addr_elem));
@@ -532,40 +657,54 @@ static void addr_list_add(addr_list_header *slh, const ioa_addr *key, ur_addr_ma
   elem->value = value;
 }
 
-static void addr_list_remove(addr_list_header *slh, const ioa_addr *key, ur_addr_map_func delfunc, int *counter) {
-  if (!slh || !key) {
+static void addr_list_remove(addr_list_header *slh, const ioa_addr *key, ur_addr_map_func delfunc, int *counter)
+{
+  if (!slh || !key)
+  {
     return;
   }
 
-  if (counter) {
+  if (counter)
+  {
     *counter = 0;
   }
 
-  for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i) {
+  for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i)
+  {
     addr_elem *elem = &(slh->main_list[i]);
-    if (elem->value) {
-      if (addr_eq(&(elem->key), key)) {
-        if (delfunc && elem->value) {
+    if (elem->value)
+    {
+      if (addr_eq(&(elem->key), key))
+      {
+        if (delfunc && elem->value)
+        {
           delfunc(elem->value);
         }
         elem->value = 0;
-        if (counter) {
+        if (counter)
+        {
           *counter += 1;
         }
       }
     }
   }
 
-  if (slh->extra_list) {
-    for (size_t i = 0; i < slh->extra_sz; ++i) {
+  if (slh->extra_list)
+  {
+    for (size_t i = 0; i < slh->extra_sz; ++i)
+    {
       addr_elem *elem = &(slh->extra_list[i]);
-      if (elem->value) {
-        if (addr_eq(&(elem->key), key)) {
-          if (delfunc && elem->value) {
+      if (elem->value)
+      {
+        if (addr_eq(&(elem->key), key))
+        {
+          if (delfunc && elem->value)
+          {
             delfunc(elem->value);
           }
           elem->value = 0;
-          if (counter) {
+          if (counter)
+          {
             *counter += 1;
           }
         }
@@ -574,20 +713,27 @@ static void addr_list_remove(addr_list_header *slh, const ioa_addr *key, ur_addr
   }
 }
 
-static void addr_list_foreach(addr_list_header *slh, ur_addr_map_func func) {
-  if (slh && func) {
+static void addr_list_foreach(addr_list_header *slh, ur_addr_map_func func)
+{
+  if (slh && func)
+  {
 
-    for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i) {
+    for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i)
+    {
       addr_elem *elem = &(slh->main_list[i]);
-      if (elem->value) {
+      if (elem->value)
+      {
         func(elem->value);
       }
     }
 
-    if (slh->extra_list) {
-      for (size_t i = 0; i < slh->extra_sz; ++i) {
+    if (slh->extra_list)
+    {
+      for (size_t i = 0; i < slh->extra_sz; ++i)
+      {
         addr_elem *elem = &(slh->extra_list[i]);
-        if (elem->value) {
+        if (elem->value)
+        {
           func(elem->value);
         }
       }
@@ -595,21 +741,28 @@ static void addr_list_foreach(addr_list_header *slh, ur_addr_map_func func) {
   }
 }
 
-static size_t addr_list_num_elements(const addr_list_header *slh) {
+static size_t addr_list_num_elements(const addr_list_header *slh)
+{
   size_t ret = 0;
 
-  if (slh) {
-    for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i) {
+  if (slh)
+  {
+    for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i)
+    {
       const addr_elem *elem = &(slh->main_list[i]);
-      if (elem->value) {
+      if (elem->value)
+      {
         ++ret;
       }
     }
 
-    if (slh->extra_list) {
-      for (size_t i = 0; i < slh->extra_sz; ++i) {
+    if (slh->extra_list)
+    {
+      for (size_t i = 0; i < slh->extra_sz; ++i)
+      {
         addr_elem *elem = &(slh->extra_list[i]);
-        if (elem->value) {
+        if (elem->value)
+        {
           ++ret;
         }
       }
@@ -619,33 +772,44 @@ static size_t addr_list_num_elements(const addr_list_header *slh) {
   return ret;
 }
 
-static size_t addr_list_size(const addr_list_header *slh) {
-  if (slh) {
+static size_t addr_list_size(const addr_list_header *slh)
+{
+  if (slh)
+  {
     return ADDR_ARRAY_SIZE + slh->extra_sz;
   }
 
   return 0;
 }
 
-static addr_elem *addr_list_get(addr_list_header *slh, const ioa_addr *key) {
-  if (!slh || !key) {
+static addr_elem *addr_list_get(addr_list_header *slh, const ioa_addr *key)
+{
+  if (!slh || !key)
+  {
     return NULL;
   }
 
-  for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i) {
+  for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i)
+  {
     addr_elem *elem = &(slh->main_list[i]);
-    if (elem->value) {
-      if (addr_eq(&(elem->key), key)) {
+    if (elem->value)
+    {
+      if (addr_eq(&(elem->key), key))
+      {
         return elem;
       }
     }
   }
 
-  if (slh->extra_list) {
-    for (size_t i = 0; i < slh->extra_sz; ++i) {
+  if (slh->extra_list)
+  {
+    for (size_t i = 0; i < slh->extra_sz; ++i)
+    {
       addr_elem *elem = &(slh->extra_list[i]);
-      if (elem->value) {
-        if (addr_eq(&(elem->key), key)) {
+      if (elem->value)
+      {
+        if (addr_eq(&(elem->key), key))
+        {
           return elem;
         }
       }
@@ -655,25 +819,34 @@ static addr_elem *addr_list_get(addr_list_header *slh, const ioa_addr *key) {
   return NULL;
 }
 
-static const addr_elem *addr_list_get_const(const addr_list_header *slh, const ioa_addr *key) {
-  if (!slh || !key) {
+static const addr_elem *addr_list_get_const(const addr_list_header *slh, const ioa_addr *key)
+{
+  if (!slh || !key)
+  {
     return NULL;
   }
 
-  for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i) {
+  for (size_t i = 0; i < ADDR_ARRAY_SIZE; ++i)
+  {
     const addr_elem *elem = &(slh->main_list[i]);
-    if (elem->value) {
-      if (addr_eq(&(elem->key), key)) {
+    if (elem->value)
+    {
+      if (addr_eq(&(elem->key), key))
+      {
         return elem;
       }
     }
   }
 
-  if (slh->extra_list) {
-    for (size_t i = 0; i < slh->extra_sz; ++i) {
+  if (slh->extra_list)
+  {
+    for (size_t i = 0; i < slh->extra_sz; ++i)
+    {
       const addr_elem *elem = &(slh->extra_list[i]);
-      if (elem->value) {
-        if (addr_eq(&(elem->key), key)) {
+      if (elem->value)
+      {
+        if (addr_eq(&(elem->key), key))
+        {
           return elem;
         }
       }
@@ -691,35 +864,46 @@ static const addr_elem *addr_list_get_const(const addr_list_header *slh, const i
 
 #define ur_addr_map_valid(map) ((map) && ((map)->magic == MAGIC_HASH))
 
-void ur_addr_map_init(ur_addr_map *map) {
-  if (map) {
+void ur_addr_map_init(ur_addr_map *map)
+{
+  if (map)
+  {
     memset(map, 0, sizeof(ur_addr_map));
     map->magic = MAGIC_HASH;
   }
 }
 
-void ur_addr_map_clean(ur_addr_map *map) {
-  if (map && ur_addr_map_valid(map)) {
-    for (size_t i = 0; i < ADDR_MAP_SIZE; i++) {
+void ur_addr_map_clean(ur_addr_map *map)
+{
+  if (map && ur_addr_map_valid(map))
+  {
+    for (size_t i = 0; i < ADDR_MAP_SIZE; i++)
+    {
       addr_list_free(&(map->lists[i]));
     }
     memset(map, 0, sizeof(ur_addr_map));
   }
 }
 
-bool ur_addr_map_put(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type value) {
-  if (!ur_addr_map_valid(map)) {
+bool ur_addr_map_put(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type value)
+{
+  if (!ur_addr_map_valid(map))
+  {
     return false;
   }
 
-  else {
+  else
+  {
 
     addr_list_header *slh = get_addr_list_header(map, key);
 
     addr_elem *elem = addr_list_get(slh, key);
-    if (elem) {
+    if (elem)
+    {
       elem->value = value;
-    } else {
+    }
+    else
+    {
       addr_list_add(slh, key, value);
     }
 
@@ -727,15 +911,19 @@ bool ur_addr_map_put(ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type val
   }
 }
 
-bool ur_addr_map_get(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type *value) {
-  if (!ur_addr_map_valid(map)) {
+bool ur_addr_map_get(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_type *value)
+{
+  if (!ur_addr_map_valid(map))
+  {
     return false;
   }
 
   const addr_list_header *slh = get_addr_list_header(map, key);
   const addr_elem *elem = addr_list_get_const(slh, key);
-  if (elem) {
-    if (value) {
+  if (elem)
+  {
+    if (value)
+    {
       *value = elem->value;
     }
     return true;
@@ -743,8 +931,10 @@ bool ur_addr_map_get(const ur_addr_map *map, ioa_addr *key, ur_addr_map_value_ty
   return false;
 }
 
-bool ur_addr_map_del(ur_addr_map *map, ioa_addr *key, ur_addr_map_func delfunc) {
-  if (!ur_addr_map_valid(map)) {
+bool ur_addr_map_del(ur_addr_map *map, ioa_addr *key, ur_addr_map_func delfunc)
+{
+  if (!ur_addr_map_valid(map))
+  {
     return false;
   }
 
@@ -756,22 +946,28 @@ bool ur_addr_map_del(ur_addr_map *map, ioa_addr *key, ur_addr_map_func delfunc) 
   return (counter > 0);
 }
 
-void ur_addr_map_foreach(ur_addr_map *map, ur_addr_map_func func) {
-  if (ur_addr_map_valid(map)) {
-    for (size_t i = 0; i < ADDR_MAP_SIZE; i++) {
+void ur_addr_map_foreach(ur_addr_map *map, ur_addr_map_func func)
+{
+  if (ur_addr_map_valid(map))
+  {
+    for (size_t i = 0; i < ADDR_MAP_SIZE; i++)
+    {
       addr_list_header *slh = &(map->lists[i]);
       addr_list_foreach(slh, func);
     }
   }
 }
 
-size_t ur_addr_map_num_elements(const ur_addr_map *map) {
-  if (!ur_addr_map_valid(map)) {
+size_t ur_addr_map_num_elements(const ur_addr_map *map)
+{
+  if (!ur_addr_map_valid(map))
+  {
     return 0;
   }
 
   size_t ret = 0;
-  for (size_t i = 0; i < ADDR_MAP_SIZE; i++) {
+  for (size_t i = 0; i < ADDR_MAP_SIZE; i++)
+  {
     const addr_list_header *slh = &(map->lists[i]);
     ret += addr_list_num_elements(slh);
   }
@@ -779,13 +975,16 @@ size_t ur_addr_map_num_elements(const ur_addr_map *map) {
   return ret;
 }
 
-size_t ur_addr_map_size(const ur_addr_map *map) {
-  if (!ur_addr_map_valid(map)) {
+size_t ur_addr_map_size(const ur_addr_map *map)
+{
+  if (!ur_addr_map_valid(map))
+  {
     return 0;
   }
 
   size_t ret = 0;
-  for (size_t i = 0; i < ADDR_MAP_SIZE; i++) {
+  for (size_t i = 0; i < ADDR_MAP_SIZE; i++)
+  {
     const addr_list_header *slh = &(map->lists[i]);
     ret += addr_list_size(slh);
   }
@@ -795,38 +994,48 @@ size_t ur_addr_map_size(const ur_addr_map *map) {
 
 ////////////////////  STRING LISTS ///////////////////////////////////
 
-typedef struct _string_list {
+typedef struct _string_list
+{
   struct _string_list *next;
 } string_list;
 
-typedef struct _string_elem {
+typedef struct _string_elem
+{
   string_list list;
   ur_string_map_key_type key;
   uint32_t key_size;
   ur_string_map_value_type value;
 } string_elem;
 
-typedef struct _string_list_header {
+typedef struct _string_list_header
+{
   string_list *list;
 } string_list_header;
 
-static size_t string_list_size(const string_list *sl) {
-  if (!sl) {
+static size_t string_list_size(const string_list *sl)
+{
+  if (!sl)
+  {
     return 0;
   }
   return 1 + string_list_size(sl->next);
 }
 
-static void string_list_free(string_list_header *slh, ur_string_map_func del_value_func) {
-  if (slh) {
+static void string_list_free(string_list_header *slh, ur_string_map_func del_value_func)
+{
+  if (slh)
+  {
     string_list *list = slh->list;
-    while (list) {
+    while (list)
+    {
       string_elem *elem = (string_elem *)list;
       string_list *tail = elem->list.next;
-      if (elem->key) {
+      if (elem->key)
+      {
         free(elem->key);
       }
-      if (del_value_func && elem->value) {
+      if (del_value_func && elem->value)
+      {
         del_value_func(elem->value);
       }
       free(elem);
@@ -836,18 +1045,22 @@ static void string_list_free(string_list_header *slh, ur_string_map_func del_val
   }
 }
 
-static string_list *string_list_add(string_list *sl, const ur_string_map_key_type key, ur_string_map_value_type value) {
-  if (!key) {
+static string_list *string_list_add(string_list *sl, const ur_string_map_key_type key, ur_string_map_value_type value)
+{
+  if (!key)
+  {
     return sl;
   }
   string_elem *elem = (string_elem *)malloc(sizeof(string_elem));
-  if (!elem) {
+  if (!elem)
+  {
     return sl;
   }
   elem->list.next = sl;
   elem->key_size = strlen(key) + 1;
   elem->key = (char *)malloc(elem->key_size);
-  if (!elem->key) {
+  if (!elem->key)
+  {
     free(elem);
     return sl;
   }
@@ -857,37 +1070,49 @@ static string_list *string_list_add(string_list *sl, const ur_string_map_key_typ
 }
 
 static string_list *string_list_remove(string_list *sl, const ur_string_map_key_type key,
-                                       ur_string_map_func del_value_func, int *counter) {
-  if (!sl || !key) {
+                                       ur_string_map_func del_value_func, int *counter)
+{
+  if (!sl || !key)
+  {
     return sl;
   }
   string_elem *elem = (string_elem *)sl;
   string_list *tail = elem->list.next;
-  if (strcmp(elem->key, key) == 0) {
+  if (strcmp(elem->key, key) == 0)
+  {
     free(elem->key);
-    if (del_value_func) {
+    if (del_value_func)
+    {
       del_value_func(elem->value);
     }
     free(elem);
-    if (counter) {
+    if (counter)
+    {
       *counter += 1;
     }
     sl = string_list_remove(tail, key, del_value_func, counter);
-  } else {
+  }
+  else
+  {
     elem->list.next = string_list_remove(tail, key, del_value_func, counter);
   }
   return sl;
 }
 
-static string_elem *string_list_get(string_list *sl, const ur_string_map_key_type key) {
-  if (!sl || !key) {
+static string_elem *string_list_get(string_list *sl, const ur_string_map_key_type key)
+{
+  if (!sl || !key)
+  {
     return NULL;
   }
 
   string_elem *elem = (string_elem *)sl;
-  if (strcmp(elem->key, key) == 0) {
+  if (strcmp(elem->key, key) == 0)
+  {
     return elem;
-  } else {
+  }
+  else
+  {
     return string_list_get(elem->list.next, key);
   }
 }
@@ -896,21 +1121,24 @@ static string_elem *string_list_get(string_list *sl, const ur_string_map_key_typ
 
 #define STRING_MAP_SIZE (1024)
 
-struct _ur_string_map {
+struct _ur_string_map
+{
   string_list_header lists[STRING_MAP_SIZE];
   uint64_t magic;
   ur_string_map_func del_value_func;
   TURN_MUTEX_DECLARE(mutex)
 };
 
-static uint32_t string_hash(const ur_string_map_key_type key) {
+static uint32_t string_hash(const ur_string_map_key_type key)
+{
 
   uint8_t *str = (uint8_t *)key;
 
   uint32_t hash = 0;
   int c = 0;
 
-  while ((c = *str++)) {
+  while ((c = *str++))
+  {
     hash = c + (hash << 6) + (hash << 16) - hash;
   }
 
@@ -919,12 +1147,15 @@ static uint32_t string_hash(const ur_string_map_key_type key) {
 
 static size_t string_map_index(const ur_string_map_key_type key) { return string_hash(key) % STRING_MAP_SIZE; }
 
-static string_list_header *get_string_list_header(ur_string_map *map, const ur_string_map_key_type key) {
+static string_list_header *get_string_list_header(ur_string_map *map, const ur_string_map_key_type key)
+{
   return &(map->lists[string_map_index(key)]);
 }
 
-static bool ur_string_map_init(ur_string_map *map) {
-  if (map) {
+static bool ur_string_map_init(ur_string_map *map)
+{
+  if (map)
+  {
     memset(map, 0, sizeof(ur_string_map));
     map->magic = MAGIC_HASH;
 
@@ -937,9 +1168,11 @@ static bool ur_string_map_init(ur_string_map *map) {
 
 #define ur_string_map_valid(map) ((map) && ((map)->magic == MAGIC_HASH))
 
-ur_string_map *ur_string_map_create(ur_string_map_func del_value_func) {
+ur_string_map *ur_string_map_create(ur_string_map_func del_value_func)
+{
   ur_string_map *map = (ur_string_map *)malloc(sizeof(ur_string_map));
-  if (!ur_string_map_init(map)) {
+  if (!ur_string_map_init(map))
+  {
     free(map);
     return NULL;
   }
@@ -947,17 +1180,22 @@ ur_string_map *ur_string_map_create(ur_string_map_func del_value_func) {
   return map;
 }
 
-bool ur_string_map_put(ur_string_map *map, const ur_string_map_key_type key, ur_string_map_value_type value) {
+bool ur_string_map_put(ur_string_map *map, const ur_string_map_key_type key, ur_string_map_value_type value)
+{
 
-  if (!ur_string_map_valid(map)) {
+  if (!ur_string_map_valid(map))
+  {
     return false;
   }
 
   string_list_header *slh = get_string_list_header(map, key);
   string_elem *elem = string_list_get(slh->list, key);
-  if (elem) {
-    if (elem->value != value) {
-      if (map->del_value_func) {
+  if (elem)
+  {
+    if (elem->value != value)
+    {
+      if (map->del_value_func)
+      {
         map->del_value_func(elem->value);
       }
       elem->value = value;
@@ -969,27 +1207,35 @@ bool ur_string_map_put(ur_string_map *map, const ur_string_map_key_type key, ur_
   return true;
 }
 
-bool ur_string_map_get(ur_string_map *map, const ur_string_map_key_type key, ur_string_map_value_type *value) {
+bool ur_string_map_get(ur_string_map *map, const ur_string_map_key_type key, ur_string_map_value_type *value)
+{
 
-  if (!ur_string_map_valid(map)) {
+  if (!ur_string_map_valid(map))
+  {
     return false;
   }
 
   string_list_header *slh = get_string_list_header(map, key);
   string_elem *elem = string_list_get(slh->list, key);
-  if (elem) {
-    if (value) {
+  if (elem)
+  {
+    if (value)
+    {
       *value = elem->value;
     }
     return true;
-  } else {
+  }
+  else
+  {
     return false;
   }
 }
 
-bool ur_string_map_del(ur_string_map *map, const ur_string_map_key_type key) {
+bool ur_string_map_del(ur_string_map *map, const ur_string_map_key_type key)
+{
 
-  if (!ur_string_map_valid(map)) {
+  if (!ur_string_map_valid(map))
+  {
     return false;
   }
 
@@ -1000,17 +1246,23 @@ bool ur_string_map_del(ur_string_map *map, const ur_string_map_key_type key) {
   return (counter > 0);
 }
 
-void ur_string_map_clean(ur_string_map *map) {
-  if (ur_string_map_valid(map)) {
-    for (size_t i = 0; i < STRING_MAP_SIZE; ++i) {
+void ur_string_map_clean(ur_string_map *map)
+{
+  if (ur_string_map_valid(map))
+  {
+    for (size_t i = 0; i < STRING_MAP_SIZE; ++i)
+    {
       string_list_free(&(map->lists[i]), map->del_value_func);
     }
   }
 }
 
-void ur_string_map_free(ur_string_map **map) {
-  if (map && ur_string_map_valid(*map)) {
-    for (size_t i = 0; i < STRING_MAP_SIZE; ++i) {
+void ur_string_map_free(ur_string_map **map)
+{
+  if (map && ur_string_map_valid(*map))
+  {
+    for (size_t i = 0; i < STRING_MAP_SIZE; ++i)
+    {
       string_list_free(&((*map)->lists[i]), (*map)->del_value_func);
     }
     (*map)->magic = 0;
@@ -1020,28 +1272,35 @@ void ur_string_map_free(ur_string_map **map) {
   }
 }
 
-size_t ur_string_map_size(const ur_string_map *map) {
-  if (!ur_string_map_valid(map)) {
+size_t ur_string_map_size(const ur_string_map *map)
+{
+  if (!ur_string_map_valid(map))
+  {
     return 0;
   }
 
   size_t ret = 0;
-  for (size_t i = 0; i < STRING_MAP_SIZE; ++i) {
+  for (size_t i = 0; i < STRING_MAP_SIZE; ++i)
+  {
     ret += string_list_size(map->lists[i].list);
   }
   return ret;
 }
 
-bool ur_string_map_lock(const ur_string_map *map) {
-  if (ur_string_map_valid(map)) {
+bool ur_string_map_lock(const ur_string_map *map)
+{
+  if (ur_string_map_valid(map))
+  {
     TURN_MUTEX_LOCK((const turn_mutex *)&(map->mutex));
     return true;
   }
   return false;
 }
 
-bool ur_string_map_unlock(const ur_string_map *map) {
-  if (ur_string_map_valid(map)) {
+bool ur_string_map_unlock(const ur_string_map *map)
+{
+  if (ur_string_map_valid(map))
+  {
     TURN_MUTEX_UNLOCK((const turn_mutex *)&(map->mutex));
     return true;
   }

--- a/src/server/ns_turn_maps.h
+++ b/src/server/ns_turn_maps.h
@@ -37,7 +37,8 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////////// UR MAP //////////////////
@@ -124,7 +125,8 @@ bool ur_map_unlock(const ur_map *map);
 #define LM_MAP_HASH_SIZE (8)
 #define LM_MAP_ARRAY_SIZE (3)
 
-typedef struct _lm_map_array {
+typedef struct _lm_map_array
+{
   ur_map_key_type main_keys[LM_MAP_ARRAY_SIZE];
   ur_map_value_type main_values[LM_MAP_ARRAY_SIZE];
   size_t extra_sz;
@@ -132,7 +134,8 @@ typedef struct _lm_map_array {
   ur_map_value_type **extra_values;
 } lm_map_array;
 
-typedef struct _lm_map {
+typedef struct _lm_map
+{
   lm_map_array table[LM_MAP_HASH_SIZE];
 } lm_map;
 
@@ -191,18 +194,21 @@ typedef uintptr_t ur_addr_map_value_type;
 #define ADDR_MAP_SIZE (1024)
 #define ADDR_ARRAY_SIZE (4)
 
-typedef struct _addr_elem {
+typedef struct _addr_elem
+{
   ioa_addr key;
   ur_addr_map_value_type value;
 } addr_elem;
 
-typedef struct _addr_list_header {
+typedef struct _addr_list_header
+{
   addr_elem main_list[ADDR_ARRAY_SIZE];
   addr_elem *extra_list;
   size_t extra_sz;
 } addr_list_header;
 
-struct _ur_addr_map {
+struct _ur_addr_map
+{
   addr_list_header lists[ADDR_MAP_SIZE];
   uint64_t magic;
 };

--- a/src/server/ns_turn_maps_rtcp.h
+++ b/src/server/ns_turn_maps_rtcp.h
@@ -37,7 +37,8 @@
 #include <stddef.h> // for size_t
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////////// RTCP MAP //////////////////

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -53,8 +53,10 @@
 
 ////////////////////////////////////////////////
 
-static inline int get_family(int stun_family, ioa_engine_handle e, ioa_socket_handle client_socket) {
-  switch (stun_family) {
+static inline int get_family(int stun_family, ioa_engine_handle e, ioa_socket_handle client_socket)
+{
+  switch (stun_family)
+  {
   case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4:
     return AF_INET;
     break;
@@ -62,9 +64,12 @@ static inline int get_family(int stun_family, ioa_engine_handle e, ioa_socket_ha
     return AF_INET6;
     break;
   case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_DEFAULT:
-    if (e->default_relays && get_ioa_socket_address_family(client_socket) == AF_INET6) {
+    if (e->default_relays && get_ioa_socket_address_family(client_socket) == AF_INET6)
+    {
       return AF_INET6;
-    } else {
+    }
+    else
+    {
       return AF_INET;
     }
   default:
@@ -74,16 +79,22 @@ static inline int get_family(int stun_family, ioa_engine_handle e, ioa_socket_ha
 
 ////////////////////////////////////////////////
 
-const char *get_version(turn_turnserver *server) {
-  if (server && server->software_attribute) {
+const char *get_version(turn_turnserver *server)
+{
+  if (server && server->software_attribute)
+  {
     return (const char *)TURN_SOFTWARE;
-  } else {
+  }
+  else
+  {
     return (const char *)"None";
   }
 }
 
-static void maybe_add_software_attribute(turn_turnserver *server, ioa_network_buffer_handle nbh) {
-  if (server->software_attribute) {
+static void maybe_add_software_attribute(turn_turnserver *server, ioa_network_buffer_handle nbh)
+{
+  if (server->software_attribute)
+  {
     const char *software = get_version(server);
     size_t fsz = strlen(get_version(server));
     size_t len = ioa_network_buffer_get_size(nbh);
@@ -97,32 +108,45 @@ static void maybe_add_software_attribute(turn_turnserver *server, ioa_network_bu
 int TURN_MAX_ALLOCATE_TIMEOUT = 60;
 int TURN_MAX_ALLOCATE_TIMEOUT_STUN_ONLY = 3;
 
-static inline void log_method(ts_ur_super_session *ss, const char *method, int err_code, const uint8_t *reason) {
-  if (ss) {
-    if (!method) {
+static inline void log_method(ts_ur_super_session *ss, const char *method, int err_code, const uint8_t *reason)
+{
+  if (ss)
+  {
+    if (!method)
+    {
       method = "unknown";
     }
-    if (!err_code) {
-      if (ss->origin[0]) {
+    if (!err_code)
+    {
+      if (ss->origin[0])
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
                       "session %018llu: origin <%s> realm <%s> user <%s>: incoming packet %s processed, success\n",
                       (unsigned long long)(ss->id), (const char *)(ss->origin), (const char *)(ss->realm_options.name),
                       (const char *)(ss->username), method);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(
             TURN_LOG_LEVEL_INFO, "session %018llu: realm <%s> user <%s>: incoming packet %s processed, success\n",
             (unsigned long long)(ss->id), (const char *)(ss->realm_options.name), (const char *)(ss->username), method);
       }
-    } else {
-      if (!reason) {
+    }
+    else
+    {
+      if (!reason)
+      {
         reason = get_default_reason(err_code);
       }
-      if (ss->origin[0]) {
+      if (ss->origin[0])
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
                       "session %018llu: origin <%s> realm <%s> user <%s>: incoming packet %s processed, error %d: %s\n",
                       (unsigned long long)(ss->id), (const char *)(ss->origin), (const char *)(ss->realm_options.name),
                       (const char *)(ss->username), method, err_code, reason);
-      } else {
+      }
+      else
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
                       "session %018llu: realm <%s> user <%s>: incoming packet %s processed, error %d: %s\n",
                       (unsigned long long)(ss->id), (const char *)(ss->realm_options.name),
@@ -162,16 +186,20 @@ static int need_stun_authentication(turn_turnserver *server, ts_ur_super_session
 
 /////////////////// timer //////////////////////////
 
-static void timer_timeout_handler(ioa_engine_handle e, void *arg) {
+static void timer_timeout_handler(ioa_engine_handle e, void *arg)
+{
   UNUSED_ARG(e);
-  if (arg) {
+  if (arg)
+  {
     turn_turnserver *server = (turn_turnserver *)arg;
     server->ctime = turn_time();
   }
 }
 
-turn_time_t get_turn_server_time(turn_turnserver *server) {
-  if (server) {
+turn_time_t get_turn_server_time(turn_turnserver *server)
+{
+  if (server)
+  {
     return server->ctime;
   }
   return turn_time();
@@ -179,20 +207,26 @@ turn_time_t get_turn_server_time(turn_turnserver *server) {
 
 /////////////////// quota //////////////////////
 
-static int inc_quota(ts_ur_super_session *ss, uint8_t *username) {
-  if (ss && !(ss->quota_used) && ss->server && ((turn_turnserver *)ss->server)->chquotacb && username) {
+static int inc_quota(ts_ur_super_session *ss, uint8_t *username)
+{
+  if (ss && !(ss->quota_used) && ss->server && ((turn_turnserver *)ss->server)->chquotacb && username)
+  {
 
-    if (((turn_turnserver *)ss->server)->ct == TURN_CREDENTIALS_LONG_TERM) {
-      if (!(ss->origin_set)) {
+    if (((turn_turnserver *)ss->server)->ct == TURN_CREDENTIALS_LONG_TERM)
+    {
+      if (!(ss->origin_set))
+      {
         return -1;
       }
     }
 
-    if ((((turn_turnserver *)ss->server)->chquotacb)(username, ss->oauth, (uint8_t *)ss->realm_options.name) < 0) {
+    if ((((turn_turnserver *)ss->server)->chquotacb)(username, ss->oauth, (uint8_t *)ss->realm_options.name) < 0)
+    {
 
       return -1;
-
-    } else {
+    }
+    else
+    {
 
       STRCPY(ss->username, username);
 
@@ -203,8 +237,10 @@ static int inc_quota(ts_ur_super_session *ss, uint8_t *username) {
   return 0;
 }
 
-static void dec_quota(ts_ur_super_session *ss) {
-  if (ss && ss->quota_used && ss->server && ((turn_turnserver *)ss->server)->raqcb) {
+static void dec_quota(ts_ur_super_session *ss)
+{
+  if (ss && ss->quota_used && ss->server && ((turn_turnserver *)ss->server)->raqcb)
+  {
 
     ss->quota_used = 0;
 
@@ -212,11 +248,15 @@ static void dec_quota(ts_ur_super_session *ss) {
   }
 }
 
-static void dec_bps(ts_ur_super_session *ss) {
-  if (ss && ss->server) {
+static void dec_bps(ts_ur_super_session *ss)
+{
+  if (ss && ss->server)
+  {
 
-    if (ss->bps) {
-      if (((turn_turnserver *)ss->server)->allocate_bps_func) {
+    if (ss->bps)
+    {
+      if (((turn_turnserver *)ss->server)->allocate_bps_func)
+      {
         ((turn_turnserver *)ss->server)->allocate_bps_func(ss->bps, 0);
       }
       ss->bps = 0;
@@ -226,8 +266,10 @@ static void dec_bps(ts_ur_super_session *ss) {
 
 /////////////////// server lists ///////////////////
 
-void init_turn_server_addrs_list(turn_server_addrs_list_t *l) {
-  if (l) {
+void init_turn_server_addrs_list(turn_server_addrs_list_t *l)
+{
+  if (l)
+  {
     l->addrs = NULL;
     l->size = 0;
     TURN_MUTEX_INIT(&(l->m));
@@ -236,13 +278,18 @@ void init_turn_server_addrs_list(turn_server_addrs_list_t *l) {
 
 /////////////////// RFC 5780 ///////////////////////
 
-void set_rfc5780(turn_turnserver *server, get_alt_addr_cb cb, send_message_cb smcb) {
-  if (server) {
-    if (!cb || !smcb) {
+void set_rfc5780(turn_turnserver *server, get_alt_addr_cb cb, send_message_cb smcb)
+{
+  if (server)
+  {
+    if (!cb || !smcb)
+    {
       server->rfc5780 = 0;
       server->alt_addr_cb = NULL;
       server->sm_cb = NULL;
-    } else {
+    }
+    else
+    {
       server->rfc5780 = 1;
       server->alt_addr_cb = cb;
       server->sm_cb = smcb;
@@ -250,16 +297,20 @@ void set_rfc5780(turn_turnserver *server, get_alt_addr_cb cb, send_message_cb sm
   }
 }
 
-static int is_rfc5780(turn_turnserver *server) {
-  if (!server) {
+static int is_rfc5780(turn_turnserver *server)
+{
+  if (!server)
+  {
     return 0;
   }
 
   return ((server->rfc5780) && (server->alt_addr_cb));
 }
 
-static int get_other_address(turn_turnserver *server, ts_ur_super_session *ss, ioa_addr *alt_addr) {
-  if (is_rfc5780(server) && ss && ss->client_socket) {
+static int get_other_address(turn_turnserver *server, ts_ur_super_session *ss, ioa_addr *alt_addr)
+{
+  if (is_rfc5780(server) && ss && ss->client_socket)
+  {
     int ret = server->alt_addr_cb(get_local_addr_from_ioa_socket(ss->client_socket), alt_addr);
     return ret;
   }
@@ -268,8 +319,10 @@ static int get_other_address(turn_turnserver *server, ts_ur_super_session *ss, i
 }
 
 static int send_turn_message_to(turn_turnserver *server, ioa_network_buffer_handle nbh, ioa_addr *response_origin,
-                                ioa_addr *response_destination) {
-  if (is_rfc5780(server) && nbh && response_origin && response_destination) {
+                                ioa_addr *response_destination)
+{
+  if (is_rfc5780(server) && nbh && response_origin && response_destination)
+  {
     return server->sm_cb(server->e, nbh, response_origin, response_destination);
   }
 
@@ -278,31 +331,39 @@ static int send_turn_message_to(turn_turnserver *server, ioa_network_buffer_hand
 
 /////////////////// Peer addr check /////////////////////////////
 
-static int good_peer_addr(turn_turnserver *server, const char *realm, ioa_addr *peer_addr, turnsession_id session_id) {
+static int good_peer_addr(turn_turnserver *server, const char *realm, ioa_addr *peer_addr, turnsession_id session_id)
+{
 #define CHECK_REALM(r)                                                                                                 \
   if ((r)[0] && realm && realm[0] && strcmp((r), realm))                                                               \
   continue
 
   turnserver_id server_id = (turnserver_id)(session_id / TURN_SESSION_ID_FACTOR);
-  if (server && peer_addr) {
-    if (*(server->no_multicast_peers) && ioa_addr_is_multicast(peer_addr)) {
+  if (server && peer_addr)
+  {
+    if (*(server->no_multicast_peers) && ioa_addr_is_multicast(peer_addr))
+    {
       return 0;
     }
-    if (!*(server->allow_loopback_peers) && ioa_addr_is_loopback(peer_addr)) {
+    if (!*(server->allow_loopback_peers) && ioa_addr_is_loopback(peer_addr))
+    {
       return 0;
     }
-    if (ioa_addr_is_zero(peer_addr)) {
+    if (ioa_addr_is_zero(peer_addr))
+    {
       return 0;
     }
 
     {
       int i;
 
-      if (server->ip_whitelist) {
+      if (server->ip_whitelist)
+      {
         // White listing of addr ranges
-        for (i = server->ip_whitelist->ranges_number - 1; i >= 0; --i) {
+        for (i = server->ip_whitelist->ranges_number - 1; i >= 0; --i)
+        {
           CHECK_REALM(server->ip_whitelist->rs[i].realm);
-          if (ioa_addr_in_range(&(server->ip_whitelist->rs[i].enc), peer_addr)) {
+          if (ioa_addr_in_range(&(server->ip_whitelist->rs[i].enc), peer_addr))
+          {
             return 1;
           }
         }
@@ -312,11 +373,14 @@ static int good_peer_addr(turn_turnserver *server, const char *realm, ioa_addr *
         ioa_lock_whitelist(server->e);
 
         const ip_range_list_t *wl = ioa_get_whitelist(server->e);
-        if (wl) {
+        if (wl)
+        {
           // White listing of addr ranges
-          for (i = wl->ranges_number - 1; i >= 0; --i) {
+          for (i = wl->ranges_number - 1; i >= 0; --i)
+          {
             CHECK_REALM(wl->rs[i].realm);
-            if (ioa_addr_in_range(&(wl->rs[i].enc), peer_addr)) {
+            if (ioa_addr_in_range(&(wl->rs[i].enc), peer_addr))
+            {
               ioa_unlock_whitelist(server->e);
               return 1;
             }
@@ -326,11 +390,14 @@ static int good_peer_addr(turn_turnserver *server, const char *realm, ioa_addr *
         ioa_unlock_whitelist(server->e);
       }
 
-      if (server->ip_blacklist) {
+      if (server->ip_blacklist)
+      {
         // Black listing of addr ranges
-        for (i = server->ip_blacklist->ranges_number - 1; i >= 0; --i) {
+        for (i = server->ip_blacklist->ranges_number - 1; i >= 0; --i)
+        {
           CHECK_REALM(server->ip_blacklist->rs[i].realm);
-          if (ioa_addr_in_range(&(server->ip_blacklist->rs[i].enc), peer_addr)) {
+          if (ioa_addr_in_range(&(server->ip_blacklist->rs[i].enc), peer_addr))
+          {
             char saddr[129];
             addr_to_string_no_port(peer_addr, (uint8_t *)saddr);
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "session %018llu: A peer IP %s denied in the range: %s in server %d \n",
@@ -344,11 +411,14 @@ static int good_peer_addr(turn_turnserver *server, const char *realm, ioa_addr *
         ioa_lock_blacklist(server->e);
 
         const ip_range_list_t *bl = ioa_get_blacklist(server->e);
-        if (bl) {
+        if (bl)
+        {
           // Black listing of addr ranges
-          for (i = bl->ranges_number - 1; i >= 0; --i) {
+          for (i = bl->ranges_number - 1; i >= 0; --i)
+          {
             CHECK_REALM(bl->rs[i].realm);
-            if (ioa_addr_in_range(&(bl->rs[i].enc), peer_addr)) {
+            if (ioa_addr_in_range(&(bl->rs[i].enc), peer_addr))
+            {
               ioa_unlock_blacklist(server->e);
               char saddr[129];
               addr_to_string_no_port(peer_addr, (uint8_t *)saddr);
@@ -374,37 +444,47 @@ static int good_peer_addr(turn_turnserver *server, const char *realm, ioa_addr *
 
 allocation *get_allocation_ss(ts_ur_super_session *ss) { return &(ss->alloc); }
 
-static inline relay_endpoint_session *get_relay_session_ss(ts_ur_super_session *ss, int family) {
+static inline relay_endpoint_session *get_relay_session_ss(ts_ur_super_session *ss, int family)
+{
   return get_relay_session(&(ss->alloc), family);
 }
 
-static inline ioa_socket_handle get_relay_socket_ss(ts_ur_super_session *ss, int family) {
+static inline ioa_socket_handle get_relay_socket_ss(ts_ur_super_session *ss, int family)
+{
   return get_relay_socket(&(ss->alloc), family);
 }
 
 /////////// Session info ///////
 
-void turn_session_info_clean(struct turn_session_info *tsi) {
-  if (tsi) {
-    if (tsi->extra_peers_data) {
+void turn_session_info_clean(struct turn_session_info *tsi)
+{
+  if (tsi)
+  {
+    if (tsi->extra_peers_data)
+    {
       free(tsi->extra_peers_data);
     }
     memset(tsi, 0, sizeof(struct turn_session_info));
   }
 }
 
-void turn_session_info_add_peer(struct turn_session_info *tsi, ioa_addr *peer) {
-  if (!tsi || !peer) {
+void turn_session_info_add_peer(struct turn_session_info *tsi, ioa_addr *peer)
+{
+  if (!tsi || !peer)
+  {
     return;
   }
 
-  for (size_t i = 0; i < tsi->main_peers_size; ++i) {
-    if (addr_eq(peer, &(tsi->main_peers_data[i].addr))) {
+  for (size_t i = 0; i < tsi->main_peers_size; ++i)
+  {
+    if (addr_eq(peer, &(tsi->main_peers_data[i].addr)))
+    {
       return;
     }
   }
 
-  if (tsi->main_peers_size < TURN_MAIN_PEERS_ARRAY_SIZE) {
+  if (tsi->main_peers_size < TURN_MAIN_PEERS_ARRAY_SIZE)
+  {
     addr_cpy(&(tsi->main_peers_data[tsi->main_peers_size].addr), peer);
     addr_to_string(&(tsi->main_peers_data[tsi->main_peers_size].addr),
                    (uint8_t *)tsi->main_peers_data[tsi->main_peers_size].saddr);
@@ -412,16 +492,20 @@ void turn_session_info_add_peer(struct turn_session_info *tsi, ioa_addr *peer) {
     return;
   }
 
-  if (tsi->extra_peers_data) {
-    for (size_t sz = 0; sz < tsi->extra_peers_size; ++sz) {
-      if (addr_eq(peer, &(tsi->extra_peers_data[sz].addr))) {
+  if (tsi->extra_peers_data)
+  {
+    for (size_t sz = 0; sz < tsi->extra_peers_size; ++sz)
+    {
+      if (addr_eq(peer, &(tsi->extra_peers_data[sz].addr)))
+      {
         return;
       }
     }
   }
 
   addr_data *pTmp = (addr_data *)realloc(tsi->extra_peers_data, (tsi->extra_peers_size + 1) * sizeof(addr_data));
-  if (!pTmp) {
+  if (!pTmp)
+  {
     return;
   }
 
@@ -432,17 +516,20 @@ void turn_session_info_add_peer(struct turn_session_info *tsi, ioa_addr *peer) {
   tsi->extra_peers_size += 1;
 }
 
-struct tsi_arg {
+struct tsi_arg
+{
   struct turn_session_info *tsi;
   ioa_addr *addr;
 };
 
-static bool turn_session_info_foreachcb(ur_map_key_type key, ur_map_value_type value, void *arg) {
+static bool turn_session_info_foreachcb(ur_map_key_type key, ur_map_value_type value, void *arg)
+{
   UNUSED_ARG(value);
 
   int port = (int)key;
   struct tsi_arg *ta = (struct tsi_arg *)arg;
-  if (port && ta && ta->tsi && ta->addr) {
+  if (port && ta && ta->tsi && ta->addr)
+  {
     ioa_addr a;
     addr_cpy(&a, ta->addr);
     addr_set_port(&a, port);
@@ -451,26 +538,35 @@ static bool turn_session_info_foreachcb(ur_map_key_type key, ur_map_value_type v
   return false;
 }
 
-int turn_session_info_copy_from(struct turn_session_info *tsi, ts_ur_super_session *ss) {
+int turn_session_info_copy_from(struct turn_session_info *tsi, ts_ur_super_session *ss)
+{
   int ret = -1;
 
-  if (tsi && ss) {
+  if (tsi && ss)
+  {
     tsi->id = ss->id;
     tsi->bps = ss->bps;
     tsi->start_time = ss->start_time;
     tsi->valid = is_allocation_valid(&(ss->alloc)) && !(ss->to_be_closed) && (ss->quota_used);
-    if (tsi->valid) {
-      if (ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].s) {
+    if (tsi->valid)
+    {
+      if (ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].s)
+      {
         tsi->expiration_time = ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].expiration_time;
-        if (ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s) {
-          if (turn_time_before(tsi->expiration_time, ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].expiration_time)) {
+        if (ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s)
+        {
+          if (turn_time_before(tsi->expiration_time, ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].expiration_time))
+          {
             tsi->expiration_time = ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].expiration_time;
           }
         }
-      } else if (ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s) {
+      }
+      else if (ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s)
+      {
         tsi->expiration_time = ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].expiration_time;
       }
-      if (ss->client_socket) {
+      if (ss->client_socket)
+      {
         tsi->client_protocol = get_ioa_socket_type(ss->client_socket);
         addr_cpy(&(tsi->local_addr_data.addr), get_local_addr_from_ioa_socket(ss->client_socket));
         addr_to_string(&(tsi->local_addr_data.addr), (uint8_t *)tsi->local_addr_data.saddr);
@@ -478,17 +574,21 @@ int turn_session_info_copy_from(struct turn_session_info *tsi, ts_ur_super_sessi
         addr_to_string(&(tsi->remote_addr_data.addr), (uint8_t *)tsi->remote_addr_data.saddr);
       }
       {
-        if (ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].s) {
+        if (ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].s)
+        {
           tsi->peer_protocol = get_ioa_socket_type(ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].s);
-          if (ss->alloc.is_valid) {
+          if (ss->alloc.is_valid)
+          {
             addr_cpy(&(tsi->relay_addr_data_ipv4.addr),
                      get_local_addr_from_ioa_socket(ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].s));
             addr_to_string(&(tsi->relay_addr_data_ipv4.addr), (uint8_t *)tsi->relay_addr_data_ipv4.saddr);
           }
         }
-        if (ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s) {
+        if (ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s)
+        {
           tsi->peer_protocol = get_ioa_socket_type(ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s);
-          if (ss->alloc.is_valid) {
+          if (ss->alloc.is_valid)
+          {
             addr_cpy(&(tsi->relay_addr_data_ipv6.addr),
                      get_local_addr_from_ioa_socket(ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s));
             addr_to_string(&(tsi->relay_addr_data_ipv6.addr), (uint8_t *)tsi->relay_addr_data_ipv6.saddr);
@@ -502,51 +602,75 @@ int turn_session_info_copy_from(struct turn_session_info *tsi, ts_ur_super_sessi
       STRCPY(tsi->realm, ss->realm_options.name);
       STRCPY(tsi->origin, ss->origin);
 
-      if (ss->t_received_packets > ss->received_packets) {
+      if (ss->t_received_packets > ss->received_packets)
+      {
         tsi->received_packets = ss->t_received_packets;
-      } else {
+      }
+      else
+      {
         tsi->received_packets = ss->received_packets;
       }
 
-      if (ss->t_sent_packets > ss->sent_packets) {
+      if (ss->t_sent_packets > ss->sent_packets)
+      {
         tsi->sent_packets = ss->t_sent_packets;
-      } else {
+      }
+      else
+      {
         tsi->sent_packets = ss->sent_packets;
       }
 
-      if (ss->t_received_bytes > ss->received_bytes) {
+      if (ss->t_received_bytes > ss->received_bytes)
+      {
         tsi->received_bytes = ss->t_received_bytes;
-      } else {
+      }
+      else
+      {
         tsi->received_bytes = ss->received_bytes;
       }
 
-      if (ss->t_sent_bytes > ss->sent_bytes) {
+      if (ss->t_sent_bytes > ss->sent_bytes)
+      {
         tsi->sent_bytes = ss->t_sent_bytes;
-      } else {
+      }
+      else
+      {
         tsi->sent_bytes = ss->sent_bytes;
       }
 
-      if (ss->t_peer_received_packets > ss->peer_received_packets) {
+      if (ss->t_peer_received_packets > ss->peer_received_packets)
+      {
         tsi->peer_received_packets = ss->t_peer_received_packets;
-      } else {
+      }
+      else
+      {
         tsi->peer_received_packets = ss->peer_received_packets;
       }
 
-      if (ss->t_peer_sent_packets > ss->peer_sent_packets) {
+      if (ss->t_peer_sent_packets > ss->peer_sent_packets)
+      {
         tsi->peer_sent_packets = ss->t_peer_sent_packets;
-      } else {
+      }
+      else
+      {
         tsi->peer_sent_packets = ss->peer_sent_packets;
       }
 
-      if (ss->t_peer_received_bytes > ss->peer_received_bytes) {
+      if (ss->t_peer_received_bytes > ss->peer_received_bytes)
+      {
         tsi->peer_received_bytes = ss->t_peer_received_bytes;
-      } else {
+      }
+      else
+      {
         tsi->peer_received_bytes = ss->peer_received_bytes;
       }
 
-      if (ss->t_peer_sent_bytes > ss->peer_sent_bytes) {
+      if (ss->t_peer_sent_bytes > ss->peer_sent_bytes)
+      {
         tsi->peer_sent_bytes = ss->t_peer_sent_bytes;
-      } else {
+      }
+      else
+      {
         tsi->peer_sent_bytes = ss->peer_sent_bytes;
       }
 
@@ -563,15 +687,18 @@ int turn_session_info_copy_from(struct turn_session_info *tsi, ts_ur_super_sessi
 
       {
         size_t i;
-        for (i = 0; i < TURN_PERMISSION_HASHTABLE_SIZE; ++i) {
+        for (i = 0; i < TURN_PERMISSION_HASHTABLE_SIZE; ++i)
+        {
 
           turn_permission_array *parray = &(ss->alloc.addr_to_perm.table[i]);
 
           {
             size_t j;
-            for (j = 0; j < TURN_PERMISSION_ARRAY_SIZE; ++j) {
+            for (j = 0; j < TURN_PERMISSION_ARRAY_SIZE; ++j)
+            {
               turn_permission_slot *slot = &(parray->main_slots[j]);
-              if (slot->info.allocated) {
+              if (slot->info.allocated)
+              {
                 turn_session_info_add_peer(tsi, &(slot->info.addr));
                 struct tsi_arg arg = {tsi, &(slot->info.addr)};
                 lm_map_foreach_arg(&(slot->info.chns), turn_session_info_foreachcb, &arg);
@@ -581,12 +708,15 @@ int turn_session_info_copy_from(struct turn_session_info *tsi, ts_ur_super_sessi
 
           {
             turn_permission_slot **slots = parray->extra_slots;
-            if (slots) {
+            if (slots)
+            {
               size_t sz = parray->extra_sz;
               size_t j;
-              for (j = 0; j < sz; ++j) {
+              for (j = 0; j < sz; ++j)
+              {
                 turn_permission_slot *slot = slots[j];
-                if (slot && slot->info.allocated) {
+                if (slot && slot->info.allocated)
+                {
                   turn_session_info_add_peer(tsi, &(slot->info.addr));
                   struct tsi_arg arg = {tsi, &(slot->info.addr)};
                   lm_map_foreach_arg(&(slot->info.chns), turn_session_info_foreachcb, &arg);
@@ -599,13 +729,17 @@ int turn_session_info_copy_from(struct turn_session_info *tsi, ts_ur_super_sessi
 
       {
         tcp_connection_list *tcl = &(ss->alloc.tcs);
-        if (tcl->elems) {
+        if (tcl->elems)
+        {
           size_t i;
           size_t sz = tcl->sz;
-          for (i = 0; i < sz; ++i) {
-            if (tcl->elems[i]) {
+          for (i = 0; i < sz; ++i)
+          {
+            if (tcl->elems[i])
+            {
               tcp_connection *tc = tcl->elems[i];
-              if (tc) {
+              if (tc)
+              {
                 turn_session_info_add_peer(tsi, &(tc->peer_addr));
               }
             }
@@ -620,19 +754,28 @@ int turn_session_info_copy_from(struct turn_session_info *tsi, ts_ur_super_sessi
   return ret;
 }
 
-int report_turn_session_info(turn_turnserver *server, ts_ur_super_session *ss, int force_invalid) {
-  if (server && ss && server->send_turn_session_info) {
+int report_turn_session_info(turn_turnserver *server, ts_ur_super_session *ss, int force_invalid)
+{
+  if (server && ss && server->send_turn_session_info)
+  {
     struct turn_session_info tsi;
     memset(&tsi, 0, sizeof(struct turn_session_info));
-    if (turn_session_info_copy_from(&tsi, ss) < 0) {
+    if (turn_session_info_copy_from(&tsi, ss) < 0)
+    {
       turn_session_info_clean(&tsi);
-    } else {
-      if (force_invalid) {
+    }
+    else
+    {
+      if (force_invalid)
+      {
         tsi.valid = 0;
       }
-      if (server->send_turn_session_info(&tsi) < 0) {
+      if (server->send_turn_session_info(&tsi) < 0)
+      {
         turn_session_info_clean(&tsi);
-      } else {
+      }
+      else
+      {
         return 0;
       }
     }
@@ -643,20 +786,24 @@ int report_turn_session_info(turn_turnserver *server, ts_ur_super_session *ss, i
 
 /////////// SS /////////////////
 
-static int mobile_id_to_string(mobile_id_t mid, char *dst, size_t dst_sz) {
+static int mobile_id_to_string(mobile_id_t mid, char *dst, size_t dst_sz)
+{
   size_t output_length = 0;
 
-  if (!dst) {
+  if (!dst)
+  {
     return -1;
   }
 
   char *s = base64_encode((const unsigned char *)&mid, sizeof(mid), &output_length);
 
-  if (!s) {
+  if (!s)
+  {
     return -1;
   }
 
-  if (!output_length || (output_length + 1 > dst_sz)) {
+  if (!output_length || (output_length + 1 > dst_sz))
+  {
     free(s);
     return -1;
   }
@@ -670,18 +817,22 @@ static int mobile_id_to_string(mobile_id_t mid, char *dst, size_t dst_sz) {
   return (int)output_length;
 }
 
-static mobile_id_t string_to_mobile_id(char *src) {
+static mobile_id_t string_to_mobile_id(char *src)
+{
   mobile_id_t mid = 0;
 
-  if (src) {
+  if (src)
+  {
 
     size_t output_length = 0;
 
     unsigned char *out = base64_decode(src, strlen(src), &output_length);
 
-    if (out) {
+    if (out)
+    {
 
-      if (output_length == sizeof(mid)) {
+      if (output_length == sizeof(mid))
+      {
         mid = *((mobile_id_t *)out);
       }
 
@@ -692,27 +843,36 @@ static mobile_id_t string_to_mobile_id(char *src) {
   return mid;
 }
 
-static mobile_id_t get_new_mobile_id(turn_turnserver *server) {
+static mobile_id_t get_new_mobile_id(turn_turnserver *server)
+{
   mobile_id_t newid = 0;
 
-  if (server && server->mobile_connections_map) {
+  if (server && server->mobile_connections_map)
+  {
     ur_map *map = server->mobile_connections_map;
     uint64_t sid = server->id;
     sid = sid << 56;
-    do {
+    do
+    {
       newid = 0;
-      while (!newid) {
-        if (TURN_RANDOM_SIZE == sizeof(mobile_id_t)) {
+      while (!newid)
+      {
+        if (TURN_RANDOM_SIZE == sizeof(mobile_id_t))
+        {
           newid = (mobile_id_t)turn_random();
-        } else {
+        }
+        else
+        {
           newid = (mobile_id_t)turn_random();
           newid = (newid << 32) + (mobile_id_t)turn_random();
         }
-        if (!newid) {
+        if (!newid)
+        {
           continue;
         }
         newid = newid & 0x00FFFFFFFFFFFFFFLL;
-        if (!newid) {
+        if (!newid)
+        {
           continue;
         }
         newid = newid | sid;
@@ -722,11 +882,15 @@ static mobile_id_t get_new_mobile_id(turn_turnserver *server) {
   return newid;
 }
 
-static void put_session_into_mobile_map(ts_ur_super_session *ss) {
-  if (ss && ss->server) {
+static void put_session_into_mobile_map(ts_ur_super_session *ss)
+{
+  if (ss && ss->server)
+  {
     turn_turnserver *server = (turn_turnserver *)(ss->server);
-    if (*(server->mobility) && server->mobile_connections_map) {
-      if (!(ss->mobile_id)) {
+    if (*(server->mobility) && server->mobile_connections_map)
+    {
+      if (!(ss->mobile_id))
+      {
         ss->mobile_id = get_new_mobile_id(server);
         mobile_id_to_string(ss->mobile_id, ss->s_mobile_id, sizeof(ss->s_mobile_id));
       }
@@ -735,10 +899,13 @@ static void put_session_into_mobile_map(ts_ur_super_session *ss) {
   }
 }
 
-static void put_session_into_map(ts_ur_super_session *ss) {
-  if (ss && ss->server) {
+static void put_session_into_map(ts_ur_super_session *ss)
+{
+  if (ss && ss->server)
+  {
     turn_turnserver *server = (turn_turnserver *)(ss->server);
-    if (!(ss->id)) {
+    if (!(ss->id))
+    {
       ss->id = (turnsession_id)((turnsession_id)server->id * TURN_SESSION_ID_FACTOR);
       ss->id += ++(server->session_id_counter);
       ss->start_time = server->ctime;
@@ -748,10 +915,13 @@ static void put_session_into_map(ts_ur_super_session *ss) {
   }
 }
 
-static void delete_session_from_mobile_map(ts_ur_super_session *ss) {
-  if (ss && ss->server && ss->mobile_id) {
+static void delete_session_from_mobile_map(ts_ur_super_session *ss)
+{
+  if (ss && ss->server && ss->mobile_id)
+  {
     turn_turnserver *server = (turn_turnserver *)(ss->server);
-    if (server->mobile_connections_map) {
+    if (server->mobile_connections_map)
+    {
       ur_map_del(server->mobile_connections_map, (ur_map_key_type)(ss->mobile_id), NULL);
     }
     ss->mobile_id = 0;
@@ -759,52 +929,65 @@ static void delete_session_from_mobile_map(ts_ur_super_session *ss) {
   }
 }
 
-static void delete_session_from_map(ts_ur_super_session *ss) {
-  if (ss && ss->server) {
+static void delete_session_from_map(ts_ur_super_session *ss)
+{
+  if (ss && ss->server)
+  {
     turn_turnserver *server = (turn_turnserver *)(ss->server);
     ur_map_del(server->sessions_map, (ur_map_key_type)(ss->id), NULL);
     delete_session_from_mobile_map(ss);
   }
 }
 
-static ts_ur_super_session *get_session_from_map(turn_turnserver *server, turnsession_id sid) {
+static ts_ur_super_session *get_session_from_map(turn_turnserver *server, turnsession_id sid)
+{
   ts_ur_super_session *ss = NULL;
-  if (server) {
+  if (server)
+  {
     ur_map_value_type value = 0;
-    if (ur_map_get(server->sessions_map, (ur_map_key_type)sid, &value) && value) {
+    if (ur_map_get(server->sessions_map, (ur_map_key_type)sid, &value) && value)
+    {
       ss = (ts_ur_super_session *)value;
     }
   }
   return ss;
 }
 
-void turn_cancel_session(turn_turnserver *server, turnsession_id sid) {
-  if (server) {
+void turn_cancel_session(turn_turnserver *server, turnsession_id sid)
+{
+  if (server)
+  {
     ts_ur_super_session *ts = get_session_from_map(server, sid);
-    if (ts) {
+    if (ts)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Session %018llu to be forcefully canceled\n", (unsigned long long)sid);
       shutdown_client_connection(server, ts, 0, "Forceful shutdown");
     }
   }
 }
 
-static ts_ur_super_session *get_session_from_mobile_map(turn_turnserver *server, mobile_id_t mid) {
+static ts_ur_super_session *get_session_from_mobile_map(turn_turnserver *server, mobile_id_t mid)
+{
   ts_ur_super_session *ss = NULL;
-  if (server && *(server->mobility) && server->mobile_connections_map && mid) {
+  if (server && *(server->mobility) && server->mobile_connections_map && mid)
+  {
     ur_map_value_type value = 0;
-    if (ur_map_get(server->mobile_connections_map, (ur_map_key_type)mid, &value) && value) {
+    if (ur_map_get(server->mobile_connections_map, (ur_map_key_type)mid, &value) && value)
+    {
       ss = (ts_ur_super_session *)value;
     }
   }
   return ss;
 }
 
-static ts_ur_super_session *create_new_ss(turn_turnserver *server) {
+static ts_ur_super_session *create_new_ss(turn_turnserver *server)
+{
   //
   // printf("%s: 111.111: session size=%lu\n",__FUNCTION__,(unsigned long)sizeof(ts_ur_super_session));
   //
   ts_ur_super_session *ss = (ts_ur_super_session *)calloc(sizeof(ts_ur_super_session), 1);
-  if (!ss) {
+  if (!ss)
+  {
     return NULL;
   }
   ss->server = server;
@@ -814,8 +997,10 @@ static ts_ur_super_session *create_new_ss(turn_turnserver *server) {
   return ss;
 }
 
-static void delete_ur_map_ss(void *p, SOCKET_TYPE socket_type) {
-  if (p) {
+static void delete_ur_map_ss(void *p, SOCKET_TYPE socket_type)
+{
+  if (p)
+  {
     ts_ur_super_session *ss = (ts_ur_super_session *)p;
     delete_session_from_map(ss);
     IOA_CLOSE_SOCKET(ss->client_socket);
@@ -827,18 +1012,25 @@ static void delete_ur_map_ss(void *p, SOCKET_TYPE socket_type) {
 
 /////////// clean all /////////////////////
 
-static int turn_server_remove_all_from_ur_map_ss(ts_ur_super_session *ss, SOCKET_TYPE socket_type) {
-  if (!ss) {
+static int turn_server_remove_all_from_ur_map_ss(ts_ur_super_session *ss, SOCKET_TYPE socket_type)
+{
+  if (!ss)
+  {
     return 0;
-  } else {
+  }
+  else
+  {
     int ret = 0;
-    if (ss->client_socket) {
+    if (ss->client_socket)
+    {
       clear_ioa_socket_session_if(ss->client_socket, ss);
     }
-    if (get_relay_socket_ss(ss, AF_INET)) {
+    if (get_relay_socket_ss(ss, AF_INET))
+    {
       clear_ioa_socket_session_if(get_relay_socket_ss(ss, AF_INET), ss);
     }
-    if (get_relay_socket_ss(ss, AF_INET6)) {
+    if (get_relay_socket_ss(ss, AF_INET6))
+    {
       clear_ioa_socket_session_if(get_relay_socket_ss(ss, AF_INET6), ss);
     }
     delete_ur_map_ss(ss, socket_type);
@@ -848,11 +1040,13 @@ static int turn_server_remove_all_from_ur_map_ss(ts_ur_super_session *ss, SOCKET
 
 /////////////////////////////////////////////////////////////////
 
-static void client_ss_channel_timeout_handler(ioa_engine_handle e, void *arg) {
+static void client_ss_channel_timeout_handler(ioa_engine_handle e, void *arg)
+{
 
   UNUSED_ARG(e);
 
-  if (!arg) {
+  if (!arg)
+  {
     return;
   }
 
@@ -861,27 +1055,32 @@ static void client_ss_channel_timeout_handler(ioa_engine_handle e, void *arg) {
   turn_channel_delete(chn);
 }
 
-static void client_ss_perm_timeout_handler(ioa_engine_handle e, void *arg) {
+static void client_ss_perm_timeout_handler(ioa_engine_handle e, void *arg)
+{
 
   UNUSED_ARG(e);
 
-  if (!arg) {
+  if (!arg)
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: empty permission to be cleaned\n", __FUNCTION__);
     return;
   }
 
   turn_permission_info *tinfo = (turn_permission_info *)arg;
 
-  if (!(tinfo->allocated)) {
+  if (!(tinfo->allocated))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: unallocated permission to be cleaned\n", __FUNCTION__);
     return;
   }
 
-  if (!(tinfo->lifetime_ev)) {
+  if (!(tinfo->lifetime_ev))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: strange (1) permission to be cleaned\n", __FUNCTION__);
   }
 
-  if (!(tinfo->owner)) {
+  if (!(tinfo->owner))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: strange (2) permission to be cleaned\n", __FUNCTION__);
   }
 
@@ -890,16 +1089,19 @@ static void client_ss_perm_timeout_handler(ioa_engine_handle e, void *arg) {
 
 ///////////////////////////////////////////////////////////////////
 
-static int update_turn_permission_lifetime(ts_ur_super_session *ss, turn_permission_info *tinfo,
-                                           turn_time_t time_delta) {
+static int update_turn_permission_lifetime(ts_ur_super_session *ss, turn_permission_info *tinfo, turn_time_t time_delta)
+{
 
-  if (ss && tinfo && tinfo->owner) {
+  if (ss && tinfo && tinfo->owner)
+  {
 
     turn_turnserver *server = (turn_turnserver *)(ss->server);
 
-    if (server) {
+    if (server)
+    {
 
-      if (!time_delta) {
+      if (!time_delta)
+      {
         time_delta = *(server->permission_lifetime);
       }
       tinfo->expiration_time = server->ctime + time_delta;
@@ -908,7 +1110,8 @@ static int update_turn_permission_lifetime(ts_ur_super_session *ss, turn_permiss
       tinfo->lifetime_ev = set_ioa_timer(server->e, time_delta, 0, client_ss_perm_timeout_handler, tinfo, 0,
                                          "client_ss_channel_timeout_handler");
 
-      if (server->verbose) {
+      if (server->verbose)
+      {
         tinfo->verbose = 1;
         tinfo->session_id = ss->id;
         char s[257] = "\0";
@@ -923,19 +1126,24 @@ static int update_turn_permission_lifetime(ts_ur_super_session *ss, turn_permiss
   return -1;
 }
 
-static int update_channel_lifetime(ts_ur_super_session *ss, ch_info *chn) {
+static int update_channel_lifetime(ts_ur_super_session *ss, ch_info *chn)
+{
 
-  if (chn) {
+  if (chn)
+  {
 
     turn_permission_info *tinfo = (turn_permission_info *)(chn->owner);
 
-    if (tinfo && tinfo->owner) {
+    if (tinfo && tinfo->owner)
+    {
 
       turn_turnserver *server = (turn_turnserver *)(ss->server);
 
-      if (server) {
+      if (server)
+      {
 
-        if (update_turn_permission_lifetime(ss, tinfo, *(server->channel_lifetime)) < 0) {
+        if (update_turn_permission_lifetime(ss, tinfo, *(server->channel_lifetime)) < 0)
+        {
           return -1;
         }
 
@@ -968,8 +1176,10 @@ static int update_channel_lifetime(ts_ur_super_session *ss, ch_info *chn) {
                                  sar);                                                                                 \
     continue
 
-static uint8_t get_transport_value(const uint8_t *value) {
-  if ((value[0] == STUN_ATTRIBUTE_TRANSPORT_UDP_VALUE) || (value[0] == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE)) {
+static uint8_t get_transport_value(const uint8_t *value)
+{
+  if ((value[0] == STUN_ATTRIBUTE_TRANSPORT_UDP_VALUE) || (value[0] == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE))
+  {
     return value[0];
   }
   return 0;
@@ -977,56 +1187,77 @@ static uint8_t get_transport_value(const uint8_t *value) {
 
 static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss, stun_tid *tid, int *resp_constructed,
                                 int *err_code, const uint8_t **reason, uint16_t *unknown_attrs, uint16_t *ua_num,
-                                ioa_net_data *in_buffer, ioa_network_buffer_handle nbh) {
+                                ioa_net_data *in_buffer, ioa_network_buffer_handle nbh)
+{
 
   int err_code4 = 0;
   int err_code6 = 0;
 
   allocation *alloc = get_allocation_ss(ss);
 
-  if (is_allocation_valid(alloc)) {
+  if (is_allocation_valid(alloc))
+  {
 
-    if (!stun_tid_equals(tid, &(alloc->tid))) {
+    if (!stun_tid_equals(tid, &(alloc->tid)))
+    {
       *err_code = 437;
       *reason = (const uint8_t *)"Wrong TID";
-    } else {
+    }
+    else
+    {
       size_t len = ioa_network_buffer_get_size(nbh);
       ioa_addr xor_relayed_addr1, *pxor_relayed_addr1 = NULL;
       ioa_addr xor_relayed_addr2, *pxor_relayed_addr2 = NULL;
       ioa_addr *relayed_addr1 = get_local_addr_from_ioa_socket(get_relay_socket_ss(ss, AF_INET));
       ioa_addr *relayed_addr2 = get_local_addr_from_ioa_socket(get_relay_socket_ss(ss, AF_INET6));
 
-      if (get_relay_session_failure(alloc, AF_INET)) {
+      if (get_relay_session_failure(alloc, AF_INET))
+      {
         addr_set_any(&xor_relayed_addr1);
         pxor_relayed_addr1 = &xor_relayed_addr1;
-      } else if (relayed_addr1) {
-        if (server->external_ip_set) {
+      }
+      else if (relayed_addr1)
+      {
+        if (server->external_ip_set)
+        {
           addr_cpy(&xor_relayed_addr1, &(server->external_ip));
           addr_set_port(&xor_relayed_addr1, addr_get_port(relayed_addr1));
-        } else {
+        }
+        else
+        {
           addr_cpy(&xor_relayed_addr1, relayed_addr1);
         }
         pxor_relayed_addr1 = &xor_relayed_addr1;
       }
 
-      if (get_relay_session_failure(alloc, AF_INET6)) {
+      if (get_relay_session_failure(alloc, AF_INET6))
+      {
         addr_set_any(&xor_relayed_addr2);
         pxor_relayed_addr2 = &xor_relayed_addr2;
-      } else if (relayed_addr2) {
-        if (server->external_ip_set) {
+      }
+      else if (relayed_addr2)
+      {
+        if (server->external_ip_set)
+        {
           addr_cpy(&xor_relayed_addr2, &(server->external_ip));
           addr_set_port(&xor_relayed_addr2, addr_get_port(relayed_addr2));
-        } else {
+        }
+        else
+        {
           addr_cpy(&xor_relayed_addr2, relayed_addr2);
         }
         pxor_relayed_addr2 = &xor_relayed_addr2;
       }
 
-      if (pxor_relayed_addr1 || pxor_relayed_addr2) {
+      if (pxor_relayed_addr1 || pxor_relayed_addr2)
+      {
         uint32_t lifetime = 0;
-        if (pxor_relayed_addr1) {
+        if (pxor_relayed_addr1)
+        {
           lifetime = (get_relay_session(alloc, pxor_relayed_addr1->ss.sa_family)->expiration_time - server->ctime);
-        } else if (pxor_relayed_addr2) {
+        }
+        else if (pxor_relayed_addr2)
+        {
           lifetime = (get_relay_session(alloc, pxor_relayed_addr2->ss.sa_family)->expiration_time - server->ctime);
         }
         stun_set_allocate_response_str(ioa_network_buffer_data(nbh), &len, tid, pxor_relayed_addr1, pxor_relayed_addr2,
@@ -1036,8 +1267,9 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
         *resp_constructed = 1;
       }
     }
-
-  } else {
+  }
+  else
+  {
 
     uint8_t transport = 0;
     turn_time_t lifetime = 0;
@@ -1053,22 +1285,27 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
 
     stun_attr_ref sar =
         stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
-    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS)) {
+    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS))
+    {
 
       int attr_type = stun_attr_get_type(sar);
 
-      if (attr_type == STUN_ATTRIBUTE_USERNAME) {
+      if (attr_type == STUN_ATTRIBUTE_USERNAME)
+      {
         const uint8_t *value = stun_attr_get_value(sar);
-        if (value) {
+        if (value)
+        {
           ulen = stun_attr_get_len(sar);
-          if (ulen >= sizeof(username)) {
+          if (ulen >= sizeof(username))
+          {
             *err_code = 400;
             *reason = (const uint8_t *)"User name is too long";
             break;
           }
           memcpy(username, value, ulen);
           username[ulen] = 0;
-          if (!is_secure_string(username, 1)) {
+          if (!is_secure_string(username, 1))
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: wrong username: %s\n", __FUNCTION__, (char *)username);
             username[0] = 0;
             *err_code = 400;
@@ -1077,138 +1314,203 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
         }
       }
 
-      switch (attr_type) {
+      switch (attr_type)
+      {
         SKIP_ATTRIBUTES;
       case STUN_ATTRIBUTE_NEW_BANDWIDTH:
         bps = stun_attr_get_bandwidth(sar);
         break;
       case STUN_ATTRIBUTE_MOBILITY_TICKET:
-        if (!(*(server->mobility))) {
+        if (!(*(server->mobility)))
+        {
           *err_code = 405;
           *reason = (const uint8_t *)"Mobility Forbidden";
-        } else if (stun_attr_get_len(sar) != 0) {
+        }
+        else if (stun_attr_get_len(sar) != 0)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Wrong Mobility Field";
-        } else {
+        }
+        else
+        {
           ss->is_mobile = 1;
         }
         break;
-      case STUN_ATTRIBUTE_REQUESTED_TRANSPORT: {
-        if (stun_attr_get_len(sar) != 4) {
+      case STUN_ATTRIBUTE_REQUESTED_TRANSPORT:
+      {
+        if (stun_attr_get_len(sar) != 4)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Wrong Transport Field";
-        } else if (transport) {
+        }
+        else if (transport)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Duplicate Transport Fields";
-        } else {
+        }
+        else
+        {
           const uint8_t *value = stun_attr_get_value(sar);
-          if (value) {
+          if (value)
+          {
             transport = get_transport_value(value);
-            if (!transport) {
+            if (!transport)
+            {
               *err_code = 442;
             }
-            if ((transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE) && *(server->no_tcp_relay)) {
+            if ((transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE) && *(server->no_tcp_relay))
+            {
               *err_code = 442;
               *reason = (const uint8_t *)"TCP Transport is not allowed by the TURN Server configuration";
-            } else if ((transport == STUN_ATTRIBUTE_TRANSPORT_UDP_VALUE) && *(server->no_udp_relay)) {
+            }
+            else if ((transport == STUN_ATTRIBUTE_TRANSPORT_UDP_VALUE) && *(server->no_udp_relay))
+            {
               *err_code = 442;
               *reason = (const uint8_t *)"UDP Transport is not allowed by the TURN Server configuration";
-            } else if (ss->client_socket) {
+            }
+            else if (ss->client_socket)
+            {
               SOCKET_TYPE cst = get_ioa_socket_type(ss->client_socket);
-              if ((transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE) && !is_stream_socket(cst)) {
+              if ((transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE) && !is_stream_socket(cst))
+              {
                 *err_code = 400;
                 *reason = (const uint8_t *)"Wrong Transport Data";
-              } else {
+              }
+              else
+              {
                 ss->is_tcp_relay = (transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE);
               }
             }
-          } else {
+          }
+          else
+          {
             *err_code = 400;
             *reason = (const uint8_t *)"Wrong Transport Data";
           }
         }
-      } break;
+      }
+      break;
       case STUN_ATTRIBUTE_DONT_FRAGMENT:
         dont_fragment = 1;
-        if (!(server->dont_fragment)) {
+        if (!(server->dont_fragment))
+        {
           unknown_attrs[(*ua_num)++] = nswap16(attr_type);
         }
         break;
-      case STUN_ATTRIBUTE_LIFETIME: {
-        if (stun_attr_get_len(sar) != 4) {
+      case STUN_ATTRIBUTE_LIFETIME:
+      {
+        if (stun_attr_get_len(sar) != 4)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Wrong Lifetime Field";
-        } else {
+        }
+        else
+        {
           const uint8_t *value = stun_attr_get_value(sar);
-          if (!value) {
+          if (!value)
+          {
             *err_code = 400;
             *reason = (const uint8_t *)"Wrong Lifetime Data";
-          } else {
+          }
+          else
+          {
             lifetime = nswap32(*((const uint32_t *)value));
           }
         }
-      } break;
-      case STUN_ATTRIBUTE_EVEN_PORT: {
-        if (in_reservation_token) {
+      }
+      break;
+      case STUN_ATTRIBUTE_EVEN_PORT:
+      {
+        if (in_reservation_token)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Even Port and Reservation Token cannot be used together";
-        } else {
+        }
+        else
+        {
           even_port = stun_attr_get_even_port(sar);
-          if (even_port) {
-            if (af4 && af6) {
+          if (even_port)
+          {
+            if (af4 && af6)
+            {
               *err_code = 400;
               *reason = (const uint8_t *)"Even Port cannot be used with Dual Allocation";
             }
           }
         }
-      } break;
-      case STUN_ATTRIBUTE_RESERVATION_TOKEN: {
+      }
+      break;
+      case STUN_ATTRIBUTE_RESERVATION_TOKEN:
+      {
         int len = stun_attr_get_len(sar);
-        if (len != 8) {
+        if (len != 8)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Wrong Format of Reservation Token";
-        } else if (af4 || af6) {
+        }
+        else if (af4 || af6)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Address family attribute can not be used with reservation token request";
-        } else {
-          if (even_port >= 0) {
+        }
+        else
+        {
+          if (even_port >= 0)
+          {
             *err_code = 400;
             *reason = (const uint8_t *)"Reservation Token cannot be used in this request with even port";
-          } else if (in_reservation_token) {
+          }
+          else if (in_reservation_token)
+          {
             *err_code = 400;
             *reason = (const uint8_t *)"Reservation Token cannot be used in this request";
-          } else {
+          }
+          else
+          {
             in_reservation_token = stun_attr_get_reservation_token_value(sar);
           }
         }
-      } break;
+      }
+      break;
       case STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY:
-        if (even_port > 0) {
+        if (even_port > 0)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Even Port cannot be used with Dual Allocation";
           break;
         }
         /* Falls through. */
-      case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY: {
-        if (in_reservation_token) {
+      case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY:
+      {
+        if (in_reservation_token)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Address family attribute can not be used with reservation token request";
-        } else if (af4 || af6) {
+        }
+        else if (af4 || af6)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Extra address family attribute can not be used in the request";
-        } else {
+        }
+        else
+        {
           int af_req = stun_get_requested_address_family(sar);
-          switch (af_req) {
+          switch (af_req)
+          {
           case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4:
-            if (attr_type == STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY) {
+            if (attr_type == STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY)
+            {
               *err_code = 400;
               *reason = (const uint8_t *)"Invalid value of the additional address family attribute";
-            } else {
+            }
+            else
+            {
               af4 = af_req;
             }
             break;
           case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6:
-            if (attr_type == STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY) {
+            if (attr_type == STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY)
+            {
               af4 = STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4;
             }
             af6 = af_req;
@@ -1217,9 +1519,11 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
             *err_code = 440;
           }
         }
-      } break;
+      }
+      break;
       default:
-        if (attr_type >= 0x0000 && attr_type <= 0x7FFF) {
+        if (attr_type >= 0x0000 && attr_type <= 0x7FFF)
+        {
           unknown_attrs[(*ua_num)++] = nswap16(attr_type);
         }
       };
@@ -1227,33 +1531,42 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
                                    sar);
     }
 
-    if (!transport) {
+    if (!transport)
+    {
 
       *err_code = 400;
-      if (!(*reason)) {
+      if (!(*reason))
+      {
         *reason = (const uint8_t *)"Transport field missed or wrong";
       }
-
-    } else if (*ua_num > 0) {
+    }
+    else if (*ua_num > 0)
+    {
 
       *err_code = 420;
-
-    } else if (*err_code) {
+    }
+    else if (*err_code)
+    {
 
       ;
-
-    } else if ((transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE) &&
-               (dont_fragment || in_reservation_token || (even_port != -1))) {
+    }
+    else if ((transport == STUN_ATTRIBUTE_TRANSPORT_TCP_VALUE) &&
+             (dont_fragment || in_reservation_token || (even_port != -1)))
+    {
 
       *err_code = 400;
-      if (!(*reason)) {
+      if (!(*reason))
+      {
         *reason = (const uint8_t *)"Request parameters are incompatible with TCP transport";
       }
+    }
+    else
+    {
 
-    } else {
-
-      if (*(server->mobility)) {
-        if (!(ss->is_mobile)) {
+      if (*(server->mobility))
+      {
+        if (!(ss->is_mobile))
+        {
           delete_session_from_mobile_map(ss);
         }
       }
@@ -1261,56 +1574,72 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
       lifetime = stun_adjust_allocate_lifetime(lifetime, *(server->max_allocate_lifetime), ss->max_session_time_auth);
       uint64_t out_reservation_token = 0;
 
-      if (inc_quota(ss, username) < 0) {
+      if (inc_quota(ss, username) < 0)
+      {
 
         *err_code = 486;
+      }
+      else
+      {
 
-      } else {
-
-        if (server->allocate_bps_func) {
+        if (server->allocate_bps_func)
+        {
           max_bps = ss->realm_options.perf_options.max_bps;
-          if (max_bps && (!bps || (bps && (bps > max_bps)))) {
+          if (max_bps && (!bps || (bps && (bps > max_bps))))
+          {
             bps = max_bps;
           }
-          if (bps && (ss->bps == 0)) {
+          if (bps && (ss->bps == 0))
+          {
             ss->bps = server->allocate_bps_func(bps, 1);
-            if (!(ss->bps)) {
+            if (!(ss->bps))
+            {
               *err_code = 486;
               *reason = (const uint8_t *)"Allocation Bandwidth Quota Reached";
             }
           }
         }
 
-        if (af4) {
+        if (af4)
+        {
           af4 = STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4;
         }
-        if (af6) {
+        if (af6)
+        {
           af6 = STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6;
         }
 
-        if (af4 && af6) {
-          if (server->external_ip_set) {
+        if (af4 && af6)
+        {
+          if (server->external_ip_set)
+          {
             *err_code = 440;
             *reason = (const uint8_t *)"Dual allocation cannot be supported in the current server configuration";
           }
-          if (even_port > 0) {
+          if (even_port > 0)
+          {
             *err_code = 440;
             *reason = (const uint8_t *)"Dual allocation cannot be supported with even-port functionality";
           }
         }
 
-        if (server->is_draining) {
+        if (server->is_draining)
+        {
           // Don't allow new allocations if we are draining
           *err_code = 403; // 403 (Forbidden): RFC8656 - The request is valid, but the server is refusing to perform it,
                            // likely due to administrative restrictions....
           *reason = (const uint8_t *)"Server is draining, then will shutdown, please try another server";
         }
 
-        if (!(*err_code)) {
-          if (!af4 && !af6) {
-            switch (server->allocation_default_address_family) {
+        if (!(*err_code))
+        {
+          if (!af4 && !af6)
+          {
+            switch (server->allocation_default_address_family)
+            {
             case ALLOCATION_DEFAULT_ADDRESS_FAMILY_KEEP:
-              switch (get_ioa_socket_address_family(ss->client_socket)) {
+              switch (get_ioa_socket_address_family(ss->client_socket))
+              {
               case AF_INET6:
                 af6 = STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6;
                 break;
@@ -1331,34 +1660,45 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
               break;
             }
           }
-          if (!af4 && af6) {
+          if (!af4 && af6)
+          {
             int af6res = create_relay_connection(server, ss, lifetime, af6, transport, even_port, in_reservation_token,
                                                  &out_reservation_token, err_code, reason, tcp_peer_accept_connection);
-            if (af6res < 0) {
+            if (af6res < 0)
+            {
               set_relay_session_failure(alloc, AF_INET6);
-              if (!(*err_code)) {
+              if (!(*err_code))
+              {
                 *err_code = 437;
               }
             }
-          } else if (af4 && !af6) {
+          }
+          else if (af4 && !af6)
+          {
             int af4res = create_relay_connection(server, ss, lifetime, af4, transport, even_port, in_reservation_token,
                                                  &out_reservation_token, err_code, reason, tcp_peer_accept_connection);
-            if (af4res < 0) {
+            if (af4res < 0)
+            {
               set_relay_session_failure(alloc, AF_INET);
-              if (!(*err_code)) {
+              if (!(*err_code))
+              {
                 *err_code = 437;
               }
             }
-          } else {
+          }
+          else
+          {
             const uint8_t *reason4 = NULL;
             const uint8_t *reason6 = NULL;
             {
               int af4res =
                   create_relay_connection(server, ss, lifetime, af4, transport, even_port, in_reservation_token,
                                           &out_reservation_token, &err_code4, &reason4, tcp_peer_accept_connection);
-              if (af4res < 0) {
+              if (af4res < 0)
+              {
                 set_relay_session_failure(alloc, AF_INET);
-                if (!err_code4) {
+                if (!err_code4)
+                {
                   err_code4 = 440;
                 }
               }
@@ -1367,35 +1707,46 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
               int af6res =
                   create_relay_connection(server, ss, lifetime, af6, transport, even_port, in_reservation_token,
                                           &out_reservation_token, &err_code6, &reason6, tcp_peer_accept_connection);
-              if (af6res < 0) {
+              if (af6res < 0)
+              {
                 set_relay_session_failure(alloc, AF_INET6);
-                if (!err_code6) {
+                if (!err_code6)
+                {
                   err_code6 = 440;
                 }
               }
             }
 
-            if (err_code4 && err_code6) {
-              if (reason4) {
+            if (err_code4 && err_code6)
+            {
+              if (reason4)
+              {
                 *err_code = err_code4;
                 *reason = reason4;
-              } else if (reason6) {
+              }
+              else if (reason6)
+              {
                 *err_code = err_code6;
                 *reason = reason6;
-              } else {
+              }
+              else
+              {
                 *err_code = err_code4;
               }
             }
           }
         }
 
-        if (*err_code) {
+        if (*err_code)
+        {
 
-          if (!(*reason)) {
+          if (!(*reason))
+          {
             *reason = (const uint8_t *)"Cannot create relay endpoint(s)";
           }
-
-        } else {
+        }
+        else
+        {
 
           set_allocation_valid(alloc, 1);
 
@@ -1408,40 +1759,54 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
           ioa_addr *relayed_addr1 = get_local_addr_from_ioa_socket(get_relay_socket_ss(ss, AF_INET));
           ioa_addr *relayed_addr2 = get_local_addr_from_ioa_socket(get_relay_socket_ss(ss, AF_INET6));
 
-          if (get_relay_session_failure(alloc, AF_INET)) {
+          if (get_relay_session_failure(alloc, AF_INET))
+          {
             addr_set_any(&xor_relayed_addr1);
             pxor_relayed_addr1 = &xor_relayed_addr1;
-          } else if (relayed_addr1) {
-            if (server->external_ip_set) {
+          }
+          else if (relayed_addr1)
+          {
+            if (server->external_ip_set)
+            {
               addr_cpy(&xor_relayed_addr1, &(server->external_ip));
               addr_set_port(&xor_relayed_addr1, addr_get_port(relayed_addr1));
-            } else {
+            }
+            else
+            {
               addr_cpy(&xor_relayed_addr1, relayed_addr1);
             }
             pxor_relayed_addr1 = &xor_relayed_addr1;
           }
 
-          if (get_relay_session_failure(alloc, AF_INET6)) {
+          if (get_relay_session_failure(alloc, AF_INET6))
+          {
             addr_set_any(&xor_relayed_addr2);
             pxor_relayed_addr2 = &xor_relayed_addr2;
-          } else if (relayed_addr2) {
-            if (server->external_ip_set) {
+          }
+          else if (relayed_addr2)
+          {
+            if (server->external_ip_set)
+            {
               addr_cpy(&xor_relayed_addr2, &(server->external_ip));
               addr_set_port(&xor_relayed_addr2, addr_get_port(relayed_addr2));
-            } else {
+            }
+            else
+            {
               addr_cpy(&xor_relayed_addr2, relayed_addr2);
             }
             pxor_relayed_addr2 = &xor_relayed_addr2;
           }
 
-          if (pxor_relayed_addr1 || pxor_relayed_addr2) {
+          if (pxor_relayed_addr1 || pxor_relayed_addr2)
+          {
 
             stun_set_allocate_response_str(ioa_network_buffer_data(nbh), &len, tid, pxor_relayed_addr1,
                                            pxor_relayed_addr2, get_remote_addr_from_ioa_socket(ss->client_socket),
                                            lifetime, *(server->max_allocate_lifetime), 0, NULL, out_reservation_token,
                                            ss->s_mobile_id);
 
-            if (ss->bps) {
+            if (ss->bps)
+            {
               stun_attr_add_bandwidth_str(ioa_network_buffer_data(nbh), &len, ss->bps);
             }
 
@@ -1455,9 +1820,11 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
     }
   }
 
-  if (!(*resp_constructed)) {
+  if (!(*resp_constructed))
+  {
 
-    if (!(*err_code)) {
+    if (!(*err_code))
+    {
       *err_code = 437;
     }
 
@@ -1468,14 +1835,17 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
     *resp_constructed = 1;
   }
 
-  if (*resp_constructed && !(*err_code)) {
-    if (err_code4) {
+  if (*resp_constructed && !(*err_code))
+  {
+    if (err_code4)
+    {
       size_t len = ioa_network_buffer_get_size(nbh);
       stun_attr_add_address_error_code(ioa_network_buffer_data(nbh), &len,
                                        STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4, err_code4);
       ioa_network_buffer_set_size(nbh, len);
     }
-    if (err_code6) {
+    if (err_code6)
+    {
       size_t len = ioa_network_buffer_get_size(nbh);
       stun_attr_add_address_error_code(ioa_network_buffer_data(nbh), &len,
                                        STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6, err_code6);
@@ -1486,8 +1856,10 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
   return 0;
 }
 
-static void copy_auth_parameters(ts_ur_super_session *orig_ss, ts_ur_super_session *ss) {
-  if (orig_ss && ss) {
+static void copy_auth_parameters(ts_ur_super_session *orig_ss, ts_ur_super_session *ss)
+{
+  if (orig_ss && ss)
+  {
     dec_quota(ss);
     memcpy(ss->nonce, orig_ss->nonce, sizeof(ss->nonce));
     ss->nonce_expiration_time = orig_ss->nonce_expiration_time;
@@ -1507,7 +1879,8 @@ static void copy_auth_parameters(ts_ur_super_session *orig_ss, ts_ur_super_sessi
 static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss, stun_tid *tid, int *resp_constructed,
                                int *err_code, const uint8_t **reason, uint16_t *unknown_attrs, uint16_t *ua_num,
                                ioa_net_data *in_buffer, ioa_network_buffer_handle nbh, int message_integrity,
-                               int *no_response, int can_resume) {
+                               int *no_response, int can_resume)
+{
 
   allocation *a = get_allocation_ss(ss);
   int af4c = 0;
@@ -1516,24 +1889,31 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
   int af6 = 0;
   {
     int i;
-    for (i = 0; i < ALLOC_PROTOCOLS_NUMBER; ++i) {
-      if (a->relay_sessions[i].s && !ioa_socket_tobeclosed(a->relay_sessions[i].s)) {
+    for (i = 0; i < ALLOC_PROTOCOLS_NUMBER; ++i)
+    {
+      if (a->relay_sessions[i].s && !ioa_socket_tobeclosed(a->relay_sessions[i].s))
+      {
         int family = get_ioa_socket_address_family(a->relay_sessions[i].s);
-        if (AF_INET == family) {
+        if (AF_INET == family)
+        {
           af4c = 1;
-        } else if (AF_INET6 == family) {
+        }
+        else if (AF_INET6 == family)
+        {
           af6c = 1;
         }
       }
     }
   }
 
-  if (!is_allocation_valid(a) && !(*(server->mobility))) {
+  if (!is_allocation_valid(a) && !(*(server->mobility)))
+  {
 
     *err_code = 437;
     *reason = (const uint8_t *)"Invalid allocation";
-
-  } else {
+  }
+  else
+  {
 
     turn_time_t lifetime = 0;
     int to_delete = 0;
@@ -1542,68 +1922,97 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
 
     stun_attr_ref sar =
         stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
-    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS)) {
+    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS))
+    {
       int attr_type = stun_attr_get_type(sar);
-      switch (attr_type) {
+      switch (attr_type)
+      {
         SKIP_ATTRIBUTES;
-      case STUN_ATTRIBUTE_MOBILITY_TICKET: {
-        if (!(*(server->mobility))) {
+      case STUN_ATTRIBUTE_MOBILITY_TICKET:
+      {
+        if (!(*(server->mobility)))
+        {
           *err_code = 405;
           *reason = (const uint8_t *)"Mobility forbidden";
-        } else {
+        }
+        else
+        {
           int smid_len = stun_attr_get_len(sar);
-          if (smid_len > 0 && (((size_t)smid_len) < sizeof(smid))) {
+          if (smid_len > 0 && (((size_t)smid_len) < sizeof(smid)))
+          {
             const uint8_t *smid_val = stun_attr_get_value(sar);
-            if (smid_val) {
+            if (smid_val)
+            {
               memcpy(smid, smid_val, (size_t)smid_len);
               mid = string_to_mobile_id(smid);
-              if (is_allocation_valid(a) && (mid != ss->old_mobile_id)) {
+              if (is_allocation_valid(a) && (mid != ss->old_mobile_id))
+              {
                 *err_code = 400;
                 *reason =
                     (const uint8_t *)"Mobility ticket cannot be used for a stable, already established allocation";
               }
             }
-          } else {
+          }
+          else
+          {
             *err_code = 400;
             *reason = (const uint8_t *)"Mobility ticket has wrong length";
           }
         }
-      } break;
-      case STUN_ATTRIBUTE_LIFETIME: {
-        if (stun_attr_get_len(sar) != 4) {
+      }
+      break;
+      case STUN_ATTRIBUTE_LIFETIME:
+      {
+        if (stun_attr_get_len(sar) != 4)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Wrong Lifetime field format";
-        } else {
+        }
+        else
+        {
           const uint8_t *value = stun_attr_get_value(sar);
-          if (!value) {
+          if (!value)
+          {
             *err_code = 400;
             *reason = (const uint8_t *)"Wrong lifetime field data";
-          } else {
+          }
+          else
+          {
             lifetime = nswap32(*((const uint32_t *)value));
-            if (!lifetime) {
+            if (!lifetime)
+            {
               to_delete = 1;
             }
           }
         }
-      } break;
+      }
+      break;
       case STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY: /* deprecated, for backward compatibility with older versions of
                                                         TURN-bis */
-      case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY: {
+      case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY:
+      {
         int af_req = stun_get_requested_address_family(sar);
         {
           int is_err = 0;
-          switch (af_req) {
+          switch (af_req)
+          {
           case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4:
-            if (!af4c) {
+            if (!af4c)
+            {
               is_err = 1;
-            } else {
+            }
+            else
+            {
               af4 = 1;
             }
             break;
           case STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6:
-            if (!af6c) {
+            if (!af6c)
+            {
               is_err = 1;
-            } else {
+            }
+            else
+            {
               af6 = 1;
             }
             break;
@@ -1611,14 +2020,17 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
             is_err = 1;
           }
 
-          if (is_err) {
+          if (is_err)
+          {
             *err_code = 443;
             *reason = (const uint8_t *)"Peer Address Family Mismatch (1)";
           }
         }
-      } break;
+      }
+      break;
       default:
-        if (attr_type >= 0x0000 && attr_type <= 0x7FFF) {
+        if (attr_type >= 0x0000 && attr_type <= 0x7FFF)
+        {
           unknown_attrs[(*ua_num)++] = nswap16(attr_type);
         }
       };
@@ -1626,110 +2038,149 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
                                    sar);
     }
 
-    if (*ua_num > 0) {
+    if (*ua_num > 0)
+    {
 
       *err_code = 420;
-
-    } else if (*err_code) {
+    }
+    else if (*err_code)
+    {
 
       ;
+    }
+    else if (!is_allocation_valid(a))
+    {
 
-    } else if (!is_allocation_valid(a)) {
-
-      if (mid && smid[0]) {
+      if (mid && smid[0])
+      {
 
         turnserver_id tsid = ((0xFF00000000000000LL) & mid) >> 56;
 
-        if (tsid != server->id) {
+        if (tsid != server->id)
+        {
 
-          if (server->send_socket_to_relay) {
+          if (server->send_socket_to_relay)
+          {
             ioa_socket_handle new_s = detach_ioa_socket(ss->client_socket);
-            if (new_s) {
+            if (new_s)
+            {
               if (server->send_socket_to_relay(tsid, mid, tid, new_s, message_integrity, RMT_MOBILE_SOCKET, in_buffer,
-                                               can_resume) < 0) {
+                                               can_resume) < 0)
+              {
                 *err_code = 400;
                 *reason = (const uint8_t *)"Wrong mobile ticket";
-              } else {
+              }
+              else
+              {
                 *no_response = 1;
               }
-            } else {
+            }
+            else
+            {
               *err_code = 500;
               *reason = (const uint8_t *)"Cannot create new socket";
               return -1;
             }
-          } else {
+          }
+          else
+          {
             *err_code = 500;
             *reason = (const uint8_t *)"Server send socket procedure is not set";
           }
 
           ss->to_be_closed = 1;
-
-        } else {
+        }
+        else
+        {
 
           ts_ur_super_session *orig_ss = get_session_from_mobile_map(server, mid);
-          if (!orig_ss || orig_ss->to_be_closed || ioa_socket_tobeclosed(orig_ss->client_socket)) {
+          if (!orig_ss || orig_ss->to_be_closed || ioa_socket_tobeclosed(orig_ss->client_socket))
+          {
             *err_code = 404;
             *reason = (const uint8_t *)"Allocation not found";
-          } else if (orig_ss == ss) {
+          }
+          else if (orig_ss == ss)
+          {
             *err_code = 437;
             *reason = (const uint8_t *)"Invalid allocation";
-          } else if (!(orig_ss->is_mobile)) {
+          }
+          else if (!(orig_ss->is_mobile))
+          {
             *err_code = 500;
             *reason = (const uint8_t *)"Software error: invalid mobile allocation";
-          } else if (orig_ss->client_socket == ss->client_socket) {
+          }
+          else if (orig_ss->client_socket == ss->client_socket)
+          {
             *err_code = 500;
             *reason = (const uint8_t *)"Software error: invalid mobile client socket (orig)";
-          } else if (!(ss->client_socket)) {
+          }
+          else if (!(ss->client_socket))
+          {
             *err_code = 500;
             *reason = (const uint8_t *)"Software error: invalid mobile client socket (new)";
-          } else {
+          }
+          else
+          {
 
             get_realm_options_by_name(orig_ss->realm_options.name, &(ss->realm_options));
 
             // Check security:
             int postpone_reply = 0;
 
-            if (!(ss->hmackey_set)) {
+            if (!(ss->hmackey_set))
+            {
               copy_auth_parameters(orig_ss, ss);
             }
 
             if (check_stun_auth(server, ss, tid, resp_constructed, err_code, reason, in_buffer, nbh,
-                                STUN_METHOD_REFRESH, &message_integrity, &postpone_reply, can_resume) < 0) {
-              if (!(*err_code)) {
+                                STUN_METHOD_REFRESH, &message_integrity, &postpone_reply, can_resume) < 0)
+            {
+              if (!(*err_code))
+              {
                 *err_code = 401;
               }
             }
 
-            if (postpone_reply) {
+            if (postpone_reply)
+            {
 
               *no_response = 1;
-
-            } else if (!(*err_code)) {
+            }
+            else if (!(*err_code))
+            {
 
               // Session transfer:
 
-              if (to_delete) {
+              if (to_delete)
+              {
                 lifetime = 0;
-              } else {
+              }
+              else
+              {
                 lifetime = stun_adjust_allocate_lifetime(lifetime, *(server->max_allocate_lifetime),
                                                          ss->max_session_time_auth);
               }
 
-              if (af4c && refresh_relay_connection(server, orig_ss, lifetime, 0, 0, 0, err_code, AF_INET) < 0) {
+              if (af4c && refresh_relay_connection(server, orig_ss, lifetime, 0, 0, 0, err_code, AF_INET) < 0)
+              {
 
-                if (!(*err_code)) {
+                if (!(*err_code))
+                {
                   *err_code = 437;
                   *reason = (const uint8_t *)"Cannot refresh relay connection (internal error)";
                 }
+              }
+              else if (af6c && refresh_relay_connection(server, orig_ss, lifetime, 0, 0, 0, err_code, AF_INET6) < 0)
+              {
 
-              } else if (af6c && refresh_relay_connection(server, orig_ss, lifetime, 0, 0, 0, err_code, AF_INET6) < 0) {
-
-                if (!(*err_code)) {
+                if (!(*err_code))
+                {
                   *err_code = 437;
                   *reason = (const uint8_t *)"Cannot refresh relay connection (internal error)";
                 }
-
-              } else {
+              }
+              else
+              {
 
                 // Transfer socket:
 
@@ -1737,18 +2188,26 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
 
                 ss->to_be_closed = 1;
 
-                if (!s) {
+                if (!s)
+                {
                   *err_code = 500;
-                } else {
+                }
+                else
+                {
 
-                  if (attach_socket_to_session(server, s, orig_ss) < 0) {
-                    if (orig_ss->client_socket != s) {
+                  if (attach_socket_to_session(server, s, orig_ss) < 0)
+                  {
+                    if (orig_ss->client_socket != s)
+                    {
                       IOA_CLOSE_SOCKET(s);
                     }
                     *err_code = 500;
-                  } else {
+                  }
+                  else
+                  {
 
-                    if (ss->hmackey_set) {
+                    if (ss->hmackey_set)
+                    {
                       copy_auth_parameters(ss, orig_ss);
                     }
 
@@ -1781,16 +2240,19 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
 
                     maybe_add_software_attribute(server, nbh);
 
-                    if (message_integrity) {
+                    if (message_integrity)
+                    {
                       size_t len = ioa_network_buffer_get_size(nbh);
                       stun_attr_add_integrity_str(server->ct, ioa_network_buffer_data(nbh), &len, ss->hmackey, ss->pwd,
                                                   SHATYPE_DEFAULT);
                       ioa_network_buffer_set_size(nbh, len);
                     }
 
-                    if ((server->fingerprint) || ss->enforce_fingerprints) {
+                    if ((server->fingerprint) || ss->enforce_fingerprints)
+                    {
                       size_t len = ioa_network_buffer_get_size(nbh);
-                      if (!stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &len)) {
+                      if (!stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &len))
+                      {
                         *err_code = 500;
                         ioa_network_buffer_delete(server->e, nbh);
                         return -1;
@@ -1809,46 +2271,59 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
             report_turn_session_info(server, orig_ss, 0);
           }
         }
-      } else {
+      }
+      else
+      {
         *err_code = 437;
         *reason = (const uint8_t *)"Invalid allocation";
       }
+    }
+    else
+    {
 
-    } else {
-
-      if (to_delete) {
+      if (to_delete)
+      {
         lifetime = 0;
-      } else {
+      }
+      else
+      {
         lifetime = stun_adjust_allocate_lifetime(lifetime, *(server->max_allocate_lifetime), ss->max_session_time_auth);
       }
 
-      if (!af4 && !af6) {
+      if (!af4 && !af6)
+      {
         af4 = af4c;
         af6 = af6c;
       }
 
-      if (af4 && refresh_relay_connection(server, ss, lifetime, 0, 0, 0, err_code, AF_INET) < 0) {
+      if (af4 && refresh_relay_connection(server, ss, lifetime, 0, 0, 0, err_code, AF_INET) < 0)
+      {
 
-        if (!(*err_code)) {
+        if (!(*err_code))
+        {
           *err_code = 437;
           *reason = (const uint8_t *)"Cannot refresh relay connection (internal error)";
         }
+      }
+      else if (af6 && refresh_relay_connection(server, ss, lifetime, 0, 0, 0, err_code, AF_INET6) < 0)
+      {
 
-      } else if (af6 && refresh_relay_connection(server, ss, lifetime, 0, 0, 0, err_code, AF_INET6) < 0) {
-
-        if (!(*err_code)) {
+        if (!(*err_code))
+        {
           *err_code = 437;
           *reason = (const uint8_t *)"Cannot refresh relay connection (internal error)";
         }
-
-      } else {
+      }
+      else
+      {
 
         turn_report_allocation_set(&(ss->alloc), lifetime, 1);
 
         size_t len = ioa_network_buffer_get_size(nbh);
         stun_init_success_response_str(STUN_METHOD_REFRESH, ioa_network_buffer_data(nbh), &len, tid);
 
-        if (ss->s_mobile_id[0]) {
+        if (ss->s_mobile_id[0])
+        {
           stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_MOBILITY_TICKET,
                             (uint8_t *)ss->s_mobile_id, strlen(ss->s_mobile_id));
           ioa_network_buffer_set_size(nbh, len);
@@ -1864,10 +2339,13 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
     }
   }
 
-  if (!no_response) {
-    if (!(*resp_constructed)) {
+  if (!no_response)
+  {
+    if (!(*resp_constructed))
+    {
 
-      if (!(*err_code)) {
+      if (!(*err_code))
+      {
         *err_code = 437;
       }
 
@@ -1884,21 +2362,28 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
 
 /* RFC 6062 ==>> */
 
-static void tcp_deliver_delayed_buffer(unsent_buffer *ub, ioa_socket_handle s, ts_ur_super_session *ss) {
-  if (ub && s && ub->bufs && ub->sz && ss) {
+static void tcp_deliver_delayed_buffer(unsent_buffer *ub, ioa_socket_handle s, ts_ur_super_session *ss)
+{
+  if (ub && s && ub->bufs && ub->sz && ss)
+  {
     size_t i = 0;
-    do {
+    do
+    {
       ioa_network_buffer_handle nbh = top_unsent_buffer(ub);
-      if (!nbh) {
+      if (!nbh)
+      {
         break;
       }
 
       uint32_t bytes = (uint32_t)ioa_network_buffer_get_size(nbh);
 
       int ret = send_data_from_ioa_socket_nbh(s, NULL, nbh, TTL_IGNORE, TOS_IGNORE, NULL);
-      if (ret < 0) {
+      if (ret < 0)
+      {
         set_ioa_socket_tobeclosed(s);
-      } else {
+      }
+      else
+      {
         ++(ss->sent_packets);
         ss->sent_bytes += bytes;
         turn_report_session_usage(ss, 0);
@@ -1909,8 +2394,10 @@ static void tcp_deliver_delayed_buffer(unsent_buffer *ub, ioa_socket_handle s, t
 }
 
 static void tcp_peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_data *in_buffer, void *arg,
-                                   int can_resume) {
-  if (!(event_type & IOA_EV_READ) || !arg) {
+                                   int can_resume)
+{
+  if (!(event_type & IOA_EV_READ) || !arg)
+  {
     return;
   }
 
@@ -1920,11 +2407,13 @@ static void tcp_peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_
   tcp_connection *tc = (tcp_connection *)arg;
   ts_ur_super_session *ss = NULL;
   allocation *a = (allocation *)tc->owner;
-  if (a) {
+  if (a)
+  {
     ss = (ts_ur_super_session *)a->owner;
   }
 
-  if ((tc->state != TC_STATE_READY) || !(tc->client_s)) {
+  if ((tc->state != TC_STATE_READY) || !(tc->client_s))
+  {
     add_unsent_buffer(&(tc->ub_to_client), in_buffer->nbh);
     in_buffer->nbh = NULL;
     return;
@@ -1935,27 +2424,34 @@ static void tcp_peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_
 
   uint32_t bytes = (uint32_t)ioa_network_buffer_get_size(nbh);
 
-  if (ss) {
+  if (ss)
+  {
     ++(ss->peer_received_packets);
     ss->peer_received_bytes += bytes;
   }
 
   int ret = send_data_from_ioa_socket_nbh(tc->client_s, NULL, nbh, TTL_IGNORE, TOS_IGNORE, NULL);
-  if (ret < 0) {
+  if (ret < 0)
+  {
     set_ioa_socket_tobeclosed(s);
-  } else if (ss) {
+  }
+  else if (ss)
+  {
     ++(ss->sent_packets);
     ss->sent_bytes += bytes;
   }
 
-  if (ss) {
+  if (ss)
+  {
     turn_report_session_usage(ss, 0);
   }
 }
 
 static void tcp_client_input_handler_rfc6062data(ioa_socket_handle s, int event_type, ioa_net_data *in_buffer,
-                                                 void *arg, int can_resume) {
-  if (!(event_type & IOA_EV_READ) || !arg) {
+                                                 void *arg, int can_resume)
+{
+  if (!(event_type & IOA_EV_READ) || !arg)
+  {
     return;
   }
 
@@ -1965,15 +2461,18 @@ static void tcp_client_input_handler_rfc6062data(ioa_socket_handle s, int event_
   tcp_connection *tc = (tcp_connection *)arg;
   ts_ur_super_session *ss = NULL;
   allocation *a = (allocation *)tc->owner;
-  if (a) {
+  if (a)
+  {
     ss = (ts_ur_super_session *)a->owner;
   }
 
-  if (tc->state != TC_STATE_READY) {
+  if (tc->state != TC_STATE_READY)
+  {
     return;
   }
 
-  if (!(tc->peer_s)) {
+  if (!(tc->peer_s))
+  {
     return;
   }
 
@@ -1981,37 +2480,45 @@ static void tcp_client_input_handler_rfc6062data(ioa_socket_handle s, int event_
   in_buffer->nbh = NULL;
 
   uint32_t bytes = (uint32_t)ioa_network_buffer_get_size(nbh);
-  if (ss) {
+  if (ss)
+  {
     ++(ss->received_packets);
     ss->received_bytes += bytes;
   }
 
   int skip = 0;
   int ret = send_data_from_ioa_socket_nbh(tc->peer_s, NULL, nbh, TTL_IGNORE, TOS_IGNORE, &skip);
-  if (ret < 0) {
+  if (ret < 0)
+  {
     set_ioa_socket_tobeclosed(s);
   }
 
-  if (!skip && ss) {
+  if (!skip && ss)
+  {
     ++(ss->peer_sent_packets);
     ss->peer_sent_bytes += bytes;
   }
 
-  if (ss) {
+  if (ss)
+  {
     turn_report_session_usage(ss, 0);
   }
 }
 
-static void tcp_conn_bind_timeout_handler(ioa_engine_handle e, void *arg) {
+static void tcp_conn_bind_timeout_handler(ioa_engine_handle e, void *arg)
+{
   UNUSED_ARG(e);
-  if (arg) {
+  if (arg)
+  {
     tcp_connection *tc = (tcp_connection *)arg;
     delete_tcp_connection(tc);
   }
 }
 
-static void tcp_peer_connection_completed_callback(int success, void *arg) {
-  if (arg) {
+static void tcp_peer_connection_completed_callback(int success, void *arg)
+{
+  if (arg)
+  {
     tcp_connection *tc = (tcp_connection *)arg;
     allocation *a = (allocation *)(tc->owner);
     ts_ur_super_session *ss = (ts_ur_super_session *)(a->owner);
@@ -2023,15 +2530,18 @@ static void tcp_peer_connection_completed_callback(int success, void *arg) {
     ioa_network_buffer_handle nbh = ioa_network_buffer_allocate(server->e);
     size_t len = ioa_network_buffer_get_size(nbh);
 
-    if (success) {
-      if (register_callback_on_ioa_socket(server->e, tc->peer_s, IOA_EV_READ, tcp_peer_input_handler, tc, 1) < 0) {
+    if (success)
+    {
+      if (register_callback_on_ioa_socket(server->e, tc->peer_s, IOA_EV_READ, tcp_peer_input_handler, tc, 1) < 0)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot set TCP peer data input callback\n", __FUNCTION__);
         success = 0;
         err_code = 500;
       }
     }
 
-    if (success) {
+    if (success)
+    {
       tc->state = TC_STATE_PEER_CONNECTED;
       stun_init_success_response_str(STUN_METHOD_CONNECT, ioa_network_buffer_data(nbh), &len, &(tc->tid));
       stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_CONNECTION_ID, (const uint8_t *)&(tc->id),
@@ -2040,17 +2550,20 @@ static void tcp_peer_connection_completed_callback(int success, void *arg) {
       IOA_EVENT_DEL(tc->conn_bind_timeout);
       tc->conn_bind_timeout = set_ioa_timer(server->e, TCP_CONN_BIND_TIMEOUT, 0, tcp_conn_bind_timeout_handler, tc, 0,
                                             "tcp_conn_bind_timeout_handler");
-
-    } else {
+    }
+    else
+    {
       tc->state = TC_STATE_FAILED;
-      if (!err_code) {
+      if (!err_code)
+      {
         err_code = 447;
       }
       {
         char ls[257] = "\0";
         char rs[257] = "\0";
         ioa_addr *laddr = get_local_addr_from_ioa_socket(ss->client_socket);
-        if (laddr) {
+        if (laddr)
+        {
           addr_to_string(laddr, (uint8_t *)ls);
         }
         addr_to_string(&(tc->peer_addr), (uint8_t *)rs);
@@ -2061,7 +2574,8 @@ static void tcp_peer_connection_completed_callback(int success, void *arg) {
 
     ioa_network_buffer_set_size(nbh, len);
 
-    if (need_stun_authentication(server, ss)) {
+    if (need_stun_authentication(server, ss))
+    {
       stun_attr_add_integrity_str(server->ct, ioa_network_buffer_data(nbh), &len, ss->hmackey, ss->pwd,
                                   SHATYPE_DEFAULT);
       ioa_network_buffer_set_size(nbh, len);
@@ -2069,13 +2583,16 @@ static void tcp_peer_connection_completed_callback(int success, void *arg) {
 
     write_client_connection(server, ss, nbh, TTL_IGNORE, TOS_IGNORE);
 
-    if (!success) {
+    if (!success)
+    {
       delete_tcp_connection(tc);
     }
     /* test */
-    else if (0) {
+    else if (0)
+    {
       int i = 0;
-      for (i = 0; i < 22; i++) {
+      for (i = 0; i < 22; i++)
+      {
         ioa_network_buffer_handle nbh_test = ioa_network_buffer_allocate(server->e);
         size_t len_test = ioa_network_buffer_get_size(nbh_test);
         uint8_t *data = ioa_network_buffer_data(nbh_test);
@@ -2089,31 +2606,36 @@ static void tcp_peer_connection_completed_callback(int success, void *arg) {
   }
 }
 
-static void tcp_peer_conn_timeout_handler(ioa_engine_handle e, void *arg) {
+static void tcp_peer_conn_timeout_handler(ioa_engine_handle e, void *arg)
+{
   UNUSED_ARG(e);
 
   tcp_peer_connection_completed_callback(0, arg);
 }
 
 static int tcp_start_connection_to_peer(turn_turnserver *server, ts_ur_super_session *ss, stun_tid *tid, allocation *a,
-                                        ioa_addr *peer_addr, int *err_code, const uint8_t **reason) {
+                                        ioa_addr *peer_addr, int *err_code, const uint8_t **reason)
+{
   FUNCSTART;
 
-  if (!server || !ss) {
+  if (!server || !ss)
+  {
     *err_code = 500;
     *reason = (const uint8_t *)"Server error: empty session";
     FUNCEND;
     return -1;
   }
 
-  if (!peer_addr) {
+  if (!peer_addr)
+  {
     *err_code = 500;
     *reason = (const uint8_t *)"Server error: empty peer addr";
     FUNCEND;
     return -1;
   }
 
-  if (!get_relay_socket(a, peer_addr->ss.sa_family)) {
+  if (!get_relay_socket(a, peer_addr->ss.sa_family))
+  {
     *err_code = 500;
     *reason = (const uint8_t *)"Server error: no relay connection created";
     FUNCEND;
@@ -2121,21 +2643,26 @@ static int tcp_start_connection_to_peer(turn_turnserver *server, ts_ur_super_ses
   }
 
   tcp_connection *tc = get_tcp_connection_by_peer(a, peer_addr);
-  if (tc) {
+  if (tc)
+  {
     *err_code = 446;
     FUNCEND;
     return -1;
   }
 
   tc = create_tcp_connection(server->id, a, tid, peer_addr, err_code);
-  if (!tc) {
-    if (!(*err_code)) {
+  if (!tc)
+  {
+    if (!(*err_code))
+    {
       *err_code = 500;
       *reason = (const uint8_t *)"Server error: TCP connection object creation failed";
     }
     FUNCEND;
     return -1;
-  } else if (*err_code) {
+  }
+  else if (*err_code)
+  {
     delete_tcp_connection(tc);
     FUNCEND;
     return -1;
@@ -2147,7 +2674,8 @@ static int tcp_start_connection_to_peer(turn_turnserver *server, ts_ur_super_ses
 
   ioa_socket_handle tcs = ioa_create_connecting_tcp_relay_socket(get_relay_socket(a, peer_addr->ss.sa_family),
                                                                  peer_addr, tcp_peer_connection_completed_callback, tc);
-  if (!tcs) {
+  if (!tcs)
+  {
     delete_tcp_connection(tc);
     *err_code = 500;
     *reason = (const uint8_t *)"Server error: TCP relay socket for connection cannot be created";
@@ -2156,7 +2684,8 @@ static int tcp_start_connection_to_peer(turn_turnserver *server, ts_ur_super_ses
   }
 
   tc->state = TC_STATE_CLIENT_TO_PEER_CONNECTING;
-  if (tc->peer_s != tcs) {
+  if (tc->peer_s != tcs)
+  {
     IOA_CLOSE_SOCKET(tc->peer_s);
     tc->peer_s = tcs;
   }
@@ -2166,10 +2695,13 @@ static int tcp_start_connection_to_peer(turn_turnserver *server, ts_ur_super_ses
   return 0;
 }
 
-static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg) {
-  if (s) {
+static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg)
+{
+  if (s)
+  {
 
-    if (!arg) {
+    if (!arg)
+    {
       close_ioa_socket(s);
       return;
     }
@@ -2177,7 +2709,8 @@ static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg) {
     ts_ur_super_session *ss = (ts_ur_super_session *)arg;
     turn_turnserver *server = (turn_turnserver *)(ss->server);
 
-    if (!server) {
+    if (!server)
+    {
       close_ioa_socket(s);
       return;
     }
@@ -2186,23 +2719,27 @@ static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg) {
 
     allocation *a = &(ss->alloc);
     ioa_addr *peer_addr = get_remote_addr_from_ioa_socket(s);
-    if (!peer_addr) {
+    if (!peer_addr)
+    {
       close_ioa_socket(s);
       FUNCEND;
       return;
     }
 
     tcp_connection *tc = get_tcp_connection_by_peer(a, peer_addr);
-    if (tc) {
+    if (tc)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: peer data socket with this address already exist\n", __FUNCTION__);
-      if (tc->peer_s != s) {
+      if (tc->peer_s != s)
+      {
         close_ioa_socket(s);
       }
       FUNCEND;
       return;
     }
 
-    if (!good_peer_addr(server, ss->realm_options.name, peer_addr, ss->id)) {
+    if (!good_peer_addr(server, ss->realm_options.name, peer_addr, ss->id))
+    {
       uint8_t saddr[256];
       addr_to_string(peer_addr, saddr);
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: an attempt to connect from a peer with forbidden address: %s\n",
@@ -2212,7 +2749,8 @@ static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg) {
       return;
     }
 
-    if (!can_accept_tcp_connection_from_peer(a, peer_addr, server->server_relay)) {
+    if (!can_accept_tcp_connection_from_peer(a, peer_addr, server->server_relay))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: peer has no permission to connect\n", __FUNCTION__);
       close_ioa_socket(s);
       FUNCEND;
@@ -2223,7 +2761,8 @@ static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg) {
     memset(&tid, 0, sizeof(stun_tid));
     int err_code = 0;
     tc = create_tcp_connection(server->id, a, &tid, peer_addr, &err_code);
-    if (!tc) {
+    if (!tc)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot create TCP connection\n", __FUNCTION__);
       close_ioa_socket(s);
       FUNCEND;
@@ -2236,7 +2775,8 @@ static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg) {
     set_ioa_socket_session(s, ss);
     set_ioa_socket_sub_session(s, tc);
 
-    if (register_callback_on_ioa_socket(server->e, s, IOA_EV_READ, tcp_peer_input_handler, tc, 1) < 0) {
+    if (register_callback_on_ioa_socket(server->e, s, IOA_EV_READ, tcp_peer_input_handler, tc, 1) < 0)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot set TCP peer data input callback\n", __FUNCTION__);
       IOA_CLOSE_SOCKET(tc->peer_s);
       tc->state = TC_STATE_UNKNOWN;
@@ -2259,7 +2799,8 @@ static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg) {
 
     maybe_add_software_attribute(server, nbh);
 
-    if ((server->fingerprint) || ss->enforce_fingerprints) {
+    if ((server->fingerprint) || ss->enforce_fingerprints)
+    {
       size_t len = ioa_network_buffer_get_size(nbh);
       stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &len);
       ioa_network_buffer_set_size(nbh, len);
@@ -2273,7 +2814,8 @@ static void tcp_peer_accept_connection(ioa_socket_handle s, void *arg) {
 
 static int handle_turn_connect(turn_turnserver *server, ts_ur_super_session *ss, stun_tid *tid, int *err_code,
                                const uint8_t **reason, uint16_t *unknown_attrs, uint16_t *ua_num,
-                               ioa_net_data *in_buffer) {
+                               ioa_net_data *in_buffer)
+{
 
   FUNCSTART;
   ioa_addr peer_addr;
@@ -2281,26 +2823,38 @@ static int handle_turn_connect(turn_turnserver *server, ts_ur_super_session *ss,
   addr_set_any(&peer_addr);
   allocation *a = get_allocation_ss(ss);
 
-  if (!(ss->is_tcp_relay)) {
+  if (!(ss->is_tcp_relay))
+  {
     *err_code = 403;
     *reason = (const uint8_t *)"Connect cannot be used with UDP relay";
-  } else if (!is_allocation_valid(a)) {
+  }
+  else if (!is_allocation_valid(a))
+  {
     *err_code = 437;
-  } else {
+  }
+  else
+  {
 
     stun_attr_ref sar =
         stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
-    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS)) {
+    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS))
+    {
       int attr_type = stun_attr_get_type(sar);
-      switch (attr_type) {
+      switch (attr_type)
+      {
         SKIP_ATTRIBUTES;
-      case STUN_ATTRIBUTE_XOR_PEER_ADDRESS: {
+      case STUN_ATTRIBUTE_XOR_PEER_ADDRESS:
+      {
         if (!stun_attr_get_addr_str(ioa_network_buffer_data(in_buffer->nbh),
-                                    ioa_network_buffer_get_size(in_buffer->nbh), sar, &peer_addr, NULL)) {
+                                    ioa_network_buffer_get_size(in_buffer->nbh), sar, &peer_addr, NULL))
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Bad Peer Address";
-        } else {
-          if (!get_relay_socket(a, peer_addr.ss.sa_family)) {
+        }
+        else
+        {
+          if (!get_relay_socket(a, peer_addr.ss.sa_family))
+          {
             *err_code = 443;
             *reason = (const uint8_t *)"Peer Address Family Mismatch (2)";
           }
@@ -2310,7 +2864,8 @@ static int handle_turn_connect(turn_turnserver *server, ts_ur_super_session *ss,
         break;
       }
       default:
-        if (attr_type >= 0x0000 && attr_type <= 0x7FFF) {
+        if (attr_type >= 0x0000 && attr_type <= 0x7FFF)
+        {
           unknown_attrs[(*ua_num)++] = nswap16(attr_type);
         }
       };
@@ -2318,24 +2873,31 @@ static int handle_turn_connect(turn_turnserver *server, ts_ur_super_session *ss,
                                    sar);
     }
 
-    if (*ua_num > 0) {
+    if (*ua_num > 0)
+    {
 
       *err_code = 420;
-
-    } else if (*err_code) {
+    }
+    else if (*err_code)
+    {
 
       ;
-
-    } else if (!peer_found) {
+    }
+    else if (!peer_found)
+    {
 
       *err_code = 400;
       *reason = (const uint8_t *)"Where is Peer Address ?";
-
-    } else {
-      if (!good_peer_addr(server, ss->realm_options.name, &peer_addr, ss->id)) {
+    }
+    else
+    {
+      if (!good_peer_addr(server, ss->realm_options.name, &peer_addr, ss->id))
+      {
         *err_code = 403;
         *reason = (const uint8_t *)"Forbidden IP";
-      } else {
+      }
+      else
+      {
         tcp_start_connection_to_peer(server, ss, tid, a, &peer_addr, err_code, reason);
       }
     }
@@ -2348,51 +2910,67 @@ static int handle_turn_connect(turn_turnserver *server, ts_ur_super_session *ss,
 static int handle_turn_connection_bind(turn_turnserver *server, ts_ur_super_session *ss, stun_tid *tid,
                                        int *resp_constructed, int *err_code, const uint8_t **reason,
                                        uint16_t *unknown_attrs, uint16_t *ua_num, ioa_net_data *in_buffer,
-                                       ioa_network_buffer_handle nbh, int message_integrity, int can_resume) {
+                                       ioa_network_buffer_handle nbh, int message_integrity, int can_resume)
+{
 
   allocation *a = get_allocation_ss(ss);
 
   uint16_t method = STUN_METHOD_CONNECTION_BIND;
 
-  if (ss->to_be_closed) {
+  if (ss->to_be_closed)
+  {
 
     *err_code = 400;
-
-  } else if (is_allocation_valid(a)) {
+  }
+  else if (is_allocation_valid(a))
+  {
 
     *err_code = 400;
     *reason = (const uint8_t *)"Bad request: CONNECTION_BIND cannot be issued after allocation";
-
-  } else if (!is_stream_socket(get_ioa_socket_type(ss->client_socket))) {
+  }
+  else if (!is_stream_socket(get_ioa_socket_type(ss->client_socket)))
+  {
 
     *err_code = 400;
     *reason = (const uint8_t *)"Bad request: CONNECTION_BIND only possible with TCP/TLS";
-
-  } else {
+  }
+  else
+  {
     tcp_connection_id id = 0;
 
     stun_attr_ref sar =
         stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
-    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS)) {
+    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS))
+    {
       int attr_type = stun_attr_get_type(sar);
-      switch (attr_type) {
+      switch (attr_type)
+      {
         SKIP_ATTRIBUTES;
-      case STUN_ATTRIBUTE_CONNECTION_ID: {
-        if (stun_attr_get_len(sar) != 4) {
+      case STUN_ATTRIBUTE_CONNECTION_ID:
+      {
+        if (stun_attr_get_len(sar) != 4)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Wrong Connection ID field format";
-        } else {
+        }
+        else
+        {
           const uint8_t *value = stun_attr_get_value(sar);
-          if (!value) {
+          if (!value)
+          {
             *err_code = 400;
             *reason = (const uint8_t *)"Wrong Connection ID field data";
-          } else {
+          }
+          else
+          {
             id = *((const uint32_t *)value); // AS-IS encoding, no conversion to/from network byte order
           }
         }
-      } break;
+      }
+      break;
       default:
-        if (attr_type >= 0x0000 && attr_type <= 0x7FFF) {
+        if (attr_type >= 0x0000 && attr_type <= 0x7FFF)
+        {
           unknown_attrs[(*ua_num)++] = nswap16(attr_type);
         }
       };
@@ -2400,42 +2978,57 @@ static int handle_turn_connection_bind(turn_turnserver *server, ts_ur_super_sess
                                    sar);
     }
 
-    if (*ua_num > 0) {
+    if (*ua_num > 0)
+    {
 
       *err_code = 420;
-
-    } else if (*err_code) {
+    }
+    else if (*err_code)
+    {
 
       ;
-
-    } else {
-      if (server->send_socket_to_relay) {
+    }
+    else
+    {
+      if (server->send_socket_to_relay)
+      {
         turnserver_id sid = (id & 0xFF000000) >> 24;
         ioa_socket_handle s = ss->client_socket;
-        if (s && !ioa_socket_tobeclosed(s)) {
+        if (s && !ioa_socket_tobeclosed(s))
+        {
           ioa_socket_handle new_s = detach_ioa_socket(s);
-          if (new_s) {
+          if (new_s)
+          {
             if (server->send_socket_to_relay(sid, id, tid, new_s, message_integrity, RMT_CB_SOCKET, in_buffer,
-                                             can_resume) < 0) {
+                                             can_resume) < 0)
+            {
               *err_code = 400;
               *reason = (const uint8_t *)"Wrong connection id";
             }
-          } else {
+          }
+          else
+          {
             *err_code = 500;
           }
-        } else {
+        }
+        else
+        {
           *err_code = 500;
         }
-      } else {
+      }
+      else
+      {
         *err_code = 500;
       }
       ss->to_be_closed = 1;
     }
   }
 
-  if (!(*resp_constructed) && ss->client_socket && !ioa_socket_tobeclosed(ss->client_socket)) {
+  if (!(*resp_constructed) && ss->client_socket && !ioa_socket_tobeclosed(ss->client_socket))
+  {
 
-    if (!(*err_code)) {
+    if (!(*err_code))
+    {
       *err_code = 437;
     }
 
@@ -2451,8 +3044,10 @@ static int handle_turn_connection_bind(turn_turnserver *server, ts_ur_super_sess
 
 int turnserver_accept_tcp_client_data_connection(turn_turnserver *server, tcp_connection_id tcid, stun_tid *tid,
                                                  ioa_socket_handle s, int message_integrity, ioa_net_data *in_buffer,
-                                                 int can_resume) {
-  if (!server) {
+                                                 int can_resume)
+{
+  if (!server)
+  {
     return -1;
   }
 
@@ -2466,34 +3061,46 @@ int turnserver_accept_tcp_client_data_connection(turn_turnserver *server, tcp_co
 
   ioa_socket_handle s_to_delete = s;
 
-  if (tcid && tid && s) {
+  if (tcid && tid && s)
+  {
 
     tc = get_tcp_connection_by_id(server->tcp_relay_connections, tcid);
     ioa_network_buffer_handle nbh = ioa_network_buffer_allocate(server->e);
     int resp_constructed = 0;
-    if (!tc || (tc->state == TC_STATE_READY) || (tc->client_s)) {
+    if (!tc || (tc->state == TC_STATE_READY) || (tc->client_s))
+    {
       err_code = 400;
-    } else {
+    }
+    else
+    {
       allocation *a = (allocation *)(tc->owner);
-      if (!a || !(a->owner)) {
+      if (!a || !(a->owner))
+      {
         err_code = 500;
-      } else {
+      }
+      else
+      {
         ss = (ts_ur_super_session *)(a->owner);
 
-        if (ss->to_be_closed || ioa_socket_tobeclosed(ss->client_socket)) {
+        if (ss->to_be_closed || ioa_socket_tobeclosed(ss->client_socket))
+        {
           err_code = 404;
-        } else {
+        }
+        else
+        {
           // Check security:
           int postpone_reply = 0;
           check_stun_auth(server, ss, tid, &resp_constructed, &err_code, &reason, in_buffer, nbh,
                           STUN_METHOD_CONNECTION_BIND, &message_integrity, &postpone_reply, can_resume);
 
-          if (postpone_reply) {
+          if (postpone_reply)
+          {
 
             ioa_network_buffer_delete(server->e, nbh);
             return 0;
-
-          } else if (!err_code) {
+          }
+          else if (!err_code)
+          {
             tc->state = TC_STATE_READY;
             tc->client_s = s;
             s_to_delete = NULL;
@@ -2501,10 +3108,13 @@ int turnserver_accept_tcp_client_data_connection(turn_turnserver *server, tcp_co
             set_ioa_socket_sub_session(s, tc);
             set_ioa_socket_app_type(s, TCP_CLIENT_DATA_SOCKET);
             if (register_callback_on_ioa_socket(server->e, s, IOA_EV_READ, tcp_client_input_handler_rfc6062data, tc,
-                                                1) < 0) {
+                                                1) < 0)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot set TCP client data input callback\n", __FUNCTION__);
               err_code = 500;
-            } else {
+            }
+            else
+            {
               IOA_EVENT_DEL(tc->conn_bind_timeout);
             }
           }
@@ -2512,16 +3122,21 @@ int turnserver_accept_tcp_client_data_connection(turn_turnserver *server, tcp_co
       }
     }
 
-    if (tc) {
+    if (tc)
+    {
       get_and_clean_tcp_connection_by_id(server->tcp_relay_connections, tcid);
     }
 
-    if (!resp_constructed) {
-      if (!err_code) {
+    if (!resp_constructed)
+    {
+      if (!err_code)
+      {
         size_t len = ioa_network_buffer_get_size(nbh);
         stun_init_success_response_str(STUN_METHOD_CONNECTION_BIND, ioa_network_buffer_data(nbh), &len, tid);
         ioa_network_buffer_set_size(nbh, len);
-      } else {
+      }
+      else
+      {
         size_t len = ioa_network_buffer_get_size(nbh);
         stun_init_error_response_str(STUN_METHOD_CONNECTION_BIND, ioa_network_buffer_data(nbh), &len, err_code, NULL,
                                      tid);
@@ -2531,35 +3146,44 @@ int turnserver_accept_tcp_client_data_connection(turn_turnserver *server, tcp_co
 
     maybe_add_software_attribute(server, nbh);
 
-    if (message_integrity && ss) {
+    if (message_integrity && ss)
+    {
       size_t len = ioa_network_buffer_get_size(nbh);
       stun_attr_add_integrity_str(server->ct, ioa_network_buffer_data(nbh), &len, ss->hmackey, ss->pwd,
                                   SHATYPE_DEFAULT);
       ioa_network_buffer_set_size(nbh, len);
     }
 
-    if ((server->fingerprint) || (ss && (ss->enforce_fingerprints))) {
+    if ((server->fingerprint) || (ss && (ss->enforce_fingerprints)))
+    {
       size_t len = ioa_network_buffer_get_size(nbh);
       stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &len);
       ioa_network_buffer_set_size(nbh, len);
     }
 
-    if (server->verbose) {
+    if (server->verbose)
+    {
       log_method(ss, "CONNECTION_BIND", err_code, reason);
     }
 
-    if (ss && !err_code) {
+    if (ss && !err_code)
+    {
       send_data_from_ioa_socket_nbh(s, NULL, nbh, TTL_IGNORE, TOS_IGNORE, NULL);
       tcp_deliver_delayed_buffer(&(tc->ub_to_client), s, ss);
       IOA_CLOSE_SOCKET(s_to_delete);
       FUNCEND;
       return 0;
-    } else {
+    }
+    else
+    {
       /* Just to set the necessary structures for the packet sending: */
-      if (register_callback_on_ioa_socket(server->e, s, IOA_EV_READ, NULL, NULL, 1) < 0) {
+      if (register_callback_on_ioa_socket(server->e, s, IOA_EV_READ, NULL, NULL, 1) < 0)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot set TCP tmp client data input callback\n", __FUNCTION__);
         ioa_network_buffer_delete(server->e, nbh);
-      } else {
+      }
+      else
+      {
         send_data_from_ioa_socket_nbh(s, NULL, nbh, TTL_IGNORE, TOS_IGNORE, NULL);
       }
     }
@@ -2576,7 +3200,8 @@ int turnserver_accept_tcp_client_data_connection(turn_turnserver *server, tcp_co
 static int handle_turn_channel_bind(turn_turnserver *server, ts_ur_super_session *ss, stun_tid *tid,
                                     int *resp_constructed, int *err_code, const uint8_t **reason,
                                     uint16_t *unknown_attrs, uint16_t *ua_num, ioa_net_data *in_buffer,
-                                    ioa_network_buffer_handle nbh) {
+                                    ioa_network_buffer_handle nbh)
+{
 
   FUNCSTART;
   uint16_t chnum = 0;
@@ -2585,51 +3210,66 @@ static int handle_turn_channel_bind(turn_turnserver *server, ts_ur_super_session
   allocation *a = get_allocation_ss(ss);
   int addr_found = 0;
 
-  if (ss->is_tcp_relay) {
+  if (ss->is_tcp_relay)
+  {
     *err_code = 403;
     *reason = (const uint8_t *)"Channel bind cannot be used with TCP relay";
-  } else if (is_allocation_valid(a)) {
+  }
+  else if (is_allocation_valid(a))
+  {
 
     stun_attr_ref sar =
         stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
-    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS)) {
+    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS))
+    {
       int attr_type = stun_attr_get_type(sar);
-      switch (attr_type) {
+      switch (attr_type)
+      {
         SKIP_ATTRIBUTES;
-      case STUN_ATTRIBUTE_CHANNEL_NUMBER: {
-        if (chnum) {
+      case STUN_ATTRIBUTE_CHANNEL_NUMBER:
+      {
+        if (chnum)
+        {
           chnum = 0;
           *err_code = 400;
           *reason = (const uint8_t *)"Channel number cannot be duplicated in this request";
           break;
         }
         chnum = stun_attr_get_channel_number(sar);
-        if (!chnum) {
+        if (!chnum)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Channel number cannot be zero in this request";
           break;
         }
-      } break;
-      case STUN_ATTRIBUTE_XOR_PEER_ADDRESS: {
+      }
+      break;
+      case STUN_ATTRIBUTE_XOR_PEER_ADDRESS:
+      {
         stun_attr_get_addr_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh),
                                sar, &peer_addr, NULL);
 
-        if (!get_relay_socket(a, peer_addr.ss.sa_family)) {
+        if (!get_relay_socket(a, peer_addr.ss.sa_family))
+        {
           *err_code = 443;
           *reason = (const uint8_t *)"Peer Address Family Mismatch (3)";
         }
 
-        if (addr_get_port(&peer_addr) < 1) {
+        if (addr_get_port(&peer_addr) < 1)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Empty port number in channel bind request";
-        } else {
+        }
+        else
+        {
           addr_found = 1;
         }
 
         break;
       }
       default:
-        if (attr_type >= 0x0000 && attr_type <= 0x7FFF) {
+        if (attr_type >= 0x0000 && attr_type <= 0x7FFF)
+        {
           unknown_attrs[(*ua_num)++] = nswap16(attr_type);
         }
       };
@@ -2637,67 +3277,93 @@ static int handle_turn_channel_bind(turn_turnserver *server, ts_ur_super_session
                                    sar);
     }
 
-    if (*ua_num > 0) {
+    if (*ua_num > 0)
+    {
 
       *err_code = 420;
-
-    } else if (*err_code) {
+    }
+    else if (*err_code)
+    {
 
       ;
-
-    } else if (!chnum || addr_any(&peer_addr) || !addr_found) {
+    }
+    else if (!chnum || addr_any(&peer_addr) || !addr_found)
+    {
 
       *err_code = 400;
       *reason = (const uint8_t *)"Bad channel bind request";
-
-    } else if (!STUN_VALID_CHANNEL(chnum)) {
+    }
+    else if (!STUN_VALID_CHANNEL(chnum))
+    {
 
       *err_code = 400;
       *reason = (const uint8_t *)"Bad channel number";
-
-    } else {
+    }
+    else
+    {
 
       ch_info *chn = allocation_get_ch_info(a, chnum);
       turn_permission_info *tinfo = NULL;
 
-      if (chn) {
-        if (!addr_eq(&peer_addr, &(chn->peer_addr))) {
+      if (chn)
+      {
+        if (!addr_eq(&peer_addr, &(chn->peer_addr)))
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"You cannot use the same channel number with different peer";
-        } else {
+        }
+        else
+        {
           tinfo = (turn_permission_info *)(chn->owner);
-          if (!tinfo) {
+          if (!tinfo)
+          {
             *err_code = 500;
             *reason = (const uint8_t *)"Wrong permission info";
-          } else {
-            if (!addr_eq_no_port(&peer_addr, &(tinfo->addr))) {
+          }
+          else
+          {
+            if (!addr_eq_no_port(&peer_addr, &(tinfo->addr)))
+            {
               *err_code = 500;
               *reason = (const uint8_t *)"Wrong permission info and peer addr combination";
-            } else if (chn->port != addr_get_port(&peer_addr)) {
+            }
+            else if (chn->port != addr_get_port(&peer_addr))
+            {
               *err_code = 500;
               *reason = (const uint8_t *)"Wrong port number";
             }
           }
         }
-
-      } else {
+      }
+      else
+      {
 
         chn = allocation_get_ch_info_by_peer_addr(a, &peer_addr);
-        if (chn) {
+        if (chn)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"You cannot use the same peer with different channel number";
-        } else {
-          if (!good_peer_addr(server, ss->realm_options.name, &peer_addr, ss->id)) {
+        }
+        else
+        {
+          if (!good_peer_addr(server, ss->realm_options.name, &peer_addr, ss->id))
+          {
             *err_code = 403;
             *reason = (const uint8_t *)"Forbidden IP";
-          } else {
+          }
+          else
+          {
             chn = allocation_get_new_ch_info(a, chnum, &peer_addr);
-            if (!chn) {
+            if (!chn)
+            {
               *err_code = 500;
               *reason = (const uint8_t *)"Cannot find channel data";
-            } else {
+            }
+            else
+            {
               tinfo = (turn_permission_info *)(chn->owner);
-              if (!tinfo) {
+              if (!tinfo)
+              {
                 *err_code = 500;
                 *reason = (const uint8_t *)"Wrong turn permission info";
               }
@@ -2706,22 +3372,29 @@ static int handle_turn_channel_bind(turn_turnserver *server, ts_ur_super_session
         }
       }
 
-      if (!(*err_code) && chn && tinfo) {
+      if (!(*err_code) && chn && tinfo)
+      {
 
-        if (update_channel_lifetime(ss, chn) < 0) {
+        if (update_channel_lifetime(ss, chn) < 0)
+        {
           *err_code = 500;
           *reason = (const uint8_t *)"Cannot update channel lifetime (internal error)";
-        } else {
+        }
+        else
+        {
           size_t len = ioa_network_buffer_get_size(nbh);
           stun_set_channel_bind_response_str(ioa_network_buffer_data(nbh), &len, tid, 0, NULL);
           ioa_network_buffer_set_size(nbh, len);
           *resp_constructed = 1;
 
-          if (!(ss->is_mobile)) {
+          if (!(ss->is_mobile))
+          {
             if (get_ioa_socket_type(ss->client_socket) == UDP_SOCKET ||
                 get_ioa_socket_type(ss->client_socket) == TCP_SOCKET ||
-                get_ioa_socket_type(ss->client_socket) == SCTP_SOCKET) {
-              if (get_ioa_socket_type(get_relay_socket(&(ss->alloc), peer_addr.ss.sa_family)) == UDP_SOCKET) {
+                get_ioa_socket_type(ss->client_socket) == SCTP_SOCKET)
+            {
+              if (get_ioa_socket_type(get_relay_socket(&(ss->alloc), peer_addr.ss.sa_family)) == UDP_SOCKET)
+              {
                 chn->kernel_channel = CREATE_TURN_CHANNEL_KERNEL(
                     chn->chnum, get_ioa_socket_address_family(ss->client_socket), peer_addr.ss.sa_family,
                     (get_ioa_socket_type(ss->client_socket) == UDP_SOCKET ? IPPROTO_UDP : IPPROTO_TCP),
@@ -2745,7 +3418,8 @@ static int handle_turn_binding(turn_turnserver *server, ts_ur_super_session *ss,
                                int *err_code, const uint8_t **reason, uint16_t *unknown_attrs, uint16_t *ua_num,
                                ioa_net_data *in_buffer, ioa_network_buffer_handle nbh, int *origin_changed,
                                ioa_addr *response_origin, int *dest_changed, ioa_addr *response_destination,
-                               uint32_t cookie, int old_stun) {
+                               uint32_t cookie, int old_stun)
+{
 
   FUNCSTART;
   bool change_ip = false;
@@ -2756,7 +3430,8 @@ static int handle_turn_binding(turn_turnserver *server, ts_ur_super_session *ss,
   SOCKET_TYPE st = get_ioa_socket_type(ss->client_socket);
   int use_reflected_from = 0;
 
-  if (!(ss->client_socket)) {
+  if (!(ss->client_socket))
+  {
     return -1;
   }
 
@@ -2765,9 +3440,11 @@ static int handle_turn_binding(turn_turnserver *server, ts_ur_super_session *ss,
 
   stun_attr_ref sar =
       stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
-  while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS)) {
+  while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS))
+  {
     int attr_type = stun_attr_get_type(sar);
-    switch (attr_type) {
+    switch (attr_type)
+    {
     case OLD_STUN_ATTRIBUTE_PASSWORD:
       SKIP_ATTRIBUTES;
     case STUN_ATTRIBUTE_CHANGE_REQUEST:
@@ -2788,56 +3465,74 @@ static int handle_turn_binding(turn_turnserver *server, ts_ur_super_session *ss,
        *
        */
       stun_attr_get_change_request_str(sar, &change_ip, &change_port);
-      if ((!is_rfc5780(server)) && (change_ip || change_port)) {
+      if ((!is_rfc5780(server)) && (change_ip || change_port))
+      {
         *err_code = 420;
         *reason = (const uint8_t *)"Unknown attribute: TURN server was configured without RFC 5780 support";
         break;
       }
-      if (change_ip || change_port) {
-        if (st != UDP_SOCKET) {
+      if (change_ip || change_port)
+      {
+        if (st != UDP_SOCKET)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Wrong request: applicable only to UDP protocol";
         }
       }
       break;
     case STUN_ATTRIBUTE_PADDING:
-      if (response_port_present) {
+      if (response_port_present)
+      {
         *err_code = 400;
         *reason = (const uint8_t *)"Wrong request format: you cannot use PADDING and RESPONSE_PORT together";
-      } else if ((st != UDP_SOCKET) && (st != DTLS_SOCKET)) {
+      }
+      else if ((st != UDP_SOCKET) && (st != DTLS_SOCKET))
+      {
         *err_code = 400;
         *reason = (const uint8_t *)"Wrong request: padding applicable only to UDP and DTLS protocols";
-      } else {
+      }
+      else
+      {
         padding = 1;
       }
       break;
     case STUN_ATTRIBUTE_RESPONSE_PORT:
-      if (padding) {
+      if (padding)
+      {
         *err_code = 400;
         *reason = (const uint8_t *)"Wrong request format: you cannot use PADDING and RESPONSE_PORT together";
-      } else if (st != UDP_SOCKET) {
+      }
+      else if (st != UDP_SOCKET)
+      {
         *err_code = 400;
         *reason = (const uint8_t *)"Wrong request: applicable only to UDP protocol";
-      } else {
+      }
+      else
+      {
         int rp = stun_attr_get_response_port_str(sar);
-        if (rp >= 0) {
+        if (rp >= 0)
+        {
           response_port_present = 1;
           response_port = (uint16_t)rp;
-        } else {
+        }
+        else
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Wrong response port format";
         }
       }
       break;
     case OLD_STUN_ATTRIBUTE_RESPONSE_ADDRESS:
-      if (old_stun) {
+      if (old_stun)
+      {
         use_reflected_from = 1;
         stun_attr_get_addr_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh),
                                sar, response_destination, response_destination);
       }
       break;
     default:
-      if (attr_type >= 0x0000 && attr_type <= 0x7FFF) {
+      if (attr_type >= 0x0000 && attr_type <= 0x7FFF)
+      {
         unknown_attrs[(*ua_num)++] = nswap16(attr_type);
       }
     };
@@ -2845,82 +3540,107 @@ static int handle_turn_binding(turn_turnserver *server, ts_ur_super_session *ss,
                                  sar);
   }
 
-  if (*ua_num > 0) {
+  if (*ua_num > 0)
+  {
     *err_code = 420;
     stun_report_binding(ss, STUN_PROMETHEUS_METRIC_TYPE_ERROR);
-  } else if (*err_code) {
+  }
+  else if (*err_code)
+  {
     stun_report_binding(ss, STUN_PROMETHEUS_METRIC_TYPE_ERROR);
-
-  } else if (ss->client_socket && get_remote_addr_from_ioa_socket(ss->client_socket)) {
+  }
+  else if (ss->client_socket && get_remote_addr_from_ioa_socket(ss->client_socket))
+  {
     stun_report_binding(ss, STUN_PROMETHEUS_METRIC_TYPE_REQUEST);
 
     size_t len = ioa_network_buffer_get_size(nbh);
     if (stun_set_binding_response_str(ioa_network_buffer_data(nbh), &len, tid,
                                       get_remote_addr_from_ioa_socket(ss->client_socket), 0, NULL, cookie, old_stun,
-                                      *server->no_stun_backward_compatibility)) {
+                                      *server->no_stun_backward_compatibility))
+    {
 
       addr_cpy(response_origin, get_local_addr_from_ioa_socket(ss->client_socket));
 
       *resp_constructed = 1;
 
-      if (old_stun && use_reflected_from) {
+      if (old_stun && use_reflected_from)
+      {
         stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_REFLECTED_FROM,
                                get_remote_addr_from_ioa_socket(ss->client_socket));
       }
 
-      if (!is_rfc5780(server)) {
+      if (!is_rfc5780(server))
+      {
 
-        if (!(*server->response_origin_only_with_rfc5780)) {
-          if (old_stun) {
+        if (!(*server->response_origin_only_with_rfc5780))
+        {
+          if (old_stun)
+          {
             stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_SOURCE_ADDRESS,
                                    response_origin);
             stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_CHANGED_ADDRESS,
                                    response_origin);
-          } else {
+          }
+          else
+          {
             stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_RESPONSE_ORIGIN, response_origin);
           }
         }
-
-      } else if (ss->client_socket) {
+      }
+      else if (ss->client_socket)
+      {
 
         ioa_addr other_address;
 
-        if (get_other_address(server, ss, &other_address) == 0) {
+        if (get_other_address(server, ss, &other_address) == 0)
+        {
 
           addr_cpy(response_destination, get_remote_addr_from_ioa_socket(ss->client_socket));
 
-          if (change_ip) {
+          if (change_ip)
+          {
             *origin_changed = 1;
-            if (change_port) {
+            if (change_port)
+            {
               addr_cpy(response_origin, &other_address);
-            } else {
+            }
+            else
+            {
               int old_port = addr_get_port(response_origin);
               addr_cpy(response_origin, &other_address);
               addr_set_port(response_origin, old_port);
             }
-          } else if (change_port) {
+          }
+          else if (change_port)
+          {
             *origin_changed = 1;
             addr_set_port(response_origin, addr_get_port(&other_address));
           }
 
-          if (old_stun) {
+          if (old_stun)
+          {
             stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_SOURCE_ADDRESS,
                                    response_origin);
             stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_CHANGED_ADDRESS,
                                    &other_address);
-          } else {
+          }
+          else
+          {
             stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_RESPONSE_ORIGIN, response_origin);
             stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_OTHER_ADDRESS, &other_address);
           }
 
-          if (response_port_present) {
+          if (response_port_present)
+          {
             *dest_changed = 1;
             addr_set_port(response_destination, (int)response_port);
           }
 
-          if (padding) {
+          if (padding)
+          {
             int mtu = get_local_mtu_ioa_socket(ss->client_socket);
-            if (mtu < 68) {
+            if (mtu < 68)
+            {
               mtu = 1500;
             }
 
@@ -2938,7 +3658,8 @@ static int handle_turn_binding(turn_turnserver *server, ts_ur_super_session *ss,
 }
 
 static int handle_turn_send(turn_turnserver *server, ts_ur_super_session *ss, int *err_code, const uint8_t **reason,
-                            uint16_t *unknown_attrs, uint16_t *ua_num, ioa_net_data *in_buffer) {
+                            uint16_t *unknown_attrs, uint16_t *ua_num, ioa_net_data *in_buffer)
+{
 
   FUNCSTART;
 
@@ -2951,44 +3672,63 @@ static int handle_turn_send(turn_turnserver *server, ts_ur_super_session *ss, in
   addr_set_any(&peer_addr);
   allocation *a = get_allocation_ss(ss);
 
-  if (ss->is_tcp_relay) {
+  if (ss->is_tcp_relay)
+  {
     *err_code = 403;
     *reason = (const uint8_t *)"Send cannot be used with TCP relay";
-  } else if (is_allocation_valid(a) && (in_buffer->recv_ttl != 0)) {
+  }
+  else if (is_allocation_valid(a) && (in_buffer->recv_ttl != 0))
+  {
 
     stun_attr_ref sar =
         stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
-    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS)) {
+    while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS))
+    {
       int attr_type = stun_attr_get_type(sar);
-      switch (attr_type) {
+      switch (attr_type)
+      {
         SKIP_ATTRIBUTES;
       case STUN_ATTRIBUTE_DONT_FRAGMENT:
-        if (!(server->dont_fragment)) {
+        if (!(server->dont_fragment))
+        {
           unknown_attrs[(*ua_num)++] = nswap16(attr_type);
-        } else {
+        }
+        else
+        {
           set_df = 1;
         }
         break;
-      case STUN_ATTRIBUTE_XOR_PEER_ADDRESS: {
-        if (addr_found) {
+      case STUN_ATTRIBUTE_XOR_PEER_ADDRESS:
+      {
+        if (addr_found)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Address duplication";
-        } else {
+        }
+        else
+        {
           stun_attr_get_addr_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh),
                                  sar, &peer_addr, NULL);
         }
-      } break;
-      case STUN_ATTRIBUTE_DATA: {
-        if (len >= 0) {
+      }
+      break;
+      case STUN_ATTRIBUTE_DATA:
+      {
+        if (len >= 0)
+        {
           *err_code = 400;
           *reason = (const uint8_t *)"Data duplication";
-        } else {
+        }
+        else
+        {
           len = stun_attr_get_len(sar);
           value = stun_attr_get_value(sar);
         }
-      } break;
+      }
+      break;
       default:
-        if (attr_type >= 0x0000 && attr_type <= 0x7FFF) {
+        if (attr_type >= 0x0000 && attr_type <= 0x7FFF)
+        {
           unknown_attrs[(*ua_num)++] = nswap16(attr_type);
         }
       };
@@ -2996,29 +3736,38 @@ static int handle_turn_send(turn_turnserver *server, ts_ur_super_session *ss, in
                                    sar);
     }
 
-    if (*err_code) {
+    if (*err_code)
+    {
       ;
-    } else if (*ua_num > 0) {
+    }
+    else if (*ua_num > 0)
+    {
 
       *err_code = 420;
-
-    } else if (!addr_any(&peer_addr) && len >= 0) {
+    }
+    else if (!addr_any(&peer_addr) && len >= 0)
+    {
 
       turn_permission_info *tinfo = NULL;
 
-      if (!(server->server_relay)) {
+      if (!(server->server_relay))
+      {
         tinfo = allocation_get_permission(a, &peer_addr);
       }
 
-      if (tinfo || (server->server_relay)) {
+      if (tinfo || (server->server_relay))
+      {
 
         set_df_on_ioa_socket(get_relay_socket_ss(ss, peer_addr.ss.sa_family), set_df);
 
         ioa_network_buffer_handle nbh = in_buffer->nbh;
-        if (value && len > 0) {
+        if (value && len > 0)
+        {
           uint16_t offset = (uint16_t)(value - ioa_network_buffer_data(nbh));
           ioa_network_buffer_add_offset_size(nbh, offset, 0, len);
-        } else {
+        }
+        else
+        {
           len = 0;
           ioa_network_buffer_set_size(nbh, len);
         }
@@ -3026,15 +3775,17 @@ static int handle_turn_send(turn_turnserver *server, ts_ur_super_session *ss, in
         int skip = 0;
         send_data_from_ioa_socket_nbh(get_relay_socket_ss(ss, peer_addr.ss.sa_family), &peer_addr, nbh,
                                       in_buffer->recv_ttl - 1, in_buffer->recv_tos, &skip);
-        if (!skip) {
+        if (!skip)
+        {
           ++(ss->peer_sent_packets);
           ss->peer_sent_bytes += len;
           turn_report_session_usage(ss, 0);
         }
         in_buffer->nbh = NULL;
       }
-
-    } else {
+    }
+    else
+    {
       *err_code = 400;
       *reason = (const uint8_t *)"No address found";
     }
@@ -3044,9 +3795,11 @@ static int handle_turn_send(turn_turnserver *server, ts_ur_super_session *ss, in
   return 0;
 }
 
-static int update_permission(ts_ur_super_session *ss, ioa_addr *peer_addr) {
+static int update_permission(ts_ur_super_session *ss, ioa_addr *peer_addr)
+{
 
-  if (!ss || !peer_addr) {
+  if (!ss || !peer_addr)
+  {
     return -1;
   }
 
@@ -3054,21 +3807,26 @@ static int update_permission(ts_ur_super_session *ss, ioa_addr *peer_addr) {
 
   turn_permission_info *tinfo = allocation_get_permission(a, peer_addr);
 
-  if (!tinfo) {
+  if (!tinfo)
+  {
     tinfo = allocation_add_permission(a, peer_addr);
   }
 
-  if (!tinfo) {
+  if (!tinfo)
+  {
     return -1;
   }
 
-  if (update_turn_permission_lifetime(ss, tinfo, 0) < 0) {
+  if (update_turn_permission_lifetime(ss, tinfo, 0) < 0)
+  {
     return -1;
   }
 
   ch_info *chn = get_turn_channel(tinfo, peer_addr);
-  if (chn) {
-    if (update_channel_lifetime(ss, chn) < 0) {
+  if (chn)
+  {
+    if (update_channel_lifetime(ss, chn) < 0)
+    {
       return -1;
     }
   }
@@ -3079,7 +3837,8 @@ static int update_permission(ts_ur_super_session *ss, ioa_addr *peer_addr) {
 static int handle_turn_create_permission(turn_turnserver *server, ts_ur_super_session *ss, stun_tid *tid,
                                          int *resp_constructed, int *err_code, const uint8_t **reason,
                                          uint16_t *unknown_attrs, uint16_t *ua_num, ioa_net_data *in_buffer,
-                                         ioa_network_buffer_handle nbh) {
+                                         ioa_network_buffer_handle nbh)
+{
 
   int ret = -1;
 
@@ -3089,21 +3848,25 @@ static int handle_turn_create_permission(turn_turnserver *server, ts_ur_super_se
 
   allocation *a = get_allocation_ss(ss);
 
-  if (is_allocation_valid(a)) {
+  if (is_allocation_valid(a))
+  {
 
     {
       stun_attr_ref sar =
           stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
 
-      while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS)) {
+      while (sar && (!(*err_code)) && (*ua_num < MAX_NUMBER_OF_UNKNOWN_ATTRS))
+      {
 
         int attr_type = stun_attr_get_type(sar);
 
-        switch (attr_type) {
+        switch (attr_type)
+        {
 
           SKIP_ATTRIBUTES;
 
-        case STUN_ATTRIBUTE_XOR_PEER_ADDRESS: {
+        case STUN_ATTRIBUTE_XOR_PEER_ADDRESS:
+        {
 
           ioa_addr peer_addr;
           addr_set_any(&peer_addr);
@@ -3111,18 +3874,25 @@ static int handle_turn_create_permission(turn_turnserver *server, ts_ur_super_se
           stun_attr_get_addr_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh),
                                  sar, &peer_addr, NULL);
 
-          if (!get_relay_socket(a, peer_addr.ss.sa_family)) {
+          if (!get_relay_socket(a, peer_addr.ss.sa_family))
+          {
             *err_code = 443;
             *reason = (const uint8_t *)"Peer Address Family Mismatch (4)";
-          } else if (!good_peer_addr(server, ss->realm_options.name, &peer_addr, ss->id)) {
+          }
+          else if (!good_peer_addr(server, ss->realm_options.name, &peer_addr, ss->id))
+          {
             *err_code = 403;
             *reason = (const uint8_t *)"Forbidden IP";
-          } else {
+          }
+          else
+          {
             addr_found++;
           }
-        } break;
+        }
+        break;
         default:
-          if (attr_type >= 0x0000 && attr_type <= 0x7FFF) {
+          if (attr_type >= 0x0000 && attr_type <= 0x7FFF)
+          {
             unknown_attrs[(*ua_num)++] = nswap16(attr_type);
           }
         };
@@ -3131,33 +3901,40 @@ static int handle_turn_create_permission(turn_turnserver *server, ts_ur_super_se
       }
     }
 
-    if (*ua_num > 0) {
+    if (*ua_num > 0)
+    {
 
       *err_code = 420;
-
-    } else if (*err_code) {
+    }
+    else if (*err_code)
+    {
 
       ;
-
-    } else if (!addr_found) {
+    }
+    else if (!addr_found)
+    {
 
       *err_code = 400;
       *reason = (const uint8_t *)"No address found";
-
-    } else {
+    }
+    else
+    {
 
       stun_attr_ref sar =
           stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
 
-      while (sar) {
+      while (sar)
+      {
 
         int attr_type = stun_attr_get_type(sar);
 
-        switch (attr_type) {
+        switch (attr_type)
+        {
 
           SKIP_ATTRIBUTES;
 
-        case STUN_ATTRIBUTE_XOR_PEER_ADDRESS: {
+        case STUN_ATTRIBUTE_XOR_PEER_ADDRESS:
+        {
 
           ioa_addr peer_addr;
           addr_set_any(&peer_addr);
@@ -3166,11 +3943,13 @@ static int handle_turn_create_permission(turn_turnserver *server, ts_ur_super_se
                                  sar, &peer_addr, NULL);
 
           addr_set_port(&peer_addr, 0);
-          if (update_permission(ss, &peer_addr) < 0) {
+          if (update_permission(ss, &peer_addr) < 0)
+          {
             *err_code = 500;
             *reason = (const uint8_t *)"Cannot update some permissions (critical server software error)";
           }
-        } break;
+        }
+        break;
         default:;
         }
 
@@ -3178,7 +3957,8 @@ static int handle_turn_create_permission(turn_turnserver *server, ts_ur_super_se
                                      ioa_network_buffer_get_size(in_buffer->nbh), sar);
       }
 
-      if (*err_code == 0) {
+      if (*err_code == 0)
+      {
         size_t len = ioa_network_buffer_get_size(nbh);
         stun_init_success_response_str(STUN_METHOD_CREATE_PERMISSION, ioa_network_buffer_data(nbh), &len, tid);
         ioa_network_buffer_set_size(nbh, len);
@@ -3194,11 +3974,14 @@ static int handle_turn_create_permission(turn_turnserver *server, ts_ur_super_se
 
 // AUTH ==>>
 
-static int need_stun_authentication(turn_turnserver *server, ts_ur_super_session *ss) {
+static int need_stun_authentication(turn_turnserver *server, ts_ur_super_session *ss)
+{
   UNUSED_ARG(ss);
 
-  if (server) {
-    switch (server->ct) {
+  if (server)
+  {
+    switch (server->ct)
+    {
     case TURN_CREDENTIALS_LONG_TERM:
       return 1;
     default:;
@@ -3209,7 +3992,8 @@ static int need_stun_authentication(turn_turnserver *server, ts_ur_super_session
 }
 
 static int create_challenge_response(ts_ur_super_session *ss, stun_tid *tid, int *resp_constructed, int *err_code,
-                                     const uint8_t **reason, ioa_network_buffer_handle nbh, uint16_t method) {
+                                     const uint8_t **reason, ioa_network_buffer_handle nbh, uint16_t method)
+{
   size_t len = ioa_network_buffer_get_size(nbh);
   stun_init_error_response_str(method, ioa_network_buffer_data(nbh), &len, *err_code, *reason, tid);
   *resp_constructed = 1;
@@ -3218,11 +4002,14 @@ static int create_challenge_response(ts_ur_super_session *ss, stun_tid *tid, int
   stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_REALM, (uint8_t *)realm,
                     (int)(strlen((char *)(realm))));
 
-  if (ss->server) {
+  if (ss->server)
+  {
     turn_turnserver *server = (turn_turnserver *)ss->server;
-    if (server->oauth) {
+    if (server->oauth)
+    {
       const char *server_name = server->oauth_server_name;
-      if (!(server_name && server_name[0])) {
+      if (!(server_name && server_name[0]))
+      {
         server_name = realm;
       }
       stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_THIRD_PARTY_AUTHORIZATION,
@@ -3236,21 +4023,26 @@ static int create_challenge_response(ts_ur_super_session *ss, stun_tid *tid, int
 
 static void resume_processing_after_username_check(int success, int oauth, int max_session_time, hmackey_t hmackey,
                                                    password_t pwd, turn_turnserver *server, uint64_t ctxkey,
-                                                   ioa_net_data *in_buffer, uint8_t *realm) {
+                                                   ioa_net_data *in_buffer, uint8_t *realm)
+{
 
-  if (server && in_buffer && in_buffer->nbh) {
+  if (server && in_buffer && in_buffer->nbh)
+  {
 
     ts_ur_super_session *ss = get_session_from_map(server, (turnsession_id)ctxkey);
-    if (ss && ss->client_socket) {
+    if (ss && ss->client_socket)
+    {
       turn_turnserver *server = (turn_turnserver *)ss->server;
 
-      if (success) {
+      if (success)
+      {
         memcpy(ss->hmackey, hmackey, sizeof(hmackey_t));
         ss->hmackey_set = 1;
         ss->oauth = oauth;
         ss->max_session_time_auth = (turn_time_t)max_session_time;
         memcpy(ss->pwd, pwd, sizeof(password_t));
-        if (realm && realm[0] && strcmp((char *)realm, ss->realm_options.name)) {
+        if (realm && realm[0] && strcmp((char *)realm, ss->realm_options.name))
+        {
           dec_quota(ss);
           get_realm_options_by_name((char *)realm, &(ss->realm_options));
           inc_quota(ss, ss->username);
@@ -3270,13 +4062,15 @@ static void resume_processing_after_username_check(int success, int oauth, int m
 static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stun_tid *tid, int *resp_constructed,
                            int *err_code, const uint8_t **reason, ioa_net_data *in_buffer,
                            ioa_network_buffer_handle nbh, uint16_t method, int *message_integrity, int *postpone_reply,
-                           int can_resume) {
+                           int can_resume)
+{
   uint8_t usname[STUN_MAX_USERNAME_SIZE + 1];
   uint8_t nonce[STUN_MAX_NONCE_SIZE + 1];
   uint8_t realm[STUN_MAX_REALM_SIZE + 1];
   size_t alen = 0;
 
-  if (!need_stun_authentication(server, ss)) {
+  if (!need_stun_authentication(server, ss))
+  {
     return 0;
   }
 
@@ -3284,29 +4078,38 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
 
   {
     int generate_new_nonce = 0;
-    if (ss->nonce[0] == 0) {
+    if (ss->nonce[0] == 0)
+    {
       generate_new_nonce = 1;
       new_nonce = 1;
     }
 
-    if (*(server->stale_nonce)) {
-      if (turn_time_before(ss->nonce_expiration_time, server->ctime)) {
+    if (*(server->stale_nonce))
+    {
+      if (turn_time_before(ss->nonce_expiration_time, server->ctime))
+      {
         generate_new_nonce = 1;
       }
     }
 
-    if (generate_new_nonce) {
+    if (generate_new_nonce)
+    {
 
       int i = 0;
 
-      if (TURN_RANDOM_SIZE == 8) {
-        for (i = 0; i < (NONCE_LENGTH_32BITS >> 1); i++) {
+      if (TURN_RANDOM_SIZE == 8)
+      {
+        for (i = 0; i < (NONCE_LENGTH_32BITS >> 1); i++)
+        {
           uint8_t *s = ss->nonce + 8 * i;
           uint64_t rand = (uint64_t)turn_random();
           snprintf((char *)s, NONCE_MAX_SIZE - 8 * i, "%08lx", (unsigned long)rand);
         }
-      } else {
-        for (i = 0; i < NONCE_LENGTH_32BITS; i++) {
+      }
+      else
+      {
+        for (i = 0; i < NONCE_LENGTH_32BITS; i++)
+        {
           uint8_t *s = ss->nonce + 4 * i;
           uint32_t rand = (uint32_t)turn_random();
           snprintf((char *)s, NONCE_MAX_SIZE - 4 * i, "%04x", (unsigned int)rand);
@@ -3322,7 +4125,8 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
       stun_attr_get_first_by_type_str(ioa_network_buffer_data(in_buffer->nbh),
                                       ioa_network_buffer_get_size(in_buffer->nbh), STUN_ATTRIBUTE_MESSAGE_INTEGRITY);
 
-  if (!sar) {
+  if (!sar)
+  {
     *err_code = 401;
     return create_challenge_response(ss, tid, resp_constructed, err_code, reason, nbh, method);
   }
@@ -3330,7 +4134,8 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
   {
     int sarlen = stun_attr_get_len(sar);
 
-    switch (sarlen) {
+    switch (sarlen)
+    {
     case SHA1SIZEBYTES:
       break;
     case SHA256SIZEBYTES:
@@ -3349,7 +4154,8 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
     sar = stun_attr_get_first_by_type_str(ioa_network_buffer_data(in_buffer->nbh),
                                           ioa_network_buffer_get_size(in_buffer->nbh), STUN_ATTRIBUTE_REALM);
 
-    if (!sar) {
+    if (!sar)
+    {
       *err_code = 400;
       return -1;
     }
@@ -3358,7 +4164,8 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
     memcpy(realm, stun_attr_get_value(sar), alen);
     realm[alen] = 0;
 
-    if (!is_secure_string(realm, 0)) {
+    if (!is_secure_string(realm, 0))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "session %018llu: %s: wrong realm: %s\n", (unsigned long long)(ss->id),
                     __FUNCTION__, (char *)realm);
       realm[0] = 0;
@@ -3366,21 +4173,29 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
       return -1;
     }
 
-    if (method == STUN_METHOD_CONNECTION_BIND) {
+    if (method == STUN_METHOD_CONNECTION_BIND)
+    {
 
       get_realm_options_by_name((char *)realm, &(ss->realm_options));
-
-    } else if (strcmp((char *)realm, (char *)(ss->realm_options.name))) {
-      if (!(ss->oauth)) {
-        if (method == STUN_METHOD_ALLOCATE) {
+    }
+    else if (strcmp((char *)realm, (char *)(ss->realm_options.name)))
+    {
+      if (!(ss->oauth))
+      {
+        if (method == STUN_METHOD_ALLOCATE)
+        {
           *err_code = 437;
           *reason = (const uint8_t *)"Allocation mismatch: wrong credentials: the realm value is incorrect";
-        } else {
+        }
+        else
+        {
           *err_code = 441;
           *reason = (const uint8_t *)"Wrong credentials: the realm value is incorrect";
         }
         return -1;
-      } else {
+      }
+      else
+      {
         memcpy(realm, ss->realm_options.name, sizeof(ss->realm_options.name));
       }
     }
@@ -3391,7 +4206,8 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
   sar = stun_attr_get_first_by_type_str(ioa_network_buffer_data(in_buffer->nbh),
                                         ioa_network_buffer_get_size(in_buffer->nbh), STUN_ATTRIBUTE_USERNAME);
 
-  if (!sar) {
+  if (!sar)
+  {
     *err_code = 400;
     return -1;
   }
@@ -3400,28 +4216,40 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
   memcpy(usname, stun_attr_get_value(sar), alen);
   usname[alen] = 0;
 
-  if (!is_secure_string(usname, 1)) {
+  if (!is_secure_string(usname, 1))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "session %018llu: %s: wrong username: %s\n", (unsigned long long)(ss->id),
                   __FUNCTION__, (char *)usname);
     usname[0] = 0;
     *err_code = 400;
     return -1;
-  } else if (ss->username[0]) {
-    if (strcmp((char *)ss->username, (char *)usname)) {
-      if (ss->oauth) {
+  }
+  else if (ss->username[0])
+  {
+    if (strcmp((char *)ss->username, (char *)usname))
+    {
+      if (ss->oauth)
+      {
         ss->hmackey_set = 0;
         STRCPY(ss->username, usname);
-      } else {
-        if (method == STUN_METHOD_ALLOCATE) {
+      }
+      else
+      {
+        if (method == STUN_METHOD_ALLOCATE)
+        {
           *err_code = 437;
           *reason = (const uint8_t *)"Allocation mismatch: wrong credentials";
-        } else {
+        }
+        else
+        {
           *err_code = 441;
         }
         return -1;
       }
     }
-  } else {
+  }
+  else
+  {
     STRCPY(ss->username, usname);
   }
 
@@ -3431,7 +4259,8 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
     sar = stun_attr_get_first_by_type_str(ioa_network_buffer_data(in_buffer->nbh),
                                           ioa_network_buffer_get_size(in_buffer->nbh), STUN_ATTRIBUTE_NONCE);
 
-    if (!sar) {
+    if (!sar)
+    {
       *err_code = 400;
       return -1;
     }
@@ -3442,13 +4271,15 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
 
     /* Stale Nonce check: */
 
-    if (new_nonce) {
+    if (new_nonce)
+    {
       *err_code = 438;
       *reason = (const uint8_t *)"Wrong nonce";
       return create_challenge_response(ss, tid, resp_constructed, err_code, reason, nbh, method);
     }
 
-    if (strcmp((char *)ss->nonce, (char *)nonce)) {
+    if (strcmp((char *)ss->nonce, (char *)nonce))
+    {
       *err_code = 438;
       *reason = (const uint8_t *)"Stale nonce";
       return create_challenge_response(ss, tid, resp_constructed, err_code, reason, nbh, method);
@@ -3456,11 +4287,14 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
   }
 
   /* Password */
-  if (!(ss->hmackey_set) && (ss->pwd[0] == 0)) {
-    if (can_resume) {
+  if (!(ss->hmackey_set) && (ss->pwd[0] == 0))
+  {
+    if (can_resume)
+    {
       (server->userkeycb)(server->id, server->ct, server->oauth, &(ss->oauth), usname, realm,
                           resume_processing_after_username_check, in_buffer, ss->id, postpone_reply);
-      if (*postpone_reply) {
+      if (*postpone_reply)
+      {
         return 0;
       }
     }
@@ -3474,12 +4308,15 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
   /* Check integrity */
   if (stun_check_message_integrity_by_key_str(server->ct, ioa_network_buffer_data(in_buffer->nbh),
                                               ioa_network_buffer_get_size(in_buffer->nbh), ss->hmackey, ss->pwd,
-                                              SHATYPE_DEFAULT) < 1) {
+                                              SHATYPE_DEFAULT) < 1)
+  {
 
-    if (can_resume) {
+    if (can_resume)
+    {
       (server->userkeycb)(server->id, server->ct, server->oauth, &(ss->oauth), usname, realm,
                           resume_processing_after_username_check, in_buffer, ss->id, postpone_reply);
-      if (*postpone_reply) {
+      if (*postpone_reply)
+      {
         return 0;
       }
     }
@@ -3499,27 +4336,34 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
 
 static void set_alternate_server(turn_server_addrs_list_t *asl, const ioa_addr *local_addr, size_t *counter,
                                  uint16_t method, stun_tid *tid, int *resp_constructed, int *err_code,
-                                 const uint8_t **reason, ioa_network_buffer_handle nbh) {
-  if (asl && asl->size && local_addr) {
+                                 const uint8_t **reason, ioa_network_buffer_handle nbh)
+{
+  if (asl && asl->size && local_addr)
+  {
 
     size_t i;
 
     /* to prevent indefinite cycle: */
 
-    for (i = 0; i < asl->size; ++i) {
+    for (i = 0; i < asl->size; ++i)
+    {
       ioa_addr *addr = &(asl->addrs[i]);
-      if (addr_eq(addr, local_addr)) {
+      if (addr_eq(addr, local_addr))
+      {
         return;
       }
     }
 
-    for (i = 0; i < asl->size; ++i) {
-      if (*counter >= asl->size) {
+    for (i = 0; i < asl->size; ++i)
+    {
+      if (*counter >= asl->size)
+      {
         *counter = 0;
       }
       ioa_addr *addr = &(asl->addrs[*counter]);
       *counter += 1;
-      if (addr->ss.sa_family == local_addr->ss.sa_family) {
+      if (addr->ss.sa_family == local_addr->ss.sa_family)
+      {
 
         *err_code = 300;
 
@@ -3536,7 +4380,8 @@ static void set_alternate_server(turn_server_addrs_list_t *asl, const ioa_addr *
 }
 
 static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss, ioa_net_data *in_buffer,
-                               ioa_network_buffer_handle nbh, int *resp_constructed, int can_resume) {
+                               ioa_network_buffer_handle nbh, int *resp_constructed, int can_resume)
+{
 
   stun_tid tid;
   int err_code = 0;
@@ -3544,7 +4389,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
   int no_response = 0;
   int message_integrity = 0;
 
-  if (!(ss->client_socket)) {
+  if (!(ss->client_socket))
+  {
     return -1;
   }
 
@@ -3557,49 +4403,63 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 
   stun_tid_from_message_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh), &tid);
 
-  if (stun_is_request_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh))) {
+  if (stun_is_request_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh)))
+  {
 
-    if ((method == STUN_METHOD_BINDING) && (*(server->no_stun))) {
+    if ((method == STUN_METHOD_BINDING) && (*(server->no_stun)))
+    {
 
       no_response = 1;
-      if (server->verbose) {
+      if (server->verbose)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: %s: STUN method 0x%x ignored\n",
                       (unsigned long long)(ss->id), __FUNCTION__, (unsigned int)method);
       }
-
-    } else if ((method != STUN_METHOD_BINDING) && (*(server->stun_only))) {
+    }
+    else if ((method != STUN_METHOD_BINDING) && (*(server->stun_only)))
+    {
 
       no_response = 1;
-      if (server->verbose) {
+      if (server->verbose)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: %s: STUN method 0x%x ignored\n",
                       (unsigned long long)(ss->id), __FUNCTION__, (unsigned int)method);
       }
+    }
+    else if ((method != STUN_METHOD_BINDING) || (*(server->secure_stun)))
+    {
 
-    } else if ((method != STUN_METHOD_BINDING) || (*(server->secure_stun))) {
-
-      if (method == STUN_METHOD_ALLOCATE) {
+      if (method == STUN_METHOD_ALLOCATE)
+      {
 
         allocation *a = get_allocation_ss(ss);
-        if (is_allocation_valid(a)) {
-          if (!stun_tid_equals(&(a->tid), &tid)) {
+        if (is_allocation_valid(a))
+        {
+          if (!stun_tid_equals(&(a->tid), &tid))
+          {
             err_code = 437;
             reason = (const uint8_t *)"Mismatched allocation: wrong transaction ID";
           }
         }
 
-        if (!err_code) {
+        if (!err_code)
+        {
           SOCKET_TYPE cst = get_ioa_socket_type(ss->client_socket);
           turn_server_addrs_list_t *asl = server->alternate_servers_list;
 
           if (((cst == UDP_SOCKET) || (cst == DTLS_SOCKET)) && server->self_udp_balance && server->aux_servers_list &&
-              server->aux_servers_list->size) {
+              server->aux_servers_list->size)
+          {
             asl = server->aux_servers_list;
-          } else if (((cst == TLS_SOCKET) || (cst == DTLS_SOCKET) || (cst == TLS_SCTP_SOCKET)) &&
-                     server->tls_alternate_servers_list && server->tls_alternate_servers_list->size) {
+          }
+          else if (((cst == TLS_SOCKET) || (cst == DTLS_SOCKET) || (cst == TLS_SCTP_SOCKET)) &&
+                   server->tls_alternate_servers_list && server->tls_alternate_servers_list->size)
+          {
             asl = server->tls_alternate_servers_list;
           }
 
-          if (asl && asl->size) {
+          if (asl && asl->size)
+          {
             TURN_MUTEX_LOCK(&(asl->m));
             set_alternate_server(asl, get_local_addr_from_ioa_socket(ss->client_socket), &(server->as_counter), method,
                                  &tid, resp_constructed, &err_code, &reason, nbh);
@@ -3609,28 +4469,34 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
       }
 
       /* check that the realm is the same as in the original request */
-      if (ss->origin_set) {
+      if (ss->origin_set)
+      {
         stun_attr_ref sar = stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh),
                                                     ioa_network_buffer_get_size(in_buffer->nbh));
 
         int origin_found = 0;
         int norigins = 0;
 
-        while (sar && !origin_found) {
-          if (stun_attr_get_type(sar) == STUN_ATTRIBUTE_ORIGIN) {
+        while (sar && !origin_found)
+        {
+          if (stun_attr_get_type(sar) == STUN_ATTRIBUTE_ORIGIN)
+          {
             int sarlen = stun_attr_get_len(sar);
-            if (sarlen > 0) {
+            if (sarlen > 0)
+            {
               ++norigins;
               char *o = (char *)malloc(sarlen + 1);
               memcpy(o, stun_attr_get_value(sar), sarlen);
               o[sarlen] = 0;
               char *corigin = (char *)malloc(STUN_MAX_ORIGIN_SIZE + 1);
               corigin[0] = 0;
-              if (get_canonic_origin(o, corigin, STUN_MAX_ORIGIN_SIZE) < 0) {
+              if (get_canonic_origin(o, corigin, STUN_MAX_ORIGIN_SIZE) < 0)
+              {
                 TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "session %018llu: %s: Wrong origin format: %s\n",
                               (unsigned long long)(ss->id), __FUNCTION__, o);
               }
-              if (!strncmp(ss->origin, corigin, STUN_MAX_ORIGIN_SIZE)) {
+              if (!strncmp(ss->origin, corigin, STUN_MAX_ORIGIN_SIZE))
+              {
                 origin_found = 1;
               }
               free(corigin);
@@ -3641,21 +4507,28 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
                                        ioa_network_buffer_get_size(in_buffer->nbh), sar);
         }
 
-        if (server->check_origin && *(server->check_origin)) {
-          if (ss->origin[0]) {
-            if (!origin_found) {
+        if (server->check_origin && *(server->check_origin))
+        {
+          if (ss->origin[0])
+          {
+            if (!origin_found)
+            {
               err_code = 441;
               reason = (const uint8_t *)"The origin attribute does not match the initial session origin value";
-              if (server->verbose) {
+              if (server->verbose)
+              {
                 char smethod[129];
                 stun_method_str(method, smethod);
                 log_method(ss, smethod, err_code, reason);
               }
             }
-          } else if (norigins > 0) {
+          }
+          else if (norigins > 0)
+          {
             err_code = 441;
             reason = (const uint8_t *)"The origin attribute is empty, does not match the initial session origin value";
-            if (server->verbose) {
+            if (server->verbose)
+            {
               char smethod[129];
               stun_method_str(method, smethod);
               log_method(ss, smethod, err_code, reason);
@@ -3665,23 +4538,28 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
       }
 
       /* get the initial origin value */
-      if (!err_code && !(ss->origin_set) && (method == STUN_METHOD_ALLOCATE)) {
+      if (!err_code && !(ss->origin_set) && (method == STUN_METHOD_ALLOCATE))
+      {
 
         stun_attr_ref sar = stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh),
                                                     ioa_network_buffer_get_size(in_buffer->nbh));
 
         int origin_found = 0;
 
-        while (sar && !origin_found) {
-          if (stun_attr_get_type(sar) == STUN_ATTRIBUTE_ORIGIN) {
+        while (sar && !origin_found)
+        {
+          if (stun_attr_get_type(sar) == STUN_ATTRIBUTE_ORIGIN)
+          {
             int sarlen = stun_attr_get_len(sar);
-            if (sarlen > 0) {
+            if (sarlen > 0)
+            {
               char *o = (char *)malloc(sarlen + 1);
               memcpy(o, stun_attr_get_value(sar), sarlen);
               o[sarlen] = 0;
               char *corigin = (char *)malloc(STUN_MAX_ORIGIN_SIZE + 1);
               corigin[0] = 0;
-              if (get_canonic_origin(o, corigin, STUN_MAX_ORIGIN_SIZE) < 0) {
+              if (get_canonic_origin(o, corigin, STUN_MAX_ORIGIN_SIZE) < 0)
+              {
                 TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "session %018llu: %s: Wrong origin format: %s\n",
                               (unsigned long long)(ss->id), __FUNCTION__, o);
               }
@@ -3698,24 +4576,31 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
         ss->origin_set = 1;
       }
 
-      if (!err_code && !(*resp_constructed) && !no_response) {
-        if (method == STUN_METHOD_CONNECTION_BIND) {
+      if (!err_code && !(*resp_constructed) && !no_response)
+      {
+        if (method == STUN_METHOD_CONNECTION_BIND)
+        {
           ;
-        } else if (!(*(server->mobility)) || (method != STUN_METHOD_REFRESH) ||
-                   is_allocation_valid(get_allocation_ss(ss))) {
+        }
+        else if (!(*(server->mobility)) || (method != STUN_METHOD_REFRESH) ||
+                 is_allocation_valid(get_allocation_ss(ss)))
+        {
           int postpone_reply = 0;
           check_stun_auth(server, ss, &tid, resp_constructed, &err_code, &reason, in_buffer, nbh, method,
                           &message_integrity, &postpone_reply, can_resume);
-          if (postpone_reply) {
+          if (postpone_reply)
+          {
             no_response = 1;
           }
         }
       }
     }
 
-    if (!err_code && !(*resp_constructed) && !no_response) {
+    if (!err_code && !(*resp_constructed) && !no_response)
+    {
 
-      switch (method) {
+      switch (method)
+      {
 
       case STUN_METHOD_ALLOCATE:
 
@@ -3723,7 +4608,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
         handle_turn_allocate(server, ss, &tid, resp_constructed, &err_code, &reason, unknown_attrs, &ua_num, in_buffer,
                              nbh);
 
-        if (server->verbose) {
+        if (server->verbose)
+        {
           log_method(ss, "ALLOCATE", err_code, reason);
         }
 
@@ -3734,11 +4620,13 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 
         handle_turn_connect(server, ss, &tid, &err_code, &reason, unknown_attrs, &ua_num, in_buffer);
 
-        if (server->verbose) {
+        if (server->verbose)
+        {
           log_method(ss, "CONNECT", err_code, reason);
         }
 
-        if (!err_code) {
+        if (!err_code)
+        {
           no_response = 1;
         }
 
@@ -3749,7 +4637,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
         handle_turn_connection_bind(server, ss, &tid, resp_constructed, &err_code, &reason, unknown_attrs, &ua_num,
                                     in_buffer, nbh, message_integrity, can_resume);
 
-        if (server->verbose && err_code) {
+        if (server->verbose && err_code)
+        {
           log_method(ss, "CONNECTION_BIND", err_code, reason);
         }
 
@@ -3760,7 +4649,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
         handle_turn_refresh(server, ss, &tid, resp_constructed, &err_code, &reason, unknown_attrs, &ua_num, in_buffer,
                             nbh, message_integrity, &no_response, can_resume);
 
-        if (server->verbose) {
+        if (server->verbose)
+        {
           log_method(ss, "REFRESH", err_code, reason);
         }
         break;
@@ -3770,7 +4660,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
         handle_turn_channel_bind(server, ss, &tid, resp_constructed, &err_code, &reason, unknown_attrs, &ua_num,
                                  in_buffer, nbh);
 
-        if (server->verbose) {
+        if (server->verbose)
+        {
           log_method(ss, "CHANNEL_BIND", err_code, reason);
         }
         break;
@@ -3780,7 +4671,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
         handle_turn_create_permission(server, ss, &tid, resp_constructed, &err_code, &reason, unknown_attrs, &ua_num,
                                       in_buffer, nbh);
 
-        if (server->verbose) {
+        if (server->verbose)
+        {
           log_method(ss, "CREATE_PERMISSION", err_code, reason);
         }
         break;
@@ -3796,13 +4688,16 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
         handle_turn_binding(server, ss, &tid, resp_constructed, &err_code, &reason, unknown_attrs, &ua_num, in_buffer,
                             nbh, &origin_changed, &response_origin, &dest_changed, &response_destination, 0, 0);
 
-        if (server->verbose && *(server->log_binding)) {
+        if (server->verbose && *(server->log_binding))
+        {
           log_method(ss, "BINDING", err_code, reason);
         }
 
-        if (*resp_constructed && !err_code && (origin_changed || dest_changed)) {
+        if (*resp_constructed && !err_code && (origin_changed || dest_changed))
+        {
 
-          if (server->verbose && *(server->log_binding)) {
+          if (server->verbose && *(server->log_binding))
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: RFC 5780 request successfully processed\n",
                           (unsigned long long)(ss->id));
           }
@@ -3821,16 +4716,18 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
                       (unsigned long long)(ss->id), (unsigned int)method);
       };
     }
-
-  } else if (stun_is_indication_str(ioa_network_buffer_data(in_buffer->nbh),
-                                    ioa_network_buffer_get_size(in_buffer->nbh))) {
+  }
+  else if (stun_is_indication_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh)))
+  {
 
     no_response = 1;
     int postpone = 0;
 
-    if (!postpone && !err_code) {
+    if (!postpone && !err_code)
+    {
 
-      switch (method) {
+      switch (method)
+      {
 
       case STUN_METHOD_BINDING:
         // ICE ?
@@ -3840,7 +4737,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 
         handle_turn_send(server, ss, &err_code, &reason, unknown_attrs, &ua_num, in_buffer);
 
-        if (eve(server->verbose)) {
+        if (eve(server->verbose))
+        {
           log_method(ss, "SEND", err_code, reason);
         }
 
@@ -3850,35 +4748,41 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 
         err_code = 403;
 
-        if (eve(server->verbose)) {
+        if (eve(server->verbose))
+        {
           log_method(ss, "DATA", err_code, reason);
         }
 
         break;
 
       default:
-        if (server->verbose) {
+        if (server->verbose)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: Unsupported STUN indication received: method 0x%x\n",
                         (unsigned long long)(ss->id), (unsigned int)method);
         }
       }
     };
-
-  } else {
+  }
+  else
+  {
 
     no_response = 1;
 
-    if (server->verbose) {
+    if (server->verbose)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: Wrong STUN message received\n",
                     (unsigned long long)(ss->id));
     }
   }
 
-  if (ss->to_be_closed || !(ss->client_socket) || ioa_socket_tobeclosed(ss->client_socket)) {
+  if (ss->to_be_closed || !(ss->client_socket) || ioa_socket_tobeclosed(ss->client_socket))
+  {
     return 0;
   }
 
-  if (ua_num > 0) {
+  if (ua_num > 0)
+  {
 
     err_code = 420;
 
@@ -3893,11 +4797,14 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
     *resp_constructed = 1;
   }
 
-  if (!no_response) {
+  if (!no_response)
+  {
 
-    if (!(*resp_constructed)) {
+    if (!(*resp_constructed))
+    {
 
-      if (!err_code) {
+      if (!err_code)
+      {
         err_code = 400;
       }
 
@@ -3909,20 +4816,24 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 
     maybe_add_software_attribute(server, nbh);
 
-    if (message_integrity) {
+    if (message_integrity)
+    {
       size_t len = ioa_network_buffer_get_size(nbh);
       stun_attr_add_integrity_str(server->ct, ioa_network_buffer_data(nbh), &len, ss->hmackey, ss->pwd,
                                   SHATYPE_DEFAULT);
       ioa_network_buffer_set_size(nbh, len);
     }
 
-    if (err_code) {
-      if (server->verbose) {
+    if (err_code)
+    {
+      if (server->verbose)
+      {
         log_method(ss, "message", err_code, reason);
       }
     }
-
-  } else {
+  }
+  else
+  {
     *resp_constructed = 0;
   }
 
@@ -3930,7 +4841,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 }
 
 static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session *ss, ioa_net_data *in_buffer,
-                                   ioa_network_buffer_handle nbh, int *resp_constructed, uint32_t cookie) {
+                                   ioa_network_buffer_handle nbh, int *resp_constructed, uint32_t cookie)
+{
 
   stun_tid tid;
   int err_code = 0;
@@ -3946,16 +4858,20 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
 
   stun_tid_from_message_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh), &tid);
 
-  if (stun_is_request_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh))) {
+  if (stun_is_request_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh)))
+  {
 
-    if (method != STUN_METHOD_BINDING) {
+    if (method != STUN_METHOD_BINDING)
+    {
       no_response = 1;
-      if (server->verbose) {
+      if (server->verbose)
+      {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: OLD STUN method 0x%x ignored\n", __FUNCTION__, (unsigned int)method);
       }
     }
 
-    if (!err_code && !(*resp_constructed) && !no_response) {
+    if (!err_code && !(*resp_constructed) && !no_response)
+    {
 
       int origin_changed = 0;
       ioa_addr response_origin;
@@ -3965,13 +4881,16 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
       handle_turn_binding(server, ss, &tid, resp_constructed, &err_code, &reason, unknown_attrs, &ua_num, in_buffer,
                           nbh, &origin_changed, &response_origin, &dest_changed, &response_destination, cookie, 1);
 
-      if (server->verbose && *(server->log_binding)) {
+      if (server->verbose && *(server->log_binding))
+      {
         log_method(ss, "OLD BINDING", err_code, reason);
       }
 
-      if (*resp_constructed && !err_code && (origin_changed || dest_changed)) {
+      if (*resp_constructed && !err_code && (origin_changed || dest_changed))
+      {
 
-        if (server->verbose) {
+        if (server->verbose)
+        {
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "RFC3489 CHANGE request successfully processed\n");
         }
 
@@ -3979,7 +4898,8 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
           size_t oldsz = strlen(get_version(server));
           size_t newsz = (((oldsz) >> 2) + 1) << 2;
           uint8_t software[120] = {0};
-          if (newsz > sizeof(software)) {
+          if (newsz > sizeof(software))
+          {
             newsz = sizeof(software);
           }
           memcpy(software, get_version(server), oldsz);
@@ -3993,16 +4913,20 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
         no_response = 1;
       }
     }
-  } else {
+  }
+  else
+  {
 
     no_response = 1;
 
-    if (server->verbose) {
+    if (server->verbose)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Wrong OLD STUN message received\n");
     }
   }
 
-  if (ua_num > 0) {
+  if (ua_num > 0)
+  {
 
     err_code = 420;
 
@@ -4017,11 +4941,14 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
     *resp_constructed = 1;
   }
 
-  if (!no_response) {
+  if (!no_response)
+  {
 
-    if (!(*resp_constructed)) {
+    if (!(*resp_constructed))
+    {
 
-      if (!err_code) {
+      if (!err_code)
+      {
         err_code = 400;
       }
 
@@ -4035,7 +4962,8 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
       size_t oldsz = strlen(get_version(server));
       size_t newsz = (((oldsz) >> 2) + 1) << 2;
       uint8_t software[120] = {0};
-      if (newsz > sizeof(software)) {
+      if (newsz > sizeof(software))
+      {
         newsz = sizeof(software);
       }
       memcpy(software, get_version(server), oldsz);
@@ -4044,13 +4972,16 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
       ioa_network_buffer_set_size(nbh, len);
     }
 
-    if (err_code) {
-      if (server->verbose) {
+    if (err_code)
+    {
+      if (server->verbose)
+      {
         log_method(ss, "OLD STUN message", err_code, reason);
       }
     }
-
-  } else {
+  }
+  else
+  {
     *resp_constructed = 0;
   }
 
@@ -4059,19 +4990,23 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
 
 //////////////////////////////////////////////////////////////////
 
-static int write_to_peerchannel(ts_ur_super_session *ss, uint16_t chnum, ioa_net_data *in_buffer) {
+static int write_to_peerchannel(ts_ur_super_session *ss, uint16_t chnum, ioa_net_data *in_buffer)
+{
 
   int rc = 0;
 
-  if (ss && (in_buffer->recv_ttl != 0)) {
+  if (ss && (in_buffer->recv_ttl != 0))
+  {
 
     allocation *a = get_allocation_ss(ss);
 
-    if (is_allocation_valid(a)) {
+    if (is_allocation_valid(a))
+    {
 
       ch_info *chn = allocation_get_ch_info(a, chnum);
 
-      if (!chn) {
+      if (!chn)
+      {
         return -1;
       }
 
@@ -4089,7 +5024,8 @@ static int write_to_peerchannel(ts_ur_super_session *ss, uint16_t chnum, ioa_net
       rc = send_data_from_ioa_socket_nbh(get_relay_socket_ss(ss, chn->peer_addr.ss.sa_family), &(chn->peer_addr), nbh,
                                          in_buffer->recv_ttl - 1, in_buffer->recv_tos, &skip);
 
-      if (!skip && rc > -1) {
+      if (!skip && rc > -1)
+      {
         ++(ss->peer_sent_packets);
         ss->peer_sent_bytes += (uint32_t)ioa_network_buffer_get_size(in_buffer->nbh);
         turn_report_session_usage(ss, 0);
@@ -4107,11 +5043,13 @@ static void peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_data
 
 /////////////// Client actions /////////////////
 
-int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss, int force, const char *reason) {
+int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss, int force, const char *reason)
+{
 
   FUNCSTART;
 
-  if (!ss) {
+  if (!ss)
+  {
     return -1;
   }
 
@@ -4122,13 +5060,16 @@ int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss,
   dec_bps(ss);
 
   allocation *alloc = get_allocation_ss(ss);
-  if (!is_allocation_valid(alloc)) {
+  if (!is_allocation_valid(alloc))
+  {
     force = 1;
   }
 
-  if (!force && ss->is_mobile) {
+  if (!force && ss->is_mobile)
+  {
 
-    if (ss->client_socket && server->verbose) {
+    if (ss->client_socket && server->verbose)
+    {
 
       char sraddr[129] = "\0";
       char sladdr[129] = "\0";
@@ -4149,16 +5090,19 @@ int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss,
     return 0;
   }
 
-  if (eve(server->verbose)) {
+  if (eve(server->verbose))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "closing session %p, client socket %p (socket session=%p)\n", ss,
                   ss->client_socket, get_ioa_socket_session(ss->client_socket));
   }
 
-  if (server->disconnect) {
+  if (server->disconnect)
+  {
     server->disconnect(ss);
   }
 
-  if (server->verbose) {
+  if (server->verbose)
+  {
 
     char sraddr[129] = "\0";
     char sladdr[129] = "\0";
@@ -4175,7 +5119,8 @@ int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss,
   IOA_CLOSE_SOCKET(ss->client_socket);
   {
     int i;
-    for (i = 0; i < ALLOC_PROTOCOLS_NUMBER; ++i) {
+    for (i = 0; i < ALLOC_PROTOCOLS_NUMBER; ++i)
+    {
       IOA_CLOSE_SOCKET(ss->alloc.relay_sessions[i].s);
     }
   }
@@ -4187,9 +5132,11 @@ int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss,
   return 0;
 }
 
-static void client_to_be_allocated_timeout_handler(ioa_engine_handle e, void *arg) {
+static void client_to_be_allocated_timeout_handler(ioa_engine_handle e, void *arg)
+{
 
-  if (!arg) {
+  if (!arg)
+  {
     return;
   }
 
@@ -4199,7 +5146,8 @@ static void client_to_be_allocated_timeout_handler(ioa_engine_handle e, void *ar
 
   turn_turnserver *server = (turn_turnserver *)(ss->server);
 
-  if (!server) {
+  if (!server)
+  {
     return;
   }
 
@@ -4209,26 +5157,39 @@ static void client_to_be_allocated_timeout_handler(ioa_engine_handle e, void *ar
 
   ioa_socket_handle s = ss->client_socket;
 
-  if (!s || ioa_socket_tobeclosed(s)) {
+  if (!s || ioa_socket_tobeclosed(s))
+  {
     to_close = 1;
-  } else if (get_ioa_socket_app_type(s) == HTTPS_CLIENT_SOCKET) {
+  }
+  else if (get_ioa_socket_app_type(s) == HTTPS_CLIENT_SOCKET)
+  {
     ;
-  } else {
+  }
+  else
+  {
     ioa_socket_handle rs4 = ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].s;
     ioa_socket_handle rs6 = ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].s;
-    if ((!rs4 || ioa_socket_tobeclosed(rs4)) && (!rs6 || ioa_socket_tobeclosed(rs6))) {
+    if ((!rs4 || ioa_socket_tobeclosed(rs4)) && (!rs6 || ioa_socket_tobeclosed(rs6)))
+    {
       to_close = 1;
-    } else if (ss->client_socket == NULL) {
+    }
+    else if (ss->client_socket == NULL)
+    {
       to_close = 1;
-    } else if (!(ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].lifetime_ev) &&
-               !(ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].lifetime_ev)) {
+    }
+    else if (!(ss->alloc.relay_sessions[ALLOC_IPV4_INDEX].lifetime_ev) &&
+             !(ss->alloc.relay_sessions[ALLOC_IPV6_INDEX].lifetime_ev))
+    {
       to_close = 1;
-    } else if (!(ss->to_be_allocated_timeout_ev)) {
+    }
+    else if (!(ss->to_be_allocated_timeout_ev))
+    {
       to_close = 1;
     }
   }
 
-  if (to_close) {
+  if (to_close)
+  {
     IOA_EVENT_DEL(ss->to_be_allocated_timeout_ev);
     shutdown_client_connection(server, ss, 1, "allocation watchdog determined stale session state");
   }
@@ -4237,24 +5198,30 @@ static void client_to_be_allocated_timeout_handler(ioa_engine_handle e, void *ar
 }
 
 static int write_client_connection(turn_turnserver *server, ts_ur_super_session *ss, ioa_network_buffer_handle nbh,
-                                   int ttl, int tos) {
+                                   int ttl, int tos)
+{
 
   FUNCSTART;
 
-  if (!(ss->client_socket)) {
+  if (!(ss->client_socket))
+  {
     ioa_network_buffer_delete(server->e, nbh);
     FUNCEND;
     return -1;
-  } else {
+  }
+  else
+  {
 
-    if (eve(server->verbose)) {
+    if (eve(server->verbose))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: prepare to write to s %p\n", __FUNCTION__, ss->client_socket);
     }
 
     int skip = 0;
     int ret = send_data_from_ioa_socket_nbh(ss->client_socket, NULL, nbh, ttl, tos, &skip);
 
-    if (!skip && ret > -1) {
+    if (!skip && ret > -1)
+    {
       ++(ss->sent_packets);
       ss->sent_bytes += (uint32_t)ioa_network_buffer_get_size(nbh);
       turn_report_session_usage(ss, 0);
@@ -4265,23 +5232,27 @@ static int write_client_connection(turn_turnserver *server, ts_ur_super_session 
   }
 }
 
-static void client_ss_allocation_timeout_handler(ioa_engine_handle e, void *arg) {
+static void client_ss_allocation_timeout_handler(ioa_engine_handle e, void *arg)
+{
 
   UNUSED_ARG(e);
 
-  if (!arg) {
+  if (!arg)
+  {
     return;
   }
 
   relay_endpoint_session *rsession = (relay_endpoint_session *)arg;
 
-  if (!(rsession->s)) {
+  if (!(rsession->s))
+  {
     return;
   }
 
   ts_ur_super_session *ss = get_ioa_socket_session(rsession->s);
 
-  if (!ss) {
+  if (!ss)
+  {
     return;
   }
 
@@ -4289,7 +5260,8 @@ static void client_ss_allocation_timeout_handler(ioa_engine_handle e, void *arg)
 
   turn_turnserver *server = (turn_turnserver *)(ss->server);
 
-  if (!server) {
+  if (!server)
+  {
     clear_allocation(a, get_ioa_socket_type(ss->client_socket));
     return;
   }
@@ -4300,7 +5272,8 @@ static void client_ss_allocation_timeout_handler(ioa_engine_handle e, void *arg)
 
   set_allocation_family_invalid(a, family);
 
-  if (!get_relay_socket(a, AF_INET) && !get_relay_socket(a, AF_INET6)) {
+  if (!get_relay_socket(a, AF_INET) && !get_relay_socket(a, AF_INET6))
+  {
     shutdown_client_connection(server, ss, 0, "allocation timeout");
   }
 
@@ -4310,20 +5283,23 @@ static void client_ss_allocation_timeout_handler(ioa_engine_handle e, void *arg)
 static int create_relay_connection(turn_turnserver *server, ts_ur_super_session *ss, uint32_t lifetime,
                                    int address_family, uint8_t transport, int even_port, uint64_t in_reservation_token,
                                    uint64_t *out_reservation_token, int *err_code, const uint8_t **reason,
-                                   accept_cb acb) {
+                                   accept_cb acb)
+{
 
-  if (server && ss && ss->client_socket && !ioa_socket_tobeclosed(ss->client_socket)) {
+  if (server && ss && ss->client_socket && !ioa_socket_tobeclosed(ss->client_socket))
+  {
 
     allocation *a = get_allocation_ss(ss);
     relay_endpoint_session *newelem = NULL;
     ioa_socket_handle rtcp_s = NULL;
 
-    if (in_reservation_token) {
+    if (in_reservation_token)
+    {
 
       ioa_socket_handle s = NULL;
 
-      if ((get_ioa_socket_from_reservation(server->e, in_reservation_token, &s) < 0) || !s ||
-          ioa_socket_tobeclosed(s)) {
+      if ((get_ioa_socket_from_reservation(server->e, in_reservation_token, &s) < 0) || !s || ioa_socket_tobeclosed(s))
+      {
 
         IOA_CLOSE_SOCKET(s);
         *err_code = 508;
@@ -4335,7 +5311,8 @@ static int create_relay_connection(turn_turnserver *server, ts_ur_super_session 
 
       newelem = get_relay_session_ss(ss, family);
 
-      if (newelem->s != s) {
+      if (newelem->s != s)
+      {
 
         IOA_CLOSE_SOCKET(newelem->s);
 
@@ -4344,8 +5321,9 @@ static int create_relay_connection(turn_turnserver *server, ts_ur_super_session 
       }
 
       addr_debug_print(server->verbose, get_local_addr_from_ioa_socket(newelem->s), "Local relay addr (RTCP)");
-
-    } else {
+    }
+    else
+    {
       int family = get_family(address_family, server->e, ss->client_socket);
 
       newelem = get_relay_session_ss(ss, family);
@@ -4357,11 +5335,14 @@ static int create_relay_connection(turn_turnserver *server, ts_ur_super_session 
 
       int res = create_relay_ioa_sockets(server->e, ss->client_socket, address_family, transport, even_port,
                                          &(newelem->s), &rtcp_s, out_reservation_token, err_code, reason, acb, ss);
-      if (res < 0) {
-        if (!(*err_code)) {
+      if (res < 0)
+      {
+        if (!(*err_code))
+        {
           *err_code = 508;
         }
-        if (!(*reason)) {
+        if (!(*reason))
+        {
           *reason = (const uint8_t *)"Cannot create socket";
         }
         IOA_CLOSE_SOCKET(newelem->s);
@@ -4370,17 +5351,22 @@ static int create_relay_connection(turn_turnserver *server, ts_ur_super_session 
       }
     }
 
-    if (newelem->s == NULL) {
+    if (newelem->s == NULL)
+    {
       IOA_CLOSE_SOCKET(rtcp_s);
       *err_code = 508;
       *reason = (const uint8_t *)"Cannot create relay socket";
       return -1;
     }
 
-    if (rtcp_s) {
-      if (out_reservation_token && *out_reservation_token) {
+    if (rtcp_s)
+    {
+      if (out_reservation_token && *out_reservation_token)
+      {
         /* OK */
-      } else {
+      }
+      else
+      {
         IOA_CLOSE_SOCKET(newelem->s);
         IOA_CLOSE_SOCKET(rtcp_s);
         *err_code = 500;
@@ -4391,20 +5377,26 @@ static int create_relay_connection(turn_turnserver *server, ts_ur_super_session 
 
     /* RFC6156: do not use DF when IPv6 is involved: */
     if ((get_ioa_socket_address_family(newelem->s) == AF_INET6) ||
-        (get_ioa_socket_address_family(ss->client_socket) == AF_INET6)) {
+        (get_ioa_socket_address_family(ss->client_socket) == AF_INET6))
+    {
       set_do_not_use_df(newelem->s);
     }
 
-    if (get_ioa_socket_type(newelem->s) != TCP_SOCKET) {
-      if (register_callback_on_ioa_socket(server->e, newelem->s, IOA_EV_READ, peer_input_handler, ss, 0) < 0) {
+    if (get_ioa_socket_type(newelem->s) != TCP_SOCKET)
+    {
+      if (register_callback_on_ioa_socket(server->e, newelem->s, IOA_EV_READ, peer_input_handler, ss, 0) < 0)
+      {
         return -1;
       }
     }
 
-    if (lifetime < 1) {
+    if (lifetime < 1)
+    {
       lifetime = STUN_DEFAULT_ALLOCATE_LIFETIME;
-    } else if (lifetime > (uint32_t) * (server->max_allocate_lifetime)) {
-      lifetime = (uint32_t) * (server->max_allocate_lifetime);
+    }
+    else if (lifetime > (uint32_t)*(server->max_allocate_lifetime))
+    {
+      lifetime = (uint32_t)*(server->max_allocate_lifetime);
     }
 
     ioa_timer_handle ev = set_ioa_timer(server->e, lifetime, 0, client_ss_allocation_timeout_handler, newelem, 0,
@@ -4419,7 +5411,8 @@ static int create_relay_connection(turn_turnserver *server, ts_ur_super_session 
 
 static int refresh_relay_connection(turn_turnserver *server, ts_ur_super_session *ss, uint32_t lifetime, int even_port,
                                     uint64_t in_reservation_token, uint64_t *out_reservation_token, int *err_code,
-                                    int family) {
+                                    int family)
+{
 
   UNUSED_ARG(even_port);
   UNUSED_ARG(in_reservation_token);
@@ -4428,9 +5421,11 @@ static int refresh_relay_connection(turn_turnserver *server, ts_ur_super_session
 
   allocation *a = get_allocation_ss(ss);
 
-  if (server && ss && is_allocation_valid(a)) {
+  if (server && ss && is_allocation_valid(a))
+  {
 
-    if (lifetime < 1) {
+    if (lifetime < 1)
+    {
       lifetime = 1;
     }
 
@@ -4441,36 +5436,42 @@ static int refresh_relay_connection(turn_turnserver *server, ts_ur_super_session
     set_allocation_lifetime_ev(a, server->ctime + lifetime, ev, family);
 
     return 0;
-
-  } else {
+  }
+  else
+  {
     return -1;
   }
 }
 
 static int read_client_connection(turn_turnserver *server, ts_ur_super_session *ss, ioa_net_data *in_buffer,
-                                  int can_resume, int count_usage) {
+                                  int can_resume, int count_usage)
+{
 
   FUNCSTART;
 
   if (!server || !ss || !in_buffer || !(ss->client_socket) || ss->to_be_closed ||
-      ioa_socket_tobeclosed(ss->client_socket)) {
+      ioa_socket_tobeclosed(ss->client_socket))
+  {
     FUNCEND;
     return -1;
   }
 
   int ret = (int)ioa_network_buffer_get_size(in_buffer->nbh);
-  if (ret < 0) {
+  if (ret < 0)
+  {
     FUNCEND;
     return -1;
   }
 
-  if (count_usage) {
+  if (count_usage)
+  {
     ++(ss->received_packets);
     ss->received_bytes += (uint32_t)ioa_network_buffer_get_size(in_buffer->nbh);
     turn_report_session_usage(ss, 0);
   }
 
-  if (eve(server->verbose)) {
+  if (eve(server->verbose))
+  {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: data.buffer=%p, data.len=%ld\n", __FUNCTION__,
                   ioa_network_buffer_data(in_buffer->nbh), (long)ioa_network_buffer_get_size(in_buffer->nbh));
   }
@@ -4484,23 +5485,27 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
   SOCKET_APP_TYPE sat = get_ioa_socket_app_type(ss->client_socket);
   int is_padding_mandatory = is_stream_socket(st);
 
-  if (sat == HTTP_CLIENT_SOCKET) {
+  if (sat == HTTP_CLIENT_SOCKET)
+  {
 
-    if (server->verbose) {
+    if (server->verbose)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: HTTP connection input: %s\n", __FUNCTION__,
                     (char *)ioa_network_buffer_data(in_buffer->nbh));
     }
 
     handle_http_echo(ss->client_socket);
-
-  } else if (sat == HTTPS_CLIENT_SOCKET) {
+  }
+  else if (sat == HTTPS_CLIENT_SOCKET)
+  {
 
     //???
+  }
+  else if (stun_is_channel_message_str(ioa_network_buffer_data(in_buffer->nbh), &blen, &chnum, is_padding_mandatory))
+  {
 
-  } else if (stun_is_channel_message_str(ioa_network_buffer_data(in_buffer->nbh), &blen, &chnum,
-                                         is_padding_mandatory)) {
-
-    if (ss->is_tcp_relay) {
+    if (ss->is_tcp_relay)
+    {
       // Forbidden
       FUNCEND;
       return -1;
@@ -4508,21 +5513,24 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
 
     int rc = 0;
 
-    if (blen <= orig_blen) {
+    if (blen <= orig_blen)
+    {
       ioa_network_buffer_set_size(in_buffer->nbh, blen);
       rc = write_to_peerchannel(ss, chnum, in_buffer);
     }
 
-    if (eve(server->verbose)) {
+    if (eve(server->verbose))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: wrote to peer %d bytes\n", __FUNCTION__, (int)rc);
     }
 
     FUNCEND;
     return 0;
-
-  } else if (stun_is_command_message_full_check_str(ioa_network_buffer_data(in_buffer->nbh),
-                                                    ioa_network_buffer_get_size(in_buffer->nbh), 0,
-                                                    &(ss->enforce_fingerprints))) {
+  }
+  else if (stun_is_command_message_full_check_str(ioa_network_buffer_data(in_buffer->nbh),
+                                                  ioa_network_buffer_get_size(in_buffer->nbh), 0,
+                                                  &(ss->enforce_fingerprints)))
+  {
 
     ioa_network_buffer_handle nbh = ioa_network_buffer_allocate(server->e);
     int resp_constructed = 0;
@@ -4532,21 +5540,26 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
 
     handle_turn_command(server, ss, in_buffer, nbh, &resp_constructed, can_resume);
 
-    if ((method != STUN_METHOD_BINDING) && (method != STUN_METHOD_SEND)) {
+    if ((method != STUN_METHOD_BINDING) && (method != STUN_METHOD_SEND))
+    {
       report_turn_session_info(server, ss, 0);
     }
 
-    if (ss->to_be_closed || ioa_socket_tobeclosed(ss->client_socket)) {
+    if (ss->to_be_closed || ioa_socket_tobeclosed(ss->client_socket))
+    {
       FUNCEND;
       ioa_network_buffer_delete(server->e, nbh);
       return 0;
     }
 
-    if (resp_constructed) {
+    if (resp_constructed)
+    {
 
-      if ((server->fingerprint) || ss->enforce_fingerprints) {
+      if ((server->fingerprint) || ss->enforce_fingerprints)
+      {
         size_t len = ioa_network_buffer_get_size(nbh);
-        if (!stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &len)) {
+        if (!stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &len))
+        {
           FUNCEND;
           ioa_network_buffer_delete(server->e, nbh);
           return -1;
@@ -4558,78 +5571,102 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
 
       FUNCEND;
       return ret;
-    } else {
+    }
+    else
+    {
       ioa_network_buffer_delete(server->e, nbh);
       return 0;
     }
-
-  } else if (old_stun_is_command_message_str(ioa_network_buffer_data(in_buffer->nbh),
-                                             ioa_network_buffer_get_size(in_buffer->nbh), &old_stun_cookie) &&
-             !(*(server->no_stun)) && !(*(server->no_stun_backward_compatibility))) {
+  }
+  else if (old_stun_is_command_message_str(ioa_network_buffer_data(in_buffer->nbh),
+                                           ioa_network_buffer_get_size(in_buffer->nbh), &old_stun_cookie) &&
+           !(*(server->no_stun)) && !(*(server->no_stun_backward_compatibility)))
+  {
 
     ioa_network_buffer_handle nbh = ioa_network_buffer_allocate(server->e);
     int resp_constructed = 0;
 
     handle_old_stun_command(server, ss, in_buffer, nbh, &resp_constructed, old_stun_cookie);
 
-    if (resp_constructed) {
+    if (resp_constructed)
+    {
 
       int ret = write_client_connection(server, ss, nbh, TTL_IGNORE, TOS_IGNORE);
 
       FUNCEND;
       return ret;
-    } else {
+    }
+    else
+    {
       ioa_network_buffer_delete(server->e, nbh);
       return 0;
     }
-  } else {
+  }
+  else
+  {
     SOCKET_TYPE st = get_ioa_socket_type(ss->client_socket);
-    if (is_stream_socket(st)) {
-      if (is_http((char *)ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh))) {
+    if (is_stream_socket(st))
+    {
+      if (is_http((char *)ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh)))
+      {
 
         const char *proto = st == TLS_SOCKET ? "HTTPS" : "HTTP";
 
         if ((st == TCP_SOCKET) && (try_acme_redirect((char *)ioa_network_buffer_data(in_buffer->nbh),
                                                      ioa_network_buffer_get_size(in_buffer->nbh), server->acme_redirect,
-                                                     ss->client_socket) == 0)) {
+                                                     ss->client_socket) == 0))
+        {
           ss->to_be_closed = 1;
           return 0;
-        } else if (*server->web_admin_listen_on_workers) {
-          if (st == TLS_SOCKET) {
+        }
+        else if (*server->web_admin_listen_on_workers)
+        {
+          if (st == TLS_SOCKET)
+          {
             set_ioa_socket_app_type(ss->client_socket, HTTPS_CLIENT_SOCKET);
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: %s (%s %s) request: %zu\n", __FUNCTION__, proto,
                           get_ioa_socket_cipher(ss->client_socket), get_ioa_socket_ssl_method(ss->client_socket),
                           ioa_network_buffer_get_size(in_buffer->nbh));
-            if (server->send_https_socket) {
+            if (server->send_https_socket)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s socket to be detached: %p, st=%d, sat=%d\n", __FUNCTION__,
                             ss->client_socket, get_ioa_socket_type(ss->client_socket),
                             get_ioa_socket_app_type(ss->client_socket));
               ioa_socket_handle new_s = detach_ioa_socket(ss->client_socket);
-              if (new_s) {
+              if (new_s)
+              {
                 TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s new detached socket: %p, st=%d, sat=%d\n", __FUNCTION__, new_s,
                               get_ioa_socket_type(new_s), get_ioa_socket_app_type(new_s));
                 server->send_https_socket(new_s);
               }
               ss->to_be_closed = 1;
             }
-          } else {
+          }
+          else
+          {
             set_ioa_socket_app_type(ss->client_socket, HTTP_CLIENT_SOCKET);
-            if (server->verbose) {
+            if (server->verbose)
+            {
               TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: %s request: %zu\n", __FUNCTION__, proto,
                             ioa_network_buffer_get_size(in_buffer->nbh));
             }
             handle_http_echo(ss->client_socket);
           }
           return 0;
-        } else if (*server->respond_http_unsupported) {
+        }
+        else if (*server->respond_http_unsupported)
+        {
           /* Our incoming connection is HTTP, but we are not serving the
            * admin site. Return a 400 response. */
-          if (st == TLS_SOCKET) {
+          if (st == TLS_SOCKET)
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: %s (%s %s) returning 400 response: %zu\n", __FUNCTION__, proto,
                           get_ioa_socket_cipher(ss->client_socket), get_ioa_socket_ssl_method(ss->client_socket),
                           ioa_network_buffer_get_size(in_buffer->nbh));
             set_ioa_socket_app_type(ss->client_socket, HTTPS_CLIENT_SOCKET);
-          } else {
+          }
+          else
+          {
             TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: %s returning 400 response", __FUNCTION__, proto);
           }
 
@@ -4651,7 +5688,9 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
           ioa_network_buffer_set_size(nbh_http, strlen(buffer));
           memcpy(ioa_network_buffer_data(nbh_http), buffer, strlen(buffer));
           send_data_from_ioa_socket_nbh(ss->client_socket, NULL, nbh_http, TTL_IGNORE, TOS_IGNORE, NULL);
-        } else {
+        }
+        else
+        {
           ss->to_be_closed = 1;
           return 0;
         }
@@ -4665,20 +5704,24 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
   return -1;
 }
 
-static int attach_socket_to_session(turn_turnserver *server, ioa_socket_handle s, ts_ur_super_session *ss) {
+static int attach_socket_to_session(turn_turnserver *server, ioa_socket_handle s, ts_ur_super_session *ss)
+{
 
   int ret = -1;
   FUNCSTART;
 
-  if (s && server && ss && !ioa_socket_tobeclosed(s)) {
+  if (s && server && ss && !ioa_socket_tobeclosed(s))
+  {
 
-    if (ss->client_socket != s) {
+    if (ss->client_socket != s)
+    {
 
       IOA_CLOSE_SOCKET(ss->client_socket);
 
       ss->client_socket = s;
 
-      if (register_callback_on_ioa_socket(server->e, s, IOA_EV_READ, client_input_handler, ss, 0) < 0) {
+      if (register_callback_on_ioa_socket(server->e, s, IOA_EV_READ, client_input_handler, ss, 0) < 0)
+      {
         return -1;
       }
 
@@ -4692,14 +5735,17 @@ static int attach_socket_to_session(turn_turnserver *server, ioa_socket_handle s
   return ret;
 }
 
-int open_client_connection_session(turn_turnserver *server, struct socket_message *sm) {
+int open_client_connection_session(turn_turnserver *server, struct socket_message *sm)
+{
   int ret = 0;
   FUNCSTART;
-  if (!server) {
+  if (!server)
+  {
     return -1;
   }
 
-  if (!(sm->s)) {
+  if (!(sm->s))
+  {
     return -1;
   }
 
@@ -4707,14 +5753,16 @@ int open_client_connection_session(turn_turnserver *server, struct socket_messag
 
   ss->client_socket = sm->s;
 
-  if (register_callback_on_ioa_socket(server->e, ss->client_socket, IOA_EV_READ, client_input_handler, ss, 0) < 0) {
+  if (register_callback_on_ioa_socket(server->e, ss->client_socket, IOA_EV_READ, client_input_handler, ss, 0) < 0)
+  {
     ret = -1;
   }
 
   set_ioa_socket_session(ss->client_socket, ss);
 
   int at = TURN_MAX_ALLOCATE_TIMEOUT;
-  if (*(server->stun_only)) {
+  if (*(server->stun_only))
+  {
     at = TURN_MAX_ALLOCATE_TIMEOUT_STUN_ONLY;
   }
 
@@ -4722,7 +5770,8 @@ int open_client_connection_session(turn_turnserver *server, struct socket_messag
   ss->to_be_allocated_timeout_ev = set_ioa_timer(server->e, at, 0, client_to_be_allocated_timeout_handler, ss, 1,
                                                  "client_to_be_allocated_timeout_handler");
 
-  if (sm->nd.nbh) {
+  if (sm->nd.nbh)
+  {
     client_input_handler(ss->client_socket, IOA_EV_READ, &(sm->nd), ss, sm->can_resume);
     ioa_network_buffer_delete(server->e, sm->nd.nbh);
     sm->nd.nbh = NULL;
@@ -4735,45 +5784,53 @@ int open_client_connection_session(turn_turnserver *server, struct socket_messag
 
 /////////////// io handlers ///////////////////
 
-static void peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_data *in_buffer, void *arg,
-                               int can_resume) {
+static void peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_data *in_buffer, void *arg, int can_resume)
+{
 
-  if (!(event_type & IOA_EV_READ) || !arg) {
+  if (!(event_type & IOA_EV_READ) || !arg)
+  {
     return;
   }
 
-  if (in_buffer->recv_ttl == 0) {
+  if (in_buffer->recv_ttl == 0)
+  {
     return;
   }
 
   UNUSED_ARG(can_resume);
 
-  if (!s || ioa_socket_tobeclosed(s)) {
+  if (!s || ioa_socket_tobeclosed(s))
+  {
     return;
   }
 
   ts_ur_super_session *ss = (ts_ur_super_session *)arg;
 
-  if (!ss) {
+  if (!ss)
+  {
     return;
   }
 
-  if (ss->to_be_closed) {
+  if (ss->to_be_closed)
+  {
     return;
   }
 
-  if (!(ss->client_socket) || ioa_socket_tobeclosed(ss->client_socket)) {
+  if (!(ss->client_socket) || ioa_socket_tobeclosed(ss->client_socket))
+  {
     return;
   }
 
   turn_turnserver *server = (turn_turnserver *)(ss->server);
 
-  if (!server) {
+  if (!server)
+  {
     return;
   }
 
   relay_endpoint_session *elem = get_relay_session_ss(ss, get_ioa_socket_address_family(s));
-  if (elem->s == NULL) {
+  if (elem->s == NULL)
+  {
     return;
   }
 
@@ -4781,7 +5838,8 @@ static void peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_data
 
   int ilen =
       min((int)ioa_network_buffer_get_size(in_buffer->nbh), (int)(ioa_network_buffer_get_capacity_udp() - offset));
-  if (ilen < 0) {
+  if (ilen < 0)
+  {
     return;
   }
 
@@ -4790,7 +5848,8 @@ static void peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_data
   turn_report_session_usage(ss, 0);
 
   allocation *a = get_allocation_ss(ss);
-  if (!is_allocation_valid(a)) {
+  if (!is_allocation_valid(a))
+  {
     return;
   }
 
@@ -4799,13 +5858,17 @@ static void peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_data
   ioa_network_buffer_handle nbh = NULL;
 
   turn_permission_info *tinfo = allocation_get_permission(a, &(in_buffer->src_addr));
-  if (tinfo) {
+  if (tinfo)
+  {
     chnum = get_turn_channel_number(tinfo, &(in_buffer->src_addr));
-  } else if (!(server->server_relay)) {
+  }
+  else if (!(server->server_relay))
+  {
     return;
   }
 
-  if (chnum) {
+  if (chnum)
+  {
 
     size_t len = (size_t)(ilen);
 
@@ -4822,10 +5885,13 @@ static void peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_data
     stun_init_channel_message_str(chnum, ioa_network_buffer_data(nbh), &len, len, do_padding);
     ioa_network_buffer_set_size(nbh, len);
     in_buffer->nbh = NULL;
-    if (eve(server->verbose)) {
+    if (eve(server->verbose))
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: send channel 0x%x\n", __FUNCTION__, (int)(chnum));
     }
-  } else {
+  }
+  else
+  {
 
     size_t len = 0;
 
@@ -4838,13 +5904,15 @@ static void peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_data
 
     maybe_add_software_attribute(server, nbh);
 
-    if ((server->fingerprint) || ss->enforce_fingerprints) {
+    if ((server->fingerprint) || ss->enforce_fingerprints)
+    {
       size_t len = ioa_network_buffer_get_size(nbh);
       stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &len);
       ioa_network_buffer_set_size(nbh, len);
     }
   }
-  if (eve(server->verbose)) {
+  if (eve(server->verbose))
+  {
     uint16_t *t = (uint16_t *)ioa_network_buffer_data(nbh);
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Send data: 0x%x\n", (int)(nswap16(t[0])));
   }
@@ -4852,9 +5920,11 @@ static void peer_input_handler(ioa_socket_handle s, int event_type, ioa_net_data
   write_client_connection(server, ss, nbh, in_buffer->recv_ttl - 1, in_buffer->recv_tos);
 }
 
-static void client_input_handler(ioa_socket_handle s, int event_type, ioa_net_data *data, void *arg, int can_resume) {
+static void client_input_handler(ioa_socket_handle s, int event_type, ioa_net_data *data, void *arg, int can_resume)
+{
 
-  if (!arg) {
+  if (!arg)
+  {
     return;
   }
 
@@ -4865,18 +5935,22 @@ static void client_input_handler(ioa_socket_handle s, int event_type, ioa_net_da
 
   turn_turnserver *server = (turn_turnserver *)ss->server;
 
-  if (!server) {
+  if (!server)
+  {
     return;
   }
 
-  if (ss->client_socket != s) {
+  if (ss->client_socket != s)
+  {
     return;
   }
 
   read_client_connection(server, ss, data, can_resume, 1);
 
-  if (ss->to_be_closed) {
-    if (server->verbose) {
+  if (ss->to_be_closed)
+  {
+    if (server->verbose)
+    {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: client socket to be closed in client handler: ss=%p\n",
                     (unsigned long long)(ss->id), ss);
     }
@@ -4901,9 +5975,11 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
                       allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
                       const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family,
                       bool *log_binding, bool *no_stun_backward_compatibility, bool *response_origin_only_with_rfc5780,
-                      bool *respond_http_unsupported) {
+                      bool *respond_http_unsupported)
+{
 
-  if (!server) {
+  if (!server)
+  {
     return;
   }
 
@@ -4927,10 +6003,12 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
   server->send_turn_session_info = send_turn_session_info;
   server->send_https_socket = send_https_socket;
   server->oauth = oauth;
-  if (oauth) {
+  if (oauth)
+  {
     server->oauth_server_name = oauth_server_name;
   }
-  if (mobility) {
+  if (mobility)
+  {
     server->mobile_connections_map = ur_map_create();
   }
   server->acme_redirect = acme_redirect;
@@ -4957,7 +6035,8 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
 
   server->dont_fragment = dont_fragment;
   server->fingerprint = fingerprint;
-  if (external_ip) {
+  if (external_ip)
+  {
     addr_cpy(&(server->external_ip), external_ip);
     server->external_ip_set = 1;
   }
@@ -4986,14 +6065,17 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
   server->is_draining = false;
 }
 
-ioa_engine_handle turn_server_get_engine(turn_turnserver *s) {
-  if (s) {
+ioa_engine_handle turn_server_get_engine(turn_turnserver *s)
+{
+  if (s)
+  {
     return s->e;
   }
   return NULL;
 }
 
-void set_disconnect_cb(turn_turnserver *server, int (*disconnect)(ts_ur_super_session *)) {
+void set_disconnect_cb(turn_turnserver *server, int (*disconnect)(ts_ur_super_session *))
+{
   server->disconnect = disconnect;
 }
 

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -40,7 +40,8 @@
 #include "ns_turn_session.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 //////////// defines //////////////
@@ -49,7 +50,8 @@ extern "C" {
 
 //////////// ALTERNATE-SERVER /////////////
 
-struct _turn_server_addrs_list {
+struct _turn_server_addrs_list
+{
   ioa_addr *addrs;
   volatile size_t size;
   TURN_MUTEX_DECLARE(m)
@@ -72,24 +74,34 @@ extern int TURN_MAX_ALLOCATE_TIMEOUT_STUN_ONLY;
 
 typedef uint8_t turnserver_id;
 
-enum _MESSAGE_TO_RELAY_TYPE { RMT_UNKNOWN = 0, RMT_SOCKET, RMT_CB_SOCKET, RMT_MOBILE_SOCKET, RMT_CANCEL_SESSION };
+enum _MESSAGE_TO_RELAY_TYPE
+{
+  RMT_UNKNOWN = 0,
+  RMT_SOCKET,
+  RMT_CB_SOCKET,
+  RMT_MOBILE_SOCKET,
+  RMT_CANCEL_SESSION
+};
 typedef enum _MESSAGE_TO_RELAY_TYPE MESSAGE_TO_RELAY_TYPE;
 
 ///////// ALLOCATION DEFAULT ADDRESS FAMILY TYPES /////////////////////
-enum _ALLOCATION_DEFAULT_ADDRESS_FAMILY {
+enum _ALLOCATION_DEFAULT_ADDRESS_FAMILY
+{
   ALLOCATION_DEFAULT_ADDRESS_FAMILY_IPV4 = 0,
   ALLOCATION_DEFAULT_ADDRESS_FAMILY_IPV6,
   ALLOCATION_DEFAULT_ADDRESS_FAMILY_KEEP,
 };
 typedef enum _ALLOCATION_DEFAULT_ADDRESS_FAMILY ALLOCATION_DEFAULT_ADDRESS_FAMILY;
 
-struct socket_message {
+struct socket_message
+{
   ioa_socket_handle s;
   ioa_net_data nd;
   int can_resume;
 };
 
-typedef enum {
+typedef enum
+{
   DONT_FRAGMENT_UNSUPPORTED = 0,
   DONT_FRAGMENT_SUPPORTED,
   DONT_FRAGMENT_SUPPORT_EMULATED
@@ -114,7 +126,8 @@ typedef void (*send_https_socket_cb)(ioa_socket_handle s);
 
 typedef band_limit_t (*allocate_bps_cb)(band_limit_t bps, int positive);
 
-struct _turn_turnserver {
+struct _turn_turnserver
+{
 
   turnserver_id id;
 

--- a/src/server/ns_turn_session.h
+++ b/src/server/ns_turn_session.h
@@ -37,12 +37,14 @@
 #include "ns_turn_utils.h"
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 ////////// REALM ////////////
 
-typedef struct _perf_options_t {
+typedef struct _perf_options_t
+{
 
   volatile band_limit_t max_bps;
   vint total_quota;
@@ -50,7 +52,8 @@ typedef struct _perf_options_t {
 
 } perf_options_t;
 
-struct _realm_options_t {
+struct _realm_options_t
+{
 
   char name[STUN_MAX_REALM_SIZE + 1];
 
@@ -65,7 +68,8 @@ typedef uint64_t turnsession_id;
 
 typedef uint64_t mobile_id_t;
 
-struct _ts_ur_super_session {
+struct _ts_ur_super_session
+{
   void *server;
   turnsession_id id;
   turn_time_t start_time;
@@ -126,12 +130,14 @@ struct _ts_ur_super_session {
 #define TURN_ADDR_STR_SIZE (65)
 #define TURN_MAIN_PEERS_ARRAY_SIZE (5)
 
-typedef struct _addr_data {
+typedef struct _addr_data
+{
   ioa_addr addr;
   char saddr[TURN_ADDR_STR_SIZE];
 } addr_data;
 
-struct turn_session_info {
+struct turn_session_info
+{
   turnsession_id id;
   int valid;
   turn_time_t start_time;


### PR DESCRIPTION
This pull request changes the .clang-format file so that a newline is inserted before opening braces in the code.

This changes, for example

```
if (bool) {
} else {
}
```
to
```
if (bool)
{
}
else
{
}
```

This has multiple benefits.

1. To find the matching brace for a particular line, you merely need to find the next brace that is indented to the same indentation level.
2. Parameter lists that are currently broken into two lines can sometimes be kept to a single line.
3. Provides a significant visual indicator about a scope beginning or ending, which for people with less than steller eyesight is a significant readability enhancement
4. Provides consistency with scopes that are not attached to a conditional, which is used in several places related to goto labels.