### PR TITLE
Add UDP-GSO send path (--udp-gso)

### DIFF
--- a/docs/PerformanceIterationLog.md
+++ b/docs/PerformanceIterationLog.md
@@ -392,3 +392,108 @@ Deferred bigger refactors from this run:
 - Consider a purpose-built benchmark mode that measures delivered relay pps at a
   controlled input rate. The current saturated packet flood is useful for
   finding hot functions but can obscure end-to-end delivery changes.
+
+## 2026-05-09 UDP-GSO send path (`--udp-gso`)
+
+Realizes the GSO backlog item from the iter-5 backlog above. The recvmmsg /
+sendmmsg follow-ups confirmed that on this workload the dominant cost is the
+per-datagram kernel TX path (`udp_sendmsg → ip_finish_output → __dev_queue_xmit
+→ start_xmit`), which mmsg-style batching does not collapse. UDP-GSO (Linux
+`UDP_SEGMENT` cmsg) does collapse it: N same-destination, same-size datagrams
+are submitted as one `sendmsg` carrying an iovec; the kernel allocates one
+super-skb that traverses the network stack once and is split at egress (NIC).
+
+Implementation lives in [src/apps/relay/ns_ioalib_engine_impl.c](../src/apps/relay/ns_ioalib_engine_impl.c)
+and reuses the existing `--udp-sendmmsg` batch state. Eligibility (same fd,
+same dest, same size, ≤ 1472 B per datagram) is tracked on every
+`udp_sendmmsg_enqueue`; eligible flushes go through `udp_gso_attempt_flush`
+ahead of the `sendmmsg` loop, with an automatic sticky disable on
+`EINVAL/ENOPROTOOPT` so a kernel/NIC without GSO support gracefully falls back.
+The relay-side `socket_udp_read_batch_recvmmsg` now wraps its callback loop
+in `udp_sendmmsg_batch_begin/end` so peer→client sends triggered inside a
+recvmmsg batch can also coalesce — without that wrapping, the relay path
+issues one `sendto` per delivered datagram.
+
+DigitalOcean validation on 2026-05-09 — fresh nyc1 `c-4` droplets (turn
+`10.116.0.4`, load `10.116.0.5`), all variants built from the same source tree
+under `/root/coturn/build`, `-Y packet -m 1 -l 120`, monitor window via `sar
+-n DEV` for `eth1`, `mpstat`, `pidstat`. The 12 s sweep first established the
+ordering, then a 30 s alternating A/B (`baseline → gso → baseline → gso`)
+confirmed the magnitude of the delta:
+
+| Variant | eth1 RX pps | eth1 TX pps | sys CPU | idle CPU |
+|---|---:|---:|---:|---:|
+| baseline_r1 | 322,091 | 127,445 | 22.9% | 67.5% |
+| `--udp-recvmmsg --udp-sendmmsg --udp-gso` (gso_r1) | 266,068 | **257,996** | 15.0% | 78.7% |
+| baseline_r2 | 309,475 | 125,573 | 20.9% | 70.7% |
+| gso_r2 | 275,992 | **225,366** | 14.9% | 74.3% |
+
+Mean server forwarding rate (eth1 TX): baseline 126,509 pps → GSO 241,681 pps,
+**+91 % (1.91×)**, with mean system CPU dropping from 21.9 % to 14.9 % — about
+**2.8× CPU efficiency** in TX pps per system-CPU-%.
+
+12 s packet sweep, all four variants, mean send_pps reported by uclient (used
+only for ordering — for absolute throughput trust eth1 TX above):
+
+| Variant | m=1 | m=2 | m=4 | m=8 | m=16 | m=32 |
+|---|---:|---:|---:|---:|---:|---:|
+| baseline | 230,401 | 150,189 | 187,055 | 174,771 | 160,871 | 167,789 |
+| `--udp-recvmmsg` | 255,660 | 148,824 | 174,767 | 142,997 | 150,743 | 144,200 |
+| `--udp-recvmmsg --udp-sendmmsg` | 231,766 | 146,776 | 148,826 | 136,542 | 148,955 | 143,575 |
+| `--udp-recvmmsg --udp-sendmmsg --udp-gso` | 136,876 | 147,458 | 124,250 | 131,081 | 137,636 | 114,714 |
+
+The uclient generator reports its own send rate, which drops with GSO because
+the loadgen droplet's `turnutils_peer` becomes the new bottleneck — it is
+single-threaded and cannot reflect 240 k pps. The 30 s `eth1` capture is the
+authoritative server-side metric; `sweep_m1` is retained only to show that
+GSO does not regress in the moderately-loaded `m=2..32` range relative to
+`recvmmsg+sendmmsg`.
+
+Perf children share, m=1 12 s perf record on the turnserver process:
+
+| Symbol | baseline | recvmmsg | recvsendmmsg | gso |
+|---|---:|---:|---:|---:|
+| `__x64_sys_sendto` (children) | 43.6 % | 47.6 % | 22.8 % | 0.0 % |
+| `__x64_sys_sendmsg` (children) | — | — | — | **38.1 %** |
+| `__x64_sys_sendmmsg` (children) | — | — | 27.0 % | 0.0 % |
+| `udp_sendmsg` | 38.8 % | 41.9 % | 20.6 % | 35.9 % |
+| `__dev_queue_xmit` | 18.5 % | — | — | 29.3 % |
+| `skb_segment` (egress GSO split) | absent | absent | absent | 2.2 % |
+| `syscall_return_via_sysret` (self) | 7.2 % | 4.7 % | 4.4 % | 2.4 % |
+| `entry_SYSCALL_64_after_hwframe` (self) | 4.1 % | 3.6 % | 2.6 % | 1.8 % |
+
+In the GSO column the per-packet kernel-stack cost is now amortized across
+the segments of a single super-skb. The proportional rise of
+`__dev_queue_xmit` is misleading on its own — it reflects a smaller
+denominator (CPU usage dropped) while the per-packet absolute cost dropped.
+
+Operational notes:
+
+- Flag is opt-in. `--udp-gso` requires `--udp-sendmmsg`; without that flag
+  the batch state never accumulates and GSO has nothing to flush. The
+  `--help` text states the dependency.
+- GSO eligibility resets on every `_begin/_end`. Mixed-destination or
+  mixed-size workloads transparently fall back through the existing
+  `sendmmsg` and `udp_send` paths.
+- Sticky disable on `EINVAL/ENOPROTOOPT` keeps a process running on an
+  un-virtio host or older kernel from hot-looping in the sticky failure
+  path. A WARNING line is logged once.
+- Tested on Linux 6.8 + virtio-net (DO `c-4`), `gso_max_segs=65535`. Older
+  hosts (kernel <4.18) lack `UDP_SEGMENT` entirely; the sticky-disable
+  path covers them.
+
+Suggested next levers if more relay throughput is needed:
+
+1. **Move loadgen off turnutils_peer.** The 240 k → 90 k tot_recv_msgs/30 s
+   gap at GSO is dominated by single-threaded peer reflection, not the TURN
+   server. A multi-thread peer or `pktgen`-style reflector would let us
+   measure the real ceiling.
+2. **Per-peer connected relay sockets.** Same-destination is the GSO
+   eligibility predicate; a connected relay socket would always be
+   same-dest and would also save `route_lookup` per send.
+3. **`MSG_ZEROCOPY` on the GSO sendmsg.** `rep_movs_alternative` is still
+   3 % self in GSO, and zerocopy avoids the userspace→kernel copy.
+   Probably small for 32-B STUN packets; revisit when payloads are larger.
+
+Artifacts (perf.data, sar/mpstat/pidstat, sweep logs, AB logs) are saved at
+`perf-results-20260508-213056/` in the worktree.

