### PR TITLE
removed unnecessary null check

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -1131,9 +1131,7 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
     if (!rtcp_map_put(e->map_rtcp, *out_reservation_token, *rtcp_s)) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot update RTCP map\n", __FUNCTION__);
       IOA_CLOSE_SOCKET(*rtp_s);
-      if (rtcp_s) {
-        IOA_CLOSE_SOCKET(*rtcp_s);
-      }
+      IOA_CLOSE_SOCKET(*rtcp_s);
       return -1;
     }
   }

--- a/src/server/ns_turn_maps_rtcp.h
+++ b/src/server/ns_turn_maps_rtcp.h
@@ -61,7 +61,7 @@ rtcp_map *rtcp_map_create(ioa_engine_handle e);
  * true - success
  * false - error
  */
-bool rtcp_map_put(rtcp_map *map, rtcp_token_type key, ioa_socket_handle s);
+bool rtcp_map_put(rtcp_map *map, rtcp_token_type token, ioa_socket_handle s);
 
 /**
  * @ret:


### PR DESCRIPTION
removing an unnecessary null check as raised in [this code scan](https://github.com/redraincatching/coturn/security/code-scanning/179)

the variable is confirmed to not be null in an outer loop guard

also changed the name of the variable in `rtcp_map_put`'s function declaration to match that used in its function definition