### PR TITLE
Fix compiler warnings from continuous integration

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -391,10 +391,10 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
         thrid = (long)pthread_self();
 #endif
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
-                      "%s: 111.111: thrid=0x%lx: Amap = 0x%lx, socket container=0x%lx, local addr %s, remote addr %s, "
-                      "s=0x%lx, done=%d, tbc=%d\n",
-                      __FUNCTION__, thrid, (long)amap, (long)(chs->sockets_container), (char *)saddr, (char *)rsaddr,
-                      (long)s, (int)(chs->done), (int)(chs->tobeclosed));
+                      "%s: 111.111: thrid=0x%lx: Amap = %p, socket container=%p, local addr %s, remote addr %s, "
+                      "s=%p, done=%d, tbc=%d\n",
+                      __FUNCTION__, thrid, amap, chs->sockets_container, (char *)saddr, (char *)rsaddr, s,
+                      (int)(chs->done), (int)(chs->tobeclosed));
       }
     }
 
@@ -417,10 +417,10 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
         thrid = (long)pthread_self();
 #endif
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
-                      "%s: 111.222: thrid=0x%lx: Amap = 0x%lx, socket container=0x%lx, local addr %s, remote addr %s, "
+                      "%s: 111.222: thrid=0x%lx: Amap = %p, socket container=%p, local addr %s, remote addr %s, "
                       "s=0x%lx, done=%d, tbc=%d, st=%d, sat=%d\n",
-                      __FUNCTION__, thrid, (long)amap, (long)(chs->sockets_container), (char *)saddr, (char *)rsaddr,
-                      (long)chs, (int)(chs->done), (int)(chs->tobeclosed), (int)(chs->st), (int)(chs->sat));
+                      __FUNCTION__, thrid, amap, chs->sockets_container, (char *)saddr, (char *)rsaddr, (long)chs,
+                      (int)(chs->done), (int)(chs->tobeclosed), (int)(chs->st), (int)(chs->sat));
       }
     }
 

--- a/src/apps/relay/hiredis_libevent2.c
+++ b/src/apps/relay/hiredis_libevent2.c
@@ -84,7 +84,7 @@ static void redisLibeventReadEvent(evutil_socket_t fd, short event, void *arg) {
       } while ((len < 0) && socket_eintr());
       if (len < 1) {
         e->invalid = 1;
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Redis connection broken: e=0x%lx\n", __FUNCTION__, ((unsigned long)e));
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Redis connection broken: e=0x%p\n", __FUNCTION__, e);
       }
     }
     if (redis_le_valid(e)) {
@@ -204,8 +204,7 @@ void send_message_to_redis(redis_context_handle rch, const char *command, const 
 
       if ((redisAsyncCommand(ac, NULL, e, rm.format, rm.arg) != REDIS_OK)) {
         e->invalid = 1;
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Redis connection broken: ac=0x%lx, e=0x%lx\n", __FUNCTION__,
-                      (unsigned long)ac, (unsigned long)e);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Redis connection broken: ac=0x%p, e=0x%p\n", __FUNCTION__, ac, e);
       }
     }
   }

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -721,8 +721,8 @@ static int handle_relay_message(relay_server_handle rs, struct message_to_relay 
       if (!s) {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: socket EMPTY\n", __FUNCTION__);
       } else if (s->read_event || s->bev) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: socket wrongly preset: 0x%lx : 0x%lx\n", __FUNCTION__,
-                      (long)s->read_event, (long)s->bev);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: socket wrongly preset: %p : %p\n", __FUNCTION__, s->read_event,
+                      s->bev);
         IOA_CLOSE_SOCKET(s);
         sm->m.sm.s = NULL;
       } else {
@@ -760,8 +760,8 @@ static int handle_relay_message(relay_server_handle rs, struct message_to_relay 
       if (!s) {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: mobile socket EMPTY\n", __FUNCTION__);
       } else if (s->read_event || s->bev) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: mobile socket wrongly preset: 0x%lx : 0x%lx\n", __FUNCTION__,
-                      (long)s->read_event, (long)s->bev);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: mobile socket wrongly preset: %p : %p\n", __FUNCTION__, s->read_event,
+                      s->bev);
         IOA_CLOSE_SOCKET(s);
         sm->m.sm.s = NULL;
       } else {

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -554,7 +554,7 @@ static void timer_event_handler(evutil_socket_t fd, short what, void *arg) {
   }
 
   if (te->e && eve(te->e->verbose)) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: timeout 0x%lx: %s\n", __FUNCTION__, (long)te, te->txt);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: timeout %p: %s\n", __FUNCTION__, te, te->txt);
   }
 
   ioa_timer_event_handler cb = te->cb;
