### PR TITLE
Memset user_db before reading conf file, not after

### DIFF
--- a/.github/workflows/amazon_linux_tests.yml
+++ b/.github/workflows/amazon_linux_tests.yml
@@ -37,4 +37,4 @@ jobs:
 
     - name: Integration Test
       working-directory: examples
-      run: ./run_tests.sh
+      run: ./run_tests.sh && ./run_tests_conf.sh

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -37,5 +37,5 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
     - name: apps tests
-      run: cd examples && ./run_tests.sh
+      run: cd examples && ./run_tests.sh && ./run_tests_conf.sh
       

--- a/.github/workflows/compiler-sanitizers.yml
+++ b/.github/workflows/compiler-sanitizers.yml
@@ -44,4 +44,4 @@ jobs:
     - name: Test
       run: |
         cd examples
-        ./run_tests.sh
+        ./run_tests.sh && ./run_tests_conf.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,4 +56,4 @@ jobs:
 
     - name: Integration Test
       working-directory: examples
-      run: ./run_tests.sh
+      run: ./run_tests.sh && ./run_tests_conf.sh

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -27,4 +27,4 @@ jobs:
     - name: make check
       run: make check
     - name: apps tests
-      run: cd examples && ./run_tests.sh
+      run: cd examples && ./run_tests.sh && ./run_tests_conf.sh

--- a/examples/run_tests_conf.sh
+++ b/examples/run_tests_conf.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+echo 'Create turnserver.conf file'
+echo "use-auth-secret" > ../bin/turnserver.conf
+echo "static-auth-secret=secret" >> ../bin/turnserver.conf
+echo "realm=north.gov" >> ../bin/turnserver.conf
+echo "allow-loopback-peers" >> ../bin/turnserver.conf
+echo "no-cli" >> ../bin/turnserver.conf
+echo "cert=../examples/ca/turn_server_cert.pem" >> ../bin/turnserver.conf
+echo "pkey=../examples/ca/turn_server_pkey.pem" >> ../bin/turnserver.conf
+
+echo 'Running turnserver'
+../bin/turnserver -c ../bin/turnserver.conf > /dev/null &
+echo 'Running peer client'
+../bin/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > /dev/null &
+
+sleep 2
+
+echo 'Running turn client TCP'
+../bin/turnutils_uclient -t -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+if [ $? -eq 0 ]; then
+    echo OK
+else
+    echo FAIL
+	exit $?
+fi
+
+echo 'Running turn client TLS'
+../bin/turnutils_uclient -t -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+if [ $? -eq 0 ]; then
+    echo OK
+else
+    echo FAIL
+	exit $?
+fi
+
+echo 'Running turn client UDP'
+../bin/turnutils_uclient -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+if [ $? -eq 0 ]; then
+    echo OK
+else
+    echo FAIL
+	exit $?
+fi
+
+echo 'Running turn client DTLS'
+../bin/turnutils_uclient -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+if [ $? -eq 0 ]; then
+    echo OK
+else
+    echo FAIL
+	exit $?
+fi

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3023,10 +3023,11 @@ int main(int argc, char **argv) {
     return adminmain(argc, argv);
   }
 
+  memset(&turn_params.default_users_db, 0, sizeof(default_users_db_t));
+  turn_params.default_users_db.ram_db.static_accounts = ur_string_map_create(free);
+
   // Zero pass apply the log options.
   read_config_file(argc, argv, 0);
-  // First pass read other config options
-  read_config_file(argc, argv, 1);
 
   {
     unsigned long cpus = get_system_active_number_of_cpus();
@@ -3045,8 +3046,8 @@ int main(int argc, char **argv) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "System enable num is %lu\n", get_system_active_number_of_cpus());
   }
 
-  memset(&turn_params.default_users_db, 0, sizeof(default_users_db_t));
-  turn_params.default_users_db.ram_db.static_accounts = ur_string_map_create(free);
+  // First pass read other config options
+  read_config_file(argc, argv, 1);
 
   struct uoptions uo;
   uo.u.m = long_options;


### PR DESCRIPTION
Fixes #1533 and #1534

Memsetting `turn_params.default_users_db` before reading conf file, not after.
Because auth is read in first iteration so secret was wiped out.

# test plan
Add new test script that uses config file to setup turnserver instead of cli arguments and confirm it works (fails without the change)