### PR TITLE
Invert RFC5780 option to default off

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -629,12 +629,12 @@ Options with values:
 			(This behavior used to be the default behavior, and was enabled by default.)
 
 --ne=[1|2|3]		Set network engine type for the process (for internal purposes).
---no-rfc5780		Disable RFC5780 (NAT behavior discovery).
+--rfc5780			Enable RFC5780 (NAT behavior discovery).
                     Originally, if there are more than one listener address from the same
                     address family, then by default the NAT behavior discovery feature enabled.
-                    This option disables this original behavior, because the NAT behavior discovery
+                    This option enables this original behavior, because the NAT behavior discovery
                     adds attributes to response, and this increase the possibility of an amplification attack.
-                    Strongly encouraged to use this option to decrease gain factor in STUN binding responses.
+                    Strongly encouraged to not use this option to decrease gain factor in STUN binding responses.
 --no-stun-backward-compatibility		Disable handling old STUN Binding requests and disable MAPPED-ADDRESS attribute in binding response (use only the XOR-MAPPED-ADDRESS).
 --response-origin-only-with-rfc5780		Only send RESPONSE-ORIGIN attribute in binding response if RFC5780 is enabled.
 					

--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -775,18 +775,19 @@ cli-password=CHANGE_ME
 #no-tlsv1_1
 #no-tlsv1_2
 
-# Disable RFC5780 (NAT behavior discovery).
+# Enable RFC5780 (NAT behavior discovery).
 #
+# This option is disabled by default.
 # Originally, if there are more than one listener address from the same
 # address family, then by default the NAT behavior discovery feature enabled.
 # This option disables the original behavior, because the NAT behavior
 # discovery adds extra attributes to response, and this increase the
 # possibility of an amplification attack.
 #
-# Strongly encouraged to use this option to decrease gain factor in STUN
+# Strongly encouraged to keep this option off to decrease gain factor in STUN
 # binding responses.
 #
-no-rfc5780
+# rfc5780
 
 # Disable handling old STUN Binding requests and disable MAPPED-ADDRESS
 # attribute in binding response (use only the XOR-MAPPED-ADDRESS).

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -799,18 +799,19 @@
 #no-tlsv1_1
 #no-tlsv1_2
 
-# Disable RFC5780 (NAT behavior discovery).
+# Enable RFC5780 (NAT behavior discovery).
 #
+# This option is disabled by default.
 # Originally, if there are more than one listener address from the same
 # address family, then by default the NAT behavior discovery feature enabled.
 # This option disables the original behavior, because the NAT behavior
 # discovery adds extra attributes to response, and this increase the
 # possibility of an amplification attack.
 #
-# Strongly encouraged to use this option to decrease gain factor in STUN
+# Strongly encouraged to keep this option off to decrease gain factor in STUN
 # binding responses.
 #
-no-rfc5780
+# rfc5780
 
 # Disable handling old STUN Binding requests and disable MAPPED-ADDRESS
 # attribute in binding response (use only the XOR-MAPPED-ADDRESS).

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -900,13 +900,13 @@ By default it is disabled for security reasons!
 Set network engine type for the process (for internal purposes).
 .TP
 .B
-\fB\-\-no\-rfc5780\fP
-Disable RFC5780 (NAT behavior discovery).
+\fB\-\-rfc5780\fP
+Enable RFC5780 (NAT behavior discovery).
 Originally, if there are more than one listener address from the same
 address family, then by default the NAT behavior discovery feature enabled.
-This option disables this original behavior, because the NAT behavior discovery
-adds attributes to response, and this increase the possibility of an amplification attack.
-Strongly encouraged to use this option to decrease gain factor in STUN binding responses.
+This option enables this original behavior (NAT behavior discovery
+adds attributes to response, and this increase the possibility of an amplification attack).
+Strongly encouraged to keep this option off to decrease gain factor in STUN binding responses.
 .TP
 .B
 \fB\-\-no\-stun\-backward\-compatibility\fP

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -904,7 +904,7 @@ Set network engine type for the process (for internal purposes).
 Enable RFC5780 (NAT behavior discovery).
 Originally, if there are more than one listener address from the same
 address family, then by default the NAT behavior discovery feature enabled.
