### PR TITLE
Add --udp-sendmmsg-log to observe egress sendmmsg/UDP-GSO batching

### DIFF
--- a/docs/multiplex-peer.md
+++ b/docs/multiplex-peer.md
@@ -169,6 +169,71 @@ closed by session teardown code.
 
 ---
 
+## Egress Batching (sendmmsg / UDP-GSO) and Observability
+
+Multiplex-peer mode does more than save ports — it is also what makes
+**cross-session egress batching** possible on Linux.
+
+### Why both directions batch under multiplex-peer
+
+`recvmmsg` on a UDP socket drains many datagrams in one syscall, and the
+drain loop (`socket_udp_read_batch_recvmmsg`) wraps its per-datagram dispatch
+in `udp_sendmmsg_batch_begin()` / `udp_sendmmsg_batch_end()`. Any sends issued
+while processing that drain are collected into a thread-local batch keyed by
+the **send fd** and flushed once (via `sendmmsg`, or a single UDP-GSO `sendmsg`
+when destination and segment size match) at `batch_end`.
+
+- **Uplink (client → relay → peer).** The client listener's `recvmmsg` drain
+  pulls many clients' datagrams; each is forwarded to its peer on the shared
+  relay socket → one `sendmmsg` on the relay fd.
+- **Downlink (peer → relay → client).** With multiplex-peer the **shared**
+  relay socket's `recvmmsg` drain pulls datagrams for *many sessions* at once;
+  each is forwarded to its client. Per-session UDP client sockets are children
+  of the listener socket (`parent_s`), and `udp_send_fd()` returns the
+  **listener fd** for all of them — so downlink sends to *different clients*
+  coalesce into one `sendmmsg` on the shared listener fd, each `mmsghdr`
+  carrying its own client destination.
+
+This is why downlink-to-client is **not** an unbatched per-packet `sendto`
+path under multiplex-peer: the listener fd is effectively a shared
+client-facing send socket, and `sendmmsg` amortizes the syscall across
+clients. (In non-multiplex mode each allocation has its own relay socket, so a
+relay `recvmmsg` drain only ever spans one session and the downlink batch is a
+singleton — cross-client batching genuinely requires multiplex-peer.)
+
+`udp_sendmmsg` is enabled automatically whenever `--multiplex-peer` is set;
+`--udp-gso` additionally turns on UDP-GSO segmentation for batches that share
+destination and size.
+
+### Measuring it: `--udp-sendmmsg-log`
+
+GSO only engages when every datagram in a batch shares the same destination
+and size, so at low per-flow packet rates (e.g. VoIP, a few dozen pps per
+flow) it rarely fires and batches tend toward singletons. To see what is
+actually happening, enable per-thread egress stats every 10 s:
+
+```bash
+turnserver --multiplex-peer --udp-gso --udp-sendmmsg-log ...
+```
+
+```
+udp-sendmmsg stats: flushes=21 datagrams=27 avg_batch=1.29 \
+  gso_flushes=0 gso_datagrams=0 gso_frac=0.000 \
+  hist_1=17 hist_2=2 hist_3_4=2 hist_5_8=0 hist_9_16=0 hist_17_32=0
+```
+
+- `avg_batch` — mean datagrams coalesced per flush (1.0 = no coalescing).
+- `gso_frac` — fraction of datagrams sent via UDP-GSO (≈0 means GSO is not
+  earning its keep at this workload).
+- `hist_*` — per-flush occupancy histogram.
+
+Batch occupancy scales with how many datagrams arrive per `recvmmsg` drain,
+which grows with aggregate pps — so these numbers rise under higher load and
+stay near 1.0 on lightly loaded servers. Pair with `--udp-recvmmsg-log` to see
+the ingress side.
+
+---
+
 ## Files Changed
 
 | File | What changes |

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -244,6 +244,7 @@ turn_params_t turn_params = {
     false, /* udp_recvmmsg */
     false, /* udp_recvmmsg_log */
     false, /* udp_sendmmsg (derived from multiplex_peer) */
+    false, /* udp_sendmmsg_log */
     false, /* udp_gso */
 #endif
     false, /* include_reason_string */
@@ -1371,6 +1372,9 @@ static char Usage[] =
     " --udp-recvmmsg				   Enable Linux-only batched UDP receive via recvmmsg() on UDP "
     "sockets.\n"
     " --udp-recvmmsg-log			   Log Linux recvmmsg batch occupancy stats every 10 seconds.\n"
+    " --udp-sendmmsg-log			   Log Linux sendmmsg/UDP-GSO egress batch occupancy and "
+    "GSO-engagement "
+    "stats every 10 seconds. Only meaningful with --multiplex-peer (which enables sendmmsg batching).\n"
     " --udp-gso				   Enable Linux UDP-GSO (UDP_SEGMENT cmsg) when a sendmmsg batch shares "
     "destination and size; collapses N datagrams into one network-stack traversal. Requires "
     "--multiplex-peer (which enables sendmmsg batching).\n"
@@ -1556,6 +1560,7 @@ enum EXTRA_OPTS {
 #if defined(__linux__)
   UDP_RECVMMSG_OPT,
   UDP_RECVMMSG_LOG_OPT,
+  UDP_SENDMMSG_LOG_OPT,
   UDP_GSO_OPT,
 #endif
   VERSION_OPT,
@@ -1712,6 +1717,7 @@ static const struct myoption long_options[] = {
 #if defined(__linux__)
     {"udp-recvmmsg", optional_argument, NULL, UDP_RECVMMSG_OPT},
     {"udp-recvmmsg-log", optional_argument, NULL, UDP_RECVMMSG_LOG_OPT},
+    {"udp-sendmmsg-log", optional_argument, NULL, UDP_SENDMMSG_LOG_OPT},
     {"udp-gso", optional_argument, NULL, UDP_GSO_OPT},
 #endif
     {"include-reason-string", optional_argument, NULL, INCLUDE_REASON_STRING_OPT},
@@ -2526,6 +2532,9 @@ static void set_option(int c, char *value) {
     break;
   case UDP_RECVMMSG_LOG_OPT:
     turn_params.udp_recvmmsg_log = get_bool_value(value);
+    break;
+  case UDP_SENDMMSG_LOG_OPT:
+    turn_params.udp_sendmmsg_log = get_bool_value(value);
     break;
   case UDP_GSO_OPT:
     turn_params.udp_gso = get_bool_value(value);

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -347,6 +347,7 @@ typedef struct _turn_params_ {
   bool udp_recvmmsg;
   bool udp_recvmmsg_log;
   bool udp_sendmmsg; /* derived: multiplex_peer; not user-settable */
+  bool udp_sendmmsg_log;
   bool udp_gso;
 #endif
   bool include_reason_string;

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -593,6 +593,59 @@ static void maybe_log_udp_recvmmsg_stats(ioa_engine_handle e, turn_time_t now) {
                                      e->udp_recvmmsg_hist[12] + e->udp_recvmmsg_hist[13] + e->udp_recvmmsg_hist[14] +
                                      e->udp_recvmmsg_hist[15] + e->udp_recvmmsg_hist[16]));
 }
+
+void ioa_engine_record_udp_sendmmsg_flush(ioa_engine_handle e, unsigned int count, unsigned int gso_count) {
+  if (!e || count == 0) {
+    return;
+  }
+
+  unsigned int bucket = count;
+  if (bucket > IOA_UDP_SENDMMSG_MAX_BATCH) {
+    bucket = IOA_UDP_SENDMMSG_MAX_BATCH;
+  }
+
+  e->udp_sendmmsg_flushes++;
+  e->udp_sendmmsg_datagrams += (uint64_t)count;
+  e->udp_sendmmsg_hist[bucket]++;
+
+  if (gso_count > 0) {
+    e->udp_sendmmsg_gso_flushes++;
+    e->udp_sendmmsg_gso_datagrams += (uint64_t)gso_count;
+  }
+}
+
+static uint64_t udp_sendmmsg_hist_sum(const ioa_engine_handle e, unsigned int lo, unsigned int hi) {
+  uint64_t s = 0;
+  for (unsigned int i = lo; i <= hi && i <= IOA_UDP_SENDMMSG_MAX_BATCH; ++i) {
+    s += e->udp_sendmmsg_hist[i];
+  }
+  return s;
+}
+
+static void maybe_log_udp_sendmmsg_stats(ioa_engine_handle e, turn_time_t now) {
+  if (!turn_params.udp_sendmmsg_log || !e || (e->udp_sendmmsg_flushes == e->udp_sendmmsg_last_report_flushes) ||
+      ((now - e->udp_sendmmsg_last_report_time) < 10)) {
+    return;
+  }
+
+  e->udp_sendmmsg_last_report_flushes = e->udp_sendmmsg_flushes;
+  e->udp_sendmmsg_last_report_time = now;
+
+  const double avg_batch =
+      e->udp_sendmmsg_flushes ? ((double)e->udp_sendmmsg_datagrams / (double)e->udp_sendmmsg_flushes) : 0.0;
+  const double gso_frac =
+      e->udp_sendmmsg_datagrams ? ((double)e->udp_sendmmsg_gso_datagrams / (double)e->udp_sendmmsg_datagrams) : 0.0;
+
+  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
+                "udp-sendmmsg stats: flushes=%llu datagrams=%llu avg_batch=%.2f gso_flushes=%llu gso_datagrams=%llu "
+                "gso_frac=%.3f hist_1=%llu hist_2=%llu hist_3_4=%llu hist_5_8=%llu hist_9_16=%llu hist_17_32=%llu\n",
+                (unsigned long long)e->udp_sendmmsg_flushes, (unsigned long long)e->udp_sendmmsg_datagrams, avg_batch,
+                (unsigned long long)e->udp_sendmmsg_gso_flushes, (unsigned long long)e->udp_sendmmsg_gso_datagrams,
+                gso_frac, (unsigned long long)e->udp_sendmmsg_hist[1], (unsigned long long)e->udp_sendmmsg_hist[2],
+                (unsigned long long)udp_sendmmsg_hist_sum(e, 3, 4), (unsigned long long)udp_sendmmsg_hist_sum(e, 5, 8),
+                (unsigned long long)udp_sendmmsg_hist_sum(e, 9, 16),
+                (unsigned long long)udp_sendmmsg_hist_sum(e, 17, 32));
+}
 #endif
 
 static void timer_handler(ioa_engine_handle e, void *arg) {
@@ -606,6 +659,7 @@ static void timer_handler(ioa_engine_handle e, void *arg) {
 
 #if defined(__linux__)
   maybe_log_udp_recvmmsg_stats(e, now);
+  maybe_log_udp_sendmmsg_stats(e, now);
 #endif
 }
 
@@ -3867,9 +3921,14 @@ static int udp_gso_attempt_flush(void) {
 static int udp_sendmmsg_flush(void) {
   udp_sendmmsg_batch_state *state = &udp_sendmmsg_batch;
   unsigned int sent = 0;
+  unsigned int gso_sent = 0;
+  const unsigned int batch_count = state->count;
+  /* All entries in a thread-local batch share the relay thread's engine. */
+  ioa_engine_handle stat_e = (batch_count > 0) ? state->entries[0].e : NULL;
 
   if (turn_params.udp_gso) {
-    sent = (unsigned int)udp_gso_attempt_flush();
+    gso_sent = (unsigned int)udp_gso_attempt_flush();
+    sent = gso_sent;
   }
 
   if (sent < state->count && (state->count - sent) < MIN_SENDMMSG_BATCH) {
@@ -3907,6 +3966,8 @@ static int udp_sendmmsg_flush(void) {
   for (unsigned int i = 0; i < state->count; ++i) {
     ioa_network_buffer_delete(state->entries[i].e, state->entries[i].nbh);
   }
+
+  ioa_engine_record_udp_sendmmsg_flush(stat_e, batch_count, gso_sent);
 
   state->count = 0;
   state->fd = -1;

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -71,6 +71,7 @@ extern "C" {
 #define MAX_BUFFER_QUEUE_SIZE_PER_ENGINE (64)
 #define MAX_SOCKET_BUFFER_BACKLOG (16)
 #define IOA_UDP_RECVMMSG_MAX_BATCH (16)
+#define IOA_UDP_SENDMMSG_MAX_BATCH (32)
 
 #define BUFFEREVENT_HIGH_WATERMARK (128 << 10)
 #define BUFFEREVENT_MAX_UDP_TO_TCP_WRITE (64 << 9)
@@ -173,6 +174,14 @@ struct _ioa_engine {
   uint64_t udp_recvmmsg_hist[IOA_UDP_RECVMMSG_MAX_BATCH + 1];
   uint64_t udp_recvmmsg_last_report_calls;
   turn_time_t udp_recvmmsg_last_report_time;
+  /* sendmmsg / UDP-GSO egress batching stats (see --udp-sendmmsg-log) */
+  uint64_t udp_sendmmsg_flushes;                              /* batch flushes carrying >=1 datagram */
+  uint64_t udp_sendmmsg_datagrams;                            /* total datagrams handed to the kernel via batches */
+  uint64_t udp_sendmmsg_gso_flushes;                          /* flushes that coalesced via a single UDP-GSO sendmsg */
+  uint64_t udp_sendmmsg_gso_datagrams;                        /* datagrams coalesced via UDP-GSO */
+  uint64_t udp_sendmmsg_hist[IOA_UDP_SENDMMSG_MAX_BATCH + 1]; /* per-flush occupancy histogram */
+  uint64_t udp_sendmmsg_last_report_flushes;
+  turn_time_t udp_sendmmsg_last_report_time;
 #endif
   redis_context_handle rch;
   /* multiplex-peer (zero-initialised = disabled) */
@@ -320,6 +329,7 @@ void ioa_engine_record_udp_recvmmsg_batch(ioa_engine_handle e, int rc);
 void ioa_engine_record_udp_recvmmsg_wouldblock(ioa_engine_handle e);
 void ioa_engine_record_udp_recvmmsg_unavailable(ioa_engine_handle e);
 void ioa_engine_record_udp_recvmmsg_no_buffer(ioa_engine_handle e);
+void ioa_engine_record_udp_sendmmsg_flush(ioa_engine_handle e, unsigned int count, unsigned int gso_count);
 #endif
 
 int set_raw_socket_ttl_options(evutil_socket_t fd, int family);


### PR DESCRIPTION
## Summary

Adds a Linux-only `--udp-sendmmsg-log` flag (mirroring `--udp-recvmmsg-log`) that logs per-relay-thread **egress** batch statistics every 10 s: flush count, total datagrams, average batch occupancy, UDP-GSO engagement (`gso_flushes`/`gso_datagrams`/`gso_frac`), and a per-flush occupancy histogram.

## Motivation

`--multiplex-peer` enables `sendmmsg`/UDP-GSO coalescing on the egress path, but there was no way to see whether it actually coalesces anything. While investigating this I confirmed a non-obvious property worth documenting:

- Per-session UDP **client** sockets are children of the listener (`parent_s`), and `udp_send_fd()` returns the shared **listener fd** for all of them. Combined with the `recvmmsg`-driven batch window, relay→client **downlink** sends to *different clients* already coalesce into one `sendmmsg` on the listener fd — the listener fd is effectively a shared client-facing send socket. (In non-multiplex mode each allocation has its own relay socket, so a `recvmmsg` drain spans only one session and the downlink batch is a singleton — cross-client batching genuinely requires `--multiplex-peer`.)
- UDP-GSO only engages when destination **and** segment size match across a batch, so at low per-flow packet rates (VoIP-style, tens of pps per flow) it rarely fires.

This flag makes both effects measurable instead of assumed.

## Example

Captured under a `--multiplex-peer --udp-gso` load:

```
udp-sendmmsg stats: flushes=21 datagrams=27 avg_batch=1.29 gso_flushes=0 \
  gso_datagrams=0 gso_frac=0.000 hist_1=17 hist_2=2 hist_3_4=2 hist_5_8=0 hist_9_16=0 hist_17_32=0
```

- `avg_batch` — mean datagrams per flush (1.0 = no coalescing)
- `gso_frac` — fraction of datagrams sent via UDP-GSO (~0 = GSO not earning its keep)
- `hist_*` — per-flush occupancy histogram

Both rise with aggregate pps and sit near the floor on lightly loaded servers.

## Implementation

- Counters on `ioa_engine` (behind `#if defined(__linux__)`), bumped once per flush in `udp_sendmmsg_flush()` and once per `recvmmsg` call — no per-datagram cost.
- New `--udp-sendmmsg-log` CLI flag + 10 s periodic logger in the engine timer, mirroring the existing recvmmsg stats path.
- Docs: a new "Egress Batching (sendmmsg / UDP-GSO) and Observability" section in `docs/multiplex-peer.md`.

## Testing

- macOS: build + `ctest` (6/6) + `run_tests.sh` pass (instrumentation is `#if __linux__`, validating flag plumbing + the non-Linux stub path).
- Linux (clean Ubuntu 24.04 Docker): build + `ctest` (4/4) + `run_tests.sh` / `run_tests_conf.sh` / `run_tests_multiplex_peer.sh` pass, and a `--multiplex-peer --udp-gso --udp-sendmmsg-log` load run emitted the stats line above.
