### PR TITLE
address possible null pointer dereferences

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -923,8 +923,12 @@ static char *_WTA(__in wchar_t *pszInBuf, __in int nInSize, __out char **pszOutB
     free(*pszOutBuf);
     return NULL;
   } else {
-    (*pszOutBuf)[*pnOutSize - 1] = '\0';
-    return *pszOutBuf;
+    if (pszOutBuf != NULL) {
+      (*pszOutBuf)[*pnOutSize - 1] = '\0';
+      return *pszOutBuf;
+    } else {
+      return NULL;
+    }
   }
 }
 

--- a/src/apps/relay/dbdrivers/dbd_mongo.c
+++ b/src/apps/relay/dbdrivers/dbd_mongo.c
@@ -98,6 +98,11 @@ static MONGO *get_mongodb_connection(void) {
 
     mydbconnection = (MONGO *)calloc(1, sizeof(MONGO));
 
+    if (mydbconnection == NULL) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
+      return NULL;
+    }
+
     mydbconnection->uri = mongoc_uri_new(pud->userdb);
 
     if (!mydbconnection->uri) {

--- a/src/apps/relay/http_server.c
+++ b/src/apps/relay/http_server.c
@@ -220,6 +220,11 @@ struct http_request *parse_http_request(char *request) {
 
     ret = (struct http_request *)calloc(sizeof(struct http_request), 1);
 
+    if (ret == NULL) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
+      return NULL;
+    }
+
     if (strstr(request, "GET ") == request) {
       ret->rtype = HRT_GET;
       ret = parse_http_request_1(ret, request + 4, 0);

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -341,6 +341,10 @@ static void update_ssl_ctx(evutil_socket_t sock, short events, update_ssl_ctx_cb
 
 void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params) {
   update_ssl_ctx_cb_args_t *args = (update_ssl_ctx_cb_args_t *)malloc(sizeof(update_ssl_ctx_cb_args_t));
+  if (args == NULL) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
+    return;
+  }
   args->engine = e;
   args->params = params;
   args->next = NULL;

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -1173,6 +1173,10 @@ static void cliserver_input_handler(struct evconnlistener *l, evutil_socket_t fd
   addr_debug_print(adminserver.verbose, (ioa_addr *)sa, "CLI connected to");
 
   struct cli_session *clisession = (struct cli_session *)calloc(sizeof(struct cli_session), 1);
+  if (clisession == NULL) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
+    return;
+  }
 
   clisession->rp = get_realm(NULL);
 
@@ -1437,6 +1441,11 @@ void admin_server_receive_message(struct bufferevent *bev, void *ptr) {
   UNUSED_ARG(ptr);
 
   struct turn_session_info *tsi = (struct turn_session_info *)calloc(1, sizeof(struct turn_session_info));
+  if (tsi == NULL) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
+    return;
+  }
+
   int n = 0;
   struct evbuffer *input = bufferevent_get_input(bev);
 

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -161,6 +161,10 @@ realm_params_t *get_realm(char *name) {
     } else {
       realm_params_t *ret = (realm_params_t *)malloc(sizeof(realm_params_t));
       memcpy(ret, default_realm_params_ptr, sizeof(realm_params_t));
+      if (ret == NULL) {
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: error allocating memory\n", __FUNCTION__);
+        return default_realm_params_ptr;
+      }
       STRCPY(ret->options.name, name);
       value = (ur_string_map_value_type)ret;
       ur_string_map_put(realms, key, value);

--- a/src/apps/uclient/startuclient.c
+++ b/src/apps/uclient/startuclient.c
@@ -1590,6 +1590,11 @@ again:
       (app_tcp_conn_info **)realloc(elem->pinfo.tcp_conn, elem->pinfo.tcp_conn_number * sizeof(app_tcp_conn_info *));
   elem->pinfo.tcp_conn[i] = (app_tcp_conn_info *)calloc(sizeof(app_tcp_conn_info), 1);
 
+  if (elem->pinfo.tcp_conn[i] == NULL) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
+    return;
+  }
+
   elem->pinfo.tcp_conn[i]->tcp_data_fd = clnet_fd;
   elem->pinfo.tcp_conn[i]->cid = cid;
 

--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -1409,6 +1409,10 @@ void start_mclient(const char *remote_address, int port, const unsigned char *if
   }
 
   elems = (app_ur_session **)malloc(sizeof(app_ur_session) * ((mclient * 2) + 1) + sizeof(void *));
+  if (elems == NULL) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: failure in call to malloc !!!\n", __FUNCTION__);
+    return;
+  }
 
   __turn_getMSTime();
   uint32_t stime = current_time;

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -181,6 +181,9 @@ bool stun_produce_integrity_key_str(const uint8_t *uname, const uint8_t *realm, 
   size_t sz = ulen + 1 + rlen + 1 + plen + 1 + 10;
   size_t strl = ulen + 1 + rlen + 1 + plen;
   uint8_t *str = (uint8_t *)malloc(sz + 1);
+  if (str == NULL) {
+    return false;
+  }
 
   strncpy((char *)str, (const char *)uname, sz);
   str[ulen] = ':';

--- a/src/server/ns_turn_maps.c
+++ b/src/server/ns_turn_maps.c
@@ -282,11 +282,13 @@ bool lm_map_put(lm_map *map, ur_map_key_type key, ur_map_value_type value) {
   a->extra_values = (ur_map_value_type **)realloc(a->extra_values, old_sz_mem + sizeof(ur_map_value_type *));
   assert(a->extra_values);
   a->extra_values[old_sz] = (ur_map_value_type *)malloc(sizeof(ur_map_value_type));
-  *(a->extra_values[old_sz]) = value;
-
-  a->extra_sz += 1;
-
-  return true;
+  if (a->extra_values[old_sz] != NULL) {
+    *(a->extra_values[old_sz]) = value;
+    a->extra_sz += 1;
+    return true;
+  } else {
+    return false;
+  }
 }
 
 bool lm_map_get(const lm_map *map, ur_map_key_type key, ur_map_value_type *value) {


### PR DESCRIPTION
# addressing all remaining code scanning instances of warning C6011, null pointer dereference

this pr aims to address more static code analyser warnings, specifically null pointer dereferences. the majority of changes are solely to quieten the analyser, as `malloc` and `calloc` are unlikely to fail, but this should at least lead to the code analysis being more readable and usable.

where functions addressed had existing failure strategies, they were used, however some functions will now silently fail rather than attempting to dereference a null pointer. if there is a preferred solution in these cases, i will be happy to implement it.

---

this is an extension of [this pull request](https://github.com/coturn/coturn/pull/1729)