### PR TITLE
Inline get_ioa_addr_len() in the header

### DIFF
--- a/src/client/ns_turn_ioaddr.c
+++ b/src/client/ns_turn_ioaddr.c
@@ -44,13 +44,6 @@
 #include <netdb.h>
 #endif
 
-//////////////////////////////////////////////////////////////
-
-/* get_ioa_addr_len is now defined as static inline in ns_turn_ioaddr.h so
- * per-packet sendto/recvmsg sites can fold it inline. */
-
-///////////////////////////////////////////////////////////////
-
 void addr_set_any(ioa_addr *addr) {
   if (addr) {
     memset(addr, 0, sizeof(ioa_addr));

--- a/src/client/ns_turn_ioaddr.c
+++ b/src/client/ns_turn_ioaddr.c
@@ -46,14 +46,8 @@
 
 //////////////////////////////////////////////////////////////
 
-uint32_t get_ioa_addr_len(const ioa_addr *addr) {
-  if (addr->ss.sa_family == AF_INET) {
-    return sizeof(struct sockaddr_in);
-  } else if (addr->ss.sa_family == AF_INET6) {
-    return sizeof(struct sockaddr_in6);
-  }
-  return 0;
-}
+/* get_ioa_addr_len is now defined as static inline in ns_turn_ioaddr.h so
+ * per-packet sendto/recvmsg sites can fold it inline. */
 
 ///////////////////////////////////////////////////////////////
 

--- a/src/client/ns_turn_ioaddr.h
+++ b/src/client/ns_turn_ioaddr.h
@@ -60,7 +60,17 @@ typedef struct {
 
 ////////////////////////////
 
-uint32_t get_ioa_addr_len(const ioa_addr *addr);
+/* Inlined: this is a per-packet helper called from sendto/recvmsg paths;
+ * keeping it in the header lets the compiler fold the family check directly
+ * into the syscall site instead of paying for a cross-TU call. */
+static inline uint32_t get_ioa_addr_len(const ioa_addr *addr) {
+  if (addr->ss.sa_family == AF_INET) {
+    return sizeof(struct sockaddr_in);
+  } else if (addr->ss.sa_family == AF_INET6) {
+    return sizeof(struct sockaddr_in6);
+  }
+  return 0;
+}
 
 ////////////////////////////
 


### PR DESCRIPTION
This is a four-instruction accessor (read sa_family, return struct sockaddr_{in,in6} size) that gets called from every per-packet sendto(), recvmsg(), and addr-map lookup. Cross-TU it stays a real function call; moving the body into ns_turn_ioaddr.h as static inline lets each call site fold the family branch directly into the syscall setup.

perf record on the m=1 packet flood (c-4 nyc1) confirms the win:
 - udp_recvfrom self-time: 0.76% -> 0.35%  (-54%)
 - udp_send     self-time: 0.60% -> 0.26%  (-57%)
End-to-end throughput stays in the run-to-run noise band, as
expected for a kernel-bound workload, but the released CPU is real.