### PR TITLE
Make REST API hash algorithm configurable

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -203,6 +203,7 @@ turn_params_t turn_params = {
     0,                                  /* mobility */
     TURN_CREDENTIALS_NONE,              /* ct */
     0,                                  /* use_auth_secret_with_timestamp */
+    SHATYPE_DEFAULT,                    /* auth_secret_with_timestamp_shatype */
     0,                                  /* max_bps */
     0,                                  /* bps_capacity */
     0,                                  /* bps_capacity_allocated */
@@ -1424,6 +1425,7 @@ enum EXTRA_OPTS {
   PROMETHEUS_PORT_OPT,
   PROMETHEUS_ENABLE_USERNAMES_OPT,
   AUTH_SECRET_OPT,
+  AUTH_SECRET_SHA256_OPT,
   NO_AUTH_PINGS_OPT,
   NO_DYNAMIC_IP_LIST_OPT,
   NO_DYNAMIC_REALMS_OPT,
@@ -1545,6 +1547,7 @@ static const struct myoption long_options[] = {
     {"prometheus-username-labels", optional_argument, NULL, PROMETHEUS_ENABLE_USERNAMES_OPT},
 #endif
     {"use-auth-secret", optional_argument, NULL, AUTH_SECRET_OPT},
+    {"use-auth-secret-sha256", optional_argument, NULL, AUTH_SECRET_SHA256_OPT},
     {"static-auth-secret", required_argument, NULL, STATIC_AUTH_SECRET_VAL_OPT},
     {"no-auth-pings", optional_argument, NULL, NO_AUTH_PINGS_OPT},
     {"no-dynamic-ip-list", optional_argument, NULL, NO_DYNAMIC_IP_LIST_OPT},
@@ -2203,6 +2206,9 @@ static void set_option(int c, char *value) {
     use_tltc = 1;
     turn_params.ct = TURN_CREDENTIALS_LONG_TERM;
     use_lt_credentials = 1;
+    break;
+  case AUTH_SECRET_SHA256_OPT:
+    turn_params.auth_secret_with_timestamp_shatype = SHATYPE_SHA256;
     break;
   case NO_AUTH_PINGS_OPT:
     turn_params.no_auth_pings = 1;

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -302,6 +302,7 @@ typedef struct _turn_params_ {
   vint mobility;
   turn_credential_type ct;
   int use_auth_secret_with_timestamp;
+  int auth_secret_with_timestamp_shatype;
   band_limit_t max_bps;
   band_limit_t bps_capacity;
   band_limit_t bps_capacity_allocated;

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -552,20 +552,19 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 
       hmac[0] = 0;
 
-      stun_attr_ref sar = stun_attr_get_first_by_type_str(
-          ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh), STUN_ATTRIBUTE_MESSAGE_INTEGRITY);
-      if (!sar) {
-        return -1;
-      }
-
-      int sarlen = stun_attr_get_len(sar);
-      switch (sarlen) {
-      case SHA1SIZEBYTES:
+      switch (turn_params.auth_secret_with_timestamp_shatype) {
+      case SHATYPE_SHA1:
         hmac_len = SHA1SIZEBYTES;
         break;
-      case SHA256SIZEBYTES:
-      case SHA384SIZEBYTES:
-      case SHA512SIZEBYTES:
+      case SHATYPE_SHA256:
+        hmac_len = SHA256SIZEBYTES;
+        break;
+      case SHATYPE_SHA384:
+        hmac_len = SHA384SIZEBYTES;
+        break;
+      case SHATYPE_SHA512:
+        hmac_len = SHA512SIZEBYTES;
+        break;
       default:
         return -1;
       };
@@ -576,7 +575,7 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 
         if (secret) {
           if (stun_calculate_hmac(usname, strlen((char *)usname), (const uint8_t *)secret, strlen(secret), hmac,
-                                  &hmac_len, SHATYPE_DEFAULT) >= 0) {
+                                  &hmac_len, turn_params.auth_secret_with_timestamp_shatype) >= 0) {
             size_t pwd_length = 0;
             char *pwd = base64_encode(hmac, hmac_len, &pwd_length);
 


### PR DESCRIPTION
Add support for configuring the hash algorithm used for the "REST API
tokens" configurable. This makes it possible to use SHA-256 rather than
SHA-1, for example.

Solves #1293