### PR TITLE
Reap TURN permissions/channels via a per-thread sweep instead of per-object timers

### DIFF
--- a/examples/run_tests_expiry.sh
+++ b/examples/run_tests_expiry.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+# Functional test for the lazy permission/channel expiry sweep.
+#
+# Background: permission and channel expiry used to be driven by one
+# libevent timer per permission and per channel. That was replaced by a
+# single per-thread sweep (timer_timeout_handler -> turn_server_sweep_timed_events
+# in src/server/ns_turn_server.c) that walks every session once a second and
+# reaps entries whose expiration_time has passed. This test proves the sweep
+# actually fires and reaps mid-session, without breaking the relay or the
+# rest of the session.
+#
+# How it forces the sweep to act:
+#   * The server uses its OWN --permission-lifetime / --channel-lifetime for
+#     every CreatePermission / ChannelBind (it ignores the lifetime the client
+#     asks for: see update_turn_permission_lifetime / update_channel_lifetime).
+#   * turnutils_uclient only re-sends CreatePermission + ChannelBind every 30s
+#     (refresh_channel() in src/apps/uclient/uclient.c). Plain channel data does
+#     NOT refresh the permission.
+#   * With server lifetimes set to 4s and a ~18s run, the permission+channel are
+#     created at t=0, then reaped by the sweep at t~=4 — well before the next
+#     client refresh. The only code path that logs "peer ... deleted" for a live,
+#     un-torn-down session is turn_permission_clean() invoked by the sweep, so a
+#     "deleted" line during the run is proof the sweep ran and reaped.
+#
+# A regression where the sweep never fires => no "deleted" line => FAIL.
+# A regression where it reaps too eagerly / crashes => server dies or never logs
+# the creation => FAIL.
+
+TURNSERVER_LOG="/tmp/run_tests_expiry.$$.turnserver.log"
+PEER_LOG="/tmp/run_tests_expiry.$$.peer.log"
+UCLIENT_LOG="/tmp/run_tests_expiry.$$.uclient.log"
+
+turnserver_pid=""
+peer_pid=""
+
+cleanup() {
+    kill "$turnserver_pid" "$peer_pid" 2>/dev/null
+    wait "$turnserver_pid" "$peer_pid" 2>/dev/null
+    rm -f "$TURNSERVER_LOG" "$PEER_LOG" "$UCLIENT_LOG"
+}
+trap cleanup EXIT
+
+BINDIR="../bin"
+if [ ! -f $BINDIR/turnserver ]; then
+    BINDIR="../build/bin"
+fi
+
+# Short lifetimes force the sweep to reap between the client's 30s refreshes.
+PERM_LIFETIME=4
+CHAN_LIFETIME=4
+RUN_SECONDS=18
+
+echo "Running turnserver (verbose, permission/channel lifetime ${PERM_LIFETIME}s)"
+# Pin loopback explicitly: without --listening-ip the server auto-detects every
+# interface address, which intermittently includes transient IPv6 privacy
+# addresses it cannot bind (errno=22), stalling startup. The test only needs
+# loopback.
+$BINDIR/turnserver --verbose --use-auth-secret --static-auth-secret=secret \
+    --realm=north.gov --allow-loopback-peers \
+    --listening-ip=127.0.0.1 --relay-ip=127.0.0.1 --no-dtls --no-tls \
+    --permission-lifetime=$PERM_LIFETIME --channel-lifetime=$CHAN_LIFETIME \
+    --log-file=stdout --simple-log \
+    --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem \
+    > "$TURNSERVER_LOG" 2>&1 &
+turnserver_pid="$!"
+
+wait_for_turnserver() {
+    local i
+    for i in $(seq 1 40); do
+        if grep -q "Total auth threads:" "$TURNSERVER_LOG" 2>/dev/null; then
+            return 0
+        fi
+        if ! kill -0 "$turnserver_pid" 2>/dev/null; then
+            echo "FATAL: turnserver exited before init completed"
+            tail -30 "$TURNSERVER_LOG" 2>/dev/null
+            return 1
+        fi
+        sleep 0.5
+    done
+    echo "FATAL: turnserver never reached 'Total auth threads:' within 20s"
+    tail -30 "$TURNSERVER_LOG" 2>/dev/null
+    return 1
+}
+wait_for_turnserver || exit 1
+sleep 1
+
+echo 'Running peer client'
+$BINDIR/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > "$PEER_LOG" 2>&1 &
+peer_pid="$!"
+sleep 1
+
+echo "Running turn client UDP for ${RUN_SECONDS}s (creates a permission + channel, then idles past the lifetime)"
+# -n large so the client keeps the session up for the whole window; timeout
+# stops it. We do NOT assert on relayed byte counts here: once the permission
+# expires mid-run the relay intentionally drops traffic, so loss is expected
+# and is not the property under test. The property is the server-side lifecycle
+# in the log, asserted below.
+timeout -s INT ${RUN_SECONDS}s "$BINDIR/turnutils_uclient" \
+    -n 1000000 -m 1 -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 \
+    > "$UCLIENT_LOG" 2>&1
+rc=$?
+# 124 (SIGTERM by timeout) / 130 (SIGINT clean exit) are the expected stop codes.
+if [ $rc -ne 0 ] && [ $rc -ne 124 ] && [ $rc -ne 130 ]; then
+    echo "FAIL: turnutils_uclient exited unexpectedly with $rc"
+    tail -20 "$UCLIENT_LOG"
+    exit 1
+fi
+
+fail() {
+    echo "FAIL: $1"
+    echo "--- turnserver log: permission lifecycle lines ---"
+    grep -iE "lifetime updated|deleted" "$TURNSERVER_LOG" 2>/dev/null | head -20
+    echo "--- turnserver log (last 20 lines) ---"
+    tail -20 "$TURNSERVER_LOG" 2>/dev/null
+    exit 1
+}
+
+# 1. The server must still be alive (the sweep ran on its event loop every 1s
+#    for the whole run; a crash/UAF in the sweep would have taken it down).
+if ! kill -0 "$turnserver_pid" 2>/dev/null; then
+    fail "turnserver is no longer running after the expiry run (possible crash in the sweep)"
+fi
+
+# 2. A permission must have been created (verbose 'lifetime updated' line). This
+#    confirms the client reached the server and the lifecycle started.
+if ! grep -q "lifetime updated" "$TURNSERVER_LOG"; then
+    fail "no 'lifetime updated' line — permission was never created; cannot test expiry"
+fi
+
+# 3. A permission must have been reaped mid-session by the sweep ('deleted'
+#    line). For a live (un-torn-down) session this is reachable only via the
+#    sweep, so its presence proves lazy expiry fired.
+deleted_count=$(grep -c "deleted" "$TURNSERVER_LOG")
+if [ "${deleted_count:-0}" -lt 1 ]; then
+    fail "no 'deleted' line — the sweep did not reap the expired permission/channel"
+fi
+
+echo "OK (sweep reaped ${deleted_count} expired permission(s)/channel(s); server healthy)"