@@ -1501,15 +1501,15 @@ void close_ioa_socket(ioa_socket_handle s) {
   if (s) {
 
     if (s->magic != SOCKET_MAGIC) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s wrong magic on socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__, (long)s,
-                    s->st, s->sat);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s wrong magic on socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st,
+                    s->sat);
       return;
     }
 
     if (s->done) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s double free on socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__, (long)s,
-                    s->st, s->sat);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s double free on socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st,
+                    s->sat);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
       return;
     }
 
@@ -1559,19 +1559,19 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Detaching NULL socket\n");
   } else {
     if ((s->magic != SOCKET_MAGIC) || (s->done)) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on bad socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__, (long)s,
-                    s->st, s->sat);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on bad socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st,
+                    s->sat);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
       return ret;
     }
     if (s->tobeclosed) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on tobeclosed socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__,
-                    (long)s, s->st, s->sat);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on tobeclosed socket: %p, st=%d, sat=%d\n", __FUNCTION__, s,
+                    s->st, s->sat);
       return ret;
     }
     if (!(s->e)) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on socket without engine: 0x%lx, st=%d, sat=%d\n",
-                    __FUNCTION__, (long)s, s->st, s->sat);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on socket without engine: %p, st=%d, sat=%d\n", __FUNCTION__,
+                    s, s->st, s->sat);
       return ret;
     }
 
@@ -1579,8 +1579,8 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
 
     if (s->parent_s) {
       if ((s->st != UDP_SOCKET) && (s->st != DTLS_SOCKET)) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on non-UDP child socket: 0x%lx, st=%d, sat=%d\n",
-                      __FUNCTION__, (long)s, s->st, s->sat);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s detach on non-UDP child socket: %p, st=%d, sat=%d\n", __FUNCTION__,
+                      s, s->st, s->sat);
         return ret;
       }
     }
@@ -2384,8 +2384,8 @@ static int socket_input_worker(ioa_socket_handle s) {
   }
 
   if ((s->magic != SOCKET_MAGIC) || (s->done)) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__, (long)s, s->st, s->sat);
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st, s->sat);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
     return -1;
   }
 
@@ -2443,12 +2443,12 @@ static int socket_input_worker(ioa_socket_handle s) {
     if (tls_type) {
       s->st = TLS_SOCKET;
       if (s->ssl) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: 0x%lx, st=%d, sat=%d: ssl already exist\n", __FUNCTION__,
-                      (long)s, s->st, s->sat);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: ssl already exist\n", __FUNCTION__, s,
+                      s->st, s->sat);
       }
       if (s->bev) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: 0x%lx, st=%d, sat=%d: bev already exist\n", __FUNCTION__,
-                      (long)s, s->st, s->sat);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: bev already exist\n", __FUNCTION__, s,
+                      s->st, s->sat);
       }
 
       if (s->e->tls_ctx) {
@@ -2467,8 +2467,8 @@ static int socket_input_worker(ioa_socket_handle s) {
     {
       s->st = TCP_SOCKET;
       if (s->bev) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: 0x%lx, st=%d, sat=%d: bev already exist\n", __FUNCTION__,
-                      (long)s, s->st, s->sat);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: bev already exist\n", __FUNCTION__, s,
+                      s->st, s->sat);
       }
       s->bev = bufferevent_socket_new(s->e->event_base, s->fd, TURN_BUFFEREVENTS_OPTIONS);
       bufferevent_setcb(s->bev, socket_input_handler_bev, socket_output_handler_bev, eventcb_bev, s);
@@ -2482,12 +2482,12 @@ static int socket_input_worker(ioa_socket_handle s) {
     if (tls_type) {
       s->st = TLS_SCTP_SOCKET;
       if (s->ssl) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: 0x%lx, st=%d, sat=%d: ssl already exist\n", __FUNCTION__,
-                      (long)s, s->st, s->sat);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: ssl already exist\n", __FUNCTION__, s,
+                      s->st, s->sat);
       }
       if (s->bev) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: 0x%lx, st=%d, sat=%d: bev already exist\n", __FUNCTION__,
