### PR TITLE
Drop udp_relay_servers_number config and clean up dead UDP id-space

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_redis.c
+++ b/src/apps/relay/dbdrivers/dbd_redis.c
@@ -753,8 +753,6 @@ static int redis_list_secrets(uint8_t *realm, secrets_list_t *secrets, secrets_l
     if (reply) {
       secrets_list_t keys;
       size_t isz = 0;
-      char s[257];
-
       init_secrets_list(&keys);
 
       if (reply->type == REDIS_REPLY_ERROR) {

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -176,7 +176,6 @@ turn_params_t turn_params = {
 
     NULL,                                 /*external_ip*/
     DEFAULT_GENERAL_RELAY_SERVERS_NUMBER, /*general_relay_servers_number*/
-    0,                                    /*udp_relay_servers_number*/
     UR_SERVER_SOCK_BUF_SIZE,
 
     ////////////// Auth server /////////////////////////////////////

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -151,9 +151,6 @@ static inline int _msvc_cas_weak(volatile LONG *ptr, band_limit_t *expected, ban
 
 #define MAX_NUMBER_OF_GENERAL_RELAY_SERVERS ((uint8_t)(0x80))
 
-#define TURNSERVER_ID_BOUNDARY_BETWEEN_TCP_AND_UDP MAX_NUMBER_OF_GENERAL_RELAY_SERVERS
-#define TURNSERVER_ID_BOUNDARY_BETWEEN_UDP_AND_TCP TURNSERVER_ID_BOUNDARY_BETWEEN_TCP_AND_UDP
-
 #define DEFAULT_CPUS_NUMBER (2)
 
 /////////// TYPES ///////////////////////////////////

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -285,7 +285,6 @@ typedef struct _turn_params_ {
   ioa_addr *external_ip;
 
   turnserver_id general_relay_servers_number;
-  turnserver_id udp_relay_servers_number;
 
   int sock_buf_size;
 

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -72,8 +72,6 @@ static struct auth_server authserver[256];
 
 #define get_real_general_relay_servers_number()                                                                        \
   (turn_params.general_relay_servers_number > 1 ? turn_params.general_relay_servers_number : 1)
-#define get_real_udp_relay_servers_number()                                                                            \
-  (turn_params.udp_relay_servers_number > 1 ? turn_params.udp_relay_servers_number : 1)
 
 static struct relay_server *general_relay_servers[1 + ((turnserver_id)-1)];
 static struct relay_server *udp_relay_servers[1 + ((turnserver_id)-1)];
@@ -418,15 +416,7 @@ static struct relay_server *get_relay_server(turnserver_id id) {
   struct relay_server *rs = NULL;
   if (id >= TURNSERVER_ID_BOUNDARY_BETWEEN_TCP_AND_UDP) {
     const size_t dest = id - TURNSERVER_ID_BOUNDARY_BETWEEN_TCP_AND_UDP;
-    if (dest >= get_real_udp_relay_servers_number()) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Too large UDP relay number: %d, total=%d\n", __FUNCTION__, (int)dest,
-                    (int)get_real_udp_relay_servers_number());
-    }
     rs = udp_relay_servers[dest];
-    if (!rs) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Wrong UDP relay number: %d, total=%d\n", __FUNCTION__, (int)dest,
-                    (int)get_real_udp_relay_servers_number());
-    }
   } else {
     const size_t dest = id;
     if (dest >= get_real_general_relay_servers_number()) {
@@ -1525,20 +1515,9 @@ void setup_server(void) {
   allocate_relay_addrs_ports();
   setup_barriers();
   setup_general_relay_servers();
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Total General servers: %d\n", (int)get_real_general_relay_servers_number());
+  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Total relay threads: %d\n", (int)get_real_general_relay_servers_number());
 
   setup_socket_per_thread_udp_listener_servers();
-
-  {
-    int tot = 0;
-    if (udp_relay_servers[0]) {
-      tot = get_real_udp_relay_servers_number();
-    }
-    if (tot) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Total UDP servers: %d\n", (int)tot);
-    }
-  }
-
   {
     const int tot = get_real_general_relay_servers_number();
     if (tot) {
@@ -1572,11 +1551,6 @@ void enable_drain_mode(void) {
   for (size_t i = 0; i < get_real_general_relay_servers_number(); i++) {
     if (general_relay_servers[i]) {
       general_relay_servers[i]->server.is_draining = true;
-    }
-  }
-  for (size_t i = 0; i < get_real_udp_relay_servers_number(); i++) {
-    if (udp_relay_servers[i]) {
-      udp_relay_servers[i]->server.is_draining = true;
     }
   }
   turn_params.drain_turn_server = true;

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -74,7 +74,6 @@ static struct auth_server authserver[256];
   (turn_params.general_relay_servers_number > 1 ? turn_params.general_relay_servers_number : 1)
 
 static struct relay_server *general_relay_servers[1 + ((turnserver_id)-1)];
-static struct relay_server *udp_relay_servers[1 + ((turnserver_id)-1)];
 
 static struct relay_server *get_relay_server(turnserver_id id);
 
@@ -413,21 +412,15 @@ static void allocate_relay_addrs_ports(void) {
 static int handle_relay_message(relay_server_handle rs, struct message_to_relay *sm);
 
 static struct relay_server *get_relay_server(turnserver_id id) {
-  struct relay_server *rs = NULL;
-  if (id >= TURNSERVER_ID_BOUNDARY_BETWEEN_TCP_AND_UDP) {
-    const size_t dest = id - TURNSERVER_ID_BOUNDARY_BETWEEN_TCP_AND_UDP;
-    rs = udp_relay_servers[dest];
-  } else {
-    const size_t dest = id;
-    if (dest >= get_real_general_relay_servers_number()) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Too large general relay number: %d, total=%d\n", __FUNCTION__, (int)dest,
-                    (int)get_real_general_relay_servers_number());
-    }
-    rs = general_relay_servers[dest];
-    if (!rs) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Wrong general relay number: %d, total=%d\n", __FUNCTION__, (int)dest,
-                    (int)get_real_general_relay_servers_number());
-    }
+  const size_t dest = id;
+  if (dest >= get_real_general_relay_servers_number()) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Too large general relay number: %d, total=%d\n", __FUNCTION__, (int)dest,
+                  (int)get_real_general_relay_servers_number());
+  }
+  struct relay_server *rs = general_relay_servers[dest];
+  if (!rs) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Wrong general relay number: %d, total=%d\n", __FUNCTION__, (int)dest,
+                  (int)get_real_general_relay_servers_number());
   }
   return rs;
 }


### PR DESCRIPTION
## Summary
- Remove the `udp-relay-servers` config knob and the `udp_relay_servers_number` field — after #1849 left only the `PER_THREAD` UDP engine, this knob is no longer wired to anything that creates extra UDP relay threads.
- Delete the now-orphaned `udp_relay_servers[]` array, the `TURNSERVER_ID_BOUNDARY_BETWEEN_TCP_AND_UDP` / `..._UDP_AND_TCP` macros, and the `id >= boundary` branch in `get_relay_server()`. The array was read but never written anywhere in the tree, so the branch was unreachable dead code.
- Drop a stray unused `char s[257]` in `dbd_redis.c::redis_list_secrets`.
- Adjust the startup banner to log "Total relay threads" (was "Total General servers" + a never-fired "Total UDP servers" block).

## Test plan
- [x] `cmake .. && make -j8` clean build
- [x] `examples/scripts/rfc5769.sh` — all RFC 5769 conformance vectors pass
- [x] `examples/scripts/basic/relay.sh` + `udp_c2c_client.sh` — 12000/12000 msgs, 0 lost, 0 dropped