### PR TITLE
Fix the ability to compile coturn using C++ compiler

### DIFF
--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -164,15 +164,15 @@ int turn_mutex_destroy(turn_mutex *mutex) {
 
 /* syslog facility */
 /*BVB-594  Syslog facility */
-static char *str_fac[] = {"LOG_AUTH",   "LOG_CRON",   "LOG_DAEMON",   "LOG_KERN",   "LOG_LOCAL0",
-                          "LOG_LOCAL1", "LOG_LOCAL2", "LOG_LOCAL3",   "LOG_LOCAL4", "LOG_LOCAL5",
-                          "LOG_LOCAL6", "LOG_LOCAL7", "LOG_LPR",      "LOG_MAIL",   "LOG_NEWS",
-                          "LOG_USER",   "LOG_UUCP",   "LOG_AUTHPRIV", "LOG_SYSLOG", 0};
+static const char *const str_fac[] = {"LOG_AUTH",   "LOG_CRON",   "LOG_DAEMON",   "LOG_KERN",   "LOG_LOCAL0",
+                                      "LOG_LOCAL1", "LOG_LOCAL2", "LOG_LOCAL3",   "LOG_LOCAL4", "LOG_LOCAL5",
+                                      "LOG_LOCAL6", "LOG_LOCAL7", "LOG_LPR",      "LOG_MAIL",   "LOG_NEWS",
+                                      "LOG_USER",   "LOG_UUCP",   "LOG_AUTHPRIV", "LOG_SYSLOG", 0};
 
 #if defined(__unix__) || defined(unix) || defined(__APPLE__)
-static int int_fac[] = {LOG_AUTH,   LOG_CRON,   LOG_DAEMON, LOG_KERN,     LOG_LOCAL0, LOG_LOCAL1, LOG_LOCAL2,
-                        LOG_LOCAL3, LOG_LOCAL4, LOG_LOCAL5, LOG_LOCAL6,   LOG_LOCAL7, LOG_LPR,    LOG_MAIL,
-                        LOG_NEWS,   LOG_USER,   LOG_UUCP,   LOG_AUTHPRIV, LOG_SYSLOG, 0};
+static const int int_fac[] = {LOG_AUTH,   LOG_CRON,   LOG_DAEMON, LOG_KERN,     LOG_LOCAL0, LOG_LOCAL1, LOG_LOCAL2,
+                              LOG_LOCAL3, LOG_LOCAL4, LOG_LOCAL5, LOG_LOCAL6,   LOG_LOCAL7, LOG_LPR,    LOG_MAIL,
+                              LOG_NEWS,   LOG_USER,   LOG_UUCP,   LOG_AUTHPRIV, LOG_SYSLOG, 0};
 
 static int syslog_facility = 0;
 
@@ -541,7 +541,8 @@ void err(int eval, const char *format, ...) {
 }
 #endif
 
-void turn_log_func_default(char *file, int line, TURN_LOG_LEVEL level, const char *format, ...) {
+void turn_log_func_default(const char *const file, const int line, const TURN_LOG_LEVEL level, const char *const format,
+                           ...) {
   va_list args;
   va_start(args, format);
 #if defined(TURN_LOG_FUNC_IMPL)

--- a/src/apps/common/ns_turn_utils.h
+++ b/src/apps/common/ns_turn_utils.h
@@ -45,6 +45,10 @@ void err(int eval, const char *format, ...);
 #include "ns_turn_ioaddr.h"
 
 #ifdef __cplusplus
+#include <algorithm> // for std::min
+#endif
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -72,7 +76,7 @@ void set_syslog_facility(char *val);
 
 void set_turn_log_timestamp_format(char *new_format);
 
-void turn_log_func_default(char *file, int line, TURN_LOG_LEVEL level, const char *format, ...)
+void turn_log_func_default(const char *file, int line, TURN_LOG_LEVEL level, const char *format, ...)
 #ifdef __GNUC__
     __attribute__((format(printf, 4, 5)))
 #endif
@@ -97,12 +101,15 @@ int is_secure_string(const uint8_t *string, int sanitizesql);
 
 ///////////////////////////////////////////////////////
 
-#if !defined(min)
-#define min(a, b) ((a) <= (b) ? (a) : (b))
-#endif
-
 #ifdef __cplusplus
 }
+#endif
+
+// Make sure that we don't try to pull std::min into the extern-c block.
+#if defined(__cplusplus)
+using std::min;
+#elif !defined(min)
+#define min(a, b) ((a) <= (b) ? (a) : (b))
 #endif
 
 #endif //__TURN_ULIB__

--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -4,20 +4,24 @@
 
 #include "ns_turn_ioalib.h"
 #include <stdbool.h>
+#include <stdlib.h>
+
+#if !defined(_MSC_VER)
+#include <unistd.h>
+#endif
 
 #define DEFAULT_PROM_SERVER_PORT (9641)
 #define TURN_ALLOC_STR_MAX_SIZE (20)
 
 #if !defined(TURN_NO_PROMETHEUS)
 
-#include <stdlib.h>
-#include <unistd.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 #include <microhttpd.h>
 #include <prom.h>
+
 #ifdef __cplusplus
 }
 #endif /* __clplusplus */
@@ -52,25 +56,13 @@ extern prom_counter_t *turn_total_traffic_peer_sentb;
 
 extern prom_gauge_t *turn_total_allocations_number;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void start_prometheus_server(void);
-
-void prom_set_finished_traffic(const char *realm, const char *user, unsigned long rsvp, unsigned long rsvb,
-                               unsigned long sentp, unsigned long sentb, bool peer);
-
-void prom_inc_allocation(SOCKET_TYPE type);
-void prom_dec_allocation(SOCKET_TYPE type);
-
 int is_ipv6_enabled(void);
 
 void prom_inc_stun_binding_request(void);
 void prom_inc_stun_binding_response(void);
 void prom_inc_stun_binding_error(void);
 
-#else
+#endif /* !defined(TURN_NO_PROMETHEUS) */
 
 void start_prometheus_server(void);
 
@@ -79,11 +71,5 @@ void prom_set_finished_traffic(const char *realm, const char *user, unsigned lon
 
 void prom_inc_allocation(SOCKET_TYPE type);
 void prom_dec_allocation(SOCKET_TYPE type);
-
-#endif /* TURN_NO_PROMETHEUS */
-
-#ifdef __cplusplus
-}
-#endif /* __clplusplus */
 
 #endif /* __PROM_SERVER_H__ */

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -513,7 +513,7 @@ bool stun_is_challenge_response_str(const uint8_t *buf, size_t len, int *err_cod
       const uint8_t *value = stun_attr_get_value(sar);
       if (value) {
         size_t vlen = (size_t)stun_attr_get_len(sar);
-        vlen = min(vlen, STUN_MAX_REALM_SIZE);
+        vlen = min(vlen, (size_t)STUN_MAX_REALM_SIZE);
         memcpy(realm, value, vlen);
         realm[vlen] = 0;
         {
@@ -522,7 +522,7 @@ bool stun_is_challenge_response_str(const uint8_t *buf, size_t len, int *err_cod
             value = stun_attr_get_value(sar);
             if (value) {
               vlen = (size_t)stun_attr_get_len(sar);
-              vlen = min(vlen, STUN_MAX_SERVER_NAME_SIZE);
+              vlen = min(vlen, (size_t)STUN_MAX_SERVER_NAME_SIZE);
               if (vlen > 0) {
                 if (server_name) {
                   memcpy(server_name, value, vlen);
@@ -538,7 +538,7 @@ bool stun_is_challenge_response_str(const uint8_t *buf, size_t len, int *err_cod
           value = stun_attr_get_value(sar);
           if (value) {
             vlen = (size_t)stun_attr_get_len(sar);
-            vlen = min(vlen, STUN_MAX_NONCE_SIZE);
+            vlen = min(vlen, (size_t)STUN_MAX_NONCE_SIZE);
             memcpy(nonce, value, vlen);
             nonce[vlen] = 0;
             if (oauth) {


### PR DESCRIPTION
This adjusts the code to allow compilation with a C++ compiler, but doesn't change the build to use a C++ compiler. Everything should continue working as-is with existing c-compilers. This is just a "let it work" change, not a "change how it works" change.