-                      (long)s, s->st, s->sat);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: bev already exist\n", __FUNCTION__, s,
+                      s->st, s->sat);
       }
       if (s->e->tls_ctx) {
         set_socket_ssl(s, SSL_new(s->e->tls_ctx));
@@ -2504,8 +2504,8 @@ static int socket_input_worker(ioa_socket_handle s) {
     {
       s->st = SCTP_SOCKET;
       if (s->bev) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: 0x%lx, st=%d, sat=%d: bev already exist\n", __FUNCTION__,
-                      (long)s, s->st, s->sat);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d: bev already exist\n", __FUNCTION__, s,
+                      s->st, s->sat);
       }
       s->bev = bufferevent_socket_new(s->e->event_base, s->fd, TURN_BUFFEREVENTS_OPTIONS);
       bufferevent_setcb(s->bev, socket_input_handler_bev, socket_output_handler_bev, eventcb_bev, s);
@@ -2699,9 +2699,9 @@ static void socket_input_handler(evutil_socket_t fd, short what, void *arg) {
 
   if ((s->magic != SOCKET_MAGIC) || (s->done)) {
     read_spare_buffer(fd);
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on bad socket, ev=%d: 0x%lx, st=%d, sat=%d\n", __FUNCTION__, (int)what,
-                  (long)s, s->st, s->sat);
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on bad socket, ev=%d: %p, st=%d, sat=%d\n", __FUNCTION__, (int)what, s,
+                  s->st, s->sat);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
     return;
   }
 
@@ -2717,9 +2717,9 @@ static void socket_input_handler(evutil_socket_t fd, short what, void *arg) {
   }
 
   if ((s->magic != SOCKET_MAGIC) || (s->done)) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s (1) on socket, ev=%d: 0x%lx, st=%d, sat=%d\n", __FUNCTION__, (int)what,
-                  (long)s, s->st, s->sat);
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s (1) on socket, ev=%d: %p, st=%d, sat=%d\n", __FUNCTION__, (int)what, s,
+                  s->st, s->sat);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
     return;
   }
 
@@ -2736,7 +2736,7 @@ void close_ioa_socket_after_processing_if_necessary(ioa_socket_handle s) {
     s->special_session_size = 0;
 
     if (!(s->session) && !(s->sub_session)) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s https server socket closed: 0x%lx, st=%d, sat=%d\n", __FUNCTION__, (long)s,
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s https server socket closed: %p, st=%d, sat=%d\n", __FUNCTION__, s,
                     get_ioa_socket_type(s), get_ioa_socket_app_type(s));
       IOA_CLOSE_SOCKET(s);
       return;
@@ -2836,15 +2836,14 @@ static void socket_input_handler_bev(struct bufferevent *bev, void *arg) {
     ioa_socket_handle s = (ioa_socket_handle)arg;
 
     if (bev != s->bev) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx: wrong bev\n", __FUNCTION__, (long)s);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p: wrong bev\n", __FUNCTION__, s);
       read_spare_buffer_bev(bev);
       return;
     }
 
     if ((s->magic != SOCKET_MAGIC) || (s->done)) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__, (long)s, s->st,
-                    s->sat);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s on socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st, s->sat);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
       read_spare_buffer_bev(bev);
       return;
     }
@@ -2863,9 +2862,8 @@ static void socket_input_handler_bev(struct bufferevent *bev, void *arg) {
     }
 
     if ((s->magic != SOCKET_MAGIC) || (s->done)) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s (1) on socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__, (long)s, s->st,
-                    s->sat);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!!%s (1) on socket: %p, st=%d, sat=%d\n", __FUNCTION__, s, s->st, s->sat);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
       return;
     }
 
@@ -2883,22 +2881,22 @@ static void eventcb_bev(struct bufferevent *bev, short events, void *arg) {
       ioa_socket_handle s = (ioa_socket_handle)arg;
 
       if (!is_stream_socket(s->st)) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: socket type is wrong on the socket: 0x%lx, st=%d, sat=%d\n",
-                      __FUNCTION__, (long)s, s->st, s->sat);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: socket type is wrong on the socket: %p, st=%d, sat=%d\n",
+                      __FUNCTION__, s, s->st, s->sat);
         return;
       }
 
       if (s->magic != SOCKET_MAGIC) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: magic is wrong on the socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__,
