### PR TITLE
Fix null pointer dereference in set_ssl_ctx function

### DIFF
--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -948,6 +948,9 @@ static ioa_engine_handle create_new_listener_engine(void) {
                         &turn_params.redis_statsdb
 #endif
       );
+  if (!e) {
+    exit(-1);
+  }
   set_ssl_ctx(e, &turn_params);
   ioa_engine_set_rtcp_map(e, turn_params.listener.rtcpmap);
   return e;
@@ -1639,6 +1642,9 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
                                     &turn_params.redis_statsdb
 #endif
     );
+    if (!rs->ioa_eng) {
+      exit(-1);
+    }
     set_ssl_ctx(rs->ioa_eng, &turn_params);
     ioa_engine_set_rtcp_map(rs->ioa_eng, turn_params.listener.rtcpmap);
   }


### PR DESCRIPTION
This PR fixes a null pointer dereference vulnerability where `set_ssl_ctx()` could crash when passed a NULL engine handle.

## Problem

The `create_ioa_engine()` function can return NULL when invalid parameters are provided:

```c
if (!relays_number || !relay_addrs || !tp) {
  TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot create TURN engine\n", __FUNCTION__);
  return NULL;
}
```

However, two calling functions don't check for NULL before passing the result to `set_ssl_ctx()`:

1. **`setup_relay_server()`** (line 1646):
   ```c
   rs->ioa_eng = create_ioa_engine(...);
   set_ssl_ctx(rs->ioa_eng, &turn_params);  // Potential NULL dereference
   ```

2. **`create_new_listener_engine()`** (line 955):
   ```c
   ioa_engine_handle e = create_ioa_engine(...);
   set_ssl_ctx(e, &turn_params);  // Potential NULL dereference
   ```

The `set_ssl_ctx()` function then dereferences the engine parameter without checking:
```c
struct event_base *base = e->event_base;  // Crashes if e is NULL
```

## Solution

Added a simple check before calling `set_ssl_ctx()`:

## Impact

- ✅ Prevents crashes when `create_ioa_engine()` fails due to invalid configuration
- ✅ Minimal change with no functional impact on normal operation
- ✅ All existing tests continue to pass
- ✅ Follows defensive programming best practices

Fixes #1718.
