### PR TITLE
Relay recvmmsg

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,9 @@ known setup used Ubuntu 24.04 `c-4` droplets in `nyc1`:
 - `--udp-recvmmsg` is opt-in and covers both UDP listener receive and plain
   connected relay UDP receive on Linux; DTLS session sockets still use the SSL
   read path
+- current `relay-recvmmsg` builds log `udp-recvmmsg stats` every 10 seconds
+  while the flag is active; use those lines to check batch occupancy per relay
+  thread
 
 Never paste DigitalOcean tokens into logs or files. Use a local environment
 variable such as `DIGITALOCEAN_TOKEN`, and revoke temporary tokens after the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,12 @@ known setup used Ubuntu 24.04 `c-4` droplets in `nyc1`:
 
 - turnserver droplet private IP: `10.116.0.2`
 - loadgen droplet private IP: `10.116.0.3`
+- current public IPs: turnserver `157.230.3.102`, loadgen `167.99.153.216`
 - build: current branch archived with `git archive`
-- important baseline: turnserver was **not** run with `--udp-recvmmsg`
+- important baseline: turnserver is not run with `--udp-recvmmsg`
+- `--udp-recvmmsg` is opt-in and covers both UDP listener receive and plain
+  connected relay UDP receive on Linux; DTLS session sockets still use the SSL
+  read path
 
 Never paste DigitalOcean tokens into logs or files. Use a local environment
 variable such as `DIGITALOCEAN_TOKEN`, and revoke temporary tokens after the
@@ -173,7 +177,8 @@ cmake --build /root/coturn/build --target turnserver turnutils_uclient turnutils
 ```
 
 Start `turnserver` on the server droplet. This is the baseline command used for
-the final run; add `--udp-recvmmsg` only when intentionally comparing that mode:
+the final run; add `--udp-recvmmsg` only when intentionally comparing batched
+Linux UDP receive:
 
 ```bash
 pkill -x turnserver || true
@@ -253,6 +258,11 @@ for m in 1 2 4 8 16 32; do
 done
 ```
 
+For higher `-m` values, the load generator can finish its default work before
+the timeout. Add `-n 1000` when you want a longer many-connection run, and if
+the final log line omits `tot_recv_msgs`, derive receive count from
+`tot_recv_bytes / message_length`.
+
 Monitored packet run:
 
 ```bash
@@ -270,13 +280,14 @@ timeout -s INT 12s /root/coturn/build/bin/turnutils_uclient \
 Packet-only CPU profile, useful when checking the relay bottleneck. Build with
 `-DCMAKE_BUILD_TYPE=RelWithDebInfo` if you want readable user-space symbols.
 Run once without `--udp-recvmmsg`, then restart `turnserver` with
-`--udp-recvmmsg` and rerun the same commands with the `recvmmsg` label:
+`--udp-recvmmsg` and rerun the same commands with labels such as
+`recvmmsg_off` and `recvmmsg_on`:
 
 ```bash
 # on turnserver
 sysctl -w kernel.perf_event_paranoid=-1 kernel.kptr_restrict=0 || true
 pid=$(cat /root/turnserver.pid)
-label=no_recvmmsg
+label=recvmmsg_off
 
 (pidstat -h -u -r -p "$pid" 1 14 > /root/${label}_pidstat.txt & \
   mpstat 1 14 > /root/${label}_mpstat.txt & \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,9 +147,8 @@ known setup used Ubuntu 24.04 `c-4` droplets in `nyc1`:
 - `--udp-recvmmsg` is opt-in and covers both UDP listener receive and plain
   connected relay UDP receive on Linux; DTLS session sockets still use the SSL
   read path
-- current `relay-recvmmsg` builds log `udp-recvmmsg stats` every 10 seconds
-  while the flag is active; use those lines to check batch occupancy per relay
-  thread
+- add `--udp-recvmmsg-log` with `--udp-recvmmsg` to log `udp-recvmmsg stats`
+  every 10 seconds; use those lines to check batch occupancy per relay thread
 
 Never paste DigitalOcean tokens into logs or files. Use a local environment
 variable such as `DIGITALOCEAN_TOKEN`, and revoke temporary tokens after the

--- a/README.turnserver
+++ b/README.turnserver
@@ -300,7 +300,9 @@ Flags:
 
 --drop-invalid-packets-log	Log invalid packets. The default behaviour is to not log invalid packets.
 
---udp-recvmmsg		Enable Linux-only batched UDP receive via recvmmsg() on listener sockets.
+--udp-recvmmsg		Enable Linux-only batched UDP receive via recvmmsg() on UDP sockets.
+
+--udp-recvmmsg-log	Log Linux recvmmsg batch occupancy stats every 10 seconds.
 
 --respond-http-unsupported	Return an HTTP response with a 400 status code to HTTP
 			connections made to ports not supporting HTTP. The default
@@ -1066,4 +1068,3 @@ https://groups.google.com/forum/?fromgroups=#!forum/turn-server-project-rfc5766-
   AUTHORS
 
 	See the AUTHORS.md file in the coturn source distribution.
-

--- a/docs/PerformanceIterationLog.md
+++ b/docs/PerformanceIterationLog.md
@@ -30,13 +30,21 @@ Current `relay-recvmmsg` follow-up:
 | 8 | `d48686b7` | Reduce relay per-socket `recvmmsg` state from 16 x 64 KiB cmsg buffers to TTL/TOS-sized buffers, avoid an extra would-block fallback `recvmsg`, and clean up all preallocated buffers after partial batches |
 | 9 | `ad81705e` | Add per-engine `recvmmsg` occupancy counters and 10 s log summaries (`calls`, `packets`, `avg_batch`, `wouldblock`, `unavailable`, `no_buffer`, batch-size histogram) |
 | 10 | `388b15d4` | Move connected relay UDP `recvmmsg` scratch from per-socket state to per-engine/per-thread state |
+| 11 | `4c4fd67e` | Make the occupancy summaries opt-in behind `--udp-recvmmsg-log`, so `--udp-recvmmsg` can ship without periodic stats logs |
 
-Validation after #7-#10:
+Validation after #7-#11:
 
 - Local `cmake -S . -B build -DBUILD_TESTING=ON` passed.
 - Local `cmake --build build --parallel 8` passed.
 - Local `ctest --test-dir build --output-on-failure` passed 3/3.
+- Local `build/bin/turnserver --udp-recvmmsg --udp-recvmmsg-log --version`
+  parsed both flags and printed `4.11.0`.
 - Linux Docker `turnserver` build passed after #7, after #8, and after #10.
+
+Shipping cleanup learning: keep the occupancy counters in place because they
+are low overhead and useful for DigitalOcean diagnostics, but keep the periodic
+summaries off by default. Use `--udp-recvmmsg-log` only during measured runs
+where the log stream is part of the observation.
 
 DigitalOcean check on 2026-05-09:
 

--- a/docs/PerformanceIterationLog.md
+++ b/docs/PerformanceIterationLog.md
@@ -28,13 +28,15 @@ Current `relay-recvmmsg` follow-up:
 | 6 | `54c589d0` / `4b1a8d71` | Initial Linux `recvmmsg` batching for UDP listener and connected relay sockets |
 | 7 | `8d9a7292` | Share the existing `--udp-recvmmsg` flag across listener and relay UDP paths; remove separate relay flag; use the shared ancillary-data parser in `dtls_listener` |
 | 8 | `d48686b7` | Reduce relay per-socket `recvmmsg` state from 16 x 64 KiB cmsg buffers to TTL/TOS-sized buffers, avoid an extra would-block fallback `recvmsg`, and clean up all preallocated buffers after partial batches |
+| 9 | `ad81705e` | Add per-engine `recvmmsg` occupancy counters and 10 s log summaries (`calls`, `packets`, `avg_batch`, `wouldblock`, `unavailable`, `no_buffer`, batch-size histogram) |
+| 10 | `388b15d4` | Move connected relay UDP `recvmmsg` scratch from per-socket state to per-engine/per-thread state |
 
-Validation after #7/#8:
+Validation after #7-#10:
 
 - Local `cmake -S . -B build -DBUILD_TESTING=ON` passed.
 - Local `cmake --build build --parallel 8` passed.
 - Local `ctest --test-dir build --output-on-failure` passed 3/3.
-- Linux Docker `turnserver` build passed after #7 and again after #8.
+- Linux Docker `turnserver` build passed after #7, after #8, and after #10.
 
 DigitalOcean check on 2026-05-09:
 
@@ -67,6 +69,41 @@ clear throughput win. Keep `--udp-recvmmsg` opt-in for now. The next useful
 step is to instrument actual batch occupancy on connected relay sockets; if
 most readiness events return one datagram, `recvmmsg` will mostly add setup
 work without reducing syscalls.
+
+DigitalOcean occupancy check on 2026-05-09:
+
+- Built fresh current artifacts from `388b15d4` on both droplets under
+  `/root/coturn_recvmmsg_current`.
+- Same-binary `--udp-recvmmsg` off/on, `-Y packet -m 1 -l 120`, 3 alternating
+  30 s rounds each:
+  - off mean 153,133, median 153,608, stdev 4,383
+  - on mean 148,452, median 149,711, stdev 10,833
+  - on was -3.1 % by mean and -2.5 % by median
+- `m=1` occupancy from the on runs: 1,129,427 `recvmmsg` calls returned
+  17,660,300 packets, average batch 15.64. Histogram buckets:
+  `hist_1=1,353`, `hist_2=1,496`, `hist_3_4=3,707`,
+  `hist_5_8=14,817`, `hist_9_16=1,108,057`; 98.1 % of calls were in the
+  `9..16` bucket.
+- Same-binary `--udp-recvmmsg` off/on, `-Y packet -m 100 -l 120`, 3 alternating
+  runs each:
+  - off mean 55,443, median 50,679, stdev 8,369
+  - on mean 60,596, median 65,404, stdev 8,383
+  - on was +9.3 % by mean and +29.1 % by median, but the client again landed
+    in two send-volume buckets, so treat the throughput delta as noisy.
+- `m=100` occupancy from the on runs across all relay threads: 1,426,401
+  `recvmmsg` calls returned 16,188,946 packets, average batch 11.35.
+  Histogram buckets: `hist_1=83,057`, `hist_2=79,781`,
+  `hist_3_4=130,066`, `hist_5_8=188,259`, `hist_9_16=945,238`; 66.3 %
+  of calls were in the `9..16` bucket.
+
+Learning: receive-side occupancy is high. The earlier hypothesis that
+`recvmmsg` was mostly returning one packet is wrong for this harness. The
+remaining bottleneck is after receive: per-packet callbacks, TURN processing,
+and especially one `sendto` per relayed packet. The per-thread scratch change
+is still worth keeping for memory/cache behavior with thousands of sockets,
+but the next performance lever should be send-side batching or a design that
+passes batches deeper instead of immediately decomposing them back into
+single-packet callbacks.
 
 Alternating A/B run on the same droplet pair, m=1 packet flood, 30 s
 per run, with a 4 s warm-up between binary swaps:
@@ -237,19 +274,20 @@ defensible and matches the iter 4/5 inlining direction.
 
 Ordered by expected impact for the m=1 packet-flood metric:
 
-1. **Instrument connected-socket `recvmmsg` batch occupancy.** The code now
-   batches plain connected UDP sockets, but the droplet measurements suggest
-   most readiness events may still have only one datagram available. Add cheap
-   counters for `recvmmsg` call count, returned-message histogram, would-block
-   count, and fallback count. Measure `m=1`, `m=100`, and real-world allocation
-   churn before changing defaults.
+1. **Batch the send side (`sendmmsg`) or pass receive batches deeper.** The
+   occupancy counters show receive batching is already working: `m=1` averaged
+   15.6 packets per call and `m=100` averaged 11.4. The code immediately
+   invokes the existing per-packet callback for each received datagram, and
+   each forwarded packet still pays a separate send syscall. The next
+   measurable lever is to queue per-thread outbound datagrams during a receive
+   batch and flush them with `sendmmsg`, or introduce a batch-aware callback
+   path for the hot UDP relay case.
 
-2. **`sendmmsg` batched send.** Each successful packet fires one
-   `sendto`. After (1) lands, when the receive loop hands a batch of
-   N packets to the dispatch layer in one go, the corresponding sends
-   could be coalesced into one `sendmmsg`. Requires a lightweight
-   per-thread send queue and a flush at the end of each event-loop
-   tick. Bigger refactor; expect another ~10 % if (1) lands.
+2. **Keep `recvmmsg` occupancy counters available while developing send
+   batching.** They are cheap enough for targeted performance builds and make
+   it obvious whether a benchmark is exercising one relay thread or all relay
+   threads. Consider hiding periodic logs behind a verbose/debug option before
+   shipping broadly.
 
 3. **GSO (`UDP_SEGMENT`)** on the send path. Linux can take one
    "large" datagram and segment it in the kernel for back-to-back

--- a/docs/PerformanceIterationLog.md
+++ b/docs/PerformanceIterationLog.md
@@ -21,6 +21,53 @@ Five commits on `claude/beautiful-black-c3b741` between `727ec2ab`
 | 4 | `a6f6767f` | Inline `get_ioa_addr_len()` via `ns_turn_ioaddr.h` |
 | 5 | `321a2d18` | Inline `addr_cpy()` via `ns_turn_ioaddr.h` |
 
+Current `relay-recvmmsg` follow-up:
+
+| # | Commit | Optimization |
+|---|---|---|
+| 6 | `54c589d0` / `4b1a8d71` | Initial Linux `recvmmsg` batching for UDP listener and connected relay sockets |
+| 7 | `8d9a7292` | Share the existing `--udp-recvmmsg` flag across listener and relay UDP paths; remove separate relay flag; use the shared ancillary-data parser in `dtls_listener` |
+| 8 | `d48686b7` | Reduce relay per-socket `recvmmsg` state from 16 x 64 KiB cmsg buffers to TTL/TOS-sized buffers, avoid an extra would-block fallback `recvmsg`, and clean up all preallocated buffers after partial batches |
+
+Validation after #7/#8:
+
+- Local `cmake -S . -B build -DBUILD_TESTING=ON` passed.
+- Local `cmake --build build --parallel 8` passed.
+- Local `ctest --test-dir build --output-on-failure` passed 3/3.
+- Linux Docker `turnserver` build passed after #7 and again after #8.
+
+DigitalOcean check on 2026-05-09:
+
+- Reused the existing `c-4` droplets in `nyc1`: turnserver public
+  `157.230.3.102`, private `10.116.0.2`; loadgen public `167.99.153.216`,
+  private `10.116.0.3`. Droplets were left running between steps.
+- Built fresh current artifacts from `d48686b7` on both droplets under
+  `/root/coturn_recvmmsg_current`.
+- Same-binary `--udp-recvmmsg` off/on, `-Y packet -m 1 -l 120`, 5 alternating
+  30 s rounds each:
+  - off mean 154,527, median 154,596, stdev 3,467
+  - on mean 149,994, median 153,011, stdev 7,174
+  - on was -2.9 % by mean and -1.0 % by median
+- Same-binary `--udp-recvmmsg` off/on, `-Y packet -m 100 -l 120`, 5 alternating
+  rounds each. The client completed before the 30 s timeout and landed in two
+  send-volume buckets, so treat this as a coarse many-connection signal:
+  - off mean 59,432, median 65,071, stdev 7,952
+  - on mean 59,640, median 65,421, stdev 7,963
+  - on was +0.3 % by mean and +0.5 % by median
+- Follow-up `m=100 -n 1000` run, 3 alternating rounds each, derived receive
+  count from `tot_recv_bytes / 120` because this log format omits
+  `tot_recv_msgs`:
+  - off mean 8,540, median 8,990, stdev 1,004
+  - on mean 8,857, median 8,749, stdev 759
+  - on was +3.7 % by mean and -2.7 % by median
+
+Learning: the corrected relay `recvmmsg` implementation is now buildable and
+much safer for many connections, but these droplet runs still do not show a
+clear throughput win. Keep `--udp-recvmmsg` opt-in for now. The next useful
+step is to instrument actual batch occupancy on connected relay sockets; if
+most readiness events return one datagram, `recvmmsg` will mostly add setup
+work without reducing syscalls.
+
 Alternating A/B run on the same droplet pair, m=1 packet flood, 30 s
 per run, with a 4 s warm-up between binary swaps:
 
@@ -33,7 +80,13 @@ The cumulative effect is what's visible.
 
 ## Test setup that was used
 
-Two `c-4` Ubuntu 24.04 droplets in `nyc1`, same VPC `default-nyc1`:
+Two `c-4` Ubuntu 24.04 droplets in `nyc1`, same VPC `default-nyc1`.
+Current active pair:
+
+- `coturn-turnserver` — public `157.230.3.102`, private `10.116.0.2`
+- `coturn-loadgen`    — public `167.99.153.216`, private `10.116.0.3`
+
+Older pair used for the iter 5 cumulative run:
 
 - `coturn-turnserver` — public `68.183.121.197`, private `10.116.0.2`
 - `coturn-loadgen`    — public `68.183.132.220`, private `10.116.0.3`
@@ -62,8 +115,9 @@ A small env file was written to `/tmp/coturn_perf_env.sh` on the local
 machine with the IPs / droplet IDs — recreate it from the current
 state of the DO account if it gets lost.
 
-The standard packet-flood command (matches CLAUDE.md baseline, runs
-*without* `--udp-recvmmsg`):
+The standard packet-flood command (matches CLAUDE.md baseline, runs without
+`--udp-recvmmsg`; add `--udp-recvmmsg` to `turnserver`, not the client, for the
+batched listener/relay receive path):
 
 ```bash
 timeout -s INT 30s /root/coturn/build/bin/turnutils_uclient \
