### PR TITLE
Perf: improve worst case scenario optimization

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -180,7 +180,7 @@ static void calculate_cookie(SSL *ssl, unsigned char *cookie_secret, unsigned in
 }
 
 static int generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len) {
-  unsigned char *buffer;
+  unsigned char buffer[sizeof(struct in6_addr) + sizeof(in_port_t)];
   unsigned char result[EVP_MAX_MD_SIZE];
   unsigned int length = 0;
   unsigned int resultlength;
@@ -208,12 +208,6 @@ static int generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie
     break;
   }
   length += sizeof(in_port_t);
-  buffer = (unsigned char *)OPENSSL_malloc(length);
-
-  if (buffer == NULL) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "out of memory\n");
-    return 0;
-  }
 
   // TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,"%s: family=%u(2)\n",__FUNCTION__,(unsigned)peer.ss.sa_family);
 
@@ -234,7 +228,6 @@ static int generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie
   /* Calculate HMAC of buffer using the secret */
   HMAC(EVP_sha1(), (const void *)cookie_secret, COOKIE_SECRET_LENGTH, (const unsigned char *)buffer, length, result,
        &resultlength);
-  OPENSSL_free(buffer);
 
   memcpy(cookie, result, resultlength);
   *cookie_len = resultlength;


### PR DESCRIPTION
Memory allocation performance optimizations:
- Replaced a heap-allocated buffer with a stack-allocated one in generate_cookie():
- Optimized buffer reuse in the UDP server's packet receive loop - reduces unnecessary allocations/frees in the hot path of the UDP batch receive loop (especially during DDoS)