-This option enables this original behavior (NAT behavior discovery
+This option enables this original behavior (NAT behavior discovery) and
 adds attributes to response, and this increase the possibility of an amplification attack).
 Strongly encouraged to keep this option off to decrease gain factor in STUN binding responses.
 .TP

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -128,7 +128,7 @@ turn_params_t turn_params = {
     0,                     /* alt_listener_port */
     0,                     /* alt_tls_listener_port */
     0,                     /* tcp_proxy_port */
-    true,                  /* rfc5780 */
+    false,                 /* rfc5780 */
 
     false, /* no_udp */
     false, /* no_tcp */
@@ -1323,15 +1323,16 @@ static char Usage[] =
     "256.\n"
     " --ne=[1|2|3]					Set network engine type for the process (for internal "
     "purposes).\n"
-    " --no-rfc5780					Disable RFC5780 (NAT behavior discovery).\n"
+    " --rfc5780					Disable RFC5780 (NAT behavior discovery).\n"
     "						Originally, if there are more than one listener address from the same\n"
     "						address family, then by default the NAT behavior discovery feature "
     "enabled.\n"
-    "						This option disables this original behavior, because the NAT behavior "
+    "						This option enables this original behavior (downside is that the NAT "
+    "behavior "
     "discovery\n"
     "						adds attributes to response, and this increase the possibility of an "
-    "amplification attack.\n"
-    "						Strongly encouraged to use this option to decrease gain factor in STUN "
+    "amplification attack.)\n"
+    "						Strongly encouraged to keep it off to decrease gain factor in STUN "
     "binding responses.\n"
     " --no-stun-backward-compatibility		Disable handling old STUN Binding requests and disable MAPPED-ADDRESS "
     "attribute\n"
@@ -1495,7 +1496,7 @@ enum EXTRA_OPTS {
   SECRET_KEY_OPT,
   ACME_REDIRECT_OPT,
   LOG_BINDING_OPT,
-  NO_RFC5780,
+  ENABLE_RFC5780,
   NO_STUN_BACKWARD_COMPATIBILITY_OPT,
   RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT,
   RESPOND_HTTP_UNSUPPORTED_OPT,
@@ -1638,7 +1639,7 @@ static const struct myoption long_options[] = {
     {"allocation-default-address-family", required_argument, NULL, 'A'},
     {"acme-redirect", required_argument, NULL, ACME_REDIRECT_OPT},
     {"log-binding", optional_argument, NULL, LOG_BINDING_OPT},
-    {"no-rfc5780", optional_argument, NULL, NO_RFC5780},
+    {"rfc5780", optional_argument, NULL, ENABLE_RFC5780},
     {"no-stun-backward-compatibility", optional_argument, NULL, NO_STUN_BACKWARD_COMPATIBILITY_OPT},
     {"response-origin-only-with-rfc5780", optional_argument, NULL, RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT},
     {"respond-http-unsupported", optional_argument, NULL, RESPOND_HTTP_UNSUPPORTED_OPT},
@@ -2346,8 +2347,8 @@ static void set_option(int c, char *value) {
   case LOG_BINDING_OPT:
     turn_params.log_binding = get_bool_value(value);
     break;
-  case NO_RFC5780:
-    turn_params.rfc5780 = 0;
+  case ENABLE_RFC5780:
+    turn_params.rfc5780 = true;
     break;
   case NO_STUN_BACKWARD_COMPATIBILITY_OPT:
     turn_params.no_stun_backward_compatibility = get_bool_value(value);

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1323,6 +1323,7 @@ static char Usage[] =
     "256.\n"
     " --ne=[1|2|3]					Set network engine type for the process (for internal "
     "purposes).\n"
+    " --no-rfc5780					DEPRECATED and now default, see --rfc5780.\n"
     " --rfc5780					Enable RFC5780 (NAT behavior discovery).\n"
     "						Originally, if there are more than one listener address from the same\n"
     "						address family, then by default the NAT behavior discovery feature "
@@ -1496,6 +1497,7 @@ enum EXTRA_OPTS {
   SECRET_KEY_OPT,
   ACME_REDIRECT_OPT,
   LOG_BINDING_OPT,
+  NO_RFC5780,
   ENABLE_RFC5780,
   NO_STUN_BACKWARD_COMPATIBILITY_OPT,
   RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT,
@@ -1639,6 +1641,7 @@ static const struct myoption long_options[] = {
     {"allocation-default-address-family", required_argument, NULL, 'A'},
     {"acme-redirect", required_argument, NULL, ACME_REDIRECT_OPT},
     {"log-binding", optional_argument, NULL, LOG_BINDING_OPT},
+    {"no-rfc5780", optional_argument, NULL, NO_RFC5780},
     {"rfc5780", optional_argument, NULL, ENABLE_RFC5780},
     {"no-stun-backward-compatibility", optional_argument, NULL, NO_STUN_BACKWARD_COMPATIBILITY_OPT},
     {"response-origin-only-with-rfc5780", optional_argument, NULL, RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT},
@@ -2346,6 +2349,8 @@ static void set_option(int c, char *value) {
     break;
   case LOG_BINDING_OPT:
     turn_params.log_binding = get_bool_value(value);
+    break;
+  case NO_RFC5780: // DEPRECATED, see below
     break;
   case ENABLE_RFC5780:
     turn_params.rfc5780 = true;

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1323,7 +1323,7 @@ static char Usage[] =
     "256.\n"
     " --ne=[1|2|3]					Set network engine type for the process (for internal "
     "purposes).\n"
-    " --rfc5780					Disable RFC5780 (NAT behavior discovery).\n"
+    " --rfc5780					Enable RFC5780 (NAT behavior discovery).\n"
     "						Originally, if there are more than one listener address from the same\n"
     "						address family, then by default the NAT behavior discovery feature "
     "enabled.\n"

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1001,9 +1001,9 @@ static void setup_listener(void) {
     bufferevent_enable(turn_params.listener.in_buf, EV_READ);
   }
 
-  if (turn_params.rfc5780 == 1) {
+  if (turn_params.rfc5780 == true) {
     if (turn_params.listener.addrs_number < 2 || turn_params.external_ip) {
-      turn_params.rfc5780 = 0;
+      turn_params.rfc5780 = false;
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "STUN CHANGE_REQUEST not supported: only one IP address is provided\n");
     } else {
       turn_params.listener.services_number = turn_params.listener.services_number * 2;


### PR DESCRIPTION
Invert `--no-rfc5780` option to be true by default
Make it `--rfc5780` to enable it
Update example/recommended configuration files

Passing `--no-rfc5780` will have no effect as this is the default behavior now