### PR TITLE
Fix msvc analyzer error on goto label on rfc5769check

### DIFF
--- a/src/apps/rfc5769/rfc5769check.c
+++ b/src/apps/rfc5769/rfc5769check.c
@@ -65,7 +65,6 @@ void print_field5769(const char *name, const void *f0, size_t len) {
 }
 
 static int check_oauth(void) {
-
   const char server_name[33] = "blackdow.carleon.gov";
 
   size_t i_encs;
@@ -90,9 +89,7 @@ static int check_oauth(void) {
 
   {
     {
-
       for (i_encs = 0; encs[i_encs]; ++i_encs) {
-
         printf("oauth token %s:", encs[i_encs]);
 
         if (print_extra) {
@@ -132,7 +129,7 @@ static int check_oauth(void) {
 
             if (convert_oauth_key_data(&okd, &key, err_msg, err_msg_size) < 0) {
               fprintf(stderr, "%s\n", err_msg);
-              goto ERROR;
+              goto err;
             }
           }
         }
@@ -148,7 +145,7 @@ static int check_oauth(void) {
 
           if (encode_oauth_token((const uint8_t *)server_name, &etoken, &key, &ot, (const uint8_t *)gcm_nonce) < 0) {
             fprintf(stderr, "%s: cannot encode oauth token\n", __FUNCTION__);
-            goto ERROR;
+            goto err;
           }
 
           if (print_extra) {
@@ -157,30 +154,30 @@ static int check_oauth(void) {
 
           if (decode_oauth_token((const uint8_t *)server_name, &etoken, &key, &dot) < 0) {
             fprintf(stderr, "%s: cannot decode oauth token\n", __FUNCTION__);
-            goto ERROR;
+            goto err;
           }
         }
 
         if (strcmp((char *)ot.enc_block.mac_key, (char *)dot.enc_block.mac_key)) {
           fprintf(stderr, "%s: wrong mac key: %s, must be %s\n", __FUNCTION__, (char *)dot.enc_block.mac_key,
                   (char *)ot.enc_block.mac_key);
-          goto ERROR;
+          goto err;
         }
 
         if (ot.enc_block.key_length != dot.enc_block.key_length) {
           fprintf(stderr, "%s: wrong key length: %d, must be %d\n", __FUNCTION__, (int)dot.enc_block.key_length,
                   (int)ot.enc_block.key_length);
-          goto ERROR;
+          goto err;
         }
         if (ot.enc_block.timestamp != dot.enc_block.timestamp) {
           fprintf(stderr, "%s: wrong timestamp: %llu, must be %llu\n", __FUNCTION__,
                   (unsigned long long)dot.enc_block.timestamp, (unsigned long long)ot.enc_block.timestamp);
-          goto ERROR;
+          goto err;
         }
         if (ot.enc_block.lifetime != dot.enc_block.lifetime) {
           fprintf(stderr, "%s: wrong lifetime: %lu, must be %lu\n", __FUNCTION__, (unsigned long)dot.enc_block.lifetime,
                   (unsigned long)ot.enc_block.lifetime);
-          goto ERROR;
+          goto err;
         }
 
         printf("OK\n");
@@ -193,7 +190,7 @@ static int check_oauth(void) {
   }
   return 0;
 
-ERROR:
+err:
   if (base64encoded_ltp) {
     free(base64encoded_ltp);
   }


### PR DESCRIPTION
rfc5769check.c file is using ERROR as a label for gotos but apparently that name is already used for a constant and msvc analyzer detects it as an error.     

Rename it to "err" that is already used in other parts of the codebase and also more consistent in terms of casing.