### PR TITLE
fix: comment out verbose mode by default

### DIFF
--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -159,7 +159,7 @@ max-port=65535
 
 # Uncomment to run TURN server in 'normal' 'moderate' verbose mode.
 # By default the verbose mode is off.
-verbose
+#verbose
 
 # Uncomment to run TURN server in 'extra' verbose mode.
 # This mode is very annoying and produces lots of output.


### PR DESCRIPTION
Following the comments, verbose mode should be commented out by default.