### PR TITLE
Update attribute values according to RFC 8656

### DIFF
--- a/src/client/ns_turn_msg_defs.h
+++ b/src/client/ns_turn_msg_defs.h
@@ -136,6 +136,11 @@
 #define STUN_ATTRIBUTE_CONNECTION_ID (0x002A)
 /* <<== RFC 6062 */
 
+/* RFC 8656 ==>> */
+#define STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY (0x8000)
+#define STUN_ATTRIBUTE_ADDRESS_ERROR_CODE (0x8001)
+/* <<== RFC 8656 */
+
 #define STUN_VALID_CHANNEL(chn) ((chn) >= 0x4000 && (chn) <= 0x7FFF)
 
 ///////// extra values //////////////////

--- a/src/client/ns_turn_msg_defs_experimental.h
+++ b/src/client/ns_turn_msg_defs_experimental.h
@@ -53,9 +53,4 @@
 
 /* <<== Bandwidth */
 
-////////////// SSODA ///////////////////
-
-#define STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY (0x8032)
-#define STUN_ATTRIBUTE_ADDRESS_ERROR_CODE (0x8033)
-
 #endif //__LIB_TURN_MSG_DEFS_NEW__


### PR DESCRIPTION
Source https://datatracker.ietf.org/doc/html/rfc8656#section-18
Now conforms to RFC specification

- ADDITIONAL_ADDRESS_FAMILY (0x8000) - was (0x8032)
- ADDRESS_ERROR_CODE (0x8001) - was (0x8033)

Fixes #1740