### PR TITLE
addressed null pointer deref warnings

### DIFF
--- a/src/server/ns_turn_allocation.c
+++ b/src/server/ns_turn_allocation.c
@@ -725,6 +725,9 @@ void add_unsent_buffer(unsent_buffer *ub, ioa_network_buffer_handle nbh) {
     ioa_network_buffer_delete(NULL, nbh);
   } else {
     ub->bufs = (ioa_network_buffer_handle *)realloc(ub->bufs, sizeof(ioa_network_buffer_handle) * (ub->sz + 1));
+    if (!ub->bufs) {
+      return NULL;
+    }
     ub->bufs[ub->sz] = nbh;
     ub->sz += 1;
   }

--- a/src/server/ns_turn_maps.c
+++ b/src/server/ns_turn_maps.c
@@ -40,6 +40,7 @@
 
 #include <stdlib.h> // for size_t, free, malloc, NULL, realloc
 #include <string.h> // for memset, strcmp, memcpy, strlen
+#include <assert.h> // for assert
 
 KHASH_MAP_INIT_INT64(3, ur_map_value_type)
 
@@ -261,6 +262,8 @@ bool lm_map_put(lm_map *map, ur_map_key_type key, ur_map_value_type value) {
           a->extra_values[i] = (ur_map_value_type *)malloc(sizeof(ur_map_value_type));
           valuep = a->extra_values[i];
         }
+        assert(keyp);
+        assert(valuep);
         *keyp = key;
         *valuep = value;
         return false;
@@ -271,11 +274,13 @@ bool lm_map_put(lm_map *map, ur_map_key_type key, ur_map_value_type value) {
   size_t old_sz = esz;
   size_t old_sz_mem = esz * sizeof(ur_map_key_type *);
   a->extra_keys = (ur_map_key_type **)realloc(a->extra_keys, old_sz_mem + sizeof(ur_map_key_type *));
+  assert(a->extra_keys);
   a->extra_keys[old_sz] = (ur_map_key_type *)malloc(sizeof(ur_map_key_type));
   *(a->extra_keys[old_sz]) = key;
 
   old_sz_mem = esz * sizeof(ur_map_value_type *);
   a->extra_values = (ur_map_value_type **)realloc(a->extra_values, old_sz_mem + sizeof(ur_map_value_type *));
+  assert(a->extra_values);
   a->extra_values[old_sz] = (ur_map_value_type *)malloc(sizeof(ur_map_value_type));
   *(a->extra_values[old_sz]) = value;
 
@@ -528,6 +533,7 @@ static void addr_list_add(addr_list_header *slh, const ioa_addr *key, ur_addr_ma
     size_t old_sz = slh->extra_sz;
     size_t old_sz_mem = old_sz * sizeof(addr_elem);
     slh->extra_list = (addr_elem *)realloc(slh->extra_list, old_sz_mem + sizeof(addr_elem));
+    assert(slh->extra_list);
     elem = &(slh->extra_list[old_sz]);
     slh->extra_sz += 1;
   }
@@ -947,6 +953,7 @@ ur_string_map *ur_string_map_create(ur_string_map_func del_value_func) {
     free(map);
     return NULL;
   }
+  assert(map);
   map->del_value_func = del_value_func;
   return map;
 }

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -2938,6 +2938,10 @@ static int handle_turn_send(turn_turnserver *server, ts_ur_super_session *ss, in
   addr_set_any(&peer_addr);
   allocation *a = get_allocation_ss(ss);
 
+  if (!server) {
+    return -1;
+  }
+
   if (ss->is_tcp_relay) {
     *err_code = 403;
     *reason = (const uint8_t *)"Send cannot be used with TCP relay";
@@ -4102,6 +4106,10 @@ int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss,
     return -1;
   }
 
+  if (!server) {
+    return -1;
+  }
+
   SOCKET_TYPE socket_type = get_ioa_socket_type(ss->client_socket);
 
   turn_report_session_usage(ss, 1);
@@ -4227,6 +4235,10 @@ static int write_client_connection(turn_turnserver *server, ts_ur_super_session 
                                    int ttl, int tos) {
 
   FUNCSTART;
+
+  if (!server) {
+    return -1;
+  }
 
   if (!(ss->client_socket)) {
     ioa_network_buffer_delete(server->e, nbh);


### PR DESCRIPTION
addressing issues raised by code scanning, specifically null pointer dereferences in server

ns_turn_server.c
- [33](https://github.com/redraincatching/coturn/security/code-scanning/33) ignored, the `is_rfc5780()` function exits early if the server is null
	- this also catches [36](https://github.com/redraincatching/coturn/security/code-scanning/36)
- [34](https://github.com/redraincatching/coturn/security/code-scanning/34) addressed
- [174](https://github.com/redraincatching/coturn/security/code-scanning/174) addressed

ns_turn_maps.c
- [27](https://github.com/redraincatching/coturn/security/code-scanning/27), [160](https://github.com/redraincatching/coturn/security/code-scanning/160), [161](https://github.com/redraincatching/coturn/security/code-scanning/161), [162](https://github.com/redraincatching/coturn/security/code-scanning/162), [163](https://github.com/redraincatching/coturn/security/code-scanning/163), [164](https://github.com/redraincatching/coturn/security/code-scanning/164), [165](https://github.com/redraincatching/coturn/security/code-scanning/165) false positives, suppressed with assert()

ns_turn_allocations.c
- [9](https://github.com/redraincatching/coturn/security/code-scanning/9) handled as other `realloc` failures are within the file