### PR TITLE
udp-notifier mechanism

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -30,8 +30,11 @@ HIREDIS_MODS = src/apps/common/hiredis_libevent2.c
 USERDB_HEADERS = src/apps/relay/dbdrivers/dbdriver.h src/apps/relay/dbdrivers/dbd_sqlite.h src/apps/relay/dbdrivers/dbd_pgsql.h src/apps/relay/dbdrivers/dbd_mysql.h src/apps/relay/dbdrivers/dbd_mongo.h src/apps/relay/dbdrivers/dbd_redis.h
 USERDB_MODS = src/apps/relay/dbdrivers/dbdriver.c src/apps/relay/dbdrivers/dbd_sqlite.c src/apps/relay/dbdrivers/dbd_pgsql.c src/apps/relay/dbdrivers/dbd_mysql.c src/apps/relay/dbdrivers/dbd_mongo.c src/apps/relay/dbdrivers/dbd_redis.c
 
-SERVERAPP_HEADERS = src/apps/relay/userdb.h src/apps/relay/tls_listener.h src/apps/relay/mainrelay.h src/apps/relay/turn_admin_server.h src/apps/relay/dtls_listener.h src/apps/relay/libtelnet.h src/apps/relay/prom_server.h ${HIREDIS_HEADERS} ${USERDB_HEADERS}
-SERVERAPP_MODS = src/apps/relay/mainrelay.c src/apps/relay/netengine.c src/apps/relay/libtelnet.c src/apps/relay/turn_admin_server.c src/apps/relay/userdb.c src/apps/relay/tls_listener.c src/apps/relay/dtls_listener.c src/apps/relay/prom_server.c ${HIREDIS_MODS} ${USERDB_MODS}
+NOTIFIER_HEADERS = src/apps/relay/ntfy_drivers/ntfy_driver.h src/apps/relay/ntfy_drivers/udp_subscriber.h
+NOTIFIER_MODS = src/apps/relay/ntfy_drivers/ntfy_driver.c src/apps/relay/ntfy_drivers/udp_subscriber.c
+
+SERVERAPP_HEADERS = src/apps/relay/userdb.h src/apps/relay/tls_listener.h src/apps/relay/mainrelay.h src/apps/relay/turn_admin_server.h src/apps/relay/dtls_listener.h src/apps/relay/libtelnet.h src/apps/relay/prom_server.h ${HIREDIS_HEADERS} ${USERDB_HEADERS} ${NOTIFIER_HEADERS}
+SERVERAPP_MODS = src/apps/relay/mainrelay.c src/apps/relay/netengine.c src/apps/relay/libtelnet.c src/apps/relay/turn_admin_server.c src/apps/relay/userdb.c src/apps/relay/tls_listener.c src/apps/relay/dtls_listener.c src/apps/relay/prom_server.c ${HIREDIS_MODS} ${USERDB_MODS} ${NOTIFIER_MODS}
 SERVERAPP_DEPS = ${SERVERTURN_MODS} ${SERVERTURN_DEPS} ${SERVERAPP_MODS} ${SERVERAPP_HEADERS} ${COMMON_DEPS} ${IMPL_DEPS} lib/libturnclient.a
 
 TURN_BUILD_RESULTS = bin/turnutils_oauth bin/turnutils_natdiscovery bin/turnutils_stunclient bin/turnutils_rfc5769check bin/turnutils_uclient bin/turnserver bin/turnutils_peer lib/libturnclient.a include/turn/ns_turn_defs.h sqlite_empty_db

--- a/README.turnserver
+++ b/README.turnserver
@@ -238,9 +238,7 @@ Flags:
 			name will be constructed as-is, without PID and date appendage.
 			This option can be used, for example, together with the logrotate tool.
 
---new-log-timestamp				Enable full ISO-8601 timestamp in all logs.
-
---new-log-timestamp-format    	<format>	Set timestamp format (in strftime(1) format)
+--new-log-timestamp				Enable timestamp in all logs.
 
 --log-binding					Log STUN binding request. It is now disabled by default to avoid DoS attacks.
 
