### PR TITLE
Show allocations increment/decrement logs behind verbose flag

### DIFF
--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -692,12 +692,13 @@ int check_new_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
   }
 
 #ifndef _MSC_VER
-  global_allocation_count++;
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "Global turn allocation count incremented, now %ld\n", global_allocation_count);
+  size_t cur_count = ++global_allocation_count;
 #else
   size_t cur_count = (size_t)InterlockedIncrement((volatile LONG *)&global_allocation_count);
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "Global turn allocation count incremented, now %ld\n", cur_count);
 #endif
+  if (turn_params.verbose > TURN_VERBOSE_NONE) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_DEBUG, "Global turn allocation count incremented, now %ld\n", cur_count);
+  }
 
   return ret;
 }
@@ -731,12 +732,13 @@ void release_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
     log_level = TURN_LOG_LEVEL_INFO;
   }
 #ifndef _MSC_VER
-  global_allocation_count--;
-  TURN_LOG_FUNC(log_level, "Global turn allocation count decremented, now %ld\n", global_allocation_count);
+  size_t cur_count = --global_allocation_count;
 #else
   size_t cur_count = (size_t)InterlockedDecrement((volatile LONG *)&global_allocation_count);
-  TURN_LOG_FUNC(log_level, "Global turn allocation count decremented, now %ld\n", cur_count);
 #endif
+  if (turn_params.verbose > TURN_VERBOSE_NONE) {
+    TURN_LOG_FUNC(log_level, "Global turn allocation count decremented, now %ld\n", cur_count);
+  }
 }
 
 //////////////////////////////////


### PR DESCRIPTION
Fix #1657 

This log was added in a recent refactor for draining support and it is very noisy.   With this change the log is moved behind the "verbose" flag and also does a minor cleanup to not have 2 duplicated lines for logging when one is enough.