@@ -119,25 +173,19 @@ That ~23 % syscall overhead is the next big lever. Halving it
 
 ## What didn't work
 
-### Default `--udp-recvmmsg=true` on Linux (tried in iter 1, reverted)
+### Default `--udp-recvmmsg=true` on Linux (tried in iter 1, kept opt-in)
 
-The flag exists and is wired to `receive_udp_batch_recvmmsg` in
-[dtls_listener.c](../src/apps/relay/dtls_listener.c), but **only on
-the listener socket** — the unconnected `udp_listen_s` that handles
-the *first* packet from a new client. Once `dtls_listener` calls
-`create_new_connected_udp_socket` (line ~583), subsequent
-client→relay traffic on that 5-tuple goes through a per-session
-*connected* UDP socket whose libevent callback is
-`socket_input_handler` → `socket_input_worker` →
-`udp_recvfrom` (single `recvmsg`). Same on the peer→relay direction.
+The flag now covers both the unconnected listener socket in
+[dtls_listener.c](../src/apps/relay/dtls_listener.c) and connected plain-UDP
+relay sockets in
+[ns_ioalib_engine_impl.c](../src/apps/relay/ns_ioalib_engine_impl.c). DTLS
+session sockets remain on the SSL read path and are not batched by the relay
+socket helper.
 
-In a steady-state packet flood with one client, almost zero packets
-hit the listener path, so flipping the default does nothing for this
-test. It would help a many-client / many-allocate workload, but
-that's not what the m=1 harness measures.
-
-Throughput parity confirmed across multiple A/B rounds; reverted to
-keep the baseline mental model in CLAUDE.md intact.
+Throughput parity or slight negative results were confirmed across multiple
+A/B rounds on `m=1` and `m=100`; keep this opt-in until batch occupancy
+instrumentation proves that real deployments commonly receive multiple queued
+datagrams per connected socket readiness event.
 
 ### Caching `get_relay_socket_ss` (iter 3) — no measurable wall-clock win
 
@@ -189,20 +237,12 @@ defensible and matches the iter 4/5 inlining direction.
 
 Ordered by expected impact for the m=1 packet-flood metric:
 