--- a/src/server/ns_turn_allocation.c
+++ b/src/server/ns_turn_allocation.c
@@ -188,11 +188,6 @@ void turn_permission_clean(turn_permission_info *tinfo) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "session %018llu: peer %s deleted\n", tinfo->session_id, s);
   }
 
-  if (!(tinfo->lifetime_ev)) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: strange (1) permission to be cleaned\n", __FUNCTION__);
-  }
-
-  IOA_EVENT_DEL(tinfo->lifetime_ev);
   lm_map_foreach(&(tinfo->chns), (foreachcb_type)delete_channel_info_from_allocation_map);
   lm_map_clean(&(tinfo->chns));
   memset(tinfo, 0, sizeof(turn_permission_info));
@@ -271,7 +266,6 @@ static void ch_info_clean(ch_info *c) {
       DELETE_TURN_CHANNEL_KERNEL(c->kernel_channel);
       c->kernel_channel = 0;
     }
-    IOA_EVENT_DEL(c->lifetime_ev);
     memset(c, 0, sizeof(ch_info));
   }
 }

--- a/src/server/ns_turn_allocation.h
+++ b/src/server/ns_turn_allocation.h
@@ -119,7 +119,6 @@ typedef struct _ch_info {
   uint16_t port;
   ioa_addr peer_addr;
   turn_time_t expiration_time;
-  ioa_timer_handle lifetime_ev;
   void *owner; // perm
   TURN_CHANNEL_HANDLER_KERNEL kernel_channel;
 } ch_info;
