### PR TITLE
Use active CPU number instead of total number

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3026,7 +3026,7 @@ int main(int argc, char **argv) {
     turn_params.general_relay_servers_number = (turnserver_id)turn_params.cpus;
 
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "System cpu num is %lu\n", get_system_number_of_cpus());
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "System enable num is %lu\n", turn_params.cpus);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "System enable num is %lu\n", get_system_active_number_of_cpus());
   }
 
   memset(&turn_params.default_users_db, 0, sizeof(default_users_db_t));

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3013,9 +3013,9 @@ int main(int argc, char **argv) {
   read_config_file(argc, argv, 1);
 
   {
-    int cpus = get_system_number_of_cpus();
-    if (0 < cpus) {
-      turn_params.cpus = get_system_number_of_cpus();
+    unsigned long cpus = get_system_active_number_of_cpus();
+    if (cpus > 0) {
+      turn_params.cpus = cpus;
     }
     if (turn_params.cpus < DEFAULT_CPUS_NUMBER) {
       turn_params.cpus = DEFAULT_CPUS_NUMBER;
@@ -3025,8 +3025,8 @@ int main(int argc, char **argv) {
 
     turn_params.general_relay_servers_number = (turnserver_id)turn_params.cpus;
 
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "System cpu num is %lu\n", turn_params.cpus);
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "System enable num is %lu\n", get_system_active_number_of_cpus());
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "System cpu num is %lu\n", get_system_number_of_cpus());
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "System enable num is %lu\n", turn_params.cpus);
   }
 
   memset(&turn_params.default_users_db, 0, sizeof(default_users_db_t));


### PR DESCRIPTION
The code used `get_system_number_of_cpus()` instead of `get_system_active_number_of_cpus()` to configure number of relay servers.
That caused incorrect number to be used on virtualized systems. See #1468