### PR TITLE
Update version to 4.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 # TODO: Modify this when the version is released
-SET(BUILD_VERSION "4.6.3")
+SET(BUILD_VERSION "4.7.0")
 
 # Find Git Version Patch
 IF(EXISTS "${CMAKE_SOURCE_DIR}/.git")

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,57 @@
+Release 4.7.0
+
+Changelist:
+- [BREAKING] Remove support for openssl older than 1.1.1 (#1397) (Michael Jones <jonesmz@users.noreply.github.com>)
+- [BREAKING] Cleanup deprecated options (#1599) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- [BREAKING] Reverse SOFTWARE_ATTRIBUTE_OPT to avoid inverse logic (#1598) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- [BREAKING] Deprecate response-origin-only-with-rfc5780 (#1690) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- [BREAKING] Invert no-stun-backward-compatibility to be default on (#1689) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Make older TLS versions optional (#1693) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Add missing close socket when ioa_socket call fails (#1694) (tyranron <tyranron@gmail.com>)
+- Add spdx tags to all source files (#1510) (Michael Jones <jonesmz@users.noreply.github.com>)
+- Address various minor clang-tidy warnings (#1513) (Michael Jones <jonesmz@users.noreply.github.com>)
+- Update reference to old draft in README to RFC8016 (Gustavo Garcia <gustavogb@gmail.com>)
+- Invert RFC5780 option to default off (#1688) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Add modules diagram to developer doc (#1685) (Gustavo Garcia <gustavogb@gmail.com>)
+- Fix compilation warning with const - non const conversions (#1686) (Gustavo Garcia <gustavogb@gmail.com>)
+- Makefile.in: Don't install sql schema into DOCSDIR (#1684) (Greg Troxel <gdt@lexort.com>)
+- Fix infinite loop in ns_turn_server.c (#1460) (Asmir Mehic <asmir.mehic@gmail.com>)
+- Fix the ability to compile coturn using C++ compiler (#1546) (Michael Jones <jonesmz@users.noreply.github.com>)
+- Restore returning 200 OK on root prometheus path for health check (#1678) (Gustavo Garcia <gustavogb@gmail.com>)
+- Improve MySQL connection error logging to include actual MySQL error message (#1679) (Gustavo Garcia <gustavogb@gmail.com>)
+- redis: use dbname param when redis is unauthenticated (#1668) (maddy <maddy@kitty.garden>)
+- Show allocations increment/decrement logs behind verbose flag (#1677) (Gustavo Garcia <gustavogb@gmail.com>)
+- [Fix] Fix Repeated Line in Example turnserver.conf (#1671) (Stefan Kieszkowski <85728496+stefankiesz@users.noreply.github.com>)
+- change for incorrect handling of TURN_NO_TLS environment variable (#1663) (Leonid Gorbachev <60500216+leonidgorbachev@users.noreply.github.com>)
+- Add Content-Type header to prometheus response (#1662) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Fix infinite loop while triggering SIGHUP and log file reset causing … (#1630) (nicolas-laduguie <111897939+nicolas-laduguie@users.noreply.github.com>)
+- rename and dependency extraction (#1634) (redraincatching <99604494+redraincatching@users.noreply.github.com>)
+- updated types to bool in _turn_params_ to reflect C11 (#1406) (redraincatching <99604494+redraincatching@users.noreply.github.com>)
+- Windows '_WTA' bug (#1624) (guoyingbo <guoyingbo@gmail.com>)
+- Fix cmake issues detecting mongo and libsystemd on macOS (#1621) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Fix hiredis detection by cmake (#1620) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Drop TLS version support detection (#1617) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Cleanup ALPN_SUPPORTED define usage (#1616) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Fix warnings type conversion (#1615) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Add parameter for specifying prometheus path (#1602) (Alex Gustafsson <89969483+alexg-axis@users.noreply.github.com>)
+- Do not build with Ubuntu 18, use 24 (#1613) (Pavel Punsky <eakraly@users.noreply.github.com>)
+
+Contributors:
+- Alex Gustafsson <89969483+alexg-axis@users.noreply.github.com>
+- Asmir Mehic <asmir.mehic@gmail.com>
+- Greg Troxel <gdt@lexort.com>
+- guoyingbo <guoyingbo@gmail.com>
+- Gustavo Garcia <gustavogb@gmail.com>
+- Kai Ren <tyranron@gmail.com>
+- Leonid Gorbachev <60500216+leonidgorbachev@users.noreply.github.com>
+- maddy <maddy@kitty.garden>
+- Michael Jones <jonesmz@users.noreply.github.com>
+- nicolas-laduguie <111897939+nicolas-laduguie@users.noreply.github.com>
+- Pavel Punsky <eakraly@users.noreply.github.com>
+- redraincatching <99604494+redraincatching@users.noreply.github.com>
+- Stefan Kieszkowski <85728496+stefankiesz@users.noreply.github.com>
+- tyranron <tyranron@gmail.com>
+
 Release 4.6.3
 
 Changelist:

--- a/examples/scripts/pack.sh
+++ b/examples/scripts/pack.sh
@@ -2,7 +2,7 @@
 
 # Run it from the root of the coturn source tree
 
-V=4.6.3
+V=4.7.0
 
 PACKDIR=`pwd`/../coturn-releases/
 SRCDIR=`pwd`

--- a/release.sh
+++ b/release.sh
@@ -27,8 +27,14 @@ fi
 
 VERSION=$1
 
-sed -i "s/SET(BUILD_VERSION \".*)/SET(BUILD_VERSION \"${VERSION}\")/g" ${SOURCE_DIR}/CMakeLists.txt
-sed -i "s/#define TURN_SERVER_VERSION .*/#define TURN_SERVER_VERSION \"${VERSION}\"/g" ${SOURCE_DIR}/src/ns_turn_defs.h
+SED="sed"
+if [ $(uname -s) = "Darwin" ]; then
+    gsed -i "s/SET(BUILD_VERSION \".*)/SET(BUILD_VERSION \"${VERSION}\")/g" ${SOURCE_DIR}/CMakeLists.txt
+    gsed -i "s/#define TURN_SERVER_VERSION .*/#define TURN_SERVER_VERSION \"${VERSION}\"/g" ${SOURCE_DIR}/src/ns_turn_defs.h
+else
+    sed -i "s/SET(BUILD_VERSION \".*)/SET(BUILD_VERSION \"${VERSION}\")/g" ${SOURCE_DIR}/CMakeLists.txt
+    sed -i "s/#define TURN_SERVER_VERSION .*/#define TURN_SERVER_VERSION \"${VERSION}\"/g" ${SOURCE_DIR}/src/ns_turn_defs.h
+fi
 
 # Generate ChangeLog
 if [ -f ${SOURCE_DIR}/ChangeLog ]; then

--- a/rpm/build.settings.sh
+++ b/rpm/build.settings.sh
@@ -2,7 +2,7 @@
 
 # Common settings script.
 
-TURNVERSION=4.6.3
+TURNVERSION=4.7.0
 BUILDDIR=~/rpmbuild
 ARCH=`uname -p`
 

--- a/rpm/turnserver.spec
+++ b/rpm/turnserver.spec
@@ -1,5 +1,5 @@
 Name:		turnserver
-Version:	4.6.3
+Version:	4.7.0
 Release:	0%{dist}
 Summary:	Coturn TURN Server
 

--- a/scripts/install_coturn_on_aws_ec2.sh
+++ b/scripts/install_coturn_on_aws_ec2.sh
@@ -4,15 +4,15 @@
 ############## verification on aws     : tested & verified on aws ec2        ########
 ############## platform                : aws ec2                             ########
 ############## aws ubuntu version      : ubuntu 22.04 LTS                    ########
-############## coturn base version     : 4.6.3                               ########
+############## coturn base version     : 4.7.0                               ########
 ############## dependent tools         : installs prometheus client as well  ########
 ############## file permissions        : chmod 777 install_coturn_on_aws_ec2.sh #####
 ############## run command             : ./install_coturn_on_aws_ec2.sh      ########
 ############## developer               : hariprasad.t@samsung.com            ########
 #####################################################################################
 
-coturn_package="https://github.com/coturn/coturn/archive/refs/tags/4.6.3.tar.gz"
-coturn_version="4.6.3"
+coturn_package="https://github.com/coturn/coturn/archive/refs/tags/4.7.0.tar.gz"
+coturn_version="4.7.0"
 
 if [ "$#" -eq 0 ]
 then

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1793,7 +1793,7 @@ unsigned char *base64decode(const void *b64_decode_this, int decode_this_many_by
   int decoded_byte_index = 0;                     // Index where the next base64_decoded byte should be written.
   while (0 < BIO_read(b64_bio, base64_decoded + decoded_byte_index, 1)) { // Read byte-by-byte.
     decoded_byte_index++; // Increment the index until read of BIO decoded data is complete.
-  } // Once we're done reading decoded data, BIO_read returns -1 even though there's no error.
+  }                       // Once we're done reading decoded data, BIO_read returns -1 even though there's no error.
 
   BIO_free_all(b64_bio); // Destroys all BIOs in chain, starting with b64 (i.e. the 1st one).
   return base64_decoded; // Returns base-64 decoded data with trailing null terminator.

--- a/src/client++/TurnMsgLib.h
+++ b/src/client++/TurnMsgLib.h
@@ -735,7 +735,7 @@ protected:
  */
 class StunMsgRequest : public StunMsg {
 public:
-  StunMsgRequest(uint16_t method) : _method(method) {};
+  StunMsgRequest(uint16_t method) : _method(method){};
   StunMsgRequest(uint8_t *buffer, size_t total_sz, size_t sz, bool constructed)
       : StunMsg(buffer, total_sz, sz, constructed), _method(0) {
 
@@ -808,11 +808,11 @@ private:
  */
 class StunMsgResponse : public StunMsg {
 public:
-  StunMsgResponse(uint16_t method, stun_tid &tid) : _method(method), _err(0), _reason(""), _tid(tid) {};
+  StunMsgResponse(uint16_t method, stun_tid &tid) : _method(method), _err(0), _reason(""), _tid(tid){};
   StunMsgResponse(uint16_t method, int error_code, std::string reason, stun_tid &tid)
-      : _method(method), _err(error_code), _reason(reason), _tid(tid) {
+      : _method(method), _err(error_code), _reason(reason), _tid(tid){
 
-        };
+                                                            };
   StunMsgResponse(uint8_t *buffer, size_t total_sz, size_t sz, bool constructed)
       : StunMsg(buffer, total_sz, sz, constructed), _method(0), _err(0), _reason("") {
 
@@ -964,7 +964,7 @@ private:
  */
 class StunMsgIndication : public StunMsg {
 public:
-  StunMsgIndication(uint16_t method) : _method(method) {};
+  StunMsgIndication(uint16_t method) : _method(method){};
   StunMsgIndication(uint8_t *buffer, size_t total_sz, size_t sz, bool constructed)
       : StunMsg(buffer, total_sz, sz, constructed), _method(0) {
 
@@ -1009,7 +1009,7 @@ private:
  */
 class StunMsgChannel : public StunMsg {
 public:
-  StunMsgChannel(uint16_t cn, int length) : _cn(cn), _len(length) {};
+  StunMsgChannel(uint16_t cn, int length) : _cn(cn), _len(length){};
   StunMsgChannel(uint8_t *buffer, size_t total_sz, size_t sz, bool constructed)
       : StunMsg(buffer, total_sz, sz, constructed), _cn(0) {
 

--- a/src/client/ns_turn_msg_defs.h
+++ b/src/client/ns_turn_msg_defs.h
@@ -55,10 +55,10 @@
 
 #define STUN_MAGIC_COOKIE (0x2112A442)
 
-#define IS_STUN_REQUEST(msg_type) (((msg_type) & 0x0110) == 0x0000)
-#define IS_STUN_INDICATION(msg_type) (((msg_type) & 0x0110) == 0x0010)
-#define IS_STUN_SUCCESS_RESP(msg_type) (((msg_type) & 0x0110) == 0x0100)
-#define IS_STUN_ERR_RESP(msg_type) (((msg_type) & 0x0110) == 0x0110)
+#define IS_STUN_REQUEST(msg_type) (((msg_type)&0x0110) == 0x0000)
+#define IS_STUN_INDICATION(msg_type) (((msg_type)&0x0110) == 0x0010)
+#define IS_STUN_SUCCESS_RESP(msg_type) (((msg_type)&0x0110) == 0x0100)
+#define IS_STUN_ERR_RESP(msg_type) (((msg_type)&0x0110) == 0x0110)
 
 #define GET_STUN_REQUEST(msg_type) (msg_type & 0xFEEF)
 #define GET_STUN_INDICATION(msg_type) ((msg_type & 0xFEEF) | 0x0010)

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -35,7 +35,7 @@
 #ifndef __IOADEFS__
 #define __IOADEFS__
 
-#define TURN_SERVER_VERSION "4.6.3"
+#define TURN_SERVER_VERSION "4.7.0"
 #define TURN_SERVER_VERSION_NAME "Gorst"
 #ifndef TURN_SERVER_BUILD_INFO
 #define TURN_SERVER_BUILD_INFO ""

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4394,8 +4394,8 @@ static int create_relay_connection(turn_turnserver *server, ts_ur_super_session 
 
     if (lifetime < 1) {
       lifetime = STUN_DEFAULT_ALLOCATE_LIFETIME;
-    } else if (lifetime > (uint32_t)*(server->max_allocate_lifetime)) {
-      lifetime = (uint32_t)*(server->max_allocate_lifetime);
+    } else if (lifetime > (uint32_t) * (server->max_allocate_lifetime)) {
+      lifetime = (uint32_t) * (server->max_allocate_lifetime);
     }
 
     ioa_timer_handle ev = set_ioa_timer(server->e, lifetime, 0, client_ss_allocation_timeout_handler, newelem, 0,

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "coturn",
-  "version-string": "4.6.3",
+  "version-string": "4.7.0",
   "dependencies": [
     {
       "name": "pthreads",


### PR DESCRIPTION
Set new release version to 4.7.0
Updating minor version due to some breaking changes in options to enable more secure/robust configuration without additional flags (or relying on recommended conf file which people seem to skip during updates)