--- a/docs/PerformanceIterationLog.md
+++ b/docs/PerformanceIterationLog.md
@@ -351,3 +351,44 @@ Ordered by expected impact for the m=1 packet-flood metric:
    environment drifted and the baseline needs re-anchoring.
 4. Pick the next item from the backlog. Item (1) — `recvmmsg` into
    `socket_input_worker` — is where the next material gain lives.
+
+## 2026-05-03 sendmmsg follow-up
+
+A later run on two DigitalOcean CPU-optimized `c-4` droplets in `sfo3`
+(`10.124.0.2` turnserver, `10.124.0.3` loadgen) tested an experimental
+Linux-only `--udp-sendmmsg` flag with `--udp-recvmmsg`.
+
+| Run | Code/flags | Generator max pps | Generator avg pps | Server RX avg pps | Server TX avg pps | Server TX peak pps | CPU avg | Perf conclusion |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| iter0 | baseline, `--udp-recvmmsg` | 335,872 | 286,721 | 360,900 | 257,357 | 323,488 | 97.8% | `sendto`/`udp_sendmsg` dominates |
+| iter1 | `--udp-sendmmsg`, both directions | 409,600 | 312,662 | 428,184 | 197,300 | 260,453 | 99.8% | `sendmmsg` path dominates; TX regressed |
+| iter2 | `sendmmsg` only for batches >= 4 | 393,216 | 315,393 | 398,121 | 163,626 | 215,068 | 98.9% | Threshold did not recover TX |
+| iter3 | listener-side batching only | 425,984 | 286,038 | 376,444 | 210,050 | 332,417 | 97.4% | Peak ingress/TX improved, average TX still below baseline |
+
+Validation result: `sendmmsg()` is not a proven general win for this workload.
+It can increase generator max pps and peak server TX, but average delivered
+server TX stayed below the `--udp-recvmmsg` baseline. Keep it opt-in until a
+follow-up change proves better end-to-end relay throughput.
+
+Perf still points at per-datagram kernel transmit cost:
+
+- baseline: `udp_send -> sendto -> __sys_sendto -> udp_sendmsg -> udp_send_skb -> ip_output`
+- sendmmsg variants: `udp_sendmmsg_flush -> __sendmmsg -> __sys_sendmmsg -> ___sys_sendmsg -> udp_sendmsg -> ip_output`
+
+The key observation is that `sendmmsg()` reduces syscall entry count but still
+walks `udp_sendmsg` and the IP output path once per datagram. On this workload,
+the extra `mmsghdr` copy/looping overhead can offset the syscall savings.
+
+Deferred bigger refactors from this run:
+
+- Per-peer connected UDP relay sockets or a destination cache could reduce
+  address handling and route lookup for repeated peer sends, but it changes
+  relay socket semantics and receive filtering.
+- Shard a single hot allocation/flow across multiple relay workers only with a
+  careful design for ordering, session accounting, socket ownership, and lock
+  contention.
+- Investigate `io_uring` send batching or kernel-bypass style transmit only as
+  a larger architecture experiment.
+- Consider a purpose-built benchmark mode that measures delivered relay pps at a
+  controlled input rate. The current saturated packet flood is useful for
+  finding hot functions but can obscure end-to-end delivery changes.

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -859,6 +859,7 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
 
     if (batch_rc > 0) {
       struct dtls_listener_recvmmsg_state *state = server->recvmmsg_state;
+      udp_sendmmsg_batch_begin();
       for (int i = 0; i < batch_rc; ++i) {
         if (!state->elems[i]) {
           continue;
@@ -872,6 +873,7 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
           state->elems[i] = NULL;
         }
       }
+      udp_sendmmsg_batch_end();
 
       prom_inc_packet_dropped(packets_dropped);
       prom_inc_packet_processed(packets_processed);
@@ -997,10 +999,12 @@ start_udp_cycle:
   }
 
   if (bsize > 0) {
+    udp_sendmmsg_batch_begin();
     process_udp_datagram(server, s, elem, &(server->sm.m.sm.nd.src_addr), bsize, server->sm.m.sm.nd.recv_ttl,
                          server->sm.m.sm.nd.recv_tos,
                          (int)classify_udp_packet(ioa_network_buffer_data(elem), (size_t)bsize), &packets_processed,
                          &packets_dropped);
+    udp_sendmmsg_batch_end();
   }
 
   if (server->sm.m.sm.nd.nbh != NULL) {

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -243,6 +243,7 @@ turn_params_t turn_params = {
     false, /* udp_recvmmsg */
     false, /* udp_recvmmsg_log */
     false, /* udp_sendmmsg */
+    false, /* udp_gso */
     false  /* include_reason_string */
 };
 
@@ -1368,6 +1369,8 @@ static char Usage[] =
     " --udp-recvmmsg-log			   Log Linux recvmmsg batch occupancy stats every 10 seconds.\n"
     " --udp-sendmmsg				   Enable Linux-only batched UDP send via sendmmsg() while processing "
     "UDP input batches.\n"
+    " --udp-gso				   Enable Linux UDP-GSO (UDP_SEGMENT cmsg) when a sendmmsg batch shares "
+    "destination and size; collapses N datagrams into one network-stack traversal. Requires --udp-sendmmsg.\n"
     " --include-reason-string			   Include descriptive reason strings in STUN/TURN error responses.\n"
     "						   By default, only the standard reason phrase for the error code is\n"
     "						   sent. Enabling this option adds detailed error descriptions which\n"
@@ -1536,6 +1539,7 @@ enum EXTRA_OPTS {
   UDP_RECVMMSG_OPT,
   UDP_RECVMMSG_LOG_OPT,
   UDP_SENDMMSG_OPT,
+  UDP_GSO_OPT,
   VERSION_OPT,
   CPUS_OPT,
   INCLUDE_REASON_STRING_OPT
@@ -1688,6 +1692,7 @@ static const struct myoption long_options[] = {
     {"udp-recvmmsg", optional_argument, NULL, UDP_RECVMMSG_OPT},
     {"udp-recvmmsg-log", optional_argument, NULL, UDP_RECVMMSG_LOG_OPT},
     {"udp-sendmmsg", optional_argument, NULL, UDP_SENDMMSG_OPT},
+    {"udp-gso", optional_argument, NULL, UDP_GSO_OPT},
     {"include-reason-string", optional_argument, NULL, INCLUDE_REASON_STRING_OPT},
     {"version", optional_argument, NULL, VERSION_OPT},
     {"syslog-facility", required_argument, NULL, SYSLOG_FACILITY_OPT},
@@ -2491,6 +2496,9 @@ static void set_option(int c, char *value) {
     break;
   case UDP_SENDMMSG_OPT:
     turn_params.udp_sendmmsg = get_bool_value(value);
+    break;
+  case UDP_GSO_OPT:
+    turn_params.udp_gso = get_bool_value(value);
     break;
   case INCLUDE_REASON_STRING_OPT:
     turn_params.include_reason_string = get_bool_value(value);

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -242,6 +242,7 @@ turn_params_t turn_params = {
     false, /* drop_invalid_packets_log */
     false, /* udp_recvmmsg */
     false, /* udp_recvmmsg_log */
+    false, /* udp_sendmmsg */
     false  /* include_reason_string */
 };
 
@@ -1365,6 +1366,8 @@ static char Usage[] =
     " --udp-recvmmsg				   Enable Linux-only batched UDP receive via recvmmsg() on UDP "
     "sockets.\n"
     " --udp-recvmmsg-log			   Log Linux recvmmsg batch occupancy stats every 10 seconds.\n"
+    " --udp-sendmmsg				   Enable Linux-only batched UDP send via sendmmsg() while processing "
+    "UDP input batches.\n"
     " --include-reason-string			   Include descriptive reason strings in STUN/TURN error responses.\n"
     "						   By default, only the standard reason phrase for the error code is\n"
     "						   sent. Enabling this option adds detailed error descriptions which\n"
@@ -1532,6 +1535,7 @@ enum EXTRA_OPTS {
   DROP_INVALID_PACKETS_LOG_OPT,
   UDP_RECVMMSG_OPT,
   UDP_RECVMMSG_LOG_OPT,
+  UDP_SENDMMSG_OPT,
   VERSION_OPT,
   CPUS_OPT,
   INCLUDE_REASON_STRING_OPT
@@ -1683,6 +1687,7 @@ static const struct myoption long_options[] = {
     {"drop-invalid-packets-log", optional_argument, NULL, DROP_INVALID_PACKETS_LOG_OPT},
     {"udp-recvmmsg", optional_argument, NULL, UDP_RECVMMSG_OPT},
     {"udp-recvmmsg-log", optional_argument, NULL, UDP_RECVMMSG_LOG_OPT},
+    {"udp-sendmmsg", optional_argument, NULL, UDP_SENDMMSG_OPT},
     {"include-reason-string", optional_argument, NULL, INCLUDE_REASON_STRING_OPT},
     {"version", optional_argument, NULL, VERSION_OPT},
     {"syslog-facility", required_argument, NULL, SYSLOG_FACILITY_OPT},
@@ -2483,6 +2488,9 @@ static void set_option(int c, char *value) {
     break;
   case UDP_RECVMMSG_LOG_OPT:
     turn_params.udp_recvmmsg_log = get_bool_value(value);
+    break;
+  case UDP_SENDMMSG_OPT:
+    turn_params.udp_sendmmsg = get_bool_value(value);
     break;
   case INCLUDE_REASON_STRING_OPT:
     turn_params.include_reason_string = get_bool_value(value);

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -362,6 +362,7 @@ typedef struct _turn_params_ {
   bool drop_invalid_packets_log;
   bool udp_recvmmsg;
   bool udp_recvmmsg_log;
+  bool udp_sendmmsg;
   bool include_reason_string;
 } turn_params_t;
 

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -363,6 +363,7 @@ typedef struct _turn_params_ {
   bool udp_recvmmsg;
   bool udp_recvmmsg_log;
   bool udp_sendmmsg;
+  bool udp_gso;
   bool include_reason_string;
 } turn_params_t;
 

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -32,6 +32,10 @@
  * SUCH DAMAGE.
  */
 
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #include "ns_turn_khash.h"
 #include "ns_turn_server.h"
 #include "ns_turn_session.h"
@@ -134,6 +138,8 @@ struct ioa_socket_recvmmsg_state {
 #endif
 
 #define TRIAL_EFFORTS_TO_SEND (2)
+#define MAX_SENDMMSG_BATCH (32)
+#define MIN_SENDMMSG_BATCH (4)
 
 #define SSL_MAX_RENEG_NUMBER (3)
 
@@ -877,18 +883,16 @@ void delete_ioa_timer(ioa_timer_handle th) {
 /************** SOCKETS HELPERS ***********************/
 
 int ioa_socket_check_bandwidth(ioa_socket_handle s, ioa_network_buffer_handle nbh, int read) {
-  /* Fast path: per-packet hot call. Most sessions have no bandwidth limit
-   * configured (max_bps == 0), so short-circuit before the multi-condition
-   * sat/session/engine checks below. */
-  if (s && s->session && s->session->bps < 1) {
-    return 1;
-  }
   if (s && (s->e) && nbh && ((s->sat == CLIENT_SOCKET) || (s->sat == RELAY_SOCKET) || (s->sat == RELAY_RTCP_SOCKET)) &&
       (s->session)) {
 
     const size_t sz = ioa_network_buffer_get_size(nbh);
 
     const band_limit_t max_bps = s->session->bps;
+
+    if (max_bps < 1) {
+      return 1;
+    }
 
     struct traffic_bytes *traffic = &(s->data_traffic);
 
@@ -3448,6 +3452,194 @@ int is_connreset(void) {
 
 int would_block(void) { return socket_ewouldblock(); }
 
+#if defined(__linux__)
+typedef struct udp_sendmmsg_batch_entry {
+  ioa_socket_handle s;
+  ioa_engine_handle e;
+  evutil_socket_t fd;
+  ioa_addr dest_addr;
+  int has_dest_addr;
+  ioa_network_buffer_handle nbh;
+  int len;
+  struct iovec iov;
+  struct mmsghdr msg;
+} udp_sendmmsg_batch_entry;
+
+typedef struct udp_sendmmsg_batch_state {
+  unsigned int depth;
+  unsigned int count;
+  evutil_socket_t fd;
+  int ttl;
+  int tos;
+  udp_sendmmsg_batch_entry entries[MAX_SENDMMSG_BATCH];
+} udp_sendmmsg_batch_state;
+
+static _Thread_local udp_sendmmsg_batch_state udp_sendmmsg_batch = {0};
+
+static evutil_socket_t udp_send_fd(ioa_socket_handle s) {
+  if (!s) {
+    return -1;
+  }
+
+  if (s->parent_s) {
+    return s->parent_s->fd;
+  }
+
+  return s->fd;
+}
+
+static int udp_sendmmsg_flush(void) {
+  udp_sendmmsg_batch_state *state = &udp_sendmmsg_batch;
+  unsigned int sent = 0;
+
+  if (state->count < MIN_SENDMMSG_BATCH) {
+    for (unsigned int i = 0; i < state->count; ++i) {
+      udp_sendmmsg_batch_entry *entry = &(state->entries[i]);
+      udp_send(entry->s, entry->has_dest_addr ? &(entry->dest_addr) : NULL,
+               (const char *)ioa_network_buffer_data(entry->nbh), entry->len);
+    }
+
+    sent = state->count;
+  }
+
+  while (sent < state->count) {
+    int rc = 0;
+
+    do {
+      rc = sendmmsg(state->fd, &(state->entries[sent].msg), state->count - sent, 0);
+    } while (rc < 0 && socket_eintr());
+
+    if (rc <= 0) {
+      break;
+    }
+
+    sent += (unsigned int)rc;
+  }
+
+  for (unsigned int i = sent; i < state->count; ++i) {
+    udp_sendmmsg_batch_entry *entry = &(state->entries[i]);
+    udp_send(entry->s, entry->has_dest_addr ? &(entry->dest_addr) : NULL,
+             (const char *)ioa_network_buffer_data(entry->nbh), entry->len);
+  }
+
+  for (unsigned int i = 0; i < state->count; ++i) {
+    ioa_network_buffer_delete(state->entries[i].e, state->entries[i].nbh);
+  }
+
+  state->count = 0;
+  state->fd = -1;
+  state->ttl = TTL_IGNORE;
+  state->tos = TOS_IGNORE;
+
+  return (int)sent;
+}
+
+void udp_sendmmsg_batch_begin(void) {
+  if (!turn_params.udp_sendmmsg) {
+    return;
+  }
+
+  ++udp_sendmmsg_batch.depth;
+}
+
+void udp_sendmmsg_batch_end(void) {
+  if (!turn_params.udp_sendmmsg || udp_sendmmsg_batch.depth == 0) {
+    return;
+  }
+
+  --udp_sendmmsg_batch.depth;
+  if (udp_sendmmsg_batch.depth == 0) {
+    udp_sendmmsg_flush();
+  }
+}
+
+static int udp_sendmmsg_enqueue(ioa_socket_handle s, const ioa_addr *dest_addr, ioa_network_buffer_handle nbh, int ttl,
+                                int tos) {
+  udp_sendmmsg_batch_state *state = &udp_sendmmsg_batch;
+  const evutil_socket_t fd = udp_send_fd(s);
+
+  if (!turn_params.udp_sendmmsg || state->depth == 0 || fd < 0 || !nbh) {
+    return 0;
+  }
+
+  if (state->count > 0 && (state->fd != fd || state->ttl != ttl || state->tos != tos)) {
+    udp_sendmmsg_flush();
+  }
+
+  if (state->count == MAX_SENDMMSG_BATCH) {
+    udp_sendmmsg_flush();
+  }
+
+  if (state->count == 0) {
+    state->fd = fd;
+    state->ttl = ttl;
+    state->tos = tos;
+  }
+
+  udp_sendmmsg_batch_entry *entry = &(state->entries[state->count]);
+  memset(entry, 0, sizeof(*entry));
+  entry->s = s;
+  entry->e = s->e;
+  entry->fd = fd;
+  entry->nbh = nbh;
+  entry->len = (int)ioa_network_buffer_get_size(nbh);
+  entry->has_dest_addr = dest_addr != NULL;
+  if (entry->has_dest_addr) {
+    addr_cpy(&(entry->dest_addr), dest_addr);
+    entry->msg.msg_hdr.msg_name = &(entry->dest_addr);
+    entry->msg.msg_hdr.msg_namelen = (socklen_t)get_ioa_addr_len(&(entry->dest_addr));
+  }
+  entry->iov.iov_base = ioa_network_buffer_data(nbh);
+  entry->iov.iov_len = (size_t)entry->len;
+  entry->msg.msg_hdr.msg_iov = &(entry->iov);
+  entry->msg.msg_hdr.msg_iovlen = 1;
+
+  ++state->count;
+
+  return 1;
+}
+
+static void udp_sendmmsg_flush_if_pending(void) {
+  if (udp_sendmmsg_batch.count > 0) {
+    udp_sendmmsg_flush();
+  }
+}
+
+static void udp_sendmmsg_flush_before_socket_options(ioa_socket_handle s, int ttl, int tos) {
+  udp_sendmmsg_batch_state *state = &udp_sendmmsg_batch;
+
+  if (state->count == 0) {
+    return;
+  }
+
+  if (state->fd == udp_send_fd(s) && (state->ttl != ttl || state->tos != tos)) {
+    udp_sendmmsg_flush();
+  }
+}
+#else
+void udp_sendmmsg_batch_begin(void) {}
+
+void udp_sendmmsg_batch_end(void) {}
+
+static int udp_sendmmsg_enqueue(ioa_socket_handle s, const ioa_addr *dest_addr, ioa_network_buffer_handle nbh, int ttl,
+                                int tos) {
+  UNUSED_ARG(s);
+  UNUSED_ARG(dest_addr);
+  UNUSED_ARG(nbh);
+  UNUSED_ARG(ttl);
+  UNUSED_ARG(tos);
+  return 0;
+}
+
+static void udp_sendmmsg_flush_if_pending(void) {}
+
+static void udp_sendmmsg_flush_before_socket_options(ioa_socket_handle s, int ttl, int tos) {
+  UNUSED_ARG(s);
+  UNUSED_ARG(ttl);
+  UNUSED_ARG(tos);
+}
+#endif
+
 int udp_send(ioa_socket_handle s, const ioa_addr *dest_addr, const char *buffer, int len) {
   int rc = 0;
   evutil_socket_t fd = -1;
@@ -3533,90 +3725,101 @@ int send_data_from_ioa_socket_nbh(ioa_socket_handle s, ioa_addr *dest_addr, ioa_
         *skip = 1;
       }
     } else {
-      /* Outer branch already established !s->done && s->fd != -1, and
-       * ioa_socket_tobeclosed() rechecks both — drop the redundant inner test
-       * that gated this path on every send. */
       if (!ioa_socket_tobeclosed(s) && s->e) {
-        set_socket_ttl(s, ttl);
-        set_socket_tos(s, tos);
 
-        if (s->connected && s->bev) {
-          if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET)) {
+        if (!(s->done || (s->fd == -1))) {
+          udp_sendmmsg_flush_before_socket_options(s, ttl, tos);
+          set_socket_ttl(s, ttl);
+          set_socket_tos(s, tos);
+
+          if (s->connected && s->bev) {
+            udp_sendmmsg_flush_if_pending();
+            if ((s->st == TLS_SOCKET) || (s->st == TLS_SCTP_SOCKET)) {
 #if TLS_SUPPORTED
-            SSL *ctx = bufferevent_openssl_get_ssl(s->bev);
-            if (!ctx || SSL_get_shutdown(ctx)) {
-              s->tobeclosed = 1;
-              ret = 0;
-            }
+              SSL *ctx = bufferevent_openssl_get_ssl(s->bev);
+              if (!ctx || SSL_get_shutdown(ctx)) {
+                s->tobeclosed = 1;
+                ret = 0;
+              }
 #endif
-          }
+            }
 
-          if (!(s->tobeclosed)) {
+            if (!(s->tobeclosed)) {
+
+              ret = (int)ioa_network_buffer_get_size(nbh);
+
+              if (!tcp_congestion_control || is_socket_writeable(s, (size_t)ret, __FUNCTION__, 2)) {
+                s->in_write = 1;
+                if (bufferevent_write(s->bev, ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh)) < 0) {
+                  ret = -1;
+                  TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "bufev send: %s\n", strerror(errno));
+                  log_socket_event(s, "socket write failed, to be closed", 1);
+                  s->tobeclosed = 1;
+                  s->broken = 1;
+                }
+                /*
+                bufferevent_flush(s->bev,
+                                                EV_READ|EV_WRITE,
+                                                BEV_FLUSH);
+                                                */
+                s->in_write = 0;
+              } else {
+                // drop the packet
+                ;
+              }
+            }
+          } else if (s->ssl) {
+            udp_sendmmsg_flush_if_pending();
+            send_ssl_backlog_buffers(s);
+            ret = ssl_send(s, (char *)ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh),
+                           (s->e ? s->e->verbose : TURN_VERBOSE_NONE));
+            if (ret < 0) {
+              s->tobeclosed = 1;
+            } else if (ret == 0) {
+              add_buffer_to_buffer_list(&(s->bufs), (char *)ioa_network_buffer_data(nbh),
+                                        ioa_network_buffer_get_size(nbh));
+            }
+          } else if (s->fd >= 0) {
+
+            if (s->connected && !(s->parent_s)) {
+              dest_addr = NULL; /* ignore dest_addr */
+            } else if (!dest_addr) {
+              dest_addr = &(s->remote_addr);
+            }
 
             ret = (int)ioa_network_buffer_get_size(nbh);
-
-            if (!tcp_congestion_control || is_socket_writeable(s, (size_t)ret, __FUNCTION__, 2)) {
-              s->in_write = 1;
-              if (bufferevent_write(s->bev, ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh)) < 0) {
-                ret = -1;
-                TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "bufev send: %s\n", strerror(errno));
-                log_socket_event(s, "socket write failed, to be closed", 1);
-                s->tobeclosed = 1;
-                s->broken = 1;
-              }
-              /*
-              bufferevent_flush(s->bev,
-                                              EV_READ|EV_WRITE,
-                                              BEV_FLUSH);
-                                              */
-              s->in_write = 0;
+            if (udp_sendmmsg_enqueue(s, dest_addr, nbh, ttl, tos)) {
+              nbh = NULL;
             } else {
-              // drop the packet
-              ;
-            }
-          }
-        } else if (s->ssl) {
-          send_ssl_backlog_buffers(s);
-          ret = ssl_send(s, (char *)ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh),
-                         (s->e ? s->e->verbose : TURN_VERBOSE_NONE));
-          if (ret < 0) {
-            s->tobeclosed = 1;
-          } else if (ret == 0) {
-            add_buffer_to_buffer_list(&(s->bufs), (char *)ioa_network_buffer_data(nbh),
-                                      ioa_network_buffer_get_size(nbh));
-          }
-        } else if (s->fd >= 0) {
-
-          if (s->connected && !(s->parent_s)) {
-            dest_addr = NULL; /* ignore dest_addr */
-          } else if (!dest_addr) {
-            dest_addr = &(s->remote_addr);
-          }
-
-          ret = udp_send(s, dest_addr, (char *)ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh));
-          if (ret < 0) {
-            s->tobeclosed = 1;
+              udp_sendmmsg_flush_if_pending();
+              ret = udp_send(s, dest_addr, (char *)ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh));
+              if (ret < 0) {
+                s->tobeclosed = 1;
 #if defined(EADDRNOTAVAIL)
-            const int perr = socket_errno();
+                const int perr = socket_errno();
 #endif
-            TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "udp send: %s\n", strerror(errno));
+                TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "udp send: %s\n", strerror(errno));
 #if defined(EADDRNOTAVAIL)
-            if (dest_addr && (perr == EADDRNOTAVAIL)) {
-              char sfrom[MAX_IOA_ADDR_STRING] = "";
-              addr_to_string(&(s->local_addr), sfrom);
-              char sto[MAX_IOA_ADDR_STRING] = "";
-              addr_to_string(dest_addr, sto);
-              TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: network error: address unreachable from %s to %s\n",
-                            __FUNCTION__, sfrom, sto);
-            }
+                if (dest_addr && (perr == EADDRNOTAVAIL)) {
+                  char sfrom[MAX_IOA_ADDR_STRING] = "";
+                  addr_to_string(&(s->local_addr), sfrom);
+                  char sto[MAX_IOA_ADDR_STRING] = "";
+                  addr_to_string(dest_addr, sto);
+                  TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: network error: address unreachable from %s to %s\n",
+                                __FUNCTION__, sfrom, sto);
+                }
 #endif
+              }
+            }
           }
         }
       }
     }
   }
 
