### PR TITLE
Remove stale --ne option from turnserver --help

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1339,8 +1339,6 @@ static char Usage[] =
     " --cli-max-output-sessions			Maximum number of output sessions in ps CLI command.\n"
     "						This value can be changed on-the-fly in CLI. The default value is "
     "256.\n"
-    " --ne=[1|2|3]					Set network engine type for the process (for internal "
-    "purposes).\n"
     " --no-rfc5780					DEPRECATED and now default, see --rfc5780.\n"
     " --rfc5780					Enable RFC5780 (NAT behavior discovery).\n"
     "						Originally, if there are more than one listener address from the same\n"


### PR DESCRIPTION
## Summary

- The `--ne=[1|2|3]` option was already removed from `long_options[]` and the option parser, so `turnserver` rejects it at runtime, but the help text printed by `turnserver --help` still advertised it.
- Delete the two-line `--ne=[1|2|3]` entry from the `Usage` string in `src/apps/relay/mainrelay.c` so `--help` matches what the binary actually accepts.
- The corresponding `--ne` references in `README.turnserver` and `man/man1/turnserver.1` were already removed previously; this is the last remaining reference inside the binary itself.

## Test plan

- [x] `cmake -S . -B build && cmake --build build --parallel` — clean build, no new warnings
- [x] `clang-format` produces no further drift on the touched file
- [ ] `turnserver --help` no longer lists `--ne` (manual smoke check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)