### PR TITLE
fix static compilation error " call to undeclared function 'THREAD_setup' "

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3408,10 +3408,11 @@ int THREAD_cleanup(void) {
 }
 #else
 static int THREAD_setup(void) { return 1; }
-
-int THREAD_cleanup(void);
 int THREAD_cleanup(void) { return 1; }
 #endif /* OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_1_1_0 */
+#else
+static int THREAD_setup(void) { return 1; }
+int THREAD_cleanup(void) { return 1; }
 #endif /* defined(OPENSSL_THREADS) */
 
 static void adjust_key_file_name(char *fn, const char *file_title, int critical) {

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3361,8 +3361,8 @@ int main(int argc, char **argv) {
 
 ////////// OpenSSL locking ////////////////////////////////////////
 
-int THREAD_cleanup(void);
 static int THREAD_setup(void);
+int THREAD_cleanup(void);
 
 #if defined(OPENSSL_THREADS)
 #if OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_1_1_0
@@ -3422,6 +3422,7 @@ int THREAD_cleanup(void) {
 static int THREAD_setup(void) { return 1; }
 int THREAD_cleanup(void) { return 1; }
 #endif /* OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_1_1_0 */
+
 #else
 static int THREAD_setup(void) { return 1; }
 int THREAD_cleanup(void) { return 1; }

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3422,7 +3422,6 @@ int THREAD_cleanup(void) {
 static int THREAD_setup(void) { return 1; }
 int THREAD_cleanup(void) { return 1; }
 #endif /* OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_1_1_0 */
-
 #else
 static int THREAD_setup(void) { return 1; }
 int THREAD_cleanup(void) { return 1; }

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3349,6 +3349,9 @@ int main(int argc, char **argv) {
 
 ////////// OpenSSL locking ////////////////////////////////////////
 
+int THREAD_cleanup(void);
+static int THREAD_setup(void);
+
 #if defined(OPENSSL_THREADS)
 #if OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_1_1_0
 
@@ -3404,7 +3407,6 @@ int THREAD_cleanup(void) {
   return 1;
 }
 #else
-static int THREAD_setup(void);
 static int THREAD_setup(void) { return 1; }
 
 int THREAD_cleanup(void);

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3404,6 +3404,7 @@ int THREAD_cleanup(void) {
   return 1;
 }
 #else
+static int THREAD_setup(void);
 static int THREAD_setup(void) { return 1; }
 
 int THREAD_cleanup(void);


### PR DESCRIPTION
##  Statically Compilation error :  ( linux openssl version > 3.0 )
```
src/apps/relay/mainrelay.c:3872:3: error: call to undeclared function 'THREAD_setup'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  THREAD_setup();
  ^
1 error generated.
```
![image](https://github.com/user-attachments/assets/cd571cd5-3e0a-4058-8285-b48ddb673805)


## Static compilation configuration： https://github.com/jingjingxyk/build-static-coturn/blob/main/sapi/src/builder/library/coturn.php#L113

Static compilation of dependency libraries ： libevent, openssl, libsqlite3,libpq, hiredis,  libmongoc

Static Compilation Result ： https://github.com/jingjingxyk/build-static-coturn/releases

## Run Statically Compiled Coturn 

```bash
# download statically compiled coturn 

curl -fSL https://github.com/jingjingxyk/swoole-cli/blob/new_dev/setup-coturn-runtime.sh?raw=true | bash


# run coturn 

cp -f ./bin/runtime/coturn/etc/turnserver.conf.default ./bin/runtime/coturn/etc/turnserver.conf

./bin/runtime/coturn/bin/turnserver -c ./bin/runtime/coturn/etc/turnserver.conf

```