-  ioa_network_buffer_delete(s->e, nbh);
+  if (nbh) {
+    ioa_network_buffer_delete(s->e, nbh);
+  }
 
   return ret;
 }
@@ -4083,98 +4286,92 @@ void turn_report_allocation_delete(void *a, SOCKET_TYPE socket_type) {
 }
 
 void turn_report_session_usage(void *session, int force_invalid) {
-  if (!session) {
-    return;
-  }
-  ts_ur_super_session *ss = (ts_ur_super_session *)session;
-  turn_turnserver *server = (turn_turnserver *)ss->server;
-  if (!server || (!ss->received_packets && !ss->sent_packets && !force_invalid)) {
-    return;
-  }
-  /* Hot path: this function is called per packet. Fast-exit when no report is
-   * due (only one call in 4096 actually does work) before the cross-TU
-   * turn_server_get_engine() call. */
-  if (!force_invalid &&
-      ((ss->received_packets + ss->sent_packets + ss->peer_received_packets + ss->peer_sent_packets) & 4095) != 0) {
-    return;
-  }
-  ioa_engine_handle e = turn_server_get_engine(server);
-  if (e && e->verbose) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
-                  "session %018llu: usage: realm=<%s>, username=<%s>, rp=%lu, rb=%lu, sp=%lu, sb=%lu\n",
-                  (unsigned long long)(ss->id), (char *)ss->realm_options.name, (char *)ss->username,
-                  (unsigned long)(ss->received_packets), (unsigned long)(ss->received_bytes),
-                  (unsigned long)(ss->sent_packets), (unsigned long)(ss->sent_bytes));
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
-                  "session %018llu: peer usage: realm=<%s>, username=<%s>, rp=%lu, rb=%lu, sp=%lu, sb=%lu\n",
-                  (unsigned long long)(ss->id), (char *)ss->realm_options.name, (char *)ss->username,
-                  (unsigned long)(ss->peer_received_packets), (unsigned long)(ss->peer_received_bytes),
-                  (unsigned long)(ss->peer_sent_packets), (unsigned long)(ss->peer_sent_bytes));
-  }
+  if (session) {
+    ts_ur_super_session *ss = (ts_ur_super_session *)session;
+    turn_turnserver *server = (turn_turnserver *)ss->server;
+    if (server && (ss->received_packets || ss->sent_packets || force_invalid)) {
+      ioa_engine_handle e = turn_server_get_engine(server);
+      if (((ss->received_packets + ss->sent_packets + ss->peer_received_packets + ss->peer_sent_packets) & 4095) == 0 ||
+          force_invalid) {
+        if (e && e->verbose) {
+          TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
+                        "session %018llu: usage: realm=<%s>, username=<%s>, rp=%lu, rb=%lu, sp=%lu, sb=%lu\n",
+                        (unsigned long long)(ss->id), (char *)ss->realm_options.name, (char *)ss->username,
+                        (unsigned long)(ss->received_packets), (unsigned long)(ss->received_bytes),
+                        (unsigned long)(ss->sent_packets), (unsigned long)(ss->sent_bytes));
+          TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
+                        "session %018llu: peer usage: realm=<%s>, username=<%s>, rp=%lu, rb=%lu, sp=%lu, sb=%lu\n",
+                        (unsigned long long)(ss->id), (char *)ss->realm_options.name, (char *)ss->username,
+                        (unsigned long)(ss->peer_received_packets), (unsigned long)(ss->peer_received_bytes),
+                        (unsigned long)(ss->peer_sent_packets), (unsigned long)(ss->peer_sent_bytes));
+        }
 #if !defined(TURN_NO_HIREDIS)
-  if (e) {
-    char key[1024];
-    if (ss->realm_options.name[0]) {
-      snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/traffic", ss->realm_options.name,
-               (char *)ss->username, (unsigned long long)(ss->id));
-    } else {
-      snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/traffic", (char *)ss->username,
-               (unsigned long long)(ss->id));
-    }
-    send_message_to_redis(e->rch, "publish", key, "rcvp=%lu, rcvb=%lu, sentp=%lu, sentb=%lu",
-                          (unsigned long)(ss->received_packets), (unsigned long)(ss->received_bytes),
-                          (unsigned long)(ss->sent_packets), (unsigned long)(ss->sent_bytes));
-    if (ss->realm_options.name[0]) {
-      snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/traffic/peer", ss->realm_options.name,
-               (char *)ss->username, (unsigned long long)(ss->id));
-    } else {
-      snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/traffic/peer", (char *)ss->username,
-               (unsigned long long)(ss->id));
-    }
-    send_message_to_redis(e->rch, "publish", key, "rcvp=%lu, rcvb=%lu, sentp=%lu, sentb=%lu",
-                          (unsigned long)(ss->peer_received_packets), (unsigned long)(ss->peer_received_bytes),
-                          (unsigned long)(ss->peer_sent_packets), (unsigned long)(ss->peer_sent_bytes));
-  }
+        if (e) {
+          char key[1024];
+          if (ss->realm_options.name[0]) {
+            snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/traffic", ss->realm_options.name,
+                     (char *)ss->username, (unsigned long long)(ss->id));
+          } else {
+            snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/traffic", (char *)ss->username,
+                     (unsigned long long)(ss->id));
+          }
+          send_message_to_redis(e->rch, "publish", key, "rcvp=%lu, rcvb=%lu, sentp=%lu, sentb=%lu",
+                                (unsigned long)(ss->received_packets), (unsigned long)(ss->received_bytes),
+                                (unsigned long)(ss->sent_packets), (unsigned long)(ss->sent_bytes));
+          if (ss->realm_options.name[0]) {
+            snprintf(key, sizeof(key), "turn/realm/%s/user/%s/allocation/%018llu/traffic/peer", ss->realm_options.name,
+                     (char *)ss->username, (unsigned long long)(ss->id));
+          } else {
+            snprintf(key, sizeof(key), "turn/user/%s/allocation/%018llu/traffic/peer", (char *)ss->username,
+                     (unsigned long long)(ss->id));
+          }
+          send_message_to_redis(e->rch, "publish", key, "rcvp=%lu, rcvb=%lu, sentp=%lu, sentb=%lu",
+                                (unsigned long)(ss->peer_received_packets), (unsigned long)(ss->peer_received_bytes),
+                                (unsigned long)(ss->peer_sent_packets), (unsigned long)(ss->peer_sent_bytes));
+        }
 #endif
