### PR TITLE
Fix infinite loop in ns_turn_server.c

### DIFF
--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -686,6 +686,7 @@ static mobile_id_t get_new_mobile_id(turn_turnserver *server) {
     uint64_t sid = server->id;
     sid = sid << 56;
     do {
+      newid = 0;
       while (!newid) {
         if (TURN_RANDOM_SIZE == sizeof(mobile_id_t)) {
           newid = (mobile_id_t)turn_random();


### PR DESCRIPTION
In case ur_map_get returns 1 server will enter infinite loop because newid != 0. 