### PR TITLE
added missing function prototype of turn_random_number()

### DIFF
--- a/src/client/ns_turn_msg.h
+++ b/src/client/ns_turn_msg.h
@@ -208,6 +208,7 @@ size_t get_hmackey_size(SHATYPE shatype);
 
 #define TURN_RANDOM_SIZE (sizeof(long))
 long turn_random(void);
+long turn_random_number(void);
 
 int stun_produce_integrity_key_str(const uint8_t *uname, const uint8_t *realm, const uint8_t *upwd, hmackey_t key,
                                    SHATYPE shatype);


### PR DESCRIPTION
trivial - cmake generated a warning that `ns_turn_msg.c` used a function that had no prior prototype - most other files used the `turn_random()` function but this uses `turn_random_number()` which has no prototype, so i've added it to the header file