### PR TITLE
Add modules diagram to developer doc

### DIFF
--- a/docs/Developer.md
+++ b/docs/Developer.md
@@ -1,6 +1,56 @@
 
 ## Developer
 
+
+### Modules
+
+The coturn repository includes different applications and libraries.   The next diagram represents those modules and their dependencies:
+
+```mermaid
+---
+  config:
+    class:
+      hideEmptyMembersBox: true
+---
+classDiagram
+   note for relay "turn server process"
+   relay --> server
+   note for stunclient "STUN test app"
+   stunclient --> client
+   note for uclient "TURN test/stress app"
+   uclient --> common
+   uclient --> client
+   note for natdiscovery "discover NAT test app"
+   natdiscovery --> common
+   natdiscovery --> client
+   note for peer "fake receiver"
+   peer --> client
+   note for oauth "create&validate tokens"
+   oauth --> common
+   oauth --> client
+   note for rfc5769_check "run vector tests"
+   rfc5769_check --> common
+
+   note for client_cpp "C++ wrapper lib"
+   client_cpp  --> client
+   relay --> common
+   namespace test_apps {
+      class stunclient {
+      }
+      class uclient {
+      }
+      class natdiscovery {
+      }
+      class peer {
+      }
+      class oauth {
+      }
+      class rfc5769_check  {
+      }
+   }
+```
+
+
 ### Flow chart
 
 ![FlowChart](drawio/FlowChart.svg)


### PR DESCRIPTION
Add basic diagram with modules of coturn inside Developer.md.

I also wanted to move the existing Flow chart to mermaid so that our doc doesn't depend on external tools but i couldn't find the time to do it properly (horizontal arrows are hard to represent with mermaid) so i postponed that part.

This is the result of the mermaid diagram: 
![Screenshot 2025-05-26 at 12 54 29](https://github.com/user-attachments/assets/860bd56b-cb4a-462c-b931-a82c9d52fdc9)
