### PR TITLE
Remove TURN_LOG_FUNC from set_rtpfile to avoid recursive calls

### DIFF
--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -364,7 +364,6 @@ static void sighup_callback_handler(int signum) {
 
 static void set_rtpfile(void) {
   if (to_reset_log_file) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "%s: resetting the log file\n", __FUNCTION__);
     reset_rtpprintf();
     to_reset_log_file = 0;
   }


### PR DESCRIPTION
set_rtpfile is called from TURN_LOG_FUNC

#1455 