### PR TITLE
Cleanup ALPN_SUPPORTED define usage

### DIFF
--- a/src/apps/common/apputils.h
+++ b/src/apps/common/apputils.h
@@ -55,10 +55,6 @@ extern "C" {
 
 extern int IS_TURN_SERVER;
 
-/* ALPN */
-
-#define ALPN_SUPPORTED 1
-
 /* TLS */
 
 #if defined(TURN_NO_TLS)

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -51,13 +51,9 @@ static int use_tltc = 0;
 
 ////// ALPN //////////
 
-#if ALPN_SUPPORTED
-
 char STUN_ALPN[128] = "stun.nat-discovery";
 char TURN_ALPN[128] = "stun.turn";
 char HTTP_ALPN[128] = "http/1.1";
-
-#endif
 
 ////// TURNDB //////////////
 
@@ -2831,11 +2827,7 @@ static void print_features(unsigned long mfn) {
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "DTLS supported\n");
 #endif
 
-#if ALPN_SUPPORTED
   TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "TURN/STUN ALPN supported\n");
-#else
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "TURN/STUN ALPN is not supported\n");
-#endif
 
   if (ENC_ALG_NUM == 0) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Third-party authorization (oAuth) is not supported\n");
@@ -3511,8 +3503,6 @@ static int pem_password_func(char *buf, int size, int rwflag, void *password) {
   return (strlen(buf));
 }
 
-#if ALPN_SUPPORTED
-
 static int ServerALPNCallback(SSL *ssl, const unsigned char **out, unsigned char *outlen, const unsigned char *in,
                               unsigned int inlen, void *arg) {
 
@@ -3559,18 +3549,12 @@ static int ServerALPNCallback(SSL *ssl, const unsigned char **out, unsigned char
   return SSL_TLSEXT_ERR_NOACK; //???
 }
 
-#endif
-
 static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *method) {
   SSL_CTX *ctx = SSL_CTX_new(method);
   int err = 0;
   int rc = 0;
-#if ALPN_SUPPORTED
   SSL_CTX_set_alpn_select_cb(ctx, ServerALPNCallback, NULL);
-#endif
-
   SSL_CTX_set_default_passwd_cb_userdata(ctx, turn_params.tls_password);
-
   SSL_CTX_set_default_passwd_cb(ctx, pem_password_func);
 
   if (!(turn_params.cipher_list[0])) {

--- a/src/apps/uclient/startuclient.c
+++ b/src/apps/uclient/startuclient.c
@@ -55,10 +55,8 @@ static uint64_t current_reservation_token = 0;
 static int allocate_rtcp = 0;
 static const int never_allocate_rtcp = 0;
 
-#if ALPN_SUPPORTED
 static const unsigned char kALPNProtos[] = "\x08http/1.1\x09stun.turn\x12stun.nat-discovery";
 static const size_t kALPNProtosLen = sizeof(kALPNProtos) - 1;
-#endif
 
 /////////////////////////////////////////
 
@@ -96,9 +94,7 @@ static SSL *tls_connect(ioa_socket_raw fd, ioa_addr *remote_addr, bool *try_agai
 
   ssl = SSL_new(root_tls_ctx[ctxtype]);
 
-#if ALPN_SUPPORTED
   SSL_set_alpn_protos(ssl, kALPNProtos, kALPNProtosLen);
-#endif
 
   if (use_tcp) {
     SSL_set_fd(ssl, fd);


### PR DESCRIPTION
As of openssl 1.1.1 ALPN is supported - no need for all the ifdefs anymore