-1. **Extend `recvmmsg` into `socket_input_worker`** for plain UDP
-   non-DTLS sockets. The existing `try_again` loop in
-   [ns_ioalib_engine_impl.c:2683](../src/apps/relay/ns_ioalib_engine_impl.c#L2683)
-   already drains up to `MAX_TRIES = 16` packets per epoll wakeup via
-   16 single `recvmsg` calls. Replacing the inner read with a
-   `recvmmsg` of up to 16 messages saves ~15 syscalls per drain
-   iteration. At ~14 % `udp_recvmsg` kernel + ~6 % syscall machinery
-   on the recv side, plausible 8–12 % throughput. Risk: the function
-   is heavily branched (TCP / TLS / DTLS / UDP all share the body)
-   and state can change mid-loop (`s->tobeclosed` etc.); the cleanest
-   shape is a separate UDP-only helper called from
-   `socket_input_handler` *before* falling through to the existing
-   `socket_input_worker`, gated on `s->ssl == NULL && s->bev == NULL
-   && !s->parent_s`. **This is the highest-value remaining item.**
+1. **Instrument connected-socket `recvmmsg` batch occupancy.** The code now
+   batches plain connected UDP sockets, but the droplet measurements suggest
+   most readiness events may still have only one datagram available. Add cheap
+   counters for `recvmmsg` call count, returned-message histogram, would-block
+   count, and fallback count. Measure `m=1`, `m=100`, and real-world allocation
+   churn before changing defaults.
 
 2. **`sendmmsg` batched send.** Each successful packet fires one
    `sendto`. After (1) lands, when the receive loop hands a batch of
@@ -228,10 +268,9 @@ Ordered by expected impact for the m=1 packet-flood metric:
    body inline doesn't break ABI but does require a recompile of all
    consumers. Likely <1 % each but cheap to do.
 
-5. **Re-evaluate `--udp-recvmmsg` default after (1) lands.** Once
-   per-session sockets also batch, the listener path is no longer a
-   special case and turning it on by default becomes a free win for
-   multi-tenant servers without hurting m=1.
+5. **Re-evaluate `--udp-recvmmsg` default after instrumentation.** The current
+   measurements do not justify default-on. Revisit only if production-like
+   traces show frequent batch sizes above one and no latency/memory downside.
 
 ## Things investigated and ruled out (don't redo)
 

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -68,7 +68,7 @@ typedef uint16_t in_port_t;
 
 #define COOKIE_SECRET_LENGTH (32)
 
-#define MAX_SINGLE_UDP_BATCH (16)
+#define MAX_SINGLE_UDP_BATCH IOA_UDP_RECVMMSG_MAX_BATCH
 #define MAX_RECVMMSG_BATCH MAX_SINGLE_UDP_BATCH
 
 #if defined(__linux__) && defined(CMSG_SPACE)
@@ -670,6 +670,7 @@ static int receive_udp_batch_recvmmsg(dtls_listener_relay_server_type *server, e
     if (!state->elems[i]) {
       state->elems[i] = ioa_network_buffer_allocate(server->e);
       if (!state->elems[i]) {
+        ioa_engine_record_udp_recvmmsg_no_buffer(server->e);
         break;
       }
     }
@@ -690,8 +691,13 @@ static int receive_udp_batch_recvmmsg(dtls_listener_relay_server_type *server, e
 
   const int rc = recvmmsg(fd, state->msgs, i, MSG_DONTWAIT, NULL);
   if (rc <= 0) {
+    if (rc == 0 || would_block()) {
+      ioa_engine_record_udp_recvmmsg_wouldblock(server->e);
+    }
     return rc;
   }
+
+  ioa_engine_record_udp_recvmmsg_batch(server->e, rc);
 
   for (int j = 0; j < rc; ++j) {
     ioa_network_buffer_set_size(state->elems[j], state->msgs[j].msg_len);
@@ -877,6 +883,7 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
       if (errno == ENOSYS || errno == EINVAL || errno == EOPNOTSUPP) {
         TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
                       "%s: recvmmsg() is unavailable on this system, disabling udp-recvmmsg fast path\n", __FUNCTION__);
+        ioa_engine_record_udp_recvmmsg_unavailable(server->e);
         turn_params.udp_recvmmsg = false;
       } else if (would_block()) {
         prom_inc_packet_dropped(packets_dropped);

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -627,63 +627,6 @@ static udp_packet_classification_t classify_udp_packet(const uint8_t *data, size
   return UDP_PACKET_CLASS_INVALID;
 }
 #if defined(__linux__)
-typedef unsigned char listener_recv_ttl_t;
-typedef unsigned char listener_recv_tos_t;
-
-static void parse_udp_cmsg(struct msghdr *msg, int *ttl, int *tos) {
-  listener_recv_ttl_t recv_ttl = TTL_DEFAULT;
-  listener_recv_tos_t recv_tos = TOS_DEFAULT;
-  struct cmsghdr *cmsgh = NULL;
-
-  for (cmsgh = CMSG_FIRSTHDR(msg); cmsgh != NULL; cmsgh = CMSG_NXTHDR(msg, cmsgh)) {
-    const int l = cmsgh->cmsg_level;
-    const int t = cmsgh->cmsg_type;
-
-    switch (l) {
-    case IPPROTO_IP:
-      switch (t) {
-#if defined(IP_RECVTTL) && !defined(__sparc_v9__)
-      case IP_RECVTTL:
-      case IP_TTL:
-        recv_ttl = *((listener_recv_ttl_t *)CMSG_DATA(cmsgh));
-        break;
-#endif
-#if defined(IP_RECVTOS)
-      case IP_RECVTOS:
-      case IP_TOS:
-        recv_tos = *((listener_recv_tos_t *)CMSG_DATA(cmsgh));
-        break;
-#endif
-      default:;
-      };
-      break;
-    case IPPROTO_IPV6:
-      switch (t) {
-#if defined(IPV6_RECVHOPLIMIT) && !defined(__sparc_v9__)
-      case IPV6_RECVHOPLIMIT:
-      case IPV6_HOPLIMIT:
-        recv_ttl = *((listener_recv_ttl_t *)CMSG_DATA(cmsgh));
-        break;
-#endif
-#if defined(IPV6_RECVTCLASS)
-      case IPV6_RECVTCLASS:
-      case IPV6_TCLASS:
-        recv_tos = *((listener_recv_tos_t *)CMSG_DATA(cmsgh));
-        break;
-#endif
-      default:;
-      };
-      break;
-    default:;
-    };
-  }
-
-  *ttl = recv_ttl;
-  CORRECT_RAW_TTL(*ttl);
-  *tos = recv_tos;
-  CORRECT_RAW_TOS(*tos);
-}
-
 static int ensure_recvmmsg_state(dtls_listener_relay_server_type *server) {
   if (!server) {
     return -1;
@@ -701,11 +644,9 @@ static int ensure_recvmmsg_state(dtls_listener_relay_server_type *server) {
   }
 
   for (unsigned int i = 0; i < MAX_RECVMMSG_BATCH; ++i) {
-    server->recvmmsg_state->msgs[i].msg_hdr.msg_name = &(server->recvmmsg_state->src_addrs[i]);
-    server->recvmmsg_state->msgs[i].msg_hdr.msg_namelen = (socklen_t)server->slen0;
-    server->recvmmsg_state->msgs[i].msg_hdr.msg_iov = &(server->recvmmsg_state->iovecs[i]);
-    server->recvmmsg_state->msgs[i].msg_hdr.msg_iovlen = 1;
-    server->recvmmsg_state->msgs[i].msg_hdr.msg_control = server->recvmmsg_state->cmsgs[i];
+    ioa_init_recvmmsg_hdr(&(server->recvmmsg_state->msgs[i]), &(server->recvmmsg_state->iovecs[i]),
+                          &(server->recvmmsg_state->src_addrs[i]), server->recvmmsg_state->cmsgs[i],
+                          (socklen_t)server->slen0, NULL, 0);
     server->recvmmsg_state->msgs[i].msg_hdr.msg_controllen = RECVMMSG_CMSG_SZ;
     server->recvmmsg_state->elems[i] = ioa_network_buffer_allocate(server->e);
     if (!server->recvmmsg_state->elems[i]) {
@@ -739,11 +680,10 @@ static int receive_udp_batch_recvmmsg(dtls_listener_relay_server_type *server, e
     state->ttls[i] = TTL_IGNORE;
     state->toss[i] = TOS_IGNORE;
     state->packet_types[i] = UDP_PACKET_CLASS_INVALID;
-    state->iovecs[i].iov_base = ioa_network_buffer_data(state->elems[i]);
-    state->iovecs[i].iov_len = ioa_network_buffer_get_capacity_udp();
-    state->msgs[i].msg_hdr.msg_namelen = (socklen_t)server->slen0;
+    ioa_init_recvmmsg_hdr(&(state->msgs[i]), &(state->iovecs[i]), &(state->src_addrs[i]), state->cmsgs[i],
+                          (socklen_t)server->slen0, ioa_network_buffer_data(state->elems[i]),
+                          ioa_network_buffer_get_capacity_udp());
     state->msgs[i].msg_hdr.msg_controllen = RECVMMSG_CMSG_SZ;
-    state->msgs[i].msg_len = 0;
   }
 
   if (i == 0) {

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -96,6 +96,7 @@ typedef uint16_t in_port_t;
 #define RECVMMSG_IPV6_CMSG_SZ (RECVMMSG_IPV6_TTL_CMSG_SZ + RECVMMSG_IPV6_TOS_CMSG_SZ)
 #define RECVMMSG_CMSG_SZ                                                                                               \
   ((RECVMMSG_IPV4_CMSG_SZ > RECVMMSG_IPV6_CMSG_SZ) ? RECVMMSG_IPV4_CMSG_SZ : RECVMMSG_IPV6_CMSG_SZ)
+#define RECVMMSG_CMSG_ALLOC_SZ ((RECVMMSG_CMSG_SZ) > 0 ? (RECVMMSG_CMSG_SZ) : 1)
 #endif
 
 #if !defined(WINDOWS)
@@ -133,7 +134,7 @@ struct dtls_listener_relay_server_info {
 struct dtls_listener_recvmmsg_state {
   struct mmsghdr msgs[MAX_RECVMMSG_BATCH];
   struct iovec iovecs[MAX_RECVMMSG_BATCH];
-  char cmsgs[MAX_RECVMMSG_BATCH][RECVMMSG_CMSG_SZ];
+  char cmsgs[MAX_RECVMMSG_BATCH][RECVMMSG_CMSG_ALLOC_SZ];
   ioa_addr src_addrs[MAX_RECVMMSG_BATCH];
   int ttls[MAX_RECVMMSG_BATCH];
   int toss[MAX_RECVMMSG_BATCH];
@@ -625,7 +626,6 @@ static udp_packet_classification_t classify_udp_packet(const uint8_t *data, size
 
   return UDP_PACKET_CLASS_INVALID;
 }
-
 #if defined(__linux__)
 typedef unsigned char listener_recv_ttl_t;
 typedef unsigned char listener_recv_tos_t;

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -697,7 +697,7 @@ static int receive_udp_batch_recvmmsg(dtls_listener_relay_server_type *server, e
 
   for (int j = 0; j < rc; ++j) {
     ioa_network_buffer_set_size(state->elems[j], state->msgs[j].msg_len);
-    parse_udp_cmsg(&(state->msgs[j].msg_hdr), &(state->ttls[j]), &(state->toss[j]));
+    ioa_parse_udp_recvmsg_cmsg(&(state->msgs[j].msg_hdr), &(state->ttls[j]), &(state->toss[j]), NULL);
     state->packet_types[j] =
         classify_udp_packet(ioa_network_buffer_data(state->elems[j]), ioa_network_buffer_get_size(state->elems[j]));
   }

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -645,9 +645,8 @@ static int ensure_recvmmsg_state(dtls_listener_relay_server_type *server) {
 
   for (unsigned int i = 0; i < MAX_RECVMMSG_BATCH; ++i) {
     ioa_init_recvmmsg_hdr(&(server->recvmmsg_state->msgs[i]), &(server->recvmmsg_state->iovecs[i]),
-                          &(server->recvmmsg_state->src_addrs[i]), server->recvmmsg_state->cmsgs[i],
+                          &(server->recvmmsg_state->src_addrs[i]), server->recvmmsg_state->cmsgs[i], RECVMMSG_CMSG_SZ,
                           (socklen_t)server->slen0, NULL, 0);
-    server->recvmmsg_state->msgs[i].msg_hdr.msg_controllen = RECVMMSG_CMSG_SZ;
     server->recvmmsg_state->elems[i] = ioa_network_buffer_allocate(server->e);
     if (!server->recvmmsg_state->elems[i]) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate recvmmsg batch buffer\n", __FUNCTION__);
@@ -681,9 +680,8 @@ static int receive_udp_batch_recvmmsg(dtls_listener_relay_server_type *server, e
     state->toss[i] = TOS_IGNORE;
     state->packet_types[i] = UDP_PACKET_CLASS_INVALID;
     ioa_init_recvmmsg_hdr(&(state->msgs[i]), &(state->iovecs[i]), &(state->src_addrs[i]), state->cmsgs[i],
-                          (socklen_t)server->slen0, ioa_network_buffer_data(state->elems[i]),
+                          RECVMMSG_CMSG_SZ, (socklen_t)server->slen0, ioa_network_buffer_data(state->elems[i]),
                           ioa_network_buffer_get_capacity_udp());
-    state->msgs[i].msg_hdr.msg_controllen = RECVMMSG_CMSG_SZ;
   }
 
   if (i == 0) {

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -241,6 +241,7 @@ turn_params_t turn_params = {
     true,  /* drop_invalid_packets */
     false, /* drop_invalid_packets_log */
     false, /* udp_recvmmsg */
+    false, /* udp_relay_recvmmsg */
     false  /* include_reason_string */
 };
 
@@ -1363,6 +1364,7 @@ static char Usage[] =
     "invalid packets.\n"
     " --udp-recvmmsg				   Enable Linux-only batched UDP receive via recvmmsg() on listener "
     "sockets.\n"
+    " --udp-relay-recvmmsg			   Enable Linux-only batched UDP receive via recvmmsg() for relay UDP sockets.\n"
     " --include-reason-string			   Include descriptive reason strings in STUN/TURN error responses.\n"
     "						   By default, only the standard reason phrase for the error code is\n"
     "						   sent. Enabling this option adds detailed error descriptions which\n"
@@ -1529,6 +1531,7 @@ enum EXTRA_OPTS {
   DROP_INVALID_PACKETS_OPT,
   DROP_INVALID_PACKETS_LOG_OPT,
   UDP_RECVMMSG_OPT,
+  UDP_RELAY_RECVMMSG_OPT,
   VERSION_OPT,
   CPUS_OPT,
   INCLUDE_REASON_STRING_OPT
@@ -1679,6 +1682,7 @@ static const struct myoption long_options[] = {
     {"drop-invalid-packets", optional_argument, NULL, DROP_INVALID_PACKETS_OPT},
     {"drop-invalid-packets-log", optional_argument, NULL, DROP_INVALID_PACKETS_LOG_OPT},
     {"udp-recvmmsg", optional_argument, NULL, UDP_RECVMMSG_OPT},
+    {"udp-relay-recvmmsg", optional_argument, NULL, UDP_RELAY_RECVMMSG_OPT},
     {"include-reason-string", optional_argument, NULL, INCLUDE_REASON_STRING_OPT},
     {"version", optional_argument, NULL, VERSION_OPT},
     {"syslog-facility", required_argument, NULL, SYSLOG_FACILITY_OPT},
@@ -2476,6 +2480,9 @@ static void set_option(int c, char *value) {
     break;
   case UDP_RECVMMSG_OPT:
     turn_params.udp_recvmmsg = get_bool_value(value);
+    break;
+  case UDP_RELAY_RECVMMSG_OPT:
+    turn_params.udp_relay_recvmmsg = get_bool_value(value);
     break;
   case INCLUDE_REASON_STRING_OPT:
     turn_params.include_reason_string = get_bool_value(value);

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -241,7 +241,6 @@ turn_params_t turn_params = {
     true,  /* drop_invalid_packets */
     false, /* drop_invalid_packets_log */
     false, /* udp_recvmmsg */
-    false, /* udp_relay_recvmmsg */
     false  /* include_reason_string */
 };
 
@@ -1362,9 +1361,8 @@ static char Usage[] =
     "packets.\n"
     " --drop-invalid-packets-log			   Log invalid packets. The default behaviour is to not log "
     "invalid packets.\n"
-    " --udp-recvmmsg				   Enable Linux-only batched UDP receive via recvmmsg() on listener "
+    " --udp-recvmmsg				   Enable Linux-only batched UDP receive via recvmmsg() on UDP "
     "sockets.\n"
-    " --udp-relay-recvmmsg			   Enable Linux-only batched UDP receive via recvmmsg() for relay UDP sockets.\n"
     " --include-reason-string			   Include descriptive reason strings in STUN/TURN error responses.\n"
     "						   By default, only the standard reason phrase for the error code is\n"
     "						   sent. Enabling this option adds detailed error descriptions which\n"
@@ -1531,7 +1529,6 @@ enum EXTRA_OPTS {
   DROP_INVALID_PACKETS_OPT,
   DROP_INVALID_PACKETS_LOG_OPT,
   UDP_RECVMMSG_OPT,
-  UDP_RELAY_RECVMMSG_OPT,
   VERSION_OPT,
   CPUS_OPT,
   INCLUDE_REASON_STRING_OPT
@@ -1682,7 +1679,6 @@ static const struct myoption long_options[] = {
     {"drop-invalid-packets", optional_argument, NULL, DROP_INVALID_PACKETS_OPT},
     {"drop-invalid-packets-log", optional_argument, NULL, DROP_INVALID_PACKETS_LOG_OPT},
     {"udp-recvmmsg", optional_argument, NULL, UDP_RECVMMSG_OPT},
-    {"udp-relay-recvmmsg", optional_argument, NULL, UDP_RELAY_RECVMMSG_OPT},
     {"include-reason-string", optional_argument, NULL, INCLUDE_REASON_STRING_OPT},
     {"version", optional_argument, NULL, VERSION_OPT},
     {"syslog-facility", required_argument, NULL, SYSLOG_FACILITY_OPT},
@@ -2480,9 +2476,6 @@ static void set_option(int c, char *value) {
     break;
   case UDP_RECVMMSG_OPT:
     turn_params.udp_recvmmsg = get_bool_value(value);
-    break;
-  case UDP_RELAY_RECVMMSG_OPT:
-    turn_params.udp_relay_recvmmsg = get_bool_value(value);
     break;
   case INCLUDE_REASON_STRING_OPT:
     turn_params.include_reason_string = get_bool_value(value);

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -241,6 +241,7 @@ turn_params_t turn_params = {
     true,  /* drop_invalid_packets */
     false, /* drop_invalid_packets_log */
     false, /* udp_recvmmsg */
+    false, /* udp_recvmmsg_log */
     false  /* include_reason_string */
 };
 
@@ -1363,6 +1364,7 @@ static char Usage[] =
     "invalid packets.\n"
     " --udp-recvmmsg				   Enable Linux-only batched UDP receive via recvmmsg() on UDP "
     "sockets.\n"
+    " --udp-recvmmsg-log			   Log Linux recvmmsg batch occupancy stats every 10 seconds.\n"
     " --include-reason-string			   Include descriptive reason strings in STUN/TURN error responses.\n"
     "						   By default, only the standard reason phrase for the error code is\n"
     "						   sent. Enabling this option adds detailed error descriptions which\n"
@@ -1529,6 +1531,7 @@ enum EXTRA_OPTS {
   DROP_INVALID_PACKETS_OPT,
   DROP_INVALID_PACKETS_LOG_OPT,
   UDP_RECVMMSG_OPT,
+  UDP_RECVMMSG_LOG_OPT,
   VERSION_OPT,
   CPUS_OPT,
   INCLUDE_REASON_STRING_OPT
@@ -1679,6 +1682,7 @@ static const struct myoption long_options[] = {
     {"drop-invalid-packets", optional_argument, NULL, DROP_INVALID_PACKETS_OPT},
     {"drop-invalid-packets-log", optional_argument, NULL, DROP_INVALID_PACKETS_LOG_OPT},
     {"udp-recvmmsg", optional_argument, NULL, UDP_RECVMMSG_OPT},
+    {"udp-recvmmsg-log", optional_argument, NULL, UDP_RECVMMSG_LOG_OPT},
     {"include-reason-string", optional_argument, NULL, INCLUDE_REASON_STRING_OPT},
     {"version", optional_argument, NULL, VERSION_OPT},
     {"syslog-facility", required_argument, NULL, SYSLOG_FACILITY_OPT},
@@ -2476,6 +2480,9 @@ static void set_option(int c, char *value) {
     break;
   case UDP_RECVMMSG_OPT:
     turn_params.udp_recvmmsg = get_bool_value(value);
+    break;
+  case UDP_RECVMMSG_LOG_OPT:
+    turn_params.udp_recvmmsg_log = get_bool_value(value);
     break;
   case INCLUDE_REASON_STRING_OPT:
     turn_params.include_reason_string = get_bool_value(value);

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -361,6 +361,7 @@ typedef struct _turn_params_ {
   bool drop_invalid_packets;
   bool drop_invalid_packets_log;
   bool udp_recvmmsg;
+  bool udp_recvmmsg_log;
   bool include_reason_string;
 } turn_params_t;
 

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -361,7 +361,6 @@ typedef struct _turn_params_ {
   bool drop_invalid_packets;
   bool drop_invalid_packets_log;
   bool udp_recvmmsg;
-  bool udp_relay_recvmmsg;
   bool include_reason_string;
 } turn_params_t;
 

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -361,6 +361,7 @@ typedef struct _turn_params_ {
   bool drop_invalid_packets;
   bool drop_invalid_packets_log;
   bool udp_recvmmsg;
+  bool udp_relay_recvmmsg;
   bool include_reason_string;
 } turn_params_t;
 

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -80,7 +80,7 @@
 */
 
 #define MAX_ERRORS_IN_UDP_BATCH (1024)
-#define MAX_SOCKET_RECVMMSG_BATCH (16)
+#define MAX_SOCKET_RECVMMSG_BATCH IOA_UDP_RECVMMSG_MAX_BATCH
 
 #if defined(__linux__) && defined(CMSG_SPACE)
 #if defined(IP_RECVTTL) || defined(IP_TTL)
@@ -519,6 +519,66 @@ void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src
 
 /************** ENGINE *************************/
 
+#if defined(__linux__)
+void ioa_engine_record_udp_recvmmsg_batch(ioa_engine_handle e, int rc) {
+  if (!e || rc <= 0) {
+    return;
+  }
+
+  unsigned int bucket = (unsigned int)rc;
+  if (bucket > IOA_UDP_RECVMMSG_MAX_BATCH) {
+    bucket = IOA_UDP_RECVMMSG_MAX_BATCH;
+  }
+
+  e->udp_recvmmsg_calls++;
+  e->udp_recvmmsg_packets += (uint64_t)rc;
+  e->udp_recvmmsg_hist[bucket]++;
+}
+
+void ioa_engine_record_udp_recvmmsg_wouldblock(ioa_engine_handle e) {
+  if (e) {
+    e->udp_recvmmsg_wouldblock++;
+  }
+}
+
+void ioa_engine_record_udp_recvmmsg_unavailable(ioa_engine_handle e) {
+  if (e) {
+    e->udp_recvmmsg_unavailable++;
+  }
+}
+
+void ioa_engine_record_udp_recvmmsg_no_buffer(ioa_engine_handle e) {
+  if (e) {
+    e->udp_recvmmsg_no_buffer++;
+  }
+}
+
+static void maybe_log_udp_recvmmsg_stats(ioa_engine_handle e, turn_time_t now) {
+  if (!e || (e->udp_recvmmsg_calls == e->udp_recvmmsg_last_report_calls) ||
+      ((now - e->udp_recvmmsg_last_report_time) < 10)) {
+    return;
+  }
+
+  e->udp_recvmmsg_last_report_calls = e->udp_recvmmsg_calls;
+  e->udp_recvmmsg_last_report_time = now;
+
+  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
+                "udp-recvmmsg stats: calls=%llu packets=%llu avg_batch=%.2f wouldblock=%llu unavailable=%llu "
+                "no_buffer=%llu hist_1=%llu hist_2=%llu hist_3_4=%llu hist_5_8=%llu hist_9_16=%llu\n",
+                (unsigned long long)e->udp_recvmmsg_calls, (unsigned long long)e->udp_recvmmsg_packets,
+                e->udp_recvmmsg_calls ? ((double)e->udp_recvmmsg_packets / (double)e->udp_recvmmsg_calls) : 0.0,
+                (unsigned long long)e->udp_recvmmsg_wouldblock, (unsigned long long)e->udp_recvmmsg_unavailable,
+                (unsigned long long)e->udp_recvmmsg_no_buffer, (unsigned long long)e->udp_recvmmsg_hist[1],
+                (unsigned long long)e->udp_recvmmsg_hist[2],
+                (unsigned long long)(e->udp_recvmmsg_hist[3] + e->udp_recvmmsg_hist[4]),
+                (unsigned long long)(e->udp_recvmmsg_hist[5] + e->udp_recvmmsg_hist[6] + e->udp_recvmmsg_hist[7] +
+                                     e->udp_recvmmsg_hist[8]),
+                (unsigned long long)(e->udp_recvmmsg_hist[9] + e->udp_recvmmsg_hist[10] + e->udp_recvmmsg_hist[11] +
+                                     e->udp_recvmmsg_hist[12] + e->udp_recvmmsg_hist[13] + e->udp_recvmmsg_hist[14] +
+                                     e->udp_recvmmsg_hist[15] + e->udp_recvmmsg_hist[16]));
+}
+#endif
+
 static void timer_handler(ioa_engine_handle e, void *arg) {
 
   UNUSED_ARG(arg);
@@ -527,6 +587,10 @@ static void timer_handler(ioa_engine_handle e, void *arg) {
   STORE_LOG_TIME(now);
 
   e->jiffie = now;
+
+#if defined(__linux__)
+  maybe_log_udp_recvmmsg_stats(e, now);
+#endif
 }
 
 ioa_engine_handle create_ioa_engine(super_memory_t *sm, struct event_base *eb, turnipports *tp,
@@ -2309,6 +2373,7 @@ static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s, int *last_len) {
   }
 
   if (count == 0) {
+    ioa_engine_record_udp_recvmmsg_no_buffer(e);
     return 0;
   }
 
@@ -2320,18 +2385,27 @@ static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s, int *last_len) {
     }
 
     if (rc == 0) {
+      ioa_engine_record_udp_recvmmsg_wouldblock(e);
       return 1;
     }
 
     if (rc < 0 && (errno == ENOSYS || errno == EINVAL || errno == EOPNOTSUPP)) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
                     "%s: recvmmsg() is unavailable on this system, disabling udp-recvmmsg fast path\n", __FUNCTION__);
+      ioa_engine_record_udp_recvmmsg_unavailable(e);
       turn_params.udp_recvmmsg = false;
       return 0;
     }
 
-    return would_block() ? 1 : 0;
+    if (would_block()) {
+      ioa_engine_record_udp_recvmmsg_wouldblock(e);
+      return 1;
+    }
+
+    return 0;
   }
+
+  ioa_engine_record_udp_recvmmsg_batch(e, rc);
 
   for (int i = 0; i < rc; ++i) {
     stun_buffer_list_elem *buf_elem = buf_elems[i];

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -2252,7 +2252,7 @@ static int ensure_socket_recvmmsg_state(ioa_socket_handle s) {
 static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s) {
   int last_len = -1;
 
-  if (!s || !s->e || !s->read_cb || s->ssl || !turn_params.udp_relay_recvmmsg) {
+  if (!s || !s->e || !s->read_cb || s->ssl || !turn_params.udp_recvmmsg) {
     return -1;
   }
 
@@ -2289,9 +2289,8 @@ static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s) {
 
     if (rc < 0 && (errno == ENOSYS || errno == EINVAL || errno == EOPNOTSUPP)) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
-                    "%s: recvmmsg() is unavailable on this system, disabling udp-relay-recvmmsg fast path\n",
-                    __FUNCTION__);
-      turn_params.udp_relay_recvmmsg = false;
+                    "%s: recvmmsg() is unavailable on this system, disabling udp-recvmmsg fast path\n", __FUNCTION__);
+      turn_params.udp_recvmmsg = false;
     }
 
     return -1;
@@ -2795,7 +2794,7 @@ try_start:
     }
   } else if (s->fd >= 0) { /* UDP and DTLS */
 #if defined(__linux__)
-    if (turn_params.udp_relay_recvmmsg && !s->ssl && s->read_cb) {
+    if (turn_params.udp_recvmmsg && !s->ssl && s->read_cb) {
       ret = socket_udp_read_batch_recvmmsg(s);
       if (ret >= 0) {
         return ret;

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -80,6 +80,7 @@
 */
 
 #define MAX_ERRORS_IN_UDP_BATCH (1024)
+#define MAX_SOCKET_RECVMMSG_BATCH (16)
 
 struct turn_sock_extended_err {
   uint32_t ee_errno; /* error number */
@@ -91,6 +92,18 @@ struct turn_sock_extended_err {
   uint32_t ee_data;  /* other data */
   /* More data may follow */
 };
+
+#if defined(__linux__)
+struct ioa_socket_recvmmsg_state {
+  struct mmsghdr msgs[MAX_SOCKET_RECVMMSG_BATCH];
+  struct iovec iovecs[MAX_SOCKET_RECVMMSG_BATCH];
+  char cmsgs[MAX_SOCKET_RECVMMSG_BATCH][TURN_CMSG_SZ];
+  ioa_addr src_addrs[MAX_SOCKET_RECVMMSG_BATCH];
+  int ttls[MAX_SOCKET_RECVMMSG_BATCH];
+  int toss[MAX_SOCKET_RECVMMSG_BATCH];
+  stun_buffer_list_elem *buf_elems[MAX_SOCKET_RECVMMSG_BATCH];
+};
+#endif
 
 #define TRIAL_EFFORTS_TO_SEND (2)
 
@@ -113,6 +126,11 @@ static int send_ssl_backlog_buffers(ioa_socket_handle s);
 static int set_accept_cb(ioa_socket_handle s, accept_cb acb, void *arg);
 
 static void close_socket_net_data(ioa_socket_handle s);
+
+#if defined(__linux__)
+static int ensure_socket_recvmmsg_state(ioa_socket_handle s);
+static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s);
+#endif
 
 /************** Utils **************************/
 
@@ -362,6 +380,114 @@ static void free_blist_elem(ioa_engine_handle e, stun_buffer_list_elem *buf_elem
     }
   }
 }
+
+#if !defined(_MSC_VER) && defined(CMSG_SPACE)
+void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, int *ttl, int *tos, uint32_t *errcode) {
+  typedef unsigned char recv_ttl_t;
+  typedef unsigned char recv_tos_t;
+
+  recv_ttl_t recv_ttl = TTL_DEFAULT;
+  recv_tos_t recv_tos = TOS_DEFAULT;
+  struct cmsghdr *cmsgh = NULL;
+
+  if (errcode) {
+    *errcode = 0;
+  }
+
+  for (cmsgh = CMSG_FIRSTHDR(msg); cmsgh != NULL; cmsgh = CMSG_NXTHDR(msg, cmsgh)) {
+    const int l = cmsgh->cmsg_level;
+    const int t = cmsgh->cmsg_type;
+
+    switch (l) {
+    case IPPROTO_IP:
+      switch (t) {
+#if defined(IP_RECVTTL) && !defined(__sparc_v9__)
+      case IP_RECVTTL:
+      case IP_TTL:
+        recv_ttl = *((recv_ttl_t *)CMSG_DATA(cmsgh));
+        break;
+#endif
+#if defined(IP_RECVTOS)
+      case IP_RECVTOS:
+      case IP_TOS:
+        recv_tos = *((recv_tos_t *)CMSG_DATA(cmsgh));
+        break;
+#endif
+#if defined(IP_RECVERR)
+      case IP_RECVERR: {
+        struct turn_sock_extended_err *e = (struct turn_sock_extended_err *)CMSG_DATA(cmsgh);
+        if (errcode) {
+          *errcode = e->ee_errno;
+        }
+      } break;
+#endif
+      default:;
+      };
+      break;
+    case IPPROTO_IPV6:
+      switch (t) {
+#if defined(IPV6_RECVHOPLIMIT) && !defined(__sparc_v9__)
+      case IPV6_RECVHOPLIMIT:
+      case IPV6_HOPLIMIT:
+        recv_ttl = *((recv_ttl_t *)CMSG_DATA(cmsgh));
+        break;
+#endif
+#if defined(IPV6_RECVTCLASS)
+      case IPV6_RECVTCLASS:
+      case IPV6_TCLASS:
+        recv_tos = *((recv_tos_t *)CMSG_DATA(cmsgh));
+        break;
+#endif
+#if defined(IPV6_RECVERR)
+      case IPV6_RECVERR: {
+        struct turn_sock_extended_err *e = (struct turn_sock_extended_err *)CMSG_DATA(cmsgh);
+        if (errcode) {
+          *errcode = e->ee_errno;
+        }
+      } break;
+#endif
+      default:;
+      };
+      break;
+    default:;
+    };
+  }
+
+  if (ttl) {
+    *ttl = recv_ttl;
+    CORRECT_RAW_TTL(*ttl);
+  }
+  if (tos) {
+    *tos = recv_tos;
+    CORRECT_RAW_TOS(*tos);
+  }
+}
+#endif
+
+#if defined(__linux__)
+void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src_addr, char *cmsg, socklen_t slen,
+                           void *buf, size_t len) {
+  if (!msg || !iov || !src_addr || !cmsg) {
+    return;
+  }
+
+  memset(msg, 0, sizeof(*msg));
+  memset(iov, 0, sizeof(*iov));
+
+  addr_set_any(src_addr);
+
+  iov->iov_base = buf;
+  iov->iov_len = len;
+
+  msg->msg_hdr.msg_name = src_addr;
+  msg->msg_hdr.msg_namelen = slen;
+  msg->msg_hdr.msg_iov = iov;
+  msg->msg_hdr.msg_iovlen = 1;
+  msg->msg_hdr.msg_control = cmsg;
+  msg->msg_hdr.msg_controllen = TURN_CMSG_SZ;
+  msg->msg_len = 0;
+}
+#endif
 
 /************** ENGINE *************************/
 
@@ -1452,6 +1578,12 @@ ioa_socket_handle create_ioa_socket_from_ssl(ioa_engine_handle e, ioa_socket_han
 
 static void close_socket_net_data(ioa_socket_handle s) {
   if (s) {
+#if defined(__linux__)
+    if (s->udp_recvmmsg_state) {
+      free(s->udp_recvmmsg_state);
+      s->udp_recvmmsg_state = NULL;
+    }
+#endif
 
     EVENT_DEL(s->read_event);
     if (s->list_ev) {
@@ -2076,71 +2208,7 @@ try_again:
 #endif
 
   if (len >= 0) {
-
-    struct cmsghdr *cmsgh;
-
-    // Receive auxiliary data in msg
-    for (cmsgh = CMSG_FIRSTHDR(&msg); cmsgh != NULL; cmsgh = CMSG_NXTHDR(&msg, cmsgh)) {
-      const int l = cmsgh->cmsg_level;
-      const int t = cmsgh->cmsg_type;
-
-      switch (l) {
-      case IPPROTO_IP:
-        switch (t) {
-#if defined(IP_RECVTTL) && !defined(__sparc_v9__)
-        case IP_RECVTTL:
-        case IP_TTL:
-          recv_ttl = *((recv_ttl_t *)CMSG_DATA(cmsgh));
-          break;
-#endif
-#if defined(IP_RECVTOS)
-        case IP_RECVTOS:
-        case IP_TOS:
-          recv_tos = *((recv_tos_t *)CMSG_DATA(cmsgh));
-          break;
-#endif
-#if defined(IP_RECVERR)
-        case IP_RECVERR: {
-          struct turn_sock_extended_err *e = (struct turn_sock_extended_err *)CMSG_DATA(cmsgh);
-          if (errcode) {
-            *errcode = e->ee_errno;
-          }
-        } break;
-#endif
-        default:;
-          /* no break */
-        };
-        break;
-      case IPPROTO_IPV6:
-        switch (t) {
-#if defined(IPV6_RECVHOPLIMIT) && !defined(__sparc_v9__)
-        case IPV6_RECVHOPLIMIT:
-        case IPV6_HOPLIMIT:
-          recv_ttl = *((recv_ttl_t *)CMSG_DATA(cmsgh));
-          break;
-#endif
-#if defined(IPV6_RECVTCLASS)
-        case IPV6_RECVTCLASS:
-        case IPV6_TCLASS:
-          recv_tos = *((recv_tos_t *)CMSG_DATA(cmsgh));
-          break;
-#endif
-#if defined(IPV6_RECVERR)
-        case IPV6_RECVERR: {
-          struct turn_sock_extended_err *e = (struct turn_sock_extended_err *)CMSG_DATA(cmsgh);
-          if (errcode) {
-            *errcode = e->ee_errno;
-          }
-        } break;
-#endif
-        default:;
-          /* no break */
-        };
-        break;
-      default:;
-        /* no break */
-      };
-    }
+    ioa_parse_udp_recvmsg_cmsg(&msg, (int *)&recv_ttl, (int *)&recv_tos, errcode);
   }
 
 #endif
@@ -2155,6 +2223,123 @@ try_again:
 
   return len;
 }
+
+#if defined(__linux__)
+static int ensure_socket_recvmmsg_state(ioa_socket_handle s) {
+  if (!s) {
+    return -1;
+  }
+
+  if (s->udp_recvmmsg_state) {
+    return 0;
+  }
+
+  s->udp_recvmmsg_state = (struct ioa_socket_recvmmsg_state *)calloc(1, sizeof(struct ioa_socket_recvmmsg_state));
+  if (!s->udp_recvmmsg_state) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc\n", __FUNCTION__);
+    return -1;
+  }
+
+  for (unsigned int i = 0; i < MAX_SOCKET_RECVMMSG_BATCH; ++i) {
+    ioa_init_recvmmsg_hdr(&(s->udp_recvmmsg_state->msgs[i]), &(s->udp_recvmmsg_state->iovecs[i]),
+                          &(s->udp_recvmmsg_state->src_addrs[i]), s->udp_recvmmsg_state->cmsgs[i],
+                          (socklen_t)get_ioa_addr_len(&(s->local_addr)), NULL, 0);
+  }
+
+  return 0;
+}
+
+static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s) {
+  int last_len = -1;
+
+  if (!s || !s->e || !s->read_cb || s->ssl || !turn_params.udp_relay_recvmmsg) {
+    return -1;
+  }
+
+  if (ensure_socket_recvmmsg_state(s) < 0) {
+    return -1;
+  }
+
+  struct ioa_socket_recvmmsg_state *state = s->udp_recvmmsg_state;
+  unsigned int count = 0;
+
+  for (count = 0; count < MAX_SOCKET_RECVMMSG_BATCH; ++count) {
+    stun_buffer_list_elem *buf_elem = new_blist_elem(s->e);
+    if (!buf_elem) {
+      break;
+    }
+    state->buf_elems[count] = buf_elem;
+    ioa_init_recvmmsg_hdr(&(state->msgs[count]), &(state->iovecs[count]), &(state->src_addrs[count]),
+                          state->cmsgs[count], (socklen_t)get_ioa_addr_len(&(s->local_addr)), buf_elem->buf.buf,
+                          UDP_STUN_BUFFER_SIZE);
+    state->ttls[count] = TTL_IGNORE;
+    state->toss[count] = TOS_IGNORE;
+  }
+
+  if (count == 0) {
+    return -1;
+  }
+
+  const int rc = recvmmsg(s->fd, state->msgs, count, MSG_DONTWAIT, NULL);
+  if (rc <= 0) {
+    for (unsigned int i = 0; i < count; ++i) {
+      free_blist_elem(s->e, state->buf_elems[i]);
+      state->buf_elems[i] = NULL;
+    }
+
+    if (rc < 0 && (errno == ENOSYS || errno == EINVAL || errno == EOPNOTSUPP)) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
+                    "%s: recvmmsg() is unavailable on this system, disabling udp-relay-recvmmsg fast path\n",
+                    __FUNCTION__);
+      turn_params.udp_relay_recvmmsg = false;
+    }
+
+    return -1;
+  }
+
+  for (int i = 0; i < rc; ++i) {
+    stun_buffer_list_elem *buf_elem = state->buf_elems[i];
+    ioa_net_data nd;
+
+    ioa_parse_udp_recvmsg_cmsg(&(state->msgs[i].msg_hdr), &(state->ttls[i]), &(state->toss[i]), NULL);
+    buf_elem->buf.len = state->msgs[i].msg_len;
+
+    if (!ioa_socket_check_bandwidth(s, (ioa_network_buffer_handle)buf_elem, 1)) {
+      free_blist_elem(s->e, buf_elem);
+      state->buf_elems[i] = NULL;
+      continue;
+    }
+
+    memset(&nd, 0, sizeof(nd));
+    addr_cpy(&(nd.src_addr), &(state->src_addrs[i]));
+    nd.nbh = (ioa_network_buffer_handle)buf_elem;
+    nd.recv_ttl = state->ttls[i];
+    nd.recv_tos = state->toss[i];
+
+    s->read_cb(s, IOA_EV_READ, &nd, s->read_ctx, 1);
+
+    if (nd.nbh) {
+      free_blist_elem(s->e, buf_elem);
+    }
+
+    state->buf_elems[i] = NULL;
+    last_len = (int)state->msgs[i].msg_len;
+
+    if (s->done || s->tobeclosed) {
+      break;
+    }
+  }
+
+  for (int i = 0; i < rc; ++i) {
+    if (state->buf_elems[i]) {
+      free_blist_elem(s->e, state->buf_elems[i]);
+      state->buf_elems[i] = NULL;
+    }
+  }
+
+  return last_len;
+}
+#endif
 
 #if TLS_SUPPORTED
 
@@ -2609,6 +2794,14 @@ try_start:
       len = -1;
     }
   } else if (s->fd >= 0) { /* UDP and DTLS */
+#if defined(__linux__)
+    if (turn_params.udp_relay_recvmmsg && !s->ssl && s->read_cb) {
+      ret = socket_udp_read_batch_recvmmsg(s);
+      if (ret >= 0) {
+        return ret;
+      }
+    }
+#endif
     ret = udp_recvfrom(s->fd, &remote_addr, &(s->local_addr), (char *)(buf_elem->buf.buf), UDP_STUN_BUFFER_SIZE, &ttl,
                        &tos, s->e->cmsg, 0, NULL);
     len = ret;

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -156,7 +156,7 @@ static int set_accept_cb(ioa_socket_handle s, accept_cb acb, void *arg);
 static void close_socket_net_data(ioa_socket_handle s);
 
 #if defined(__linux__)
-static int ensure_socket_recvmmsg_state(ioa_socket_handle s);
+static int ensure_engine_recvmmsg_state(ioa_engine_handle e);
 static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s, int *last_len);
 #endif
 
@@ -1670,13 +1670,6 @@ ioa_socket_handle create_ioa_socket_from_ssl(ioa_engine_handle e, ioa_socket_han
 
 static void close_socket_net_data(ioa_socket_handle s) {
   if (s) {
-#if defined(__linux__)
-    if (s->udp_recvmmsg_state) {
-      free(s->udp_recvmmsg_state);
-      s->udp_recvmmsg_state = NULL;
-    }
-#endif
-
     EVENT_DEL(s->read_event);
     if (s->list_ev) {
       evconnlistener_free(s->list_ev);
@@ -2317,25 +2310,19 @@ try_again:
 }
 
 #if defined(__linux__)
-static int ensure_socket_recvmmsg_state(ioa_socket_handle s) {
-  if (!s) {
+static int ensure_engine_recvmmsg_state(ioa_engine_handle e) {
+  if (!e) {
     return -1;
   }
 
-  if (s->udp_recvmmsg_state) {
+  if (e->udp_recvmmsg_state) {
     return 0;
   }
 
-  s->udp_recvmmsg_state = (struct ioa_socket_recvmmsg_state *)calloc(1, sizeof(struct ioa_socket_recvmmsg_state));
-  if (!s->udp_recvmmsg_state) {
+  e->udp_recvmmsg_state = (struct ioa_socket_recvmmsg_state *)calloc(1, sizeof(struct ioa_socket_recvmmsg_state));
+  if (!e->udp_recvmmsg_state) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc\n", __FUNCTION__);
     return -1;
-  }
-
-  for (unsigned int i = 0; i < MAX_SOCKET_RECVMMSG_BATCH; ++i) {
-    ioa_init_recvmmsg_hdr(&(s->udp_recvmmsg_state->msgs[i]), &(s->udp_recvmmsg_state->iovecs[i]),
-                          &(s->udp_recvmmsg_state->src_addrs[i]), s->udp_recvmmsg_state->cmsgs[i],
-                          SOCKET_RECVMMSG_CMSG_SZ, (socklen_t)get_ioa_addr_len(&(s->local_addr)), NULL, 0);
   }
 
   return 0;
@@ -2350,12 +2337,12 @@ static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s, int *last_len) {
     return 0;
   }
 
-  if (ensure_socket_recvmmsg_state(s) < 0) {
+  ioa_engine_handle e = s->e;
+  if (ensure_engine_recvmmsg_state(e) < 0) {
     return 0;
   }
 
-  ioa_engine_handle e = s->e;
-  struct ioa_socket_recvmmsg_state *state = s->udp_recvmmsg_state;
+  struct ioa_socket_recvmmsg_state *state = e->udp_recvmmsg_state;
   stun_buffer_list_elem *buf_elems[MAX_SOCKET_RECVMMSG_BATCH] = {0};
   unsigned int count = 0;
 

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -82,6 +82,35 @@
 #define MAX_ERRORS_IN_UDP_BATCH (1024)
 #define MAX_SOCKET_RECVMMSG_BATCH (16)
 
+#if defined(__linux__) && defined(CMSG_SPACE)
+#if defined(IP_RECVTTL) || defined(IP_TTL)
+#define SOCKET_RECVMMSG_IPV4_TTL_CMSG_SZ CMSG_SPACE(sizeof(int))
+#else
+#define SOCKET_RECVMMSG_IPV4_TTL_CMSG_SZ 0
+#endif
+#if defined(IP_RECVTOS) || defined(IP_TOS)
+#define SOCKET_RECVMMSG_IPV4_TOS_CMSG_SZ CMSG_SPACE(sizeof(int))
+#else
+#define SOCKET_RECVMMSG_IPV4_TOS_CMSG_SZ 0
+#endif
+#if defined(IPV6_RECVHOPLIMIT) || defined(IPV6_HOPLIMIT)
+#define SOCKET_RECVMMSG_IPV6_TTL_CMSG_SZ CMSG_SPACE(sizeof(int))
+#else
+#define SOCKET_RECVMMSG_IPV6_TTL_CMSG_SZ 0
+#endif
+#if defined(IPV6_RECVTCLASS) || defined(IPV6_TCLASS)
+#define SOCKET_RECVMMSG_IPV6_TOS_CMSG_SZ CMSG_SPACE(sizeof(int))
+#else
+#define SOCKET_RECVMMSG_IPV6_TOS_CMSG_SZ 0
+#endif
+#define SOCKET_RECVMMSG_IPV4_CMSG_SZ (SOCKET_RECVMMSG_IPV4_TTL_CMSG_SZ + SOCKET_RECVMMSG_IPV4_TOS_CMSG_SZ)
+#define SOCKET_RECVMMSG_IPV6_CMSG_SZ (SOCKET_RECVMMSG_IPV6_TTL_CMSG_SZ + SOCKET_RECVMMSG_IPV6_TOS_CMSG_SZ)
+#define SOCKET_RECVMMSG_CMSG_SZ                                                                                        \
+  ((SOCKET_RECVMMSG_IPV4_CMSG_SZ > SOCKET_RECVMMSG_IPV6_CMSG_SZ) ? SOCKET_RECVMMSG_IPV4_CMSG_SZ                        \
+                                                                 : SOCKET_RECVMMSG_IPV6_CMSG_SZ)
+#define SOCKET_RECVMMSG_CMSG_ALLOC_SZ ((SOCKET_RECVMMSG_CMSG_SZ) > 0 ? (SOCKET_RECVMMSG_CMSG_SZ) : 1)
+#endif
+
 struct turn_sock_extended_err {
   uint32_t ee_errno; /* error number */
   uint8_t ee_origin; /* where the error originated */
@@ -97,11 +126,10 @@ struct turn_sock_extended_err {
 struct ioa_socket_recvmmsg_state {
   struct mmsghdr msgs[MAX_SOCKET_RECVMMSG_BATCH];
   struct iovec iovecs[MAX_SOCKET_RECVMMSG_BATCH];
-  char cmsgs[MAX_SOCKET_RECVMMSG_BATCH][TURN_CMSG_SZ];
+  char cmsgs[MAX_SOCKET_RECVMMSG_BATCH][SOCKET_RECVMMSG_CMSG_ALLOC_SZ];
   ioa_addr src_addrs[MAX_SOCKET_RECVMMSG_BATCH];
   int ttls[MAX_SOCKET_RECVMMSG_BATCH];
   int toss[MAX_SOCKET_RECVMMSG_BATCH];
-  stun_buffer_list_elem *buf_elems[MAX_SOCKET_RECVMMSG_BATCH];
 };
 #endif
 
@@ -129,7 +157,7 @@ static void close_socket_net_data(ioa_socket_handle s);
 
 #if defined(__linux__)
 static int ensure_socket_recvmmsg_state(ioa_socket_handle s);
-static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s);
+static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s, int *last_len);
 #endif
 
 /************** Utils **************************/
@@ -465,8 +493,8 @@ void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, int *ttl, int *tos, uint32_t
 #endif
 
 #if defined(__linux__)
-void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src_addr, char *cmsg, socklen_t slen,
-                           void *buf, size_t len) {
+void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src_addr, char *cmsg, size_t cmsg_len,
+                           socklen_t slen, void *buf, size_t len) {
   if (!msg || !iov || !src_addr || !cmsg) {
     return;
   }
@@ -484,7 +512,7 @@ void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src
   msg->msg_hdr.msg_iov = iov;
   msg->msg_hdr.msg_iovlen = 1;
   msg->msg_hdr.msg_control = cmsg;
-  msg->msg_hdr.msg_controllen = TURN_CMSG_SZ;
+  msg->msg_hdr.msg_controllen = cmsg_len;
   msg->msg_len = 0;
 }
 #endif
@@ -2243,69 +2271,80 @@ static int ensure_socket_recvmmsg_state(ioa_socket_handle s) {
   for (unsigned int i = 0; i < MAX_SOCKET_RECVMMSG_BATCH; ++i) {
     ioa_init_recvmmsg_hdr(&(s->udp_recvmmsg_state->msgs[i]), &(s->udp_recvmmsg_state->iovecs[i]),
                           &(s->udp_recvmmsg_state->src_addrs[i]), s->udp_recvmmsg_state->cmsgs[i],
-                          (socklen_t)get_ioa_addr_len(&(s->local_addr)), NULL, 0);
+                          SOCKET_RECVMMSG_CMSG_SZ, (socklen_t)get_ioa_addr_len(&(s->local_addr)), NULL, 0);
   }
 
   return 0;
 }
 
-static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s) {
-  int last_len = -1;
+static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s, int *last_len) {
+  if (last_len) {
+    *last_len = -1;
+  }
 
   if (!s || !s->e || !s->read_cb || s->ssl || !turn_params.udp_recvmmsg) {
-    return -1;
+    return 0;
   }
 
   if (ensure_socket_recvmmsg_state(s) < 0) {
-    return -1;
+    return 0;
   }
 
+  ioa_engine_handle e = s->e;
   struct ioa_socket_recvmmsg_state *state = s->udp_recvmmsg_state;
+  stun_buffer_list_elem *buf_elems[MAX_SOCKET_RECVMMSG_BATCH] = {0};
   unsigned int count = 0;
 
   for (count = 0; count < MAX_SOCKET_RECVMMSG_BATCH; ++count) {
-    stun_buffer_list_elem *buf_elem = new_blist_elem(s->e);
+    stun_buffer_list_elem *buf_elem = new_blist_elem(e);
     if (!buf_elem) {
       break;
     }
-    state->buf_elems[count] = buf_elem;
+    buf_elems[count] = buf_elem;
     ioa_init_recvmmsg_hdr(&(state->msgs[count]), &(state->iovecs[count]), &(state->src_addrs[count]),
-                          state->cmsgs[count], (socklen_t)get_ioa_addr_len(&(s->local_addr)), buf_elem->buf.buf,
-                          UDP_STUN_BUFFER_SIZE);
+                          state->cmsgs[count], SOCKET_RECVMMSG_CMSG_SZ, (socklen_t)get_ioa_addr_len(&(s->local_addr)),
+                          buf_elem->buf.buf, UDP_STUN_BUFFER_SIZE);
     state->ttls[count] = TTL_IGNORE;
     state->toss[count] = TOS_IGNORE;
   }
 
   if (count == 0) {
-    return -1;
+    return 0;
   }
 
   const int rc = recvmmsg(s->fd, state->msgs, count, MSG_DONTWAIT, NULL);
   if (rc <= 0) {
     for (unsigned int i = 0; i < count; ++i) {
-      free_blist_elem(s->e, state->buf_elems[i]);
-      state->buf_elems[i] = NULL;
+      free_blist_elem(e, buf_elems[i]);
+      buf_elems[i] = NULL;
+    }
+
+    if (rc == 0) {
+      return 1;
     }
 
     if (rc < 0 && (errno == ENOSYS || errno == EINVAL || errno == EOPNOTSUPP)) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
                     "%s: recvmmsg() is unavailable on this system, disabling udp-recvmmsg fast path\n", __FUNCTION__);
       turn_params.udp_recvmmsg = false;
+      return 0;
     }
 
-    return -1;
+    return would_block() ? 1 : 0;
   }
 
   for (int i = 0; i < rc; ++i) {
-    stun_buffer_list_elem *buf_elem = state->buf_elems[i];
+    stun_buffer_list_elem *buf_elem = buf_elems[i];
     ioa_net_data nd;
+    const int msg_len = (int)state->msgs[i].msg_len;
+
+    buf_elems[i] = NULL;
 
     ioa_parse_udp_recvmsg_cmsg(&(state->msgs[i].msg_hdr), &(state->ttls[i]), &(state->toss[i]), NULL);
-    buf_elem->buf.len = state->msgs[i].msg_len;
+    buf_elem->buf.len = (size_t)msg_len;
 
     if (!ioa_socket_check_bandwidth(s, (ioa_network_buffer_handle)buf_elem, 1)) {
-      free_blist_elem(s->e, buf_elem);
-      state->buf_elems[i] = NULL;
+      free_blist_elem(e, buf_elem);
       continue;
     }
 
@@ -2318,25 +2357,26 @@ static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s) {
     s->read_cb(s, IOA_EV_READ, &nd, s->read_ctx, 1);
 
     if (nd.nbh) {
-      free_blist_elem(s->e, buf_elem);
+      free_blist_elem(e, buf_elem);
     }
 
-    state->buf_elems[i] = NULL;
-    last_len = (int)state->msgs[i].msg_len;
+    if (last_len) {
+      *last_len = msg_len;
+    }
 
-    if (s->done || s->tobeclosed) {
+    if ((s->magic != SOCKET_MAGIC) || s->done || s->tobeclosed) {
       break;
     }
   }
 
-  for (int i = 0; i < rc; ++i) {
-    if (state->buf_elems[i]) {
-      free_blist_elem(s->e, state->buf_elems[i]);
-      state->buf_elems[i] = NULL;
+  for (unsigned int i = 0; i < count; ++i) {
+    if (buf_elems[i]) {
+      free_blist_elem(e, buf_elems[i]);
+      buf_elems[i] = NULL;
     }
   }
 
-  return last_len;
+  return 1;
 }
 #endif
 
@@ -2795,9 +2835,9 @@ try_start:
   } else if (s->fd >= 0) { /* UDP and DTLS */
 #if defined(__linux__)
     if (turn_params.udp_recvmmsg && !s->ssl && s->read_cb) {
-      ret = socket_udp_read_batch_recvmmsg(s);
-      if (ret >= 0) {
-        return ret;
+      int batch_len = -1;
+      if (socket_udp_read_batch_recvmmsg(s, &batch_len)) {
+        return batch_len;
       }
     }
 #endif

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -554,7 +554,7 @@ void ioa_engine_record_udp_recvmmsg_no_buffer(ioa_engine_handle e) {
 }
 
 static void maybe_log_udp_recvmmsg_stats(ioa_engine_handle e, turn_time_t now) {
-  if (!e || (e->udp_recvmmsg_calls == e->udp_recvmmsg_last_report_calls) ||
+  if (!turn_params.udp_recvmmsg_log || !e || (e->udp_recvmmsg_calls == e->udp_recvmmsg_last_report_calls) ||
       ((now - e->udp_recvmmsg_last_report_time) < 10)) {
     return;
   }

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -220,6 +220,9 @@ struct _ioa_socket {
   /* <<== RFC 6062 */
   void *special_session;
   size_t special_session_size;
+#if defined(__linux__)
+  struct ioa_socket_recvmmsg_state *udp_recvmmsg_state;
+#endif
 };
 
 typedef struct _timer_event {
@@ -270,6 +273,15 @@ int udp_send(ioa_socket_handle s, const ioa_addr *dest_addr, const char *buffer,
 int udp_recvfrom(evutil_socket_t fd, ioa_addr *orig_addr, const ioa_addr *like_addr, char *buffer, int buf_size,
                  int *ttl, int *tos, char *ecmsg, int flags, uint32_t *errcode);
 int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int verbose);
+
+#if defined(__linux__)
+void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src_addr, char *cmsg, socklen_t slen,
+                           void *buf, size_t len);
+#endif
+
+#if !defined(_MSC_VER) && defined(CMSG_SPACE)
+void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, int *ttl, int *tos, uint32_t *errcode);
+#endif
 
 int set_raw_socket_ttl_options(evutil_socket_t fd, int family);
 int set_raw_socket_tos_options(evutil_socket_t fd, int family);

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -275,8 +275,8 @@ int udp_recvfrom(evutil_socket_t fd, ioa_addr *orig_addr, const ioa_addr *like_a
 int ssl_read(evutil_socket_t fd, SSL *ssl, ioa_network_buffer_handle nbh, int verbose);
 
 #if defined(__linux__)
-void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src_addr, char *cmsg, socklen_t slen,
-                           void *buf, size_t len);
+void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src_addr, char *cmsg, size_t cmsg_len,
+                           socklen_t slen, void *buf, size_t len);
 #endif
 
 #if !defined(_MSC_VER) && defined(CMSG_SPACE)

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -70,6 +70,7 @@ extern "C" {
 
 #define MAX_BUFFER_QUEUE_SIZE_PER_ENGINE (64)
 #define MAX_SOCKET_BUFFER_BACKLOG (16)
+#define IOA_UDP_RECVMMSG_MAX_BATCH (16)
 
 #define BUFFEREVENT_HIGH_WATERMARK (128 << 10)
 #define BUFFEREVENT_MAX_UDP_TO_TCP_WRITE (64 << 9)
@@ -159,6 +160,16 @@ struct _ioa_engine {
   size_t relays_number;
   size_t relay_addr_counter;
   ioa_addr *relay_addrs;
+#if defined(__linux__)
+  uint64_t udp_recvmmsg_calls;
+  uint64_t udp_recvmmsg_packets;
+  uint64_t udp_recvmmsg_wouldblock;
+  uint64_t udp_recvmmsg_unavailable;
+  uint64_t udp_recvmmsg_no_buffer;
+  uint64_t udp_recvmmsg_hist[IOA_UDP_RECVMMSG_MAX_BATCH + 1];
+  uint64_t udp_recvmmsg_last_report_calls;
+  turn_time_t udp_recvmmsg_last_report_time;
+#endif
   redis_context_handle rch;
 };
 
@@ -281,6 +292,13 @@ void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src
 
 #if !defined(_MSC_VER) && defined(CMSG_SPACE)
 void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, int *ttl, int *tos, uint32_t *errcode);
+#endif
+
+#if defined(__linux__)
+void ioa_engine_record_udp_recvmmsg_batch(ioa_engine_handle e, int rc);
+void ioa_engine_record_udp_recvmmsg_wouldblock(ioa_engine_handle e);
+void ioa_engine_record_udp_recvmmsg_unavailable(ioa_engine_handle e);
+void ioa_engine_record_udp_recvmmsg_no_buffer(ioa_engine_handle e);
 #endif
 
 int set_raw_socket_ttl_options(evutil_socket_t fd, int family);

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -161,6 +161,7 @@ struct _ioa_engine {
   size_t relay_addr_counter;
   ioa_addr *relay_addrs;
 #if defined(__linux__)
+  struct ioa_socket_recvmmsg_state *udp_recvmmsg_state;
   uint64_t udp_recvmmsg_calls;
   uint64_t udp_recvmmsg_packets;
   uint64_t udp_recvmmsg_wouldblock;
@@ -231,9 +232,6 @@ struct _ioa_socket {
   /* <<== RFC 6062 */
   void *special_session;
   size_t special_session_size;
-#if defined(__linux__)
-  struct ioa_socket_recvmmsg_state *udp_recvmmsg_state;
-#endif
 };
 
 typedef struct _timer_event {

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -698,6 +698,7 @@ static void cli_print_configuration(struct cli_session *cs) {
     cli_print_flag(cs, turn_params.mobility, "mobility", 1);
     cli_print_flag(cs, turn_params.udp_self_balance, "udp-self-balance", 0);
     cli_print_flag(cs, turn_params.udp_recvmmsg, "udp-recvmmsg", 0);
+    cli_print_flag(cs, turn_params.udp_recvmmsg_log, "udp-recvmmsg-log", 0);
     cli_print_str(cs, turn_params.pidfile, "pidfile", 0);
 #if defined(WINDOWS)
     // TODO: implement it!!!

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -698,6 +698,7 @@ static void cli_print_configuration(struct cli_session *cs) {
     cli_print_flag(cs, turn_params.mobility, "mobility", 1);
     cli_print_flag(cs, turn_params.udp_self_balance, "udp-self-balance", 0);
     cli_print_flag(cs, turn_params.udp_recvmmsg, "udp-recvmmsg", 0);
+    cli_print_flag(cs, turn_params.udp_relay_recvmmsg, "udp-relay-recvmmsg", 0);
     cli_print_str(cs, turn_params.pidfile, "pidfile", 0);
 #if defined(WINDOWS)
     // TODO: implement it!!!

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -698,7 +698,6 @@ static void cli_print_configuration(struct cli_session *cs) {
     cli_print_flag(cs, turn_params.mobility, "mobility", 1);
     cli_print_flag(cs, turn_params.udp_self_balance, "udp-self-balance", 0);
     cli_print_flag(cs, turn_params.udp_recvmmsg, "udp-recvmmsg", 0);
-    cli_print_flag(cs, turn_params.udp_relay_recvmmsg, "udp-relay-recvmmsg", 0);
     cli_print_str(cs, turn_params.pidfile, "pidfile", 0);
 #if defined(WINDOWS)
     // TODO: implement it!!!


### PR DESCRIPTION
## Summary

Extends the existing Linux-only `--udp-recvmmsg` flag from the UDP listener socket to also cover **connected per-session UDP relay sockets**, so steady-state client→relay and peer→relay traffic on plain UDP is read in batches of up to 16 datagrams per `recvmmsg(2)` instead of one `recvmsg` per packet. DTLS sessions still go through the SSL read path and are unchanged.

The flag stays **opt-in**: receive-side batching works correctly, but on the current `m=1` / `m=100` benchmarks throughput is flat to slightly negative — the bottleneck has moved past receive (see results below).

## What's in the change

- **Shared receive helpers** (`src/apps/relay/ns_ioalib_engine_impl.c`, `src/apps/relay/ns_ioalib_impl.h`):
  - `ioa_parse_udp_recvmsg_cmsg()` — single TTL/TOS/`IP_RECVERR` cmsg parser used by both `udp_recvfrom()` and the new batch path. Replaces the duplicated parser previously inlined in `dtls_listener.c` and `udp_recvfrom()`.
  - `ioa_init_recvmmsg_hdr()` — single initializer for `mmsghdr`/`iovec`/cmsg/source-address fields, also used by the listener.
  - New `IOA_UDP_RECVMMSG_MAX_BATCH = 16` constant; both listener and relay paths now share it.
- **Connected relay batch read** (`socket_udp_read_batch_recvmmsg` in `ns_ioalib_engine_impl.c`): called from `socket_input_worker` for non-SSL UDP sockets when `--udp-recvmmsg` is on. Allocates per-message `stun_buffer_list_elem`s, calls `recvmmsg(MSG_DONTWAIT)`, dispatches each datagram through the existing `read_cb` path, and falls back cleanly on `ENOSYS`/`EINVAL`/`EOPNOTSUPP` (auto-disables the flag) and on `EAGAIN`/short-batch (releases unused buffers).
- **Per-engine scratch state**: the `mmsghdr[16]` / `iovec[16]` / cmsg / src-addr arrays live on `ioa_engine`, not on every socket — keeps memory flat at thousands of allocations.
- **TTL/TOS-sized cmsg buffers** in the listener: the listener previously over-allocated `64 KiB` per slot; it now uses the same TTL+TOS sizing as the relay path.
- **Opt-in occupancy stats** behind a new `--udp-recvmmsg-log` flag: every 10 s the relay logs `udp-recvmmsg stats: calls=… packets=… avg_batch=… wouldblock=… unavailable=… no_buffer=… hist_1=… hist_2=… hist_3_4=… hist_5_8=… hist_9_16=…`. Counters are always tracked (cheap); the periodic log is gated by the new flag so default operation is silent.
- **CLI plumbing**: `--udp-recvmmsg-log` long option in `mainrelay.c`/`mainrelay.h`, `cli_print_flag` entry in `turn_admin_server.c`, doc updates in `README.turnserver`.
- **Docs**: `docs/PerformanceIterationLog.md` records the iteration steps, validation, and two rounds of DigitalOcean A/B numbers. `CLAUDE.md` load-test instructions updated to mention the new flag and the `tot_recv_msgs` / `tot_recv_bytes` workaround.
