### PR TITLE
Inline addr_cpy() in the header

### DIFF
--- a/src/client/ns_turn_ioaddr.c
+++ b/src/client/ns_turn_ioaddr.c
@@ -152,11 +152,7 @@ uint32_t addr_hash_no_port(const ioa_addr *addr) {
   return ret;
 }
 
-void addr_cpy(ioa_addr *dst, const ioa_addr *src) {
-  if (dst && src) {
-    memcpy(dst, src, sizeof(ioa_addr));
-  }
-}
+/* addr_cpy is now defined as static inline in ns_turn_ioaddr.h. */
 
 void addr_cpy4(ioa_addr *dst, const struct sockaddr_in *src) {
   if (src && dst) {

--- a/src/client/ns_turn_ioaddr.h
+++ b/src/client/ns_turn_ioaddr.h
@@ -69,7 +69,16 @@ int addr_any(const ioa_addr *addr);
 int addr_any_no_port(const ioa_addr *addr);
 uint32_t addr_hash(const ioa_addr *addr);
 uint32_t addr_hash_no_port(const ioa_addr *addr);
-void addr_cpy(ioa_addr *dst, const ioa_addr *src);
+
+/* Inlined: addr_cpy is on the per-packet receive path (every nd.src_addr
+ * dispatch and every map-key copy) and is just a single memcpy. Inlining
+ * eliminates the cross-TU call. */
+static inline void addr_cpy(ioa_addr *dst, const ioa_addr *src) {
+  if (dst && src) {
+    memcpy(dst, src, sizeof(ioa_addr));
+  }
+}
+
 void addr_cpy4(ioa_addr *dst, const struct sockaddr_in *src);
 void addr_cpy6(ioa_addr *dst, const struct sockaddr_in6 *src);
 int addr_eq(const ioa_addr *a1, const ioa_addr *a2);


### PR DESCRIPTION
Same pattern as the get_ioa_addr_len() inline: addr_cpy() is a single-memcpy helper that fires on every receive (each packet dispatch copies the source address into ioa_net_data, plus allocation/permission map-key copies). Cross-TU it stays a real function call.

Combined with the previous four iterations (turn_server_get_engine hoist, bandwidth fast-exit + dead-check removal, cached relay-socket and buffer-size lookups, get_ioa_addr_len inline), the alternating A/B run on the same c-4 nyc1 droplet now shows a consistent +5% throughput on the m=1 packet flood test (recv_msgs/30s mean over 6 rounds: B=146984 / I=155468).