### PR TITLE
Fix TTL/TOS type conversion

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -428,7 +428,7 @@ static void free_blist_elem(ioa_engine_handle e, stun_buffer_list_elem *buf_elem
 }
 
 #if !defined(_MSC_VER) && defined(CMSG_SPACE)
-void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, recv_ttl_t *ttl, recv_tos_t *tos, uint32_t *errcode) {
+void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, int *ttl, int *tos, uint32_t *errcode) {
 
   recv_ttl_t recv_ttl = TTL_DEFAULT;
   recv_tos_t recv_tos = TOS_DEFAULT;
@@ -2246,8 +2246,8 @@ int udp_recvfrom(evutil_socket_t fd, ioa_addr *orig_addr, const ioa_addr *like_a
   }
 
   const int slen = get_ioa_addr_len(like_addr);
-  recv_ttl_t recv_ttl = TTL_DEFAULT;
-  recv_tos_t recv_tos = TOS_DEFAULT;
+  int recv_ttl = TTL_DEFAULT;
+  int recv_tos = TOS_DEFAULT;
 
 #if defined(_MSC_VER) || !defined(CMSG_SPACE)
   do {

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -428,9 +428,7 @@ static void free_blist_elem(ioa_engine_handle e, stun_buffer_list_elem *buf_elem
 }
 
 #if !defined(_MSC_VER) && defined(CMSG_SPACE)
-void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, int *ttl, int *tos, uint32_t *errcode) {
-  typedef unsigned char recv_ttl_t;
-  typedef unsigned char recv_tos_t;
+void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, recv_ttl_t *ttl, recv_tos_t *tos, uint32_t *errcode) {
 
   recv_ttl_t recv_ttl = TTL_DEFAULT;
   recv_tos_t recv_tos = TOS_DEFAULT;
@@ -2235,9 +2233,6 @@ static int socket_readerr(evutil_socket_t fd, ioa_addr *orig_addr) {
   return 0;
 }
 
-typedef unsigned char recv_ttl_t;
-typedef unsigned char recv_tos_t;
-
 int udp_recvfrom(evutil_socket_t fd, ioa_addr *orig_addr, const ioa_addr *like_addr, char *buffer, int buf_size,
                  int *ttl, int *tos, char *ecmsg, int flags, uint32_t *errcode) {
   int len = 0;
@@ -2309,7 +2304,7 @@ try_again:
 #endif
 
   if (len >= 0) {
-    ioa_parse_udp_recvmsg_cmsg(&msg, (int *)&recv_ttl, (int *)&recv_tos, errcode);
+    ioa_parse_udp_recvmsg_cmsg(&msg, &recv_ttl, &recv_tos, errcode);
   }
 
 #endif

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -76,6 +76,9 @@ extern "C" {
 #define BUFFEREVENT_MAX_UDP_TO_TCP_WRITE (64 << 9)
 #define BUFFEREVENT_MAX_TCP_TO_TCP_WRITE (192 << 10)
 
+typedef unsigned char recv_ttl_t;
+typedef unsigned char recv_tos_t;
+
 typedef struct _stun_buffer_list_elem {
   struct _stun_buffer_list_elem *next;
   stun_buffer buf;
@@ -291,7 +294,7 @@ void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src
 #endif
 
 #if !defined(_MSC_VER) && defined(CMSG_SPACE)
-void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, int *ttl, int *tos, uint32_t *errcode);
+void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, recv_ttl_t *ttl, recv_tos_t *tos, uint32_t *errcode);
 #endif
 
 #if defined(__linux__)

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -294,7 +294,7 @@ void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src
 #endif
 
 #if !defined(_MSC_VER) && defined(CMSG_SPACE)
-void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, recv_ttl_t *ttl, recv_tos_t *tos, uint32_t *errcode);
+void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, int *ttl, int *tos, uint32_t *errcode);
 #endif
 
 #if defined(__linux__)


### PR DESCRIPTION

Fix UB in udp_recvfrom: recv_ttl/recv_tos were unsigned char locals whose addresses were cast to int * and passed to ioa_parse_udp_recvmsg_cmsg, which writes a full int through that pointer — clobbering 3 bytes of adjacent stack on every UDP receive. Manifested as a TTL/TOS bug on macOS.
Change the locals in udp_recvfrom to int so no pointer cast is needed.
Hoist the recv_ttl_t / recv_tos_t typedefs out of the two function bodies and into ns_ioalib_impl.h so they remain shared by the cmsg parser.

## Test plan
[x] cmake -S . -B build -DBUILD_TESTING=ON && cmake --build build -j && ctest --test-dir build --output-on-failure
[x] cd examples && ./run_tests.sh && ./run_tests_conf.sh
[x] Verify relayed UDP carries the expected TTL/TOS on macOS (previously corrupted)
[x] Linux build + system tests in Docker per CLAUDE.md