### PR TITLE
Windows '_WTA' bug

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -903,7 +903,7 @@ char *dirname(char *path) {
  * \return
  */
 static char *_WTA(__in wchar_t *pszInBuf, __in int nInSize, __out char **pszOutBuf, __out int *pnOutSize) {
-  if (!pszInBuf || !pszOutBuf || !*pszOutBuf || !pnOutSize || nInSize <= 0) {
+  if (!pszInBuf || !pszOutBuf || !pnOutSize || nInSize <= 0) {
     return NULL;
   }
   *pnOutSize = WideCharToMultiByte((UINT)0, (DWORD)0, pszInBuf, nInSize, NULL, 0, NULL, NULL);


### PR DESCRIPTION
Every time the '_WTA' is called, its initial value is null, so the function returns directly.

https://github.com/coturn/coturn/blob/c98bb935148288b6d13a8b954422a52edfb17a83/src/apps/common/apputils.c#L905-L908
https://github.com/coturn/coturn/blob/c98bb935148288b6d13a8b954422a52edfb17a83/src/apps/common/apputils.c#L939-L941
https://github.com/coturn/coturn/blob/c98bb935148288b6d13a8b954422a52edfb17a83/src/apps/common/apputils.c#L960-L962
https://github.com/coturn/coturn/blob/c98bb935148288b6d13a8b954422a52edfb17a83/src/apps/common/apputils.c#L981-L983