### PR TITLE
Always run lint, regardless of branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,6 @@ name: Lint
 
 on:
   push:
-    branches: [ $default-branch ]
   pull_request:
     types: [ opened, reopened, synchronize ]
 
@@ -12,14 +11,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: install dependencies
+      with:
+        fetch-depth: 0
+
+    - name: Install Dependencies
       uses: ./.github/workflows/actions/ubuntu-build-deps
       with:
         SUDO: true
-    - name: install clang-format-15
+
+    - name: Install clang-format-15
       run: sudo apt install -y clang-format-15
-    - name: configure
+
+    - name: Configure
       run: ./configure
+
     - name: lint
       run: |
         if which clang-format-15 2>&1 >/dev/null


### PR DESCRIPTION
Someone working on a branch in their own fork won't see the lint running on their github-actions CI until they open a pull request.

It'd be much easier to ensure changes being worked on are going to pass the linter if the linter runs before the last step of opening the PR.