### PR TITLE
reduce calls to random

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1773,7 +1773,7 @@ static void generate_aes_128_key(char *filePath, unsigned char *returnedKey) {
     key[i] = (i < 8) ? (random_value_0 >> (i * 8)) & 0xff : (random_value_1 >> ((i - 8) * 8)) & 0xff;
   }
 
-  FILE *fptr = fopen(filePath, "w");
+  FILE *fptr = fopen(filePath, "wb");
   if (!fptr) {
     return;
   }


### PR DESCRIPTION
implemented change suggested in TODO to speed up aes key generation without, hopefully, negatively impacting the overall randomness of the function