### PR TITLE
Fix missing null termination after strncpy in MongoDB driver (dbd_mongo.c)

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_mongo.c
+++ b/src/apps/relay/dbdrivers/dbd_mongo.c
@@ -905,7 +905,7 @@ static int mongo_set_realm_option_one(uint8_t *realm, unsigned long value, const
   BSON_APPEND_UTF8(&query, "realm", (const char *)realm);
   bson_init(&doc);
 
-  size_t klen = 9 + strlen(opt);
+  size_t klen = 9 + strlen(opt) + 1; /* "options." + opt + null */
   char *_k = (char *)malloc(klen);
   if (!_k) {
     return -1;
@@ -1021,7 +1021,7 @@ static int mongo_read_realms_ip_lists(const char *kind, ip_range_list_t *list) {
   int ret = 0;
 
   char field_name[129];
-  sprintf(field_name, "%s_peer_ip", kind);
+  snprintf(field_name, sizeof(field_name), "%s_peer_ip", kind);
 
   mongoc_collection_t *collection = mongo_get_collection("realm");
 


### PR DESCRIPTION
## Issue
strncpy(realm/pwd, ...) without null termination
when source is long left buffers unterminated.

## Fix
Set realm[STUN_MAX_REALM_SIZE] and pwd[STUN_MAX_PWD_SIZE]
to '\0' after each strncpy.