-                      (long)s, s->st, s->sat);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: magic is wrong on the socket: %p, st=%d, sat=%d\n", __FUNCTION__, s,
+                      s->st, s->sat);
         return;
       }
 
       if (s->done) {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
-                      "!!! %s: closed socket: 0x%lx (1): done=%d, fd=%d, br=%d, st=%d, sat=%d, tbc=%d\n", __FUNCTION__,
-                      (long)s, (int)s->done, (int)s->fd, s->broken, s->st, s->sat, s->tobeclosed);
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+                      "!!! %s: closed socket: %p (1): done=%d, fd=%d, br=%d, st=%d, sat=%d, tbc=%d\n", __FUNCTION__, s,
+                      (int)s->done, (int)s->fd, s->broken, s->st, s->sat, s->tobeclosed);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
         return;
       }
 
@@ -2917,8 +2915,8 @@ static void eventcb_bev(struct bufferevent *bev, short events, void *arg) {
       if (!(s->session) && !(s->sub_session)) {
         char sraddr[129] = "\0";
         addr_to_string(&(s->remote_addr), (uint8_t *)sraddr);
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s https server socket closed: 0x%lx, st=%d, sat=%d, remote addr=%s\n",
-                      __FUNCTION__, (long)s, get_ioa_socket_type(s), get_ioa_socket_app_type(s), sraddr);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s https server socket closed: %p, st=%d, sat=%d, remote addr=%s\n",
+                      __FUNCTION__, s, get_ioa_socket_type(s), get_ioa_socket_app_type(s), sraddr);
         IOA_CLOSE_SOCKET(s);
         return;
       }
@@ -2997,7 +2995,7 @@ static int ssl_send(ioa_socket_handle s, const char *buffer, int len, int verbos
   SSL *ssl = s->ssl;
 
   if (eve(verbose)) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: before write: buffer=0x%lx, len=%d\n", __FUNCTION__, (long)buffer, len);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: before write: buffer=%p, len=%d\n", __FUNCTION__, buffer, len);
   }
 
   if (s->parent_s) {
@@ -3095,9 +3093,8 @@ try_start:
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "DTLS Socket lost packet... fine\n");
           return 0;
         }
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
-                      "DTLS Socket write error unrecoverable: %d; buffer=0x%lx, len=%d, ssl=0x%lx\n", err, (long)buffer,
-                      (int)len, (long)ssl);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "DTLS Socket write error unrecoverable: %d; buffer=%p, len=%d, ssl=%p\n",
+                      err, buffer, (int)len, ssl);
         return -1;
       } else {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "DTLS Socket write error recoverable: %d\n", err);
@@ -3221,9 +3218,9 @@ int send_data_from_ioa_socket_nbh(ioa_socket_handle s, ioa_addr *dest_addr, ioa_
 
   if (s->done || (s->fd == -1)) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
-                  "!!! %s: (1) Trying to send data from closed socket: 0x%lx (1): done=%d, fd=%d, st=%d, sat=%d\n",
-                  __FUNCTION__, (long)s, (int)s->done, (int)s->fd, s->st, s->sat);
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+                  "!!! %s: (1) Trying to send data from closed socket: %p (1): done=%d, fd=%d, st=%d, sat=%d\n",
+                  __FUNCTION__, s, (int)s->done, (int)s->fd, s->st, s->sat);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
 
   } else if (nbh) {
     if (!ioa_socket_check_bandwidth(s, nbh, 0)) {
@@ -3328,9 +3325,9 @@ int send_data_from_ioa_socket_tcp(ioa_socket_handle s, const void *data, size_t 
 
     if (s->done || (s->fd == -1) || ioa_socket_tobeclosed(s) || !(s->e)) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
-                    "!!! %s: (1) Trying to send data from bad socket: 0x%lx (1): done=%d, fd=%d, st=%d, sat=%d\n",
-                    __FUNCTION__, (long)s, (int)s->done, (int)s->fd, s->st, s->sat);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+                    "!!! %s: (1) Trying to send data from bad socket: %p (1): done=%d, fd=%d, st=%d, sat=%d\n",
+                    __FUNCTION__, s, (int)s->done, (int)s->fd, s->st, s->sat);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
 
     } else if (s->connected && s->bev) {
       if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET)) {
@@ -3485,15 +3482,15 @@ int register_callback_on_ioa_socket(ioa_engine_handle e, ioa_socket_handle s, in
 int ioa_socket_tobeclosed(ioa_socket_handle s) {
   if (s) {
     if (s->magic != SOCKET_MAGIC) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: magic is wrong on the socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__,
-                    (long)s, s->st, s->sat);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: magic is wrong on the socket: %p, st=%d, sat=%d\n", __FUNCTION__, s,
+                    s->st, s->sat);
       return 1;
     }
 
     if (s->done) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: check on already closed socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__,
-                    (long)s, s->st, s->sat);
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: 0x%lx was closed\n", __FUNCTION__, (long)s);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: check on already closed socket: %p, st=%d, sat=%d\n", __FUNCTION__, s,
+                    s->st, s->sat);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s socket: %p was closed\n", __FUNCTION__, s);
       return 1;
     }
     if (s->tobeclosed) {

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -1220,13 +1220,13 @@ static void web_admin_input_handler(ioa_socket_handle s, int event_type, ioa_net
                         get_ioa_socket_cipher(s), get_ioa_socket_ssl_method(s),
                         (char *)ioa_network_buffer_data(in_buffer->nbh));
 
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s socket to be detached: 0x%lx, st=%d, sat=%d\n", __FUNCTION__, (long)s,
+          TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s socket to be detached: %p, st=%d, sat=%d\n", __FUNCTION__, s,
                         get_ioa_socket_type(s), get_ioa_socket_app_type(s));
 
           ioa_socket_handle new_s = detach_ioa_socket(s);
           if (new_s) {
-            TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s new detached socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__,
-                          (long)new_s, get_ioa_socket_type(new_s), get_ioa_socket_app_type(new_s));
+            TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s new detached socket: %p, st=%d, sat=%d\n", __FUNCTION__, new_s,
+                          get_ioa_socket_type(new_s), get_ioa_socket_app_type(new_s));
 
             send_https_socket(new_s);
           }
