### PR TITLE
CLI interface is disabled by default

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -267,7 +267,7 @@ Flags:
 
 --mobility		Mobility with ICE (MICE) specs support.
 
---no-cli		Turn OFF the CLI support. By default it is always ON.
+--cli		Turn ON the CLI support. By default it is always OFF.
 			See also options --cli-ip and --cli-port.
 
 --server-relay		Server relay. NON-STANDARD AND DANGEROUS OPTION.

--- a/docker/coturn/README.md
+++ b/docker/coturn/README.md
@@ -80,7 +80,7 @@ By default, default Coturn configuration and CLI options provided in the `CMD` [
                -n --log-file=stdout \
                --min-port=49160 --max-port=49200 \
                --lt-cred-mech --fingerprint \
-               --no-multicast-peers --no-cli \
+               --no-multicast-peers \
                --no-tlsv1 --no-tlsv1_1 \
                --realm=my.realm.org \  
     ```

--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -705,11 +705,11 @@ syslog
 #
 #proc-group=<group-name>
 
-# Turn OFF the CLI support.
-# By default it is always ON.
+# Turn on CLI support.
+# By default it is always OFF.
 # See also options cli-ip and cli-port.
 #
-#no-cli
+#cli
 
 #Local system IP address to be used for CLI server endpoint. Default value
 # is 127.0.0.1.

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -737,11 +737,11 @@
 #
 #proc-group=<group-name>
 
-# Turn OFF the CLI support.
+# Enable CLI support.
 # By default it is always ON.
 # See also options cli-ip and cli-port.
 #
-#no-cli
+#cli
 
 #Local system IP address to be used for CLI server endpoint. Default value
 # is 127.0.0.1.

--- a/examples/run_tests.sh
+++ b/examples/run_tests.sh
@@ -7,7 +7,7 @@ if [ ! -f $BINDIR/turnserver ]; then
 fi
 
 echo 'Running turnserver'
-$BINDIR/turnserver --use-auth-secret  --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --no-cli --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > /dev/null &
+$BINDIR/turnserver --use-auth-secret  --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --cli --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > /dev/null &
 turnserver_pid="$!"
 echo 'Running peer client'
 $BINDIR/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > /dev/null &

--- a/examples/run_tests_conf.sh
+++ b/examples/run_tests_conf.sh
@@ -11,7 +11,6 @@ echo "use-auth-secret" > $BINDIR/turnserver.conf
 echo "static-auth-secret=secret" >> $BINDIR/turnserver.conf
 echo "realm=north.gov" >> $BINDIR/turnserver.conf
 echo "allow-loopback-peers" >> $BINDIR/turnserver.conf
-echo "no-cli" >> $BINDIR/turnserver.conf
 echo "cert=../examples/ca/turn_server_cert.pem" >> $BINDIR/turnserver.conf
 echo "pkey=../examples/ca/turn_server_pkey.pem" >> $BINDIR/turnserver.conf
 

--- a/scripts/install_coturn_on_aws_ec2.sh
+++ b/scripts/install_coturn_on_aws_ec2.sh
@@ -85,7 +85,6 @@ tls-listening-port=5349
 no-tlsv1
 no-tlsv1_1
 userdb=/usr/local/var/db/turndb
-no-cli
 min-port=45000
 max-port=65535
 log-file=/var/log/turnserver/turnserver.log

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1313,7 +1313,7 @@ static char Usage[] =
     "						The standard RFC explicitly define actually that this default must be "
     "IPv4,\n"
     "						so use other option values with care!\n"
-    " --no-cli					Turn OFF the CLI support. By default it is always ON.\n"
+    " --cli					Turn ON the CLI support. By default it is always OFF.\n"
     " --cli-ip=<IP>					Local system IP address to be used for CLI server endpoint. "
     "Default value\n"
     "						is 127.0.0.1.\n"
@@ -1490,6 +1490,7 @@ enum EXTRA_OPTS {
   PROC_GROUP_OPT,
   MOBILITY_OPT,
   NO_CLI_OPT,
+  CLI_OPT,
   CLI_IP_OPT,
   CLI_PORT_OPT,
   CLI_PASSWORD_OPT,
@@ -1645,6 +1646,7 @@ static const struct myoption long_options[] = {
     {"proc-group", required_argument, NULL, PROC_GROUP_OPT},
     {"mobility", optional_argument, NULL, MOBILITY_OPT},
     {"no-cli", optional_argument, NULL, NO_CLI_OPT},
+    {"cli", optional_argument, NULL, CLI_OPT},
     {"cli-ip", required_argument, NULL, CLI_IP_OPT},
     {"cli-port", required_argument, NULL, CLI_PORT_OPT},
     {"cli-password", required_argument, NULL, CLI_PASSWORD_OPT},
@@ -2027,7 +2029,10 @@ static void set_option(int c, char *value) {
     turn_params.mobility = get_bool_value(value);
     break;
   case NO_CLI_OPT:
-    use_cli = !get_bool_value(value);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "no-cli option is deprecated, see --cli\n");
+    break;
+  case CLI_OPT:
+    use_cli = get_bool_value(value);
     break;
   case CLI_IP_OPT:
     if (make_ioa_addr((const uint8_t *)value, 0, &cli_addr) < 0) {
@@ -3263,7 +3268,7 @@ int main(int argc, char **argv) {
   if (use_cli && cli_password[0] == 0) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "CONFIG: Empty cli-password, and so telnet cli interface is disabled! "
                                         "Please set a non empty cli-password!\n");
-    use_cli = 0;
+    use_cli = false;
   }
 
   if (!use_lt_credentials && !anon_credentials) {

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -99,7 +99,7 @@ struct str_buffer;
 
 struct admin_server adminserver;
 
-int use_cli = 1;
+bool use_cli = false;
 
 ioa_addr cli_addr;
 int cli_addr_set = 0;

--- a/src/apps/relay/turn_admin_server.h
+++ b/src/apps/relay/turn_admin_server.h
@@ -83,7 +83,7 @@ struct admin_server {
 
 extern struct admin_server adminserver;
 
-extern int use_cli;
+extern bool use_cli;
 
 #define CLI_DEFAULT_IP ("127.0.0.1")
 extern ioa_addr cli_addr;


### PR DESCRIPTION
cli interface is ON by default which creates a security risk (even though requires a password) and recommended to be disabled.
Instead of just recommendation, this PR disables CLI by default and now requires an explicit flag to enable it

If using old configuration or cli arguments to turnserver - it will log an error message about `--no-cli` being deprecated while doing nothing (already disabled). This log line will be removed in the future