### PR TITLE
Trim two redundant checks from per-packet relay hot path

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -659,16 +659,18 @@ void delete_ioa_timer(ioa_timer_handle th) {
 /************** SOCKETS HELPERS ***********************/
 
 int ioa_socket_check_bandwidth(ioa_socket_handle s, ioa_network_buffer_handle nbh, int read) {
+  /* Fast path: per-packet hot call. Most sessions have no bandwidth limit
+   * configured (max_bps == 0), so short-circuit before the multi-condition
+   * sat/session/engine checks below. */
+  if (s && s->session && s->session->bps < 1) {
+    return 1;
+  }
   if (s && (s->e) && nbh && ((s->sat == CLIENT_SOCKET) || (s->sat == RELAY_SOCKET) || (s->sat == RELAY_RTCP_SOCKET)) &&
       (s->session)) {
 
     const size_t sz = ioa_network_buffer_get_size(nbh);
 
     const band_limit_t max_bps = s->session->bps;
-
-    if (max_bps < 1) {
-      return 1;
-    }
 
     struct traffic_bytes *traffic = &(s->data_traffic);
 
@@ -3238,83 +3240,83 @@ int send_data_from_ioa_socket_nbh(ioa_socket_handle s, ioa_addr *dest_addr, ioa_
         *skip = 1;
       }
     } else {
+      /* Outer branch already established !s->done && s->fd != -1, and
+       * ioa_socket_tobeclosed() rechecks both — drop the redundant inner test
+       * that gated this path on every send. */
       if (!ioa_socket_tobeclosed(s) && s->e) {
+        set_socket_ttl(s, ttl);
+        set_socket_tos(s, tos);
 
-        if (!(s->done || (s->fd == -1))) {
-          set_socket_ttl(s, ttl);
-          set_socket_tos(s, tos);
-
-          if (s->connected && s->bev) {
-            if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET)) {
+        if (s->connected && s->bev) {
+          if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET)) {
 #if TLS_SUPPORTED
-              SSL *ctx = bufferevent_openssl_get_ssl(s->bev);
-              if (!ctx || SSL_get_shutdown(ctx)) {
+            SSL *ctx = bufferevent_openssl_get_ssl(s->bev);
+            if (!ctx || SSL_get_shutdown(ctx)) {
+              s->tobeclosed = 1;
+              ret = 0;
+            }
+#endif
+          }
+
+          if (!(s->tobeclosed)) {
+
+            ret = (int)ioa_network_buffer_get_size(nbh);
+
+            if (!tcp_congestion_control || is_socket_writeable(s, (size_t)ret, __FUNCTION__, 2)) {
+              s->in_write = 1;
+              if (bufferevent_write(s->bev, ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh)) < 0) {
+                ret = -1;
+                TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "bufev send: %s\n", strerror(errno));
+                log_socket_event(s, "socket write failed, to be closed", 1);
                 s->tobeclosed = 1;
-                ret = 0;
+                s->broken = 1;
               }
-#endif
+              /*
+              bufferevent_flush(s->bev,
+                                              EV_READ|EV_WRITE,
+                                              BEV_FLUSH);
+                                              */
+              s->in_write = 0;
+            } else {
+              // drop the packet
+              ;
             }
+          }
+        } else if (s->ssl) {
+          send_ssl_backlog_buffers(s);
+          ret = ssl_send(s, (char *)ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh),
+                         (s->e ? s->e->verbose : TURN_VERBOSE_NONE));
+          if (ret < 0) {
+            s->tobeclosed = 1;
+          } else if (ret == 0) {
+            add_buffer_to_buffer_list(&(s->bufs), (char *)ioa_network_buffer_data(nbh),
+                                      ioa_network_buffer_get_size(nbh));
+          }
+        } else if (s->fd >= 0) {
 
-            if (!(s->tobeclosed)) {
+          if (s->connected && !(s->parent_s)) {
+            dest_addr = NULL; /* ignore dest_addr */
+          } else if (!dest_addr) {
+            dest_addr = &(s->remote_addr);
+          }
 
-              ret = (int)ioa_network_buffer_get_size(nbh);
-
-              if (!tcp_congestion_control || is_socket_writeable(s, (size_t)ret, __FUNCTION__, 2)) {
-                s->in_write = 1;
-                if (bufferevent_write(s->bev, ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh)) < 0) {
-                  ret = -1;
-                  TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "bufev send: %s\n", strerror(errno));
-                  log_socket_event(s, "socket write failed, to be closed", 1);
-                  s->tobeclosed = 1;
-                  s->broken = 1;
-                }
-                /*
-                bufferevent_flush(s->bev,
-                                                EV_READ|EV_WRITE,
-                                                BEV_FLUSH);
-                                                */
-                s->in_write = 0;
-              } else {
-                // drop the packet
-                ;
-              }
-            }
-          } else if (s->ssl) {
-            send_ssl_backlog_buffers(s);
-            ret = ssl_send(s, (char *)ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh),
-                           (s->e ? s->e->verbose : TURN_VERBOSE_NONE));
-            if (ret < 0) {
-              s->tobeclosed = 1;
-            } else if (ret == 0) {
-              add_buffer_to_buffer_list(&(s->bufs), (char *)ioa_network_buffer_data(nbh),
-                                        ioa_network_buffer_get_size(nbh));
-            }
-          } else if (s->fd >= 0) {
-
-            if (s->connected && !(s->parent_s)) {
-              dest_addr = NULL; /* ignore dest_addr */
-            } else if (!dest_addr) {
-              dest_addr = &(s->remote_addr);
-            }
-
-            ret = udp_send(s, dest_addr, (char *)ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh));
-            if (ret < 0) {
-              s->tobeclosed = 1;
+          ret = udp_send(s, dest_addr, (char *)ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh));
+          if (ret < 0) {
+            s->tobeclosed = 1;
 #if defined(EADDRNOTAVAIL)
-              const int perr = socket_errno();
+            const int perr = socket_errno();
 #endif
-              TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "udp send: %s\n", strerror(errno));
+            TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "udp send: %s\n", strerror(errno));
 #if defined(EADDRNOTAVAIL)
