### PR TITLE
Install openssl-1.1.1 on amazonlinux:2 instead of openssl-1.0.1

### DIFF
--- a/.github/workflows/amazon_linux2023_tests.yml
+++ b/.github/workflows/amazon_linux2023_tests.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # amazonlinux 2 is end-of-life 2025-06
-        os: [ 'amazonlinux:2', 'amazonlinux:2023' ]
+=        os: [ 'amazonlinux:2023' ]
 
     runs-on: ubuntu-latest
     container: ${{ matrix.os }}
@@ -25,7 +24,7 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        yum install -y gcc make gzip tar openssl11-devel libevent-devel
+        yum install -y gcc make gzip tar openssl-devel libevent-devel
     # Delay checkout until after dependencies have been installed. Amazon linux is very minimal and lacks basic stuff by default.
     # use v3 of checkout until the weird container, nodejs, glibc issue is fixed
     - uses: actions/checkout@v3

--- a/.github/workflows/amazon_linux2023_tests.yml
+++ b/.github/workflows/amazon_linux2023_tests.yml
@@ -1,4 +1,4 @@
-name: AmazonLinux
+name: AmazonLinux2023
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-=        os: [ 'amazonlinux:2023' ]
+       os: [ 'amazonlinux:2023' ]
 
     runs-on: ubuntu-latest
     container: ${{ matrix.os }}

--- a/.github/workflows/amazon_linux2_tests.yml
+++ b/.github/workflows/amazon_linux2_tests.yml
@@ -1,4 +1,4 @@
-name: AmazonLinux
+name: AmazonLinux2
 
 on:
   push:

--- a/.github/workflows/amazon_linux2_tests.yml
+++ b/.github/workflows/amazon_linux2_tests.yml
@@ -1,0 +1,46 @@
+name: AmazonLinux
+
+on:
+  push:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+
+# make GHA actions use node16 to use ancient container images
+# See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+# Unclear how long this will work though
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+jobs:
+  builds:
+    strategy:
+      fail-fast: false
+      matrix:
+        # amazonlinux 2 is end-of-life 2025-06
+        os: [ 'amazonlinux:2' ]
+
+    runs-on: ubuntu-latest
+    container: ${{ matrix.os }}
+
+    steps:
+    - name: Install Dependencies
+      run: |
+        yum install -y gcc make gzip tar openssl11-devel libevent-devel
+    # Delay checkout until after dependencies have been installed. Amazon linux is very minimal and lacks basic stuff by default.
+    # use v3 of checkout until the weird container, nodejs, glibc issue is fixed
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Configure
+      run: ./configure
+
+    - name: Compile
+      run: make
+
+    - name: Unit Test
+      run: make check
+
+    - name: Integration Test
+      working-directory: examples
+      run: ./run_tests.sh && ./run_tests_conf.sh

--- a/.github/workflows/amazon_linux_tests.yml
+++ b/.github/workflows/amazon_linux_tests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - name: Install Dependencies
       run: |
-        yum install -y gcc make gzip tar openssl-devel libevent-devel
+        yum install -y gcc make gzip tar openssl11-devel libevent-devel
     # Delay checkout until after dependencies have been installed. Amazon linux is very minimal and lacks basic stuff by default.
     # use v3 of checkout until the weird container, nodejs, glibc issue is fixed
     - uses: actions/checkout@v3


### PR DESCRIPTION
In preparation to deprecation of openssl below version 1.1.1 switch to using openssl-1.1.1 on amazonlinux:2 (where 1.0.2 is the default)

Fixes build issue for #1397