### PR TITLE
Add missing close socket when ioa_socket call fails

### DIFF
--- a/docker/coturn/CHANGELOG.md
+++ b/docker/coturn/CHANGELOG.md
@@ -9,7 +9,7 @@ Coturn TURN server Docker image changelog
 
 ### Security updated
 
-- [Debian Linux] "bookworm" 20250428 (12.10): <https://github.com/docker-library/official-images/commit/e36248008ab07678097f211f0fb0656d37f60c80>
+- [Debian Linux] "bookworm" 20250520 (12.11): <https://github.com/docker-library/official-images/commit/6d7afdaec5dec1a0b4021b4e470853c3e9fba2bc>
 
 
 

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4396,6 +4396,10 @@ static int create_relay_connection(turn_turnserver *server, ts_ur_super_session 
 
     if (get_ioa_socket_type(newelem->s) != TCP_SOCKET) {
       if (register_callback_on_ioa_socket(server->e, newelem->s, IOA_EV_READ, peer_input_handler, ss, 0) < 0) {
+        IOA_CLOSE_SOCKET(newelem->s);
+        IOA_CLOSE_SOCKET(rtcp_s);
+        *err_code = 500;
+        *reason = (const uint8_t *)"Wrong initialization (internal error)";
         return -1;
       }
     }


### PR DESCRIPTION
Fixes [#1071](https://github.com/coturn/coturn/issues/1071)

Not sure how this case can happen but better to handle the error case.