### PR TITLE
Fix compiler warnings in source files

### DIFF
--- a/src/apps/relay/acme.c
+++ b/src/apps/relay/acme.c
@@ -56,7 +56,7 @@ static int is_acme_req(char *req, size_t len) {
     // finally check for allowed chars
     for (size_t k = GET_ACME_PREFIX_LEN; k < i; k++) {
       const char c = req[k];
-      if ((c > 127) || (A[c] == ' ')) {
+      if ((c > 127) || (A[(unsigned char)c] == ' ')) {
         return -3;
       }
     }

--- a/src/apps/relay/acme.c
+++ b/src/apps/relay/acme.c
@@ -55,8 +55,8 @@ static int is_acme_req(char *req, size_t len) {
     }
     // finally check for allowed chars
     for (size_t k = GET_ACME_PREFIX_LEN; k < i; k++) {
-      const char c = req[k];
-      if ((c > 127) || (A[(unsigned char)c] == ' ')) {
+      const unsigned char c = req[k];
+      if ((c > 127) || (A[c] == ' ')) {
         return -3;
       }
     }

--- a/src/apps/relay/http_server.c
+++ b/src/apps/relay/http_server.c
@@ -74,7 +74,7 @@ static void write_http_echo(ioa_socket_handle s) {
                TURN_SOFTWARE, strlen(content_http), content_http);
 
       ioa_network_buffer_handle nbh_http = ioa_network_buffer_allocate(s->e);
-      char *data = ioa_network_buffer_data(nbh_http);
+      char *data = (char *)ioa_network_buffer_data(nbh_http);
 
       strcpy(data, data_http);
       ioa_network_buffer_set_size(nbh_http, strlen(data_http));


### PR DESCRIPTION
Two compiler warnings were addressed:

*   In `src/apps/relay/http_server.c`, line 77, a `-Wpointer-sign` warning occurred when initializing a `char *` with the `uint8_t *` return type of `ioa_network_buffer_data()`.
    *   An explicit cast `(char *)` was added to `ioa_network_buffer_data(nbh_http)` to resolve the type mismatch.

*   In `src/apps/relay/acme.c`, line 59, a `-Wchar-subscripts` warning was present because a `char` variable `c` was used as an array index. `char` can be signed, potentially leading to negative indices.
    *   Initially, `c` was cast to `(unsigned char)` at the point of use: `A[(unsigned char)c]`.
    *   This was later improved by changing the declaration of `c` from `const char` to `const unsigned char c = req[k]