### PR TITLE
Fix nodejs/glibc problem with old container images.

### DIFF
--- a/.github/workflows/amazon_linux_tests.yml
+++ b/.github/workflows/amazon_linux_tests.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
 
+# make GHA actions use node16 to use ancient container images
+# See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+# Unclear how long this will work though
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   builds:
     strategy:

--- a/.github/workflows/ubuntu_tests.yml
+++ b/.github/workflows/ubuntu_tests.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize ]
 
+# make GHA actions use node16 to use ancient container images
+# See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+# Unclear how long this will work though
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   builds:
     strategy:


### PR DESCRIPTION
This problem is caused by this issue: https://github.com/actions/checkout/issues/1809

Several comments include documentation on various environment variables to force it to use the older nodejs release still, but probably those various workarounds will stop working eventually.