### PR TITLE
[BREAKING] Deprecate response-origin-only-with-rfc5780

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -636,8 +636,7 @@ Options with values:
                     adds attributes to response, and this increase the possibility of an amplification attack.
                     Strongly encouraged to use this option to decrease gain factor in STUN binding responses.
 --stun-backward-compatibility		Enable handling old STUN Binding requests using MAPPED-ADDRESS attribute in binding response (instead of XOR-MAPPED-ADDRESS).
---response-origin-only-with-rfc5780		Only send RESPONSE-ORIGIN attribute in binding response if RFC5780 is enabled.
-					
+
 
 ==================================
 

--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -796,10 +796,3 @@ cli-password=CHANGE_ME
 # binding responses.
 #
 # stun-backward-compatibility
-
-# Only send RESPONSE-ORIGIN attribute in binding response if RFC5780 is enabled.
-#
-# Strongly encouraged to use this option to decrease gain factor in STUN
-# binding responses.
-#
-response-origin-only-with-rfc5780

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -821,12 +821,6 @@
 #
 # stun-backward-compatibility
 
-# Only send RESPONSE-ORIGIN attribute in binding response if RFC5780 is enabled.
-#
-# Strongly encouraged to use this option to decrease gain factor in STUN
-# binding responses.
-#
-response-origin-only-with-rfc5780
 
 # Return an HTTP/S response when an HTTP/S connection is made to a TCP port
 # otherwise only supporting STUN/TURN. This may be useful for debugging and

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -224,7 +224,6 @@ turn_params_t turn_params = {
 
     false, /* log_binding */
     false, /* stun_backward_compatibility */
-    false, /* response_origin_only_with_rfc5780 */
     false  /* respond_http_unsupported */
 };
 
@@ -1336,11 +1335,7 @@ static char Usage[] =
     "						Strongly encouraged to keep it off to decrease gain factor in STUN "
     "binding responses.\n"
     " --stun-backward-compatibility		        Enable handling old STUN Binding requests and enable "
-    "MAPPED-ADDRESS "
-    "attribute\n"
-    "						in binding response (instead of XOR-MAPPED-ADDRESS).\n"
-    " --response-origin-only-with-rfc5780		Only send RESPONSE-ORIGIN attribute in binding response if "
-    "RFC5780 is enabled.\n"
+    "MAPPED-ADDRESS attribute\n"
     " --respond-http-unsupported			Return an HTTP reponse with a 400 status code to HTTP "
     "connections made to ports not\n"
     "						supporting HTTP. The default behaviour is to immediately "
@@ -2360,7 +2355,6 @@ static void set_option(int c, char *value) {
     turn_params.stun_backward_compatibility = get_bool_value(value);
     break;
   case RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT:
-    turn_params.response_origin_only_with_rfc5780 = get_bool_value(value);
     break;
   case RESPOND_HTTP_UNSUPPORTED_OPT:
     turn_params.respond_http_unsupported = get_bool_value(value);

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -331,7 +331,6 @@ typedef struct _turn_params_ {
 
   bool log_binding;
   bool stun_backward_compatibility;
-  bool response_origin_only_with_rfc5780;
   bool respond_http_unsupported;
 } turn_params_t;
 

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1664,8 +1664,7 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
       turn_params.server_relay, send_turn_session_info, send_https_socket, allocate_bps, turn_params.oauth,
       turn_params.oauth_server_name, turn_params.acme_redirect, turn_params.allocation_default_address_family,
       &turn_params.log_binding, &turn_params.stun_backward_compatibility,
-      &turn_params.response_origin_only_with_rfc5780, &turn_params.respond_http_unsupported);
-
+      &turn_params.respond_http_unsupported);
   if (to_set_rfc5780) {
     set_rfc5780(&(rs->server), get_alt_addr, send_message_from_listener_to_client);
   }

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -2868,20 +2868,7 @@ static int handle_turn_binding(turn_turnserver *server, ts_ur_super_session *ss,
                                get_remote_addr_from_ioa_socket(ss->client_socket));
       }
 
