### PR TITLE
Restore CodeQL permissions, category, and manual build mode

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,8 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@v6
@@ -33,11 +35,14 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: c-cpp
+          build-mode: manual
 
       - name: Configure
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
       - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:c-cpp"


### PR DESCRIPTION
PR #1517 (Jun 2024) simplified codeql.yml in ways that left scans incomplete: it dropped the actions:read / contents:read permissions and the analyze category, both of which CodeQL Action requires for results to land under the existing language category. Combined with the later cpp -> c-cpp rename and v3 -> v4 upgrade, scheduled scans have not refreshed the Security tab since Jun 1, 2024.

- Add actions:read and contents:read back to job permissions
- Set build-mode: manual on init (required for v3+/v4 manual builds)
- Pass category "/language:c-cpp" on analyze so SARIF de-duplicates against the configured language
- Build with --parallel so the tracer keeps up on default runners