@@ -149,7 +148,6 @@ typedef struct _turn_permission_info {
   lm_map chns;
   ioa_addr addr;
   turn_time_t expiration_time;
-  ioa_timer_handle lifetime_ev;
   void *owner; // a
   bool verbose;
   unsigned long long session_id;

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -167,11 +167,14 @@ static int need_stun_authentication(turn_turnserver *server, ts_ur_super_session
 
 /////////////////// timer //////////////////////////
 
+static void turn_server_sweep_timed_events(turn_turnserver *server);
+
 static void timer_timeout_handler(ioa_engine_handle e, void *arg) {
   UNUSED_ARG(e);
   if (arg) {
     turn_turnserver *server = (turn_turnserver *)arg;
     server->ctime = turn_time();
+    turn_server_sweep_timed_events(server);
   }
 }
 
@@ -909,10 +912,6 @@ static void client_ss_perm_timeout_handler(ioa_engine_handle e, void *arg) {
     return;
   }
 
-  if (!(tinfo->lifetime_ev)) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: strange (1) permission to be cleaned\n", __FUNCTION__);
-  }
-
   if (!(tinfo->owner)) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: strange (2) permission to be cleaned\n", __FUNCTION__);
   }
@@ -943,9 +942,8 @@ static int update_turn_permission_lifetime(ts_ur_super_session *ss, turn_permiss
       }
       tinfo->expiration_time = server->ctime + time_delta;
 
-      IOA_EVENT_DEL(tinfo->lifetime_ev);
-      tinfo->lifetime_ev = set_ioa_timer(server->e, time_delta, 0, client_ss_perm_timeout_handler, tinfo, 0,
-                                         "client_ss_channel_timeout_handler");
+      /* Expiry is reaped lazily by the per-thread sweep in timer_timeout_handler();
+       * touching the permission only needs to push its expiration_time forward. */
 
       if (server->verbose) {
         tinfo->verbose = true;
@@ -980,15 +978,87 @@ static int update_channel_lifetime(ts_ur_super_session *ss, ch_info *chn) {
 
         chn->expiration_time = server->ctime + *(server->channel_lifetime);
 
-        IOA_EVENT_DEL(chn->lifetime_ev);
-        chn->lifetime_ev = set_ioa_timer(server->e, *(server->channel_lifetime), 0, client_ss_channel_timeout_handler,
-                                         chn, 0, "client_ss_channel_timeout_handler");
+        /* Channel expiry is reaped lazily by the per-thread sweep in
+         * timer_timeout_handler(); just push its expiration_time forward. */
 
         return 0;
       }
     }
   }
   return -1;
+}
+
+//////////////// lazy expiry sweep ////////////////////////
+
+/* Reap expired permissions and channels for a single allocation. This replaces
+ * the former per-permission / per-channel libevent timers: update_*_lifetime()
+ * only pushes expiration_time forward, and this sweep (driven once per second by
+ * the per-thread timer_timeout_handler) tears down whatever has fallen past its
+ * deadline. At high allocation counts this trades ~1M libevent min-heap nodes and
+ * two heap ops per refresh for a bounded per-thread array walk. */
+static void sweep_allocation_timed_events(turn_turnserver *server, allocation *a) {
+  if (!a || !is_allocation_valid(a)) {
+    return;
+  }
+
+  const turn_time_t ctime = server->ctime;
+
+  /* Permissions first: cleaning a permission also tears down its channels, so
+   * channels of an expired permission are already gone by the channel pass. */
+  turn_permission_hashtable *pmap = allocation_get_turn_permission_hashtable(a);
+  for (size_t i = 0; i < TURN_PERMISSION_HASHTABLE_SIZE; ++i) {
+    turn_permission_array *parray = &(pmap->table[i]);
+    for (size_t j = 0; j < TURN_PERMISSION_ARRAY_SIZE; ++j) {
+      turn_permission_info *tinfo = &(parray->main_slots[j].info);
+      if (tinfo->allocated && turn_time_before(tinfo->expiration_time, ctime)) {
+        client_ss_perm_timeout_handler(server->e, tinfo);
+      }
+    }
+    if (parray->extra_slots) {
+      for (size_t j = 0; j < parray->extra_sz; ++j) {
+        turn_permission_slot *slot = parray->extra_slots[j];
+        if (slot && slot->info.allocated && turn_time_before(slot->info.expiration_time, ctime)) {
+          client_ss_perm_timeout_handler(server->e, &(slot->info));
+        }
+      }
+    }
+  }
+
+  /* Channels whose owning permission is still alive but whose own deadline passed. */
+  ch_map *cmap = &(a->chns);
+  for (size_t i = 0; i < CH_MAP_HASH_SIZE; ++i) {
+    ch_map_array *carray = &(cmap->table[i]);
+    for (size_t j = 0; j < CH_MAP_ARRAY_SIZE; ++j) {
+      ch_info *chn = &(carray->main_chns[j]);
+      if (chn->allocated && turn_time_before(chn->expiration_time, ctime)) {
+        client_ss_channel_timeout_handler(server->e, chn);
+      }
+    }
+    if (carray->extra_chns) {
+      for (size_t j = 0; j < carray->extra_sz; ++j) {
+        ch_info *chn = carray->extra_chns[j];
+        if (chn && chn->allocated && turn_time_before(chn->expiration_time, ctime)) {
+          client_ss_channel_timeout_handler(server->e, chn);
+        }
+      }
+    }
+  }
+}
+
+static bool sweep_session_cb(ur_map_key_type key, ur_map_value_type value, void *arg) {
+  UNUSED_ARG(key);
+  if (value) {
+    ts_ur_super_session *ss = (ts_ur_super_session *)value;
+    turn_turnserver *server = (turn_turnserver *)arg;
+    sweep_allocation_timed_events(server, get_allocation_ss(ss));
+  }
+  return false; /* keep iterating all sessions */
+}
+
+static void turn_server_sweep_timed_events(turn_turnserver *server) {
+  if (server && server->sessions_map) {
+    ur_map_foreach_arg(server->sessions_map, sweep_session_cb, server);
+  }
 }
 
 /////////////// TURN ///////////////////////////


