### PR TITLE
Ignore more files (.gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,20 @@ qrc_*.cpp
 Thumbs.db
 *.res
 *.rc
+
+# CMake
 /.qmake.cache
 /.qmake.stash
+/*.cmake
+/src/**/*.cmake
+**/CMakeFiles/**
+/CMakeCache.txt
+
+# Make
+Makefile
+
+# clangd
+/.cache/
 
 # qtcreator generated files
 *.pro.user*


### PR DESCRIPTION
Add files to `.gitignore` that are generated by the build system.