@@ -611,6 +609,9 @@ Options with values:
 
 --cli-max-output-sessions	Maximum number of output sessions in ps CLI command.
 			This value can be changed on-the-fly in CLI. The default value is 256.
+
+--udp-notifier		Send  notification  messages to target device via UDP interface.
+			"host=<host> port=<port>"
 
 --web-admin		Enable Turn Web-admin support. By default it is disabled.
 

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -541,11 +541,8 @@
 #
 #simple-log
 
-# Enable full ISO-8601 timestamp in all logs.
+# Enable timestamp in all logs.
 #new-log-timestamp
-
-# Set timestamp format (in strftime(1) format). Depends on new-log-timestamp to be enabled.
-#new-log-timestamp-format "%FT%T%z"
 
 # Disabled by default binding logging in verbose log mode to avoid DoS attacks.
 # Enable binding logging and UDP endpoint logs in verbose log mode.
@@ -769,6 +766,11 @@
 #no-tlsv1
 #no-tlsv1_1
 #no-tlsv1_2
+
+# UDP notifier
+# Send notification messages to target device via UDP interface
+#
+#udp-notifier "host=127.0.0.1 port=5555"
 
 # Disable RFC5780 (NAT behavior discovery).
 #

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -355,11 +355,7 @@ This option can be used, for example, together with the logrotate tool.
 .TP
 .B
 \fB\-\-new\-log\-timestamp\fP
-Enable full ISO\-8601 timestamp in all logs.
-.TP
-.B
-\fB\-\-new\-log\-timestamp\-format\fP
-<format>        Set timestamp format (in \fBstrftime\fP(1) format)
+Enable timestamp in all logs.
 .TP
 .B
 \fB\-\-log\-binding\fP
@@ -878,6 +874,10 @@ Maximum number of output sessions in ps CLI command.
 This value can be changed on\-the\-fly in CLI. The default value is 256.
 .TP
 .B
+\fB\-\-udp\-notifier\fP
+Send notification messages to target device via UDP interface.
+"host=<host> port=<port>"
+.PP
 \fB\-\-web\-admin\fP
 Enable Turn Web\-admin support. By default it is disabled.
 .TP

--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -207,11 +207,7 @@ static int no_stdout_log = 0;
 void set_no_stdout_log(int val) { no_stdout_log = val; }
 
 #define MAX_LOG_TIMESTAMP_FORMAT_LEN 48
-static char turn_log_timestamp_format[MAX_LOG_TIMESTAMP_FORMAT_LEN] = "%FT%T%z";
-
-void set_turn_log_timestamp_format(char *new_format) {
-  strncpy(turn_log_timestamp_format, new_format, MAX_LOG_TIMESTAMP_FORMAT_LEN - 1);
-}
+static char turn_log_timestamp_format[MAX_LOG_TIMESTAMP_FORMAT_LEN] = "%Y-%m-%d %H:%M:%S";
 
 int use_new_log_timestamp_format = 0;
 