### PR DESCRIPTION
## Summary

Each TURN permission and channel carried its own libevent timer, torn down and recreated (`IOA_EVENT_DEL` + `set_ioa_timer`) on **every** refresh. At high allocation counts this is the dominant scheduling and memory cost: ~200k+ live libevent events at 100k allocations (≥2 per allocation), each ~228 B of resident heap (a `timer_event`, a libevent `struct event`, and a `strdup` of the handler name) plus a min-heap node.

This replaces per-object timers with a single **per-thread sweep**. `timer_timeout_handler` already runs once a second per relay thread on that thread's own engine; after refreshing `ctime` it now walks the thread-local `sessions_map` and reaps permissions/channels whose `expiration_time` has passed, **reusing the existing `client_ss_perm_timeout_handler` / `client_ss_channel_timeout_handler`** so teardown (including `mp_deregister_permission_peers` in multiplex-peer mode) is unchanged. `update_turn_permission_lifetime` / `update_channel_lifetime` now just push `expiration_time` forward.

The now-dead `lifetime_ev` fields are removed from `turn_permission_info` (648→640 B) and `ch_info` (64→56 B), along with the spurious "strange permission" error log that would otherwise fire on every sweep-driven expiry.

## Why

For workloads with many concurrent allocations (e.g. 100k VoIP sessions), the per-object timer model puts ~200k+ nodes in libevent's min-heap and burns a free/malloc/strdup cycle on every refresh. The expiry deadline is already stored in `expiration_time`; a periodic sweep makes the timer redundant.

## Trade-offs

- Expiry latency rises to **≤1s** (negligible vs 300–600s permission/channel TTLs).
- The sweep is a bounded per-thread array walk — ~39k trivial comparisons/thread/s at 100k allocations over 128 threads.

## Performance (measured)

Faithful libevent 2.1.12 microbenchmark of the create/refresh/destroy path:

| Metric | Before | After |
|---|---|---|
| Resident heap per timer | ~228 B | 0 |
| Refresh op | 110 ns (del+create at 100k heap depth) | 0.28 ns (field store) |
| `sizeof(turn_permission_info)` | 648 B | 640 B |
| `sizeof(ch_info)` | 64 B | 56 B |

At 100k allocations (≥2 timers each): **~46 MB** of libevent objects freed and ~200k fewer min-heap nodes.

## Testing

- Unit (`ctest`), `run_tests.sh`, `run_tests_conf.sh`, `run_tests_multiplex_peer.sh` — pass on macOS and in a clean Ubuntu 24.04 Docker build.
- New `examples/run_tests_expiry.sh`: forces 4s server-side permission/channel lifetimes so the sweep must reap mid-session, and asserts the verbose log shows reaping while the server stays healthy. **Verified to FAIL when the sweep call is disabled** (negative control), confirming it catches the regression rather than passing trivially.
