### PR TITLE
Skip response buffer allocation for STUN indications

### DIFF
--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -3885,7 +3885,7 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
     return 0;
   }
 
-  if (ua_num > 0) {
+  if (ua_num > 0 && nbh) {
 
     err_code = 420;
 
@@ -4555,11 +4555,16 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
                                                     ioa_network_buffer_get_size(in_buffer->nbh), 0,
                                                     &(ss->enforce_fingerprints))) {
 
-    ioa_network_buffer_handle nbh = ioa_network_buffer_allocate(server->e);
     int resp_constructed = 0;
 
     const uint16_t method =
         stun_get_method_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
+
+    const int is_indication = stun_is_indication_str(ioa_network_buffer_data(in_buffer->nbh),
+                                                     ioa_network_buffer_get_size(in_buffer->nbh));
+
+    /* Indications never produce a response, so skip the response buffer allocation. */
+    ioa_network_buffer_handle nbh = is_indication ? NULL : ioa_network_buffer_allocate(server->e);
 
     handle_turn_command(server, ss, in_buffer, nbh, &resp_constructed, can_resume);
 

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4560,8 +4560,8 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
     const uint16_t method =
         stun_get_method_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
 
-    const int is_indication = stun_is_indication_str(ioa_network_buffer_data(in_buffer->nbh),
-                                                     ioa_network_buffer_get_size(in_buffer->nbh));
+    const int is_indication =
+        stun_is_indication_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));
 
     /* Indications never produce a response, so skip the response buffer allocation. */
     ioa_network_buffer_handle nbh = is_indication ? NULL : ioa_network_buffer_allocate(server->e);


### PR DESCRIPTION
## Summary

- Skip allocating a 65 KB response buffer for STUN indications (SEND, DATA, BINDING indication) in `read_client_connection()` — indications never produce a response, so the buffer was immediately freed
- Guard the unknown-attributes error-response block in `handle_turn_command()` with a NULL check on `nbh` to match

## Motivation

On the UDP data-relay hot path, every SEND indication triggered a pool-get + pool-put cycle for a response buffer that was never used. This is the highest-frequency STUN command type during active media relay. The change eliminates one unnecessary 65 KB buffer round-trip per SEND indication.

## Test plan

- [ ] Build passes clean (`cmake .. && make -j$(nproc)`)
- [ ] Run RFC 5769 conformance tests (`examples/scripts/rfc5769.sh`)
- [ ] Run basic UDP relay test to verify SEND indications still relay data correctly
- [ ] Verify STUN requests (ALLOCATE, REFRESH, BINDING request) still receive proper error responses