### PR TITLE
Address some build issues introduced by api changes

### DIFF
--- a/src/server/ns_turn_maps.c
+++ b/src/server/ns_turn_maps.c
@@ -929,7 +929,7 @@ static bool ur_string_map_init(ur_string_map *map) {
 
 ur_string_map *ur_string_map_create(ur_string_map_func del_value_func) {
   ur_string_map *map = (ur_string_map *)malloc(sizeof(ur_string_map));
-  if (ur_string_map_init(map) < 0) {
+  if (!ur_string_map_init(map)) {
     free(map);
     return NULL;
   }

--- a/src/server/ns_turn_maps_rtcp.c
+++ b/src/server/ns_turn_maps_rtcp.c
@@ -172,7 +172,7 @@ static bool rtcp_map_init(rtcp_map *map, ioa_engine_handle e) {
 
 rtcp_map *rtcp_map_create(ioa_engine_handle e) {
   rtcp_map *map = (rtcp_map *)calloc(sizeof(rtcp_map), 1);
-  if (rtcp_map_init(map, e) < 0) {
+  if (!rtcp_map_init(map, e)) {
     free(map);
     return NULL;
   }

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -426,7 +426,7 @@ struct tsi_arg {
   ioa_addr *addr;
 };
 
-static int turn_session_info_foreachcb(ur_map_key_type key, ur_map_value_type value, void *arg) {
+static bool turn_session_info_foreachcb(ur_map_key_type key, ur_map_value_type value, void *arg) {
   UNUSED_ARG(value);
 
   int port = (int)key;
@@ -437,7 +437,7 @@ static int turn_session_info_foreachcb(ur_map_key_type key, ur_map_value_type va
     addr_set_port(&a, port);
     turn_session_info_add_peer(ta->tsi, &a);
   }
-  return 0;
+  return false;
 }
 
 int turn_session_info_copy_from(struct turn_session_info *tsi, ts_ur_super_session *ss) {


### PR DESCRIPTION
#1502 made APIs consistent with using bool as a return value where true is success and false is failure
In a few places the change broke code

This PR fixes the breakage