### PR TITLE
generate_enc_password: increase rsalt by 2

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -303,7 +303,7 @@ static void generate_enc_password(const char *pwd, char *result, const unsigned 
     memcpy(salt, orig_salt, PWD_SALT_SIZE);
     salt[PWD_SALT_SIZE] = 0;
   }
-  unsigned char rsalt[PWD_SALT_SIZE * 2 + 1];
+  unsigned char rsalt[PWD_SALT_SIZE * 2 + 2];
   readable_string(salt, rsalt, PWD_SALT_SIZE);
   result[0] = '$';
   result[1] = '5';


### PR DESCRIPTION
before this change i see a bufferflow during `readable_string`.

steps to reproduce

1. [install nix](https://nixos.org/download/) if you haven't
2. run turnadmin: `nix shell nixpkgs/nixos-23.11#coturn --command turnadmin -P -p test`

result:

```
0: (143511): INFO: System cpu num is 8
0: (143511): INFO: log file opened: /var/tmp/turn_143511_2024-03-21.log
0: (143511): INFO: System enable num is 8
*** buffer overflow detected ***: terminated
[1]    143511 IOT instruction (core dumped)  nix shell nixpkgs/nixos-23.11#coturn --command turnadmin -P -p test
```

coredump:

```
[🡕] Process 143511 (turnadmin) of user 1000 dumped core.

Module libffi.so.8 without build-id.
Module libgmp.so.10 without build-id.
Module libhogweed.so.6 without build-id.
Module libnettle.so.8 without build-id.
Module libtasn1.so.6 without build-id.
Module libunistring.so.5 without build-id.
Module libidn2.so.0 without build-id.
Module libp11-kit.so.0 without build-id.
Module libgnutls.so.30 without build-id.
Module libz.so.1 without build-id.
Module libmicrohttpd.so.12 without build-id.
Module libpromhttp.so without build-id.
Module libprom.so without build-id.
Module libevent-2.1.so.7 without build-id.
Module libevent_pthreads-2.1.so.7 without build-id.
Module libevent_openssl-2.1.so.7 without build-id.
Module libevent_extra-2.1.so.7 without build-id.
Module libevent_core-2.1.so.7 without build-id.
Module turnadmin without build-id.
Stack trace of thread 143511:
#0  0x0000ffff7f1054b0 __pthread_kill_implementation (libc.so.6 + 0x854b0)
#1  0x0000ffff7f0beeac raise (libc.so.6 + 0x3eeac)
#2  0x0000ffff7f0aaefc abort (libc.so.6 + 0x2aefc)
#3  0x0000ffff7f0f930c __libc_message (libc.so.6 + 0x7930c)
#4  0x0000ffff7f17b688 __fortify_fail (libc.so.6 + 0xfb688)
#5  0x0000ffff7f17aec4 __chk_fail (libc.so.6 + 0xfaec4)
#6  0x0000ffff7f17c518 __snprintf_chk (libc.so.6 + 0xfc518)
#7  0x00000000004338f8 generate_enc_password (turnadmin + 0x338f8)
#8  0x00000000004089d8 main (turnadmin + 0x89d8)
#9  0x0000ffff7f0ab580 __libc_start_call_main (libc.so.6 + 0x2b580)
#10 0x0000ffff7f0ab658 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2b658)
#11 0x0000000000408bf0 _start (turnadmin + 0x8bf0)
ELF object binary architecture: AARCH64
```
