### PR TITLE
typo correction

### DIFF
--- a/src/apps/uclient/startuclient.c
+++ b/src/apps/uclient/startuclient.c
@@ -657,7 +657,7 @@ beg_allocate:
       if (dual_allocation && !mobility) {
         uint8_t rand = (uint8_t)turn_random();
         bool add_requested_family = rand & 0x01;
-        bool use_ipv4 = rand & 0x03;
+        bool use_ipv4 = rand & 0x02;
 
         if (add_requested_family) {
           uint8_t field[4];


### PR DESCRIPTION
@ggarber i noticed too late that i used `0x03` instead of `0x02` by mistake - this is an issue because it means that `add_requested_family` will never be set when ipv6 is being used, so this should be fixed