### PR TITLE
generate_enc_password: increase rsalt by 2

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -292,8 +292,9 @@ static void readable_string(unsigned char *orig, unsigned char *out, size_t sz) 
   out[0] = 0;
 
   for (i = 0; i < sz; ++i) {
-    snprintf((char *)(out + (i * 2)), 4, "%02x", (unsigned int)orig[i]);
+    snprintf((char *)(out + (i * 2)), 3, "%02x", (unsigned int)orig[i]);
   }
+  out[sz * 2] = 0;
 }
 
 static void generate_enc_password(const char *pwd, char *result, const unsigned char *orig_salt) {

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -304,7 +304,7 @@ static void generate_enc_password(const char *pwd, char *result, const unsigned 
     memcpy(salt, orig_salt, PWD_SALT_SIZE);
     salt[PWD_SALT_SIZE] = 0;
   }
-  unsigned char rsalt[PWD_SALT_SIZE * 2 + 1];
+  unsigned char rsalt[PWD_SALT_SIZE * 2 + 2];
   readable_string(salt, rsalt, PWD_SALT_SIZE);
   result[0] = '$';
   result[1] = '5';

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -305,7 +305,7 @@ static void generate_enc_password(const char *pwd, char *result, const unsigned 
     memcpy(salt, orig_salt, PWD_SALT_SIZE);
     salt[PWD_SALT_SIZE] = 0;
   }
-  unsigned char rsalt[PWD_SALT_SIZE * 2 + 2];
+  unsigned char rsalt[PWD_SALT_SIZE * 2 + 1];
   readable_string(salt, rsalt, PWD_SALT_SIZE);
   result[0] = '$';
   result[1] = '5';


### PR DESCRIPTION
before this change i see a bufferflow during `readable_string`.