### PR TITLE
changed variables in ns_turn_session.h and to bool

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -477,8 +477,8 @@ int old_stun_is_command_message_str(const uint8_t *buf, size_t blen, uint32_t *c
   return 0;
 }
 
-int stun_is_command_message_full_check_str(const uint8_t *buf, size_t blen, int must_check_fingerprint,
-                                           int *fingerprint_present) {
+int stun_is_command_message_full_check_str(const uint8_t *buf, size_t blen, bool must_check_fingerprint,
+                                           bool *fingerprint_present) {
   if (!stun_is_command_message_str(buf, blen)) {
     return 0;
   }

--- a/src/client/ns_turn_msg.h
+++ b/src/client/ns_turn_msg.h
@@ -33,6 +33,7 @@
 
 #include "ns_turn_ioaddr.h"
 #include "ns_turn_msg_defs.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -110,8 +111,8 @@ int stun_init_channel_message_str(uint16_t chnumber, uint8_t *buf, size_t *len, 
 
 int stun_is_command_message_str(const uint8_t *buf, size_t blen);
 int old_stun_is_command_message_str(const uint8_t *buf, size_t blen, uint32_t *cookie);
-int stun_is_command_message_full_check_str(const uint8_t *buf, size_t blen, int must_check_fingerprint,
-                                           int *fingerprint_present);
+int stun_is_command_message_full_check_str(const uint8_t *buf, size_t blen, bool must_check_fingerprint,
+                                           bool *fingerprint_present);
 int stun_is_command_message_offset_str(const uint8_t *buf, size_t blen, int offset);
 int stun_is_request_str(const uint8_t *buf, size_t len);
 int stun_is_success_response_str(const uint8_t *buf, size_t len);

--- a/src/server/ns_turn_session.h
+++ b/src/server/ns_turn_session.h
@@ -35,6 +35,7 @@
 #include "ns_turn_ioalib.h"
 #include "ns_turn_maps.h"
 #include "ns_turn_utils.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,17 +73,17 @@ struct _ts_ur_super_session {
   ioa_socket_handle client_socket;
   allocation alloc;
   ioa_timer_handle to_be_allocated_timeout_ev;
-  int enforce_fingerprints;
-  int is_tcp_relay;
-  int to_be_closed;
+  bool enforce_fingerprints;
+  bool is_tcp_relay;
+  bool to_be_closed;
   /* Auth */
   uint8_t nonce[NONCE_MAX_SIZE];
   turn_time_t nonce_expiration_time;
   uint8_t username[STUN_MAX_USERNAME_SIZE + 1];
   hmackey_t hmackey;
-  int hmackey_set;
+  bool hmackey_set;
   password_t pwd;
-  int quota_used;
+  bool quota_used;
   int oauth;
   turn_time_t max_session_time_auth;
   /* Realm */
@@ -113,7 +114,7 @@ struct _ts_ur_super_session {
   size_t peer_sent_rate;
   size_t peer_total_rate;
   /* Mobile */
-  int is_mobile;
+  bool is_mobile;
   mobile_id_t mobile_id;
   mobile_id_t old_mobile_id;
   char s_mobile_id[33];
@@ -133,7 +134,7 @@ typedef struct _addr_data {
 
 struct turn_session_info {
   turnsession_id id;
-  int valid;
+  bool valid;
   turn_time_t start_time;
   turn_time_t expiration_time;
   SOCKET_TYPE client_protocol;
@@ -145,7 +146,7 @@ struct turn_session_info {
   addr_data relay_addr_data_ipv4;
   addr_data relay_addr_data_ipv6;
   uint8_t username[STUN_MAX_USERNAME_SIZE + 1];
-  int enforce_fingerprints;
+  bool enforce_fingerprints;
   /* Stats */
   uint64_t received_packets;
   uint64_t sent_packets;
@@ -162,7 +163,7 @@ struct turn_session_info {
   uint32_t peer_sent_rate;
   uint32_t peer_total_rate;
   /* Mobile */
-  int is_mobile;
+  bool is_mobile;
   /* Peers */
   addr_data main_peers_data[TURN_MAIN_PEERS_ARRAY_SIZE];
   size_t main_peers_size;


### PR DESCRIPTION
# changed variables that appeared in `ns_turn_session.h` and and their uses to `bool` to follow C11 idioms
## approach was as follows:
- if a variable of type `int` was only being used as a boolean, replace it with bool as defined in `<stdbool.h>`
- replace its declaration and assignment with true/false, depending on prior assignment as 0/1
- then check any error that appear after build and update them to reflect changes

changes were only made when i was certain the variables were not being used as an int, so i may have missed some