### PR TITLE
Delete dead code

### DIFF
--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1648,7 +1648,7 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
   bufferevent_enable(rs->auth_in_buf, EV_READ);
 
   init_turn_server(
-      &(rs->server), rs->id, turn_params.verbose, rs->ioa_eng, turn_params.ct, 0, turn_params.fingerprint,
+      &(rs->server), rs->id, turn_params.verbose, rs->ioa_eng, turn_params.ct, turn_params.fingerprint,
       DONT_FRAGMENT_SUPPORTED, start_user_check, check_new_allocation_quota, release_allocation_quota,
       turn_params.external_ip, &turn_params.check_origin, &turn_params.no_tcp_relay, &turn_params.no_udp_relay,
       &turn_params.stale_nonce, &turn_params.max_allocate_lifetime, &turn_params.channel_lifetime,

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4905,7 +4905,7 @@ static void client_input_handler(ioa_socket_handle s, int event_type, ioa_net_da
 ///////////////////////////////////////////////////////////
 
 void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, ioa_engine_handle e,
-                      turn_credential_type ct, int stun_port, int fingerprint, dont_fragment_option_t dont_fragment,
+                      turn_credential_type ct, int fingerprint, dont_fragment_option_t dont_fragment,
                       get_user_key_cb userkeycb, check_new_allocation_quota_cb chquotacb,
                       release_allocation_quota_cb raqcb, ioa_addr *external_ip, vintp check_origin, vintp no_tcp_relay,
                       vintp no_udp_relay, vintp stale_nonce, vintp max_allocate_lifetime, vintp channel_lifetime,
@@ -4978,9 +4978,6 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
   if (external_ip) {
     addr_cpy(&(server->external_ip), external_ip);
     server->external_ip_set = 1;
-  }
-  if (stun_port < 1) {
-    stun_port = DEFAULT_STUN_PORT;
   }
 
   server->verbose = verbose;

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -210,7 +210,7 @@ const char *get_version(turn_turnserver *server);
 ///////////////////////////////////////////
 
 void init_turn_server(
-    turn_turnserver *server, turnserver_id id, int verbose, ioa_engine_handle e, turn_credential_type ct, int stun_port,
+    turn_turnserver *server, turnserver_id id, int verbose, ioa_engine_handle e, turn_credential_type ct,
     int fingerprint, dont_fragment_option_t dont_fragment, get_user_key_cb userkeycb,
     check_new_allocation_quota_cb chquotacb, release_allocation_quota_cb raqcb, ioa_addr *external_addr,
     vintp check_origin, vintp no_tcp_relay, vintp no_udp_relay, vintp stale_nonce, vintp max_allocate_lifetime,


### PR DESCRIPTION
`stun_port` isn't read after setting it. Thus, we can remove it.