### PR TITLE
Revert "Change printf() to TURN_LOG_FUNC() for --no-stdout-log"

### DIFF
--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -364,7 +364,7 @@ static void sighup_callback_handler(int signum) {
 
 static void set_rtpfile(void) {
   if (to_reset_log_file) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "%s: resetting the log file\n", __FUNCTION__);
+    printf("%s: resetting the log file\n", __FUNCTION__);
     reset_rtpprintf();
     to_reset_log_file = 0;
   }


### PR DESCRIPTION
Reverts coturn/coturn#1221

Avoid recursive calls because TURN_LOG_FUNC also calls set_rtpfile