### PR TITLE
mainreplay: fix leak in decrypt_aes_128()

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1841,6 +1841,7 @@ void decrypt_aes_128(char *in, const unsigned char *mykey) {
   CRYPTO_ctr128_encrypt(encryptedText, outdata, newTotalSize, &key, state.ivec, state.ecount, &state.num,
                         (block128_f)AES_encrypt);
 
+  free(encryptedText);
   strcat(last, (char *)outdata);
   printf("%s\n", last);
 }


### PR DESCRIPTION
In decrypt_aes_128() at src/apps/replay/mainreplay.c, it calls base64decode() to allocates memory in encryptedText, but forgets to free encryptedText in the end of this function. Add free() after finished using encryptedText.