@@ -1246,8 +1246,8 @@ static void web_admin_input_handler(ioa_socket_handle s, int event_type, ioa_net
 
   if (to_be_closed) {
     if (adminserver.verbose) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: web-admin socket to be closed in client handler: s=0x%lx\n", __FUNCTION__,
-                    (long)s);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: web-admin socket to be closed in client handler: s=%p\n", __FUNCTION__,
+                    s);
     }
     set_ioa_socket_tobeclosed(s);
   }
@@ -1274,8 +1274,8 @@ static int send_socket_to_admin_server(ioa_engine_handle e, struct message_to_re
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: web-admin socket EMPTY\n", __FUNCTION__);
 
   } else if (s->read_event || s->bev) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: web-admin socket wrongly preset: 0x%lx : 0x%lx\n", __FUNCTION__,
-                  (long)s->read_event, (long)s->bev);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: web-admin socket wrongly preset: %p : %p\n", __FUNCTION__, s->read_event,
+                  s->bev);
 
     IOA_CLOSE_SOCKET(s);
     sm->m.sm.s = NULL;

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -768,7 +768,7 @@ int add_static_user_account(char *user) {
 
   // the ur_string_map functions only fail (well... other than allocation failures, which aren't handled)
   // if the map isn't valid. So we only need to check the result of locking.
-  if (ur_string_map_lock(turn_params.default_users_db.ram_db.static_accounts) < 0) {
+  if (!ur_string_map_lock(turn_params.default_users_db.ram_db.static_accounts)) {
     free(usname);
     free(key);
     return -1;

--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -855,7 +855,7 @@ static int client_shutdown(app_ur_session *elem) {
   remove_all_from_ss(elem);
 
   if (clnet_verbose) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "done, connection 0x%lx closed.\n", (long)elem);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "done, connection %p closed.\n", elem);
   }
 
   return 0;
@@ -899,7 +899,7 @@ static int client_write(app_ur_session *elem) {
     int i = (unsigned int)(turn_random()) % elem->pinfo.tcp_conn_number;
     atc = elem->pinfo.tcp_conn[i];
     if (!atc->tcp_data_bound) {
-      printf("%s: Uninitialized atc: i=%d, atc=0x%lx\n", __FUNCTION__, i, (long)atc);
+      printf("%s: Uninitialized atc: i=%d, atc=%p\n", __FUNCTION__, i, atc);
       return -1;
     }
   } else if (!do_not_use_channel) {

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -222,7 +222,7 @@ typedef uint32_t turn_time_t;
 
 ////////////////////////////////////////////////////////
 
-#if !defined(IPPROTO_SCTP)
+#if !defined(IPPROTO_SCTP) && !defined(TURN_NO_SCTP)
 #define TURN_NO_SCTP
 #endif
 

--- a/src/server/ns_turn_allocation.c
+++ b/src/server/ns_turn_allocation.c
@@ -613,8 +613,7 @@ tcp_connection *create_tcp_connection(uint8_t server_id, allocation *a, stun_tid
 void delete_tcp_connection(tcp_connection *tc) {
   if (tc) {
     if (tc->done) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: check on already closed tcp data connection: 0x%lx\n", __FUNCTION__,
-                    (unsigned long)tc);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "!!! %s: check on already closed tcp data connection: %p\n", __FUNCTION__, tc);
       return;
     }
     tc->done = 1;

--- a/src/server/ns_turn_maps_rtcp.c
+++ b/src/server/ns_turn_maps_rtcp.c
@@ -61,7 +61,7 @@ static bool rtcp_map_valid(const rtcp_map *map) { return (map && (map->magic == 
 
 typedef struct {
   rtcp_token_type tokens[MAX_TOKEN_DEL];
-  int tn;
+  size_t tn;
   turn_time_t t;
 } timeout_check_arg_type;
 

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4170,8 +4170,8 @@ int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss,
   }
 
   if (eve(server->verbose)) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "closing session 0x%lx, client socket 0x%lx (socket session=0x%lx)\n", (long)ss,
-                  (long)ss->client_socket, (long)get_ioa_socket_session(ss->client_socket));
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "closing session %p, client socket %p (socket session=%p)\n", ss,
+                  ss->client_socket, get_ioa_socket_session(ss->client_socket));
   }
 
   if (server->disconnect) {
@@ -4268,7 +4268,7 @@ static int write_client_connection(turn_turnserver *server, ts_ur_super_session 
   } else {
 
     if (eve(server->verbose)) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: prepare to write to s 0x%lx\n", __FUNCTION__, (long)(ss->client_socket));
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: prepare to write to s %p\n", __FUNCTION__, ss->client_socket);
     }
 
     int skip = 0;
@@ -4491,8 +4491,8 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
   }
 
   if (eve(server->verbose)) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: data.buffer=0x%lx, data.len=%ld\n", __FUNCTION__,
-                  (long)ioa_network_buffer_data(in_buffer->nbh), (long)ioa_network_buffer_get_size(in_buffer->nbh));
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: data.buffer=%p, data.len=%ld\n", __FUNCTION__,
+                  ioa_network_buffer_data(in_buffer->nbh), (long)ioa_network_buffer_get_size(in_buffer->nbh));
   }
 
   uint16_t chnum = 0;