-  ss->t_received_packets += ss->received_packets;
-  ss->t_received_bytes += ss->received_bytes;
-  ss->t_sent_packets += ss->sent_packets;
-  ss->t_sent_bytes += ss->sent_bytes;
-  ss->t_peer_received_packets += ss->peer_received_packets;
-  ss->t_peer_received_bytes += ss->peer_received_bytes;
-  ss->t_peer_sent_packets += ss->peer_sent_packets;
-  ss->t_peer_sent_bytes += ss->peer_sent_bytes;
+        ss->t_received_packets += ss->received_packets;
+        ss->t_received_bytes += ss->received_bytes;
+        ss->t_sent_packets += ss->sent_packets;
+        ss->t_sent_bytes += ss->sent_bytes;
+        ss->t_peer_received_packets += ss->peer_received_packets;
+        ss->t_peer_received_bytes += ss->peer_received_bytes;
+        ss->t_peer_sent_packets += ss->peer_sent_packets;
+        ss->t_peer_sent_bytes += ss->peer_sent_bytes;
 
-  {
-    turn_time_t ct = get_turn_server_time(server);
-    if (ct != ss->start_time) {
-      ct = ct - ss->start_time;
-      ss->received_rate = (uint32_t)(ss->t_received_bytes / ct);
-      ss->sent_rate = (uint32_t)(ss->t_sent_bytes / ct);
-      ss->total_rate = ss->received_rate + ss->sent_rate;
-      ss->peer_received_rate = (uint32_t)(ss->t_peer_received_bytes / ct);
-      ss->peer_sent_rate = (uint32_t)(ss->t_peer_sent_bytes / ct);
-      ss->peer_total_rate = ss->peer_received_rate + ss->peer_sent_rate;
+        {
+          turn_time_t ct = get_turn_server_time(server);
+          if (ct != ss->start_time) {
+            ct = ct - ss->start_time;
+            ss->received_rate = (uint32_t)(ss->t_received_bytes / ct);
+            ss->sent_rate = (uint32_t)(ss->t_sent_bytes / ct);
+            ss->total_rate = ss->received_rate + ss->sent_rate;
+            ss->peer_received_rate = (uint32_t)(ss->t_peer_received_bytes / ct);
+            ss->peer_sent_rate = (uint32_t)(ss->t_peer_sent_bytes / ct);
+            ss->peer_total_rate = ss->peer_received_rate + ss->peer_sent_rate;
+          }
+        }
+
+        report_turn_session_info(server, ss, force_invalid);
+
+        if (force_invalid) {
+          const turn_dbdriver_t *dbd = get_dbdriver();
+          if (dbd && dbd->report_usage) {
+            dbd->report_usage(session);
+          }
+        }
+
+        ss->received_packets = 0;
+        ss->received_bytes = 0;
+        ss->sent_packets = 0;
+        ss->sent_bytes = 0;
+        ss->peer_received_packets = 0;
+        ss->peer_received_bytes = 0;
+        ss->peer_sent_packets = 0;
+        ss->peer_sent_bytes = 0;
+      }
     }
   }
