### PR TITLE
Fix cmake and prometheus test build jobs 

### DIFF
--- a/.github/workflows/amazon_linux2023_tests.yml
+++ b/.github/workflows/amazon_linux2023_tests.yml
@@ -42,4 +42,4 @@ jobs:
 
     - name: Integration Test
       working-directory: examples
-      run: ./run_tests.sh && ./run_tests_conf.sh && ./run_tests_prom.sh
+      run: ./run_tests.sh && ./run_tests_conf.sh

--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -35,4 +35,4 @@ jobs:
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
       - name: apps tests
-        run: cd examples && ./run_tests.sh && ./run_tests_conf.sh && ./run_tests_prom.sh
+        run: cd examples && ./run_tests.sh && ./run_tests_conf.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,4 +56,4 @@ jobs:
 
     - name: Integration Test
       working-directory: examples
-      run: ./run_tests.sh && ./run_tests_conf.sh && ./run_tests_prom.sh
+      run: ./run_tests.sh && ./run_tests_conf.sh

--- a/examples/run_tests.sh
+++ b/examples/run_tests.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 
+# Detect cmake build and adjust path
+BINDIR="../bin"
+if [ ! -f $BINDIR/turnserver ]; then
+    BINDIR="../build/bin"
+fi
+
 echo 'Running turnserver'
-../bin/turnserver --use-auth-secret  --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --no-cli --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > /dev/null &
+$BINDIR/turnserver --use-auth-secret  --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --no-cli --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > /dev/null &
 echo 'Running peer client'
-../bin/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > /dev/null &
+$BINDIR/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > /dev/null &
 
 sleep 2
 
 echo 'Running turn client TCP'
-../bin/turnutils_uclient -t -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+$BINDIR/turnutils_uclient -t -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else
@@ -17,7 +23,7 @@ else
 fi
 
 echo 'Running turn client TLS'
-../bin/turnutils_uclient -t -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+$BINDIR/turnutils_uclient -t -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else
@@ -26,7 +32,7 @@ else
 fi
 
 echo 'Running turn client UDP'
-../bin/turnutils_uclient -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+$BINDIR/turnutils_uclient -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else
@@ -35,7 +41,7 @@ else
 fi
 
 echo 'Running turn client DTLS'
-../bin/turnutils_uclient -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+$BINDIR/turnutils_uclient -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else

--- a/examples/run_tests_conf.sh
+++ b/examples/run_tests_conf.sh
@@ -1,22 +1,29 @@
 #!/bin/bash
-echo 'Create turnserver.conf file'
-echo "use-auth-secret" > ../bin/turnserver.conf
-echo "static-auth-secret=secret" >> ../bin/turnserver.conf
-echo "realm=north.gov" >> ../bin/turnserver.conf
-echo "allow-loopback-peers" >> ../bin/turnserver.conf
-echo "no-cli" >> ../bin/turnserver.conf
-echo "cert=../examples/ca/turn_server_cert.pem" >> ../bin/turnserver.conf
-echo "pkey=../examples/ca/turn_server_pkey.pem" >> ../bin/turnserver.conf
+
+# Detect cmake build and adjust path
+BINDIR="../bin"
+if [ ! -f $BINDIR/turnserver ]; then
+    BINDIR="../build/bin"
+fi
+
+echo "Creating $BINDIR/turnserver.conf file"
+echo "use-auth-secret" > $BINDIR/turnserver.conf
+echo "static-auth-secret=secret" >> $BINDIR/turnserver.conf
+echo "realm=north.gov" >> $BINDIR/turnserver.conf
+echo "allow-loopback-peers" >> $BINDIR/turnserver.conf
+echo "no-cli" >> $BINDIR/turnserver.conf
+echo "cert=../examples/ca/turn_server_cert.pem" >> $BINDIR/turnserver.conf
+echo "pkey=../examples/ca/turn_server_pkey.pem" >> $BINDIR/turnserver.conf
 
 echo 'Running turnserver'
-../bin/turnserver -c ../bin/turnserver.conf > /dev/null &
+$BINDIR/turnserver -c $BINDIR/turnserver.conf > /dev/null &
 echo 'Running peer client'
-../bin/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > /dev/null &
+$BINDIR/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > /dev/null &
 
 sleep 2
 
 echo 'Running turn client TCP'
-../bin/turnutils_uclient -t -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+$BINDIR/turnutils_uclient -t -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else
@@ -25,7 +32,7 @@ else
 fi
 
 echo 'Running turn client TLS'
-../bin/turnutils_uclient -t -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+$BINDIR/turnutils_uclient -t -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else
@@ -34,7 +41,7 @@ else
 fi
 
 echo 'Running turn client UDP'
-../bin/turnutils_uclient -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+$BINDIR/turnutils_uclient -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else
@@ -43,7 +50,7 @@ else
 fi
 
 echo 'Running turn client DTLS'
-../bin/turnutils_uclient -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
+$BINDIR/turnutils_uclient -S -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1  | grep "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" > /dev/null
 if [ $? -eq 0 ]; then
     echo OK
 else

--- a/examples/run_tests_prom.sh
+++ b/examples/run_tests_prom.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+
+# Detect cmake build and adjust path
+BINDIR="../bin"
+if [ ! -f $BINDIR/turnserver ]; then
+    BINDIR="../build/bin"
+fi
+
 function assert_prom_no_response() {
   wget --quiet --output-document=/dev/null --tries=1 "$1"
   status="$?"
@@ -24,35 +31,35 @@ function assert_prom_response() {
 }
 
 echo "Running without prometheus"
-../bin/turnserver &
+$BINDIR/turnserver /dev/null &
 turnserver_pid="$!"
 sleep 2
 assert_prom_no_response "http://localhost:9641/metrics"
 kill "$turnserver_pid"
 
 echo "Running turnserver with prometheus, using defaults"
-../bin/turnserver --prometheus &
+$BINDIR/turnserver --prometheus > /dev/null &
 turnserver_pid="$!"
 sleep 2
 assert_prom_response "http://localhost:9641/metrics"
 kill "$turnserver_pid"
 
 echo "Running turnserver with prometheus, using custom address"
-../bin/turnserver --prometheus --prometheus-address="127.0.0.1" &
+$BINDIR/turnserver --prometheus --prometheus-address="127.0.0.1" > /dev/null &
 turnserver_pid="$!"
 sleep 2
 assert_prom_response "http://127.0.0.1:9641/metrics"
 kill "$turnserver_pid"
-
+ 
 echo "Running turnserver with prometheus, using custom port"
-../bin/turnserver --prometheus --prometheus-port="8080" &
+$BINDIR/turnserver --prometheus --prometheus-port="8080" > /dev/null &
 turnserver_pid="$!"
 sleep 2
 assert_prom_response "http://localhost:8080/metrics"
 kill "$turnserver_pid"
 
 echo "Running turnserver with prometheus, using custom address and port"
-../bin/turnserver --prometheus --prometheus-address="127.0.0.1" --prometheus-port="8080" &
+$BINDIR/turnserver --prometheus --prometheus-address="127.0.0.1" --prometheus-port="8080" > /dev/null &
 turnserver_pid="$!"
 sleep 2
 assert_prom_response "http://127.0.0.1:8080/metrics"


### PR DESCRIPTION
Some actions do not build with prometheus - adding prometheus tests fails the jobs
cmake build tests did not run due to different target folder (while reporting success) - now the bin folder is detected