@@ -4621,13 +4621,13 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
                           get_ioa_socket_cipher(ss->client_socket), get_ioa_socket_ssl_method(ss->client_socket),
                           ioa_network_buffer_get_size(in_buffer->nbh));
             if (server->send_https_socket) {
-              TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s socket to be detached: 0x%lx, st=%d, sat=%d\n", __FUNCTION__,
-                            (long)ss->client_socket, get_ioa_socket_type(ss->client_socket),
+              TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s socket to be detached: %p, st=%d, sat=%d\n", __FUNCTION__,
+                            ss->client_socket, get_ioa_socket_type(ss->client_socket),
                             get_ioa_socket_app_type(ss->client_socket));
               ioa_socket_handle new_s = detach_ioa_socket(ss->client_socket);
               if (new_s) {
-                TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s new detached socket: 0x%lx, st=%d, sat=%d\n", __FUNCTION__,
-                              (long)new_s, get_ioa_socket_type(new_s), get_ioa_socket_app_type(new_s));
+                TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s new detached socket: %p, st=%d, sat=%d\n", __FUNCTION__, new_s,
+                              get_ioa_socket_type(new_s), get_ioa_socket_app_type(new_s));
                 server->send_https_socket(new_s);
               }
               ss->to_be_closed = 1;
@@ -4903,8 +4903,8 @@ static void client_input_handler(ioa_socket_handle s, int event_type, ioa_net_da
 
   if (ss->to_be_closed) {
     if (server->verbose) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: client socket to be closed in client handler: ss=0x%lx\n",
-                    (unsigned long long)(ss->id), (long)ss);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: client socket to be closed in client handler: ss=%p\n",
+                    (unsigned long long)(ss->id), ss);
     }
     set_ioa_socket_tobeclosed(s);
   }


### PR DESCRIPTION
Almost all of the warnings were about truncating pointers, because sizeof(void*) != sizeof(long) on all platforms.