@@ -550,8 +546,11 @@ void turn_log_func_default(char *file, int line, TURN_LOG_LEVEL level, const cha
   char s[MAX_RTPPRINTF_BUFFER_SIZE + 1];
   size_t so_far = 0;
   if (use_new_log_timestamp_format) {
-    time_t now = time(NULL);
-    so_far += strftime(s, sizeof(s), turn_log_timestamp_format, localtime(&now));
+   	struct timeval now;
+		if(gettimeofday(&now, NULL) == 0) {
+      so_far += strftime(s, sizeof(s), turn_log_timestamp_format, localtime(&now.tv_sec));
+      so_far += snprintf(s + so_far, sizeof(s) - (so_far+1), ",%ld", now.tv_usec);
+		}
   } else {
     so_far += snprintf(s, sizeof(s), "%lu: ", (unsigned long)log_time());
   }

--- a/src/apps/common/ns_turn_utils.h
+++ b/src/apps/common/ns_turn_utils.h
@@ -69,8 +69,6 @@ void set_simple_log(int val);
 
 void set_syslog_facility(char *val);
 
-void set_turn_log_timestamp_format(char *new_format);
-
 void turn_log_func_default(char *file, int line, TURN_LOG_LEVEL level, const char *format, ...)
 #ifdef __GNUC__
     __attribute__((format(printf, 4, 5)))

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -225,7 +225,9 @@ turn_params_t turn_params = {
     0,                                      /* no_auth_pings */
     0,                                      /* no_dynamic_ip_list */
     0,                                      /* no_dynamic_realms */
-
+    ///// UDP NOTIFIER /////
+    0,
+    "",
     0, /* log_binding */
     0, /* no_stun_backward_compatibility */
     0, /* response_origin_only_with_rfc5780 */
@@ -1217,9 +1219,7 @@ static char Usage[] =
     "						name will be constructed as-is, without PID and date appendage.\n"
     "						This option can be used, for example, together with the logrotate "
     "tool.\n"
-    " --new-log-timestamp				Enable full ISO-8601 timestamp in all logs.\n"
-    " --new-log-timestamp-format    	<format>	Set timestamp format (in strftime(1) format). Depends on "
-    "--new-log-timestamp to be enabled.\n"
+    " --new-log-timestamp				Enable timestamp in all logs.\n"
     " --log-binding					Log STUN binding request. It is now disabled by default to "
     "avoid DoS attacks.\n"
     " --stale-nonce[=<value>]			Use extra security with nonce value having limited lifetime (default "
@@ -1308,6 +1308,7 @@ static char Usage[] =
     "						when we want to run server applications on the relay endpoints.\n"
     "						This option eliminates the IP permissions check on the packets\n"
     "						incoming to the relay endpoints.\n"
+    " --udp-notifier					Send notification messages to target device via UDP interface.\n"
     " --cli-max-output-sessions			Maximum number of output sessions in ps CLI command.\n"
     "						This value can be changed on-the-fly in CLI. The default value is "
     "256.\n"
@@ -1435,7 +1436,6 @@ enum EXTRA_OPTS {
   SYSLOG_FACILITY_OPT,
   SIMPLE_LOG_OPT,
   NEW_LOG_TIMESTAMP_OPT,
-  NEW_LOG_TIMESTAMP_FORMAT_OPT,
   AUX_SERVER_OPT,
   UDP_SELF_BALANCE_OPT,
   ALTERNATE_SERVER_OPT,
@@ -1483,6 +1483,7 @@ enum EXTRA_OPTS {
   NO_HTTP_OPT,
   SECRET_KEY_OPT,
   ACME_REDIRECT_OPT,
+  UDP_NOTIFIER_OPT,
   LOG_BINDING_OPT,
   NO_RFC5780,
   NO_STUN_BACKWARD_COMPATIBILITY_OPT,
@@ -1584,7 +1585,6 @@ static const struct myoption long_options[] = {
     {"syslog", optional_argument, NULL, SYSLOG_OPT},
     {"simple-log", optional_argument, NULL, SIMPLE_LOG_OPT},
     {"new-log-timestamp", optional_argument, NULL, NEW_LOG_TIMESTAMP_OPT},
-    {"new-log-timestamp-format", required_argument, NULL, NEW_LOG_TIMESTAMP_FORMAT_OPT},
     {"aux-server", required_argument, NULL, AUX_SERVER_OPT},
     {"udp-self-balance", optional_argument, NULL, UDP_SELF_BALANCE_OPT},
     {"alternate-server", required_argument, NULL, ALTERNATE_SERVER_OPT},
@@ -1626,6 +1626,7 @@ static const struct myoption long_options[] = {
     {"keep-address-family", optional_argument, NULL, 'K'},
     {"allocation-default-address-family", required_argument, NULL, 'A'},
     {"acme-redirect", required_argument, NULL, ACME_REDIRECT_OPT},
+    {"udp-notifier", required_argument, NULL, UDP_NOTIFIER_OPT },
     {"log-binding", optional_argument, NULL, LOG_BINDING_OPT},
     {"no-rfc5780", optional_argument, NULL, NO_RFC5780},
     {"no-stun-backward-compatibility", optional_argument, NULL, NO_STUN_BACKWARD_COMPATIBILITY_OPT},
@@ -2328,6 +2329,10 @@ static void set_option(int c, char *value) {
       turn_params.rest_api_separator = *value;
     }
     break;
+  case UDP_NOTIFIER_OPT:
+    turn_params.udp_notifier = 1;
+    STRCPY(turn_params.udp_notifier_params, value);
+    break;
   case LOG_BINDING_OPT:
     turn_params.log_binding = get_bool_value(value);
     break;
@@ -2350,7 +2355,6 @@ static void set_option(int c, char *value) {
   case SYSLOG_OPT:
   case SIMPLE_LOG_OPT:
   case NEW_LOG_TIMESTAMP_OPT:
-  case NEW_LOG_TIMESTAMP_FORMAT_OPT:
   case SYSLOG_FACILITY_OPT:
   case 'c':
   case 'n':
@@ -2491,8 +2495,6 @@ static void read_config_file(int argc, char **argv, int pass) {
             set_simple_log(get_bool_value(value));
           } else if ((pass == 0) && (c == NEW_LOG_TIMESTAMP_OPT)) {
             use_new_log_timestamp_format = 1;
-          } else if ((pass == 0) && (c == NEW_LOG_TIMESTAMP_FORMAT_OPT)) {
-            set_turn_log_timestamp_format(value);
           } else if ((pass == 0) && (c == SYSLOG_FACILITY_OPT)) {
             set_syslog_facility(value);
           } else if ((pass == 1) && (c != 'u')) {
@@ -2981,9 +2983,6 @@ int main(int argc, char **argv) {
         break;
       case NEW_LOG_TIMESTAMP_OPT:
         use_new_log_timestamp_format = 1;
-        break;
-      case NEW_LOG_TIMESTAMP_FORMAT_OPT:
-        set_turn_log_timestamp_format(optarg);
         break;
       case SYSLOG_FACILITY_OPT:
         set_syslog_facility(optarg);

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -326,6 +326,10 @@ typedef struct _turn_params_ {
   int no_auth_pings;
   int no_dynamic_ip_list;
   int no_dynamic_realms;
+  
+  //// UDP Notifier ////
+  int udp_notifier;
+  char udp_notifier_params[1025];
 
   vint log_binding;
   vint no_stun_backward_compatibility;

--- a/src/apps/relay/ntfy_drivers/ntfy_driver.c
+++ b/src/apps/relay/ntfy_drivers/ntfy_driver.c
@@ -1,0 +1,130 @@
+#include "ntfy_driver.h"
+#include "../mainrelay.h"
+#include "../../common/apputils.h"
+#include "udp_subscriber.h"
+#include "apps/relay/mainrelay.h"
+typedef struct _turn_notifier_t{
+    turn_ntfy_subscriber_if_t** subscribers;
+    size_t subscriber_count;
+}turn_notifier_t;
+
+
+pthread_key_t notifier_key;
+pthread_once_t notifier_key_once = PTHREAD_ONCE_INIT;
+
+static void notifier_interface_remove(void*notifier_p);
+
+
+static void make_notifier_key(void)
+{
+    (void) pthread_key_create(&notifier_key, notifier_interface_remove);
+}
+
+static void subscriber_add(turn_notifier_t* notifier, turn_ntfy_subscriber_if_t* subscriber)
+{
+       if(notifier && subscriber) {
+         notifier->subscribers = (turn_ntfy_subscriber_if_t**)realloc(notifier->subscribers,(sizeof(turn_ntfy_subscriber_if_t*)*(notifier->subscriber_count+1)));
+         notifier->subscribers[notifier->subscriber_count] = subscriber;
+         notifier->subscriber_count += 1;
+       }
+}
+
+static void subscribers_init(turn_notifier_t *notifier){
+
+    size_t i;
+
+    for(i=0; i<(notifier->subscriber_count); i++){
+        if(notifier->subscribers[i]->init) {
+            notifier->subscribers[i]->long_term_data = notifier->subscribers[i]->init();
+        }
+    }
+}
+
+static void subscribers_notify(turn_notifier_t *notifier, TURN_NTFY_LEVEL level, const char* string){
+
+    size_t i;
+
+    for(i=0; i<(notifier->subscriber_count); i++){
+        if(notifier->subscribers[i]->notify) {
+            notifier->subscribers[i]->notify(notifier->subscribers[i]->long_term_data, level, string);
+        }
+    }
+}
+
+static void subscribers_remove(turn_notifier_t *notifier){
+
+    size_t i;
+
+    for(i=0; i<(notifier->subscriber_count); i++){
+        if(notifier->subscribers[i]->remove) {
+            notifier->subscribers[i]->remove(notifier->subscribers[i]->long_term_data);
+        }
+    }
+}
+
+static turn_notifier_t* notifier_interface_get(void){
+
+    (void) pthread_once(&notifier_key_once, make_notifier_key);
+
+    turn_notifier_t *notifier = (turn_notifier_t *)pthread_getspecific(notifier_key);
+
+    if(!notifier){
+
+        turn_notifier_t* notifier=(turn_notifier_t*)malloc(sizeof(turn_notifier_t));
+        if(!notifier) return notifier;
+
+        bzero(notifier,sizeof(turn_notifier_t));
+
+        subscriber_add(notifier,udp_subscriber_inferface_get());
+
+        subscribers_init(notifier);
+
+        pthread_setspecific(notifier_key, notifier);
+    }
+    return notifier;
+}
+
+static void notifier_interface_remove(void*notifier_p){
+
+    turn_notifier_t *notifier = (turn_notifier_t *)notifier_p;
+
+    if(notifier){
+
+        subscribers_remove(notifier);
+
+        free(notifier);
+    }
+}
+
+int turn_ntfy_check(){
+
+    turn_notifier_t* notifier = notifier_interface_get();
+
+    if(notifier){
+        if(notifier->subscriber_count>0)
+            return 1;
+    }
+    return 0;
+}
+
+void turn_ntfy_func_default(TURN_NTFY_LEVEL level, const char* format, ...){
+
+#define MAX_RTPPRINTF_BUFFER_SIZE (1024)
+       char string[MAX_RTPPRINTF_BUFFER_SIZE+1];
+#undef MAX_RTPPRINTF_BUFFER_SIZE
+
+        va_list args;
+
+        turn_notifier_t* notifier = notifier_interface_get();
+
+        if(notifier){
+            va_start(args,format);
+
+            vsnprintf(string, sizeof(string)-1, format, args);
+            string[sizeof(string)-1]=0;
+
+            va_end(args);
+
+            subscribers_notify(notifier, level, string);
+        }
+}

--- a/src/apps/relay/ntfy_drivers/ntfy_driver.h
+++ b/src/apps/relay/ntfy_drivers/ntfy_driver.h
@@ -1,0 +1,39 @@
+#ifndef NTFY_DRIVER_H
+#define NTFY_DRIVER_H
+
+#include "../../../ns_turn_defs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef enum {
+  TURN_NTFY_LEVEL_INFO = 0,
+  TURN_NTFY_LEVEL_CONTROL,
+  TURN_NTFY_LEVEL_WARNING,
+  TURN_NTFY_LEVEL_ERROR
+} TURN_NTFY_LEVEL;
+
+extern pthread_key_t notifier_key;
+extern pthread_once_t notifier_key_once;
+
+typedef void* subs_long_term_data_t;
+
+typedef struct _turn_ntfy_subscriber_if_t {
+  char* name;
+  subs_long_term_data_t long_term_data;
+  subs_long_term_data_t (*init)(void);
+  int (*notify)( subs_long_term_data_t, TURN_NTFY_LEVEL, const char*);
+  int (*remove)( subs_long_term_data_t);
+} turn_ntfy_subscriber_if_t;
+
+#define TURN_NTFY_CHECK (turn_ntfy_check())
+#define TURN_NTFY_FUNC turn_ntfy_func_default
+
+int turn_ntfy_check(void);
+void turn_ntfy_func_default(TURN_NTFY_LEVEL level, const char* format, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NTFY_DRIVER_H */s

--- a/src/apps/relay/ntfy_drivers/udp_subscriber.c
+++ b/src/apps/relay/ntfy_drivers/udp_subscriber.c
@@ -1,0 +1,160 @@
+#include "udp_subscriber.h"
+#include "apps/common/ns_turn_utils.h"
+#include "apps/relay/mainrelay.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+
+typedef struct _udp_subs_ltd{
+    char config_string[1025];
+    char* host;
+    unsigned int port;
+    int sockfd;
+    ioa_addr addr;
+}udp_subs_ltd_t;
+
+subs_long_term_data_t udp_init(void);
+int udp_notify( subs_long_term_data_t long_term_data, TURN_NTFY_LEVEL level , const char* message );
+int udp_remove( subs_long_term_data_t long_term_data);
+
+int udp_subscriber_flag(){
+    return turn_params.udp_notifier;
+}
+
+static char* udp_subs_config_str( void ){
+    return turn_params.udp_notifier_params;
+}
+
+static int udp_subs_config_parse( udp_subs_ltd_t* data ){
+
+    int ret = 0;
+    char *s0=strdup(data->config_string);
+    char *s = s0;
+
+    while(s && *s) {
+
+            while(*s && (*s==' ')) ++s;
+            char *snext = strstr(s," ");
+            if(snext) {
+                    *snext = 0;
+                    ++snext;
+            }
+
+            char* seq = strstr(s,"=");
+            if(!seq) {
+                ret = -1;
+                break;
+            }
+
+            *seq = 0;
+            if(!strcmp(s,"host"))
+                    data->host = strdup(seq+1);
+            else if(!strcmp(s,"ip"))
+                    data->host = strdup(seq+1);
+            else if(!strcmp(s,"addr"))
+                    data->host = strdup(seq+1);
+            else if(!strcmp(s,"ipaddr"))
+                    data->host = strdup(seq+1);
+            else if(!strcmp(s,"hostaddr"))
+                    data->host = strdup(seq+1);
+            else if(!strcmp(s,"port"))
+                    data->port = (unsigned int)atoi(seq+1);
+            else if(!strcmp(s,"p"))
+                    data->port = (unsigned int)atoi(seq+1);
+            else {
+                ret = -1;
+                break;
+            }
+
+            s = snext;
+    }
+
+    free(s0);
+
+    if ( ret == 0 ){
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"UDP notifier parameters: host=%s port=%d\n",data->host,data->port);
+    }else{
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,"WRONG UDP notifier parameters: %s\n",data->config_string);
+    }
+
+    return ret;
+}
+
+subs_long_term_data_t udp_init( void ){
+
+    udp_subs_ltd_t* data=(udp_subs_ltd_t*)malloc(sizeof(udp_subs_ltd_t));
+        if(!data) return data;
+
+    bzero(data,sizeof(udp_subs_ltd_t));
+
+    STRCPY(data->config_string, udp_subs_config_str());
+
+    if( udp_subs_config_parse(data) < 0 ){
+        return NULL;
+    }
+
+    if(make_ioa_addr((const uint8_t*)data->host,0,&(data->addr))<0) {
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,"Cannot set address %s\n",data->host);
+        return NULL;
+    }
+
+    addr_set_port(&(data->addr),data->port);
+
+    data->sockfd = socket(data->addr.ss.sa_family, SOCK_DGRAM, 0);
+    if (data->sockfd < 0) {
+        perror("socket");
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,"Cannot open socket\n");
+        return NULL;
+    }
+
+    return (subs_long_term_data_t)data;
+}
+
+int udp_notify( subs_long_term_data_t long_term_data, TURN_NTFY_LEVEL level , const char* message ){
+
+    UNUSED_ARG(level);
+
+    udp_subs_ltd_t* data = (udp_subs_ltd_t*)long_term_data;
+    int slen=0;
+
+    if(!data)
+        return -1;
+
+    slen = get_ioa_addr_len((const ioa_addr*)&(data->addr));
+
+    return (int) sendto(data->sockfd, message, strlen(message), 0,(const struct sockaddr*)&(data->addr), (socklen_t) slen);
+}
+
+int udp_remove( subs_long_term_data_t long_term_data){
+
+    udp_subs_ltd_t* data = (udp_subs_ltd_t*)long_term_data;
+
+    close(data->sockfd);
+
+    free(data->host);
+    free(data);
+
+    return 0;
+}
+
+static turn_ntfy_subscriber_if_t subscriber = {
+    /*name*/    "udp",
+    /*date*/    NULL,
+    /*init*/    udp_init,
+    /*notify*/  udp_notify,
+    /*remove*/  udp_remove
+};
+
+turn_ntfy_subscriber_if_t* udp_subscriber_inferface_get(){
+
+    if(udp_subscriber_flag())
+        return &subscriber;
+    return (turn_ntfy_subscriber_if_t*)NULL;
+}

--- a/src/apps/relay/ntfy_drivers/udp_subscriber.h
+++ b/src/apps/relay/ntfy_drivers/udp_subscriber.h
@@ -1,0 +1,17 @@
+#ifndef UDP_SUBSCRIBER_H
+#define UDP_SUBSCRIBER_H
+
+#include "ntfy_driver.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int udp_subscriber_flag(void);
+turn_ntfy_subscriber_if_t* udp_subscriber_inferface_get(void);
+
+#ifdef __cplusplus
+}
+#endifs
+
+#endif /* UDP_SUBSCRIBER_H */

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -34,6 +34,7 @@
 #include "ns_turn_allocation.h"
 #include "ns_turn_ioalib.h"
 #include "ns_turn_utils.h"
+#include "../apps/relay/ntfy_drivers/ntfy_driver.h"
 
 ///////////////////////////////////////////
 
@@ -3924,6 +3925,24 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 
   } else {
     *resp_constructed = 0;
+  }
+	
+  if((*resp_constructed) && (TURN_NTFY_CHECK)){
+		ioa_addr remote;
+		char ip_port[256];
+
+		addr_cpy(&remote, get_remote_addr_from_ioa_socket(ss->client_socket));
+		addr_to_string(&remote, (uint8_t*)ip_port);
+
+		TURN_NTFY_FUNC(TURN_NTFY_LEVEL_INFO,"[Turn Server Command Execution Notification: {\"session\": \"%018llu\", \"origin\": \"%s\", \"realm\": \"%s\", \"user\": \"%s\", \"connection\": \"%s\", \"method\": \"%d\", \"response\": \"%d\", \"reason\": \"%s\"}]",
+                                        (unsigned long long)(ss->id),                                                           /* session id */
+                                        ((char*)ss->origin == (char*)NULL ? "":(char*)ss->origin),                              /* origin */
+                                        ((char*)ss->realm_options.name == (char*)NULL ? "":(char*)ss->realm_options.name),      /* realm */
+                                        ((char*)ss->username == (char*)NULL ? "":(char*)ss->username),                          /* username */
+                                        ((char*)ip_port == (char*)NULL ? "":(char*)ip_port),                                    /* ip:port */
+                                        method,                                                                                 /* turn command method */
+                                        err_code,                                                                               /* response error code */
+                                        (err_code == 0) ? (const char*)"Success" : (const char*)get_default_reason(err_code));  /* response reason */
   }
 
   return 0;


### PR DESCRIPTION
Hi All,
It allows retrieving information about failed turn command request to generate some statistics.

This PR provides a general notification interface for the Turn server. It generates informational messages and logs for the Turn server.

The UDP interface is implemented.

The notification interface is currently used for "executed turn command".
