### PR TITLE
Fix build failure: define _GNU_SOURCE for recvmmsg() on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,10 @@ if(DEFINED TURN_SERVER_BUILD_INFO)
     add_definitions(-DTURN_SERVER_BUILD_INFO=${TURN_SERVER_BUILD_INFO})
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_definitions(-D_GNU_SOURCE)
+endif()
+
 IF(MSVC)
     # This option is to enable the /MP switch for Visual Studio 2005 and above compilers
     OPTION(WIN32_USE_MP "Set to ON to build with the /MP option (Visual Studio 2005 and above)." ON)

--- a/configure
+++ b/configure
@@ -424,6 +424,9 @@ OSCFLAGS="${CFLAGS}"
 OSLIBS="${LDFLAGS}"
 
 SYSTEM=`uname`
+if [ "${SYSTEM}" = "Linux" ] ; then
+	OSCFLAGS="${OSCFLAGS} -D_GNU_SOURCE"
+fi
 if [ "${SYSTEM}" = "NetBSD" ] ; then
 	OSCFLAGS="${OSCFLAGS} -I/usr/pkg/include"
 	OSLIBS="-L/usr/pkg/lib ${OSLIBS}"

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -32,6 +32,11 @@
  * SUCH DAMAGE.
  */
 
+/* recvmmsg() and struct mmsghdr require _GNU_SOURCE on Linux */
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #include "apputils.h"
 #include "mainrelay.h"
 #include <errno.h>


### PR DESCRIPTION
## Summary

- Fixes compilation error on Linux when `_GNU_SOURCE` is not defined by the toolchain: `struct mmsghdr` has incomplete type and `recvmmsg()` is implicitly declared
- Defines `_GNU_SOURCE` in three places for full coverage across build systems:
  - `dtls_listener.c` — before includes, guarded by `#if defined(__linux__)`
  - `configure` — adds `-D_GNU_SOURCE` to `OSCFLAGS` on Linux for the legacy build path
  - `CMakeLists.txt` — adds `-D_GNU_SOURCE` on Linux for the CMake build

## Context

The `recvmmsg()` batched receive path added in #1852 uses `struct mmsghdr` and `recvmmsg()`, which are glibc extensions requiring `_GNU_SOURCE`. Some Linux distros/toolchains don't define this implicitly, causing:

```
src/apps/relay/dtls_listener.c:129:18: error: array type has incomplete element type 'struct mmsghdr'
src/apps/relay/dtls_listener.c:748:18: warning: implicit declaration of function 'recvmmsg'
```
Fixes #1867

## Test plan

- [x] Verified CMake build succeeds on macOS (recvmmsg code is `#if defined(__linux__)` guarded — no effect on non-Linux)
- [x] Verify build succeeds on Linux with and without `_GNU_SOURCE` in the environment
- [x] Verify both `cmake` and `./configure && make` build paths work
