### PR TITLE
Fix null pointer dereference in set_ssl_ctx

### DIFF
--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -341,6 +341,10 @@ static void update_ssl_ctx(evutil_socket_t sock, short events, update_ssl_ctx_cb
 
 void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params) {
   update_ssl_ctx_cb_args_t *args = (update_ssl_ctx_cb_args_t *)malloc(sizeof(update_ssl_ctx_cb_args_t));
+  if (!args) {
+	  TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Failed to allocate memory for SSL context update args\n");
+	  return;
+	}
   args->engine = e;
   args->params = params;
   args->next = NULL;


### PR DESCRIPTION
### What this fixes
Hi,
This PR addresses a potential NULL pointer dereference in `src/apps/relay/netengine.c`.  
In the function `set_ssl_ctx()`, `malloc()` may return `NULL` under low-memory conditions, but this was not checked.  
As a result, the server could crash by dereferencing a `NULL` pointer.

### Why this is important

If the system runs out of memory and `malloc()` fails, dereferencing the result causes a crash, leading to a denial of service.  
This kind of failure is critical in production TURN deployments where uptime and availability are essential.

### What this PR does

Adds a straightforward `NULL` check after `malloc()` and logs an error if allocation fails.  
The function's logic remains unchanged — this is a minimal, defensive improvement for stability without any functional side effects.


Thanks for your consideration. I look forward to your feedback.