-      if (!is_rfc5780(server)) {
-
-        if (!(*server->response_origin_only_with_rfc5780)) {
-          if (old_stun) {
-            stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_SOURCE_ADDRESS,
-                                   response_origin);
-            stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_CHANGED_ADDRESS,
-                                   response_origin);
-          } else {
-            stun_attr_add_addr_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_RESPONSE_ORIGIN, response_origin);
-          }
-        }
-
-      } else if (ss->client_socket) {
+      if (is_rfc5780(server) && (ss->client_socket)) {
 
         ioa_addr other_address;
 
@@ -4900,8 +4887,7 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
                       send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
                       allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
                       const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family,
-                      bool *log_binding, bool *stun_backward_compatibility, bool *response_origin_only_with_rfc5780,
-                      bool *respond_http_unsupported) {
+                      bool *log_binding, bool *stun_backward_compatibility, bool *respond_http_unsupported) {
 
   if (!server) {
     return;
@@ -4978,8 +4964,6 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
   server->log_binding = log_binding;
 
   server->stun_backward_compatibility = stun_backward_compatibility;
-
-  server->response_origin_only_with_rfc5780 = response_origin_only_with_rfc5780;
 
   server->respond_http_unsupported = respond_http_unsupported;
 

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -197,9 +197,6 @@ struct _turn_turnserver {
   /* Enable handling old STUN Binding Requests and enable MAPPED-ADDRESS attribute in response */
   bool *stun_backward_compatibility;
 
-  /* Only send RESPONSE-ORIGIN attribute in response if RFC5780 is enabled */
-  bool *response_origin_only_with_rfc5780;
-
   /* Return an HTTP 400 response to HTTP connections made to ports not
      otherwise handling HTTP. */
   bool *respond_http_unsupported;
@@ -212,20 +209,22 @@ const char *get_version(turn_turnserver *server);
 
 ///////////////////////////////////////////
 
-void init_turn_server(
-    turn_turnserver *server, turnserver_id id, int verbose, ioa_engine_handle e, turn_credential_type ct,
-    int fingerprint, dont_fragment_option_t dont_fragment, get_user_key_cb userkeycb,
-    check_new_allocation_quota_cb chquotacb, release_allocation_quota_cb raqcb, ioa_addr *external_addr,
-    bool *check_origin, bool *no_tcp_relay, bool *no_udp_relay, vintp stale_nonce, vintp max_allocate_lifetime,
-    vintp channel_lifetime, vintp permission_lifetime, bool *stun_only, bool *no_stun, bool software_attribute,
-    bool *web_admin_listen_on_workers, turn_server_addrs_list_t *alternate_servers_list,
-    turn_server_addrs_list_t *tls_alternate_servers_list, turn_server_addrs_list_t *aux_servers_list,
-    int self_udp_balance, bool *no_multicast_peers, bool *allow_loopback_peers, ip_range_list_t *ip_whitelist,
-    ip_range_list_t *ip_blacklist, send_socket_to_relay_cb send_socket_to_relay, bool *secure_stun, bool *mobility,
-    int server_relay, send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
-    allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name, const char *acme_redirect,
-    ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family, bool *log_binding,
-    bool *stun_backward_compatibility, bool *response_origin_only_with_rfc5780, bool *respond_http_unsupported);
+void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, ioa_engine_handle e,
+                      turn_credential_type ct, int fingerprint, dont_fragment_option_t dont_fragment,
+                      get_user_key_cb userkeycb, check_new_allocation_quota_cb chquotacb,
+                      release_allocation_quota_cb raqcb, ioa_addr *external_addr, bool *check_origin,
+                      bool *no_tcp_relay, bool *no_udp_relay, vintp stale_nonce, vintp max_allocate_lifetime,
+                      vintp channel_lifetime, vintp permission_lifetime, bool *stun_only, bool *no_stun,
+                      bool software_attribute, bool *web_admin_listen_on_workers,
+                      turn_server_addrs_list_t *alternate_servers_list,
+                      turn_server_addrs_list_t *tls_alternate_servers_list, turn_server_addrs_list_t *aux_servers_list,
+                      int self_udp_balance, bool *no_multicast_peers, bool *allow_loopback_peers,
+                      ip_range_list_t *ip_whitelist, ip_range_list_t *ip_blacklist,
+                      send_socket_to_relay_cb send_socket_to_relay, bool *secure_stun, bool *mobility, int server_relay,
+                      send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
+                      allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
+                      const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family,
+                      bool *log_binding, bool *stun_backward_compatibility, bool *respond_http_unsupported);
 
 ioa_engine_handle turn_server_get_engine(turn_turnserver *s);
 


### PR DESCRIPTION
Make this true - response-origin-only will only be enabled with rfc5780 option on