### PR TITLE
malloc now allocates space for string terminator

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_mysql.c
+++ b/src/apps/relay/dbdrivers/dbd_mysql.c
@@ -115,7 +115,7 @@ char *decryptPassword(char *in, const unsigned char *mykey) {
 #endif
 
   strcat(last, (char *)outdata);
-  out = (char *)malloc(sizeof(char) * strlen(last));
+  out = (char *)malloc(sizeof(char) * (strlen(last) + 1)); // add 1 to allocate space for terminating '\0'
   strcpy(out, last);
   return out;
 }

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -779,8 +779,8 @@ int add_static_user_account(char *user) {
     return -1;
   }
 
-  // key argument (the usname variable) is deep-copied, so ownership isn't transfered, and we still need to free usname later..
-  // value argument (the key variable) has ownership transfered into this function
+  // key argument (the usname variable) is deep-copied, so ownership isn't transfered, and we still need to free usname
+  // later.. value argument (the key variable) has ownership transfered into this function
   ur_string_map_put(turn_params.default_users_db.ram_db.static_accounts, (ur_string_map_key_type)usname,
                     (ur_string_map_value_type)*key);
   ur_string_map_unlock(turn_params.default_users_db.ram_db.static_accounts);


### PR DESCRIPTION
addresses a code scanner vulnerability

the combination of `strlen` and `malloc` results in space being allocated for the string, but not the null terminator required to end the string, so space for an extra character has to be manually specified

#### references
- CERT C Coding Standard: [MEM35-C. Allocate sufficient memory for an object](https://www.securecoding.cert.org/confluence/display/c/MEM35-C.+Allocate+sufficient+memory+for+an+object).
- Common Weakness Enumeration: [CWE-131](https://cwe.mitre.org/data/definitions/131.html).
- Common Weakness Enumeration: [CWE-120](https://cwe.mitre.org/data/definitions/120.html).
- Common Weakness Enumeration: [CWE-122](https://cwe.mitre.org/data/definitions/122.html).