-
-  report_turn_session_info(server, ss, force_invalid);
-
-  if (force_invalid) {
-    const turn_dbdriver_t *dbd = get_dbdriver();
-    if (dbd && dbd->report_usage) {
-      dbd->report_usage(session);
-    }
-  }
-
-  ss->received_packets = 0;
-  ss->received_bytes = 0;
-  ss->sent_packets = 0;
-  ss->sent_bytes = 0;
-  ss->peer_received_packets = 0;
-  ss->peer_received_bytes = 0;
-  ss->peer_sent_packets = 0;
-  ss->peer_sent_bytes = 0;
 }
 
 /////////////// SSL ///////////////////

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -140,6 +140,18 @@ struct ioa_socket_recvmmsg_state {
 #define TRIAL_EFFORTS_TO_SEND (2)
 #define MAX_SENDMMSG_BATCH (32)
 #define MIN_SENDMMSG_BATCH (4)
+#define MIN_UDP_GSO_BATCH (2)
+#define MAX_UDP_GSO_DGRAM_SIZE (1472)
+
+#if defined(__linux__)
+#include <netinet/udp.h>
+#ifndef UDP_SEGMENT
+#define UDP_SEGMENT 103
+#endif
+#ifndef SOL_UDP
+#define SOL_UDP 17
+#endif
+#endif
 
 #define SSL_MAX_RENEG_NUMBER (3)
 
@@ -2398,6 +2410,11 @@ static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s, int *last_len) {
 
   ioa_engine_record_udp_recvmmsg_batch(e, rc);
 
+  /* Wrap the per-datagram callbacks so that any sends triggered by them can
+   * be coalesced via udp_sendmmsg / UDP-GSO. Without this, the relay-side
+   * recvmmsg path issues one send syscall per delivered datagram. */
+  udp_sendmmsg_batch_begin();
+
   for (int i = 0; i < rc; ++i) {
     stun_buffer_list_elem *buf_elem = buf_elems[i];
     ioa_net_data nd;
@@ -2433,6 +2450,8 @@ static int socket_udp_read_batch_recvmmsg(ioa_socket_handle s, int *last_len) {
       break;
     }
   }
+
+  udp_sendmmsg_batch_end();
 
   for (unsigned int i = 0; i < count; ++i) {
     if (buf_elems[i]) {
@@ -3471,6 +3490,11 @@ typedef struct udp_sendmmsg_batch_state {
   evutil_socket_t fd;
   int ttl;
   int tos;
+  /* GSO eligibility tracked while enqueuing: when true, all entries so far
+   * share the same destination address and size, so the batch can be flushed
+   * with one sendmsg + UDP_SEGMENT cmsg instead of N sendmsg-equivalents. */
+  int gso_eligible;
+  uint16_t gso_size;
   udp_sendmmsg_batch_entry entries[MAX_SENDMMSG_BATCH];
 } udp_sendmmsg_batch_state;
 
@@ -3488,12 +3512,76 @@ static evutil_socket_t udp_send_fd(ioa_socket_handle s) {
   return s->fd;
 }
 
+/* Attempt to flush the batch as a single UDP-GSO sendmsg.
+ * Returns the number of datagrams handed to the kernel (== state->count) on
+ * success, or 0 if the GSO path is disabled / not eligible / not supported.
+ * On EINVAL/ENOPROTOOPT the GSO flag is sticky-disabled to avoid retrying.
+ */
+static int udp_gso_attempt_flush(void) {
+  udp_sendmmsg_batch_state *state = &udp_sendmmsg_batch;
+
+  if (!turn_params.udp_gso || !state->gso_eligible || state->count < MIN_UDP_GSO_BATCH || state->gso_size == 0 ||
+      state->gso_size > MAX_UDP_GSO_DGRAM_SIZE || state->fd < 0) {
+    return 0;
+  }
+
+  struct iovec iov[MAX_SENDMMSG_BATCH];
+  for (unsigned int i = 0; i < state->count; ++i) {
+    iov[i].iov_base = ioa_network_buffer_data(state->entries[i].nbh);
+    iov[i].iov_len = (size_t)state->entries[i].len;
+  }
+
+  union {
+    struct cmsghdr align;
+    char buf[CMSG_SPACE(sizeof(uint16_t))];
+  } cmsg_buf = {0};
+
+  struct msghdr mh = {0};
+  mh.msg_iov = iov;
+  mh.msg_iovlen = state->count;
+  if (state->entries[0].has_dest_addr) {
+    mh.msg_name = &(state->entries[0].dest_addr);
+    mh.msg_namelen = (socklen_t)get_ioa_addr_len(&(state->entries[0].dest_addr));
+  }
+  mh.msg_control = cmsg_buf.buf;
+  mh.msg_controllen = sizeof(cmsg_buf.buf);
+
+  struct cmsghdr *cm = CMSG_FIRSTHDR(&mh);
+  cm->cmsg_level = SOL_UDP;
+  cm->cmsg_type = UDP_SEGMENT;
+  cm->cmsg_len = CMSG_LEN(sizeof(uint16_t));
+  uint16_t seg = state->gso_size;
+  memcpy(CMSG_DATA(cm), &seg, sizeof(seg));
+
+  ssize_t rc = 0;
+  do {
+    rc = sendmsg(state->fd, &mh, 0);
+  } while (rc < 0 && socket_eintr());
+
+  if (rc < 0) {
+    if (errno == EINVAL || errno == ENOPROTOOPT || errno == EOPNOTSUPP) {
+      /* Kernel/NIC does not support UDP_SEGMENT here. Disable to avoid
+       * retrying on every flush; user can re-enable next process restart. */
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "UDP-GSO sendmsg failed (errno=%d), disabling --udp-gso for this process\n",
+                    errno);
+      turn_params.udp_gso = false;
+    }
+    return 0;
+  }
+
+  return (int)state->count;
+}
+
 static int udp_sendmmsg_flush(void) {
   udp_sendmmsg_batch_state *state = &udp_sendmmsg_batch;
   unsigned int sent = 0;
 
-  if (state->count < MIN_SENDMMSG_BATCH) {
-    for (unsigned int i = 0; i < state->count; ++i) {
+  if (turn_params.udp_gso) {
+    sent = (unsigned int)udp_gso_attempt_flush();
+  }
+
+  if (sent < state->count && (state->count - sent) < MIN_SENDMMSG_BATCH) {
+    for (unsigned int i = sent; i < state->count; ++i) {
       udp_sendmmsg_batch_entry *entry = &(state->entries[i]);
       udp_send(entry->s, entry->has_dest_addr ? &(entry->dest_addr) : NULL,
                (const char *)ioa_network_buffer_data(entry->nbh), entry->len);
@@ -3530,6 +3618,8 @@ static int udp_sendmmsg_flush(void) {
   state->fd = -1;
   state->ttl = TTL_IGNORE;
   state->tos = TOS_IGNORE;
+  state->gso_eligible = 0;
+  state->gso_size = 0;
 
   return (int)sent;
 }
@@ -3574,6 +3664,8 @@ static int udp_sendmmsg_enqueue(ioa_socket_handle s, const ioa_addr *dest_addr, 
     state->fd = fd;
     state->ttl = ttl;
     state->tos = tos;
+    state->gso_eligible = 1;
+    state->gso_size = 0;
   }
 
   udp_sendmmsg_batch_entry *entry = &(state->entries[state->count]);
@@ -3593,6 +3685,22 @@ static int udp_sendmmsg_enqueue(ioa_socket_handle s, const ioa_addr *dest_addr, 
   entry->iov.iov_len = (size_t)entry->len;
   entry->msg.msg_hdr.msg_iov = &(entry->iov);
   entry->msg.msg_hdr.msg_iovlen = 1;
+
+  /* Maintain GSO eligibility: same dest, same size, fits one segment. */
+  if (state->gso_eligible) {
+    if (entry->len <= 0 || entry->len > MAX_UDP_GSO_DGRAM_SIZE) {
+      state->gso_eligible = 0;
+    } else if (state->count == 0) {
+      /* First entry — lock in the segment size and dest. */
+      state->gso_size = (uint16_t)entry->len;
+    } else if ((uint16_t)entry->len != state->gso_size) {
+      state->gso_eligible = 0;
+    } else if (state->entries[0].has_dest_addr != entry->has_dest_addr) {
+      state->gso_eligible = 0;
+    } else if (entry->has_dest_addr && !addr_eq(&(entry->dest_addr), &(state->entries[0].dest_addr))) {
+      state->gso_eligible = 0;
+    }
+  }
 
   ++state->count;
 

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -278,6 +278,8 @@ void delete_socket_from_map(ioa_socket_handle s);
 
 int is_connreset(void);
 int would_block(void);
+void udp_sendmmsg_batch_begin(void);
+void udp_sendmmsg_batch_end(void);
 int udp_send(ioa_socket_handle s, const ioa_addr *dest_addr, const char *buffer, int len);
 int udp_recvfrom(evutil_socket_t fd, ioa_addr *orig_addr, const ioa_addr *like_addr, char *buffer, int buf_size,
                  int *ttl, int *tos, char *ecmsg, int flags, uint32_t *errcode);

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -700,6 +700,7 @@ static void cli_print_configuration(struct cli_session *cs) {
     cli_print_flag(cs, turn_params.udp_recvmmsg, "udp-recvmmsg", 0);
     cli_print_flag(cs, turn_params.udp_recvmmsg_log, "udp-recvmmsg-log", 0);
     cli_print_flag(cs, turn_params.udp_sendmmsg, "udp-sendmmsg", 0);
+    cli_print_flag(cs, turn_params.udp_gso, "udp-gso", 0);
     cli_print_str(cs, turn_params.pidfile, "pidfile", 0);
 #if defined(WINDOWS)
     // TODO: implement it!!!

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -699,6 +699,7 @@ static void cli_print_configuration(struct cli_session *cs) {
     cli_print_flag(cs, turn_params.udp_self_balance, "udp-self-balance", 0);
     cli_print_flag(cs, turn_params.udp_recvmmsg, "udp-recvmmsg", 0);
     cli_print_flag(cs, turn_params.udp_recvmmsg_log, "udp-recvmmsg-log", 0);
+    cli_print_flag(cs, turn_params.udp_sendmmsg, "udp-sendmmsg", 0);
     cli_print_str(cs, turn_params.pidfile, "pidfile", 0);
 #if defined(WINDOWS)
     // TODO: implement it!!!


### PR DESCRIPTION
## Summary

- New `--udp-gso` flag (Linux, requires `--udp-sendmmsg`) collapses same-destination, same-size sendmmsg batches into a single `sendmsg` with a `UDP_SEGMENT` cmsg, so the kernel allocates one super-skb that traverses the network stack once and is segmented at egress instead of running `udp_sendmsg → ip_finish_output → __dev_queue_xmit` per datagram.
- Also wraps the relay-side `recvmmsg` callback loop in `udp_sendmmsg_batch_begin/end` so peer→client sends triggered inside a recv batch can also coalesce — without that wrapping the relay path issues one `sendto` per delivered datagram.
- Sticky-disable on `EINVAL/ENOPROTOOPT` for older kernels/NICs that lack UDP-GSO; one warning logged, then transparent fallback to the existing `sendmmsg` and `udp_send` paths.

## Why

The `--udp-recvmmsg` and `--udp-sendmmsg` follow-ups confirmed (see [docs/PerformanceIterationLog.md](docs/PerformanceIterationLog.md)) that on the relay flood workload the dominant cost is the per-datagram kernel TX path. mmsg-style batching reduces only the syscall entry/exit, not the per-skb stack traversal — UDP-GSO collapses both.

## Result

DigitalOcean nyc1 c-4, 30 s alternating A/B, `-Y packet -m 1`, eth1 TX as the authoritative server forwarding metric:

| Variant | eth1 RX | eth1 TX | sys CPU | idle CPU |
|---|---:|---:|---:|---:|
| baseline (no flags) | 322,091 | 127,445 | 22.9 % | 67.5 % |
| `--udp-recvmmsg --udp-sendmmsg --udp-gso` | 266,068 | **257,996** | 15.0 % | 78.7 % |
| baseline (no flags) | 309,475 | 125,573 | 20.9 % | 70.7 % |
| `--udp-recvmmsg --udp-sendmmsg --udp-gso` | 275,992 | **225,366** | 14.9 % | 74.3 % |

Mean server forwarding rate: **126.5 k → 241.7 k pps (+91 %, 1.91×)**, mean system CPU **21.9 % → 14.9 %** — about **2.8× CPU efficiency** (TX pps per system-CPU-%). Full perf-children comparison and methodology in the new section of [docs/PerformanceIterationLog.md](docs/PerformanceIterationLog.md).

## Notes for reviewers

- `--udp-gso` is opt-in and requires `--udp-sendmmsg` (the help text states the dependency). Without `--udp-sendmmsg` the batch state never accumulates and GSO has nothing to flush.
- GSO eligibility resets on every `_begin/_end`. Mixed-destination, mixed-size, or oversize batches transparently fall back through `sendmmsg` / `udp_send`.
- Rebased onto current `master`; the recvmmsg dependency is already merged via #1906.

## Test plan

- [x] `cmake --build build --target turnserver` (RelWithDebInfo + ASan local builds clean)
- [x] `ctest --test-dir build --output-on-failure` — 3/3 unit tests pass
- [x] `examples/run_tests.sh` — TCP/TLS/UDP pass; DTLS pre-existing failure on macOS environment, unrelated to this change
- [x] DigitalOcean A/B perf validation captured above
- [ ] Reviewer to confirm CI green on Linux build/test/CodeQL