### PR TITLE
Fix unbounded strcpy in stun_method_str (ns_turn_msg.c)

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -51,7 +51,8 @@
 ///////////
 
 #define FINGERPRINT_XOR 0x5354554e
-
+// Longest method string is "CONNECTION_ATTEMPT" (20 chars)
+#define STUN_METHOD_STR_MAX 32
 ///////////
 
 int stun_method_str(uint16_t method, char *smethod) {
@@ -95,7 +96,8 @@ int stun_method_str(uint16_t method, char *smethod) {
   };
 
   if (smethod) {
-    strcpy(smethod, s);
+    strncpy(smethod, s, STUN_METHOD_STR_MAX - 1);
+    smethod[STUN_METHOD_STR_MAX - 1] = '\0';
   }
 
   return ret;

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -3643,7 +3643,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
               err_code = 441;
               reason = (const uint8_t *)"The origin attribute does not match the initial session origin value";
               if (server->verbose) {
-                char smethod[129];
+				// STUN_METHOD_STR_MAX=32
+                char smethod[32];
                 stun_method_str(method, smethod);
                 log_method(ss, smethod, err_code, reason);
               }
@@ -3652,7 +3653,8 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
             err_code = 441;
             reason = (const uint8_t *)"The origin attribute is empty, does not match the initial session origin value";
             if (server->verbose) {
-              char smethod[129];
+              // STUN_METHOD_STR_MAX=32
+              char smethod[32];
               stun_method_str(method, smethod);
               log_method(ss, smethod, err_code, reason);
             }


### PR DESCRIPTION
## Issue
strcpy(smethod, s) with no size check. Callers pass fixed buffers (e.g. 32 bytes); if API were misused with a smaller
buffer, or s were ever longer, this could overflow.

## Fix
Use strncpy with a fixed maximum (32), then null-terminate,
so at most 32 bytes are written regardless of caller buffer size.