### PR TITLE
add fuzzing to ci workflows

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,42 @@
+name: CIFuzz
+on: 
+  [pull_request]
+permissions: {}
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix: 
+        sanitizer: [address, memory, undefined]
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v5
+    - name: build fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'coturn'
+        language: c
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: run fuzzers (${{ matrix.sanitizer }})
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'coturn'
+        language: c
+        sanitizer: ${{ matrix.sanitizer }}
+        fuzz-seconds: 600
+        output-sarif: true
+    - name: upload crash
+      uses: actions/upload-artifact@v4
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: ${{ matrix.sanitizer }}_artifacts
+        path: ./out/artifacts
+    - name: upload sarif
+      if: always() && steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: cifuzz-sarif/results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Docker CI](https://github.com/coturn/coturn/actions/workflows/docker.yml/badge.svg  "Docker CI")](https://github.com/coturn/coturn/actions/workflows/docker.yml)
 [![Docker Hub](https://img.shields.io/docker/pulls/coturn/coturn?label=Docker%20Hub%20pulls "Docker Hub pulls")](https://hub.docker.com/r/coturn/coturn)
+[![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/coturn.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:coturn)
 
 [Docker Hub](https://hub.docker.com/r/coturn/coturn)
 | [GitHub Container Registry](https://github.com/orgs/coturn/packages/container/package/coturn)


### PR DESCRIPTION
allow fuzzing to be performed as part of the continuous integration.

the timing of the fuzzing can be extended, and i aim to broaden the scope of the fuzz testing as well, since we currently only test the stun message parser.