### PR TITLE
Add prometheus setting suggestions on turn.conf in example folder

### DIFF
--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -213,6 +213,16 @@
 #
 #prometheus
 
+# Enable labeling prometheus traffic metrics with client usernames.
+# Labeling with client usernames is disabled by default, because this may cause memory
+# leaks when using authentication with ephemeral usernames (e.g. TURN REST API).
+#
+#prometheus-username-labels
+
+# Prometheus listener port (Default: 9641).
+#
+#prometheus-port=9641
+
 # TURN REST API flag.
 # (Time Limited Long Term Credential)
 # Flag that sets a special authorization option that is based upon authentication secret.


### PR DESCRIPTION
I believe that many users, like myself, prefer to reference the `turn.conf` file when deploying the TURN server with Docker, rather than the `Readme.turnserver`. Additionally, I think it's important to synchronize the Prometheus settings from the README into the` turn.conf` file for better clarity. This way, users won't overlook any essential options.