### PR TITLE
[Quick Fix] Fix Repeated Line in Example turnserver.conf

### DIFF
--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -713,7 +713,6 @@
 # the TURN client allocation request connection address family.
 #
 #allocation-default-address-family="ipv4"
-#allocation-default-address-family="ipv6"
 
 # User name to run the process. After the initialization, the turnserver process
 # will attempt to change the current user ID to that user.

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -713,7 +713,7 @@
 # the TURN client allocation request connection address family.
 #
 #allocation-default-address-family="ipv4"
-#allocation-default-address-family="ipv4"
+#allocation-default-address-family="ipv6"
 
 # User name to run the process. After the initialization, the turnserver process
 # will attempt to change the current user ID to that user.


### PR DESCRIPTION
The `#allocation-default-address-family="ipv4"` line is repeated twice in the example config, changed the second one to be `"ipv6"` which I assume it was intended to be.