### PR TITLE
Fix logging before partsing logging cmd line args

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1807,7 +1807,7 @@ unsigned char *base64decode(const void *b64_decode_this, int decode_this_many_by
   int decoded_byte_index = 0;                     // Index where the next base64_decoded byte should be written.
   while (0 < BIO_read(b64_bio, base64_decoded + decoded_byte_index, 1)) { // Read byte-by-byte.
     decoded_byte_index++; // Increment the index until read of BIO decoded data is complete.
-  }                       // Once we're done reading decoded data, BIO_read returns -1 even though there's no error.
+  } // Once we're done reading decoded data, BIO_read returns -1 even though there's no error.
 
   BIO_free_all(b64_bio); // Destroys all BIOs in chain, starting with b64 (i.e. the 1st one).
   return base64_decoded; // Returns base-64 decoded data with trailing null terminator.
@@ -2988,21 +2988,8 @@ int main(int argc, char **argv) {
 
   init_super_memory();
 
-  init_domain();
-  create_default_realm();
-
-  init_turn_server_addrs_list(&turn_params.alternate_servers_list);
-  init_turn_server_addrs_list(&turn_params.tls_alternate_servers_list);
-  init_turn_server_addrs_list(&turn_params.aux_servers_list);
-
-  set_network_engine();
-
-  init_listener();
-  init_secrets_list(&turn_params.default_users_db.ram_db.static_auth_secrets);
-  init_dynamic_ip_lists();
-
+  // Read the log options first because some initialization can generate logs
   if (!strstr(argv[0], "turnadmin")) {
-
     struct uoptions uo;
     uo.u.m = long_options;
 
@@ -3035,6 +3022,19 @@ int main(int argc, char **argv) {
   }
 
   optind = 0;
+
+  init_domain();
+  create_default_realm();
+
+  init_turn_server_addrs_list(&turn_params.alternate_servers_list);
+  init_turn_server_addrs_list(&turn_params.tls_alternate_servers_list);
+  init_turn_server_addrs_list(&turn_params.aux_servers_list);
+
+  set_network_engine();
+
+  init_listener();
+  init_secrets_list(&turn_params.default_users_db.ram_db.static_auth_secrets);
+  init_dynamic_ip_lists();
 
 #if !TLS_SUPPORTED
   turn_params.no_tls = 1;


### PR DESCRIPTION
When using --log-file stdout to redirect turnserver logs to stdout instead of creating a log file, a default log file was still being created. This happened because the --log-file argument was processed after logging had already occurred during startup.

Fix #1670 