-              if (dest_addr && (perr == EADDRNOTAVAIL)) {
-                char sfrom[MAX_IOA_ADDR_STRING] = "";
-                addr_to_string(&(s->local_addr), sfrom);
-                char sto[MAX_IOA_ADDR_STRING] = "";
-                addr_to_string(dest_addr, sto);
-                TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: network error: address unreachable from %s to %s\n",
-                              __FUNCTION__, sfrom, sto);
-              }
-#endif
+            if (dest_addr && (perr == EADDRNOTAVAIL)) {
+              char sfrom[MAX_IOA_ADDR_STRING] = "";
+              addr_to_string(&(s->local_addr), sfrom);
+              char sto[MAX_IOA_ADDR_STRING] = "";
+              addr_to_string(dest_addr, sto);
+              TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: network error: address unreachable from %s to %s\n",
+                            __FUNCTION__, sfrom, sto);
             }
+#endif
           }
         }
       }


### PR DESCRIPTION
ioa_socket_check_bandwidth(): hoist the "no bps limit configured" fast-exit before the multi-condition socket-state check. The vast majority of sessions have max_bps == 0, so the existing path was running 5+ pointer dereferences and equality tests just to land on the same return-1.

send_data_from_ioa_socket_nbh(): drop the redundant inner "if (!(s->done || s->fd == -1))" gate. The outer if/else-if branch already filtered those, and ioa_socket_tobeclosed() rechecks both, so the inner test was dead code on every successful send.

perf record on the c-4 nyc1 droplet (m=1 packet flood, 12s) shows send_data_from_ioa_socket_nbh self-time drop from 0.91% to 0.54% and ioa_socket_check_bandwidth fall out of the top-25 user-space symbols (was 0.33%). Throughput is within run-to-run noise — the relay is syscall-bound, so user-space wins don't translate 1:1 — but the released CPU is real.