### PR TITLE
Security hardening: port parsing, admin brute-force throttle, credential log redaction, constant-time compare, OAuth bounds checks, permission cap

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1975,6 +1975,24 @@ static int get_int_value(const char *s, int default_value) {
   return atoi(s);
 }
 
+/* Parse a TCP/UDP port from a config/CLI value with range validation.
+ * Accepts 0 (meaning OS-assigned/disabled, depending on the option) through
+ * 65535. Rejects non-numeric, negative, and out-of-range values rather than
+ * silently truncating them into a uint16_t (e.g. 65536 -> 0). */
+static uint16_t get_port_value(const char *s) {
+  if (!s || !(s[0])) {
+    return 0;
+  }
+  char *endptr = NULL;
+  errno = 0;
+  const long parsed = strtol(s, &endptr, 10);
+  if (errno != 0 || endptr == s || (endptr && *endptr != '\0') || parsed < 0 || parsed > 65535) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Invalid port value: %s (must be 0-65535)\n", s);
+    exit(-1);
+  }
+  return (uint16_t)parsed;
+}
+
 static int get_bool_value(const char *s) {
   if (!s || !(s[0])) {
     return 1;
@@ -2086,7 +2104,7 @@ static void set_option(int c, char *value) {
     }
     break;
   case CLI_PORT_OPT:
-    cli_port = atoi(value);
+    cli_port = get_port_value(value);
     break;
   case CLI_PASSWORD_OPT:
     STRCPY(cli_password, value);
@@ -2102,7 +2120,7 @@ static void set_option(int c, char *value) {
     }
     break;
   case WEB_ADMIN_PORT_OPT:
-    web_admin_port = atoi(value);
+    web_admin_port = get_port_value(value);
     break;
   case WEB_ADMIN_LISTEN_ON_WORKERS_OPT:
     turn_params.web_admin_listen_on_workers = get_bool_value(value);
@@ -2150,26 +2168,26 @@ static void set_option(int c, char *value) {
     STRCPY(turn_params.listener_ifname, value);
     break;
   case 'p':
-    turn_params.listener_port = atoi(value);
+    turn_params.listener_port = get_port_value(value);
     break;
   case TLS_PORT_OPT:
-    turn_params.tls_listener_port = atoi(value);
+    turn_params.tls_listener_port = get_port_value(value);
     break;
   case ALT_PORT_OPT:
-    turn_params.alt_listener_port = atoi(value);
+    turn_params.alt_listener_port = get_port_value(value);
     break;
   case ALT_TLS_PORT_OPT:
-    turn_params.alt_tls_listener_port = atoi(value);
+    turn_params.alt_tls_listener_port = get_port_value(value);
     break;
   case TCP_PROXY_PORT_OPT:
-    turn_params.tcp_proxy_port = atoi(value);
+    turn_params.tcp_proxy_port = get_port_value(value);
     turn_params.tcp_use_proxy = true;
     break;
   case MIN_PORT_OPT:
-    turn_params.min_port = atoi(value);
+    turn_params.min_port = get_port_value(value);
     break;
   case MAX_PORT_OPT:
-    turn_params.max_port = atoi(value);
+    turn_params.max_port = get_port_value(value);
     break;
   case SOCK_BUF_SIZE_OPT:
     turn_params.sock_buf_size = atoi(value);
@@ -2343,7 +2361,7 @@ static void set_option(int c, char *value) {
     turn_params.prometheus = true;
     break;
   case PROMETHEUS_PORT_OPT:
-    turn_params.prometheus_port = atoi(value);
+    turn_params.prometheus_port = get_port_value(value);
     break;
   case PROMETHEUS_ADDRESS_OPT:
     STRCPY(turn_params.prometheus_address, value);

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -100,7 +100,11 @@ struct str_buffer;
 
 struct admin_server adminserver;
 
-bool use_cli = false;
+/* Guards the HTTPS admin logon brute-force throttle table (defined lower in this
+ * file). Declared here because setup_admin_thread() initializes it. */
+static TURN_MUTEX_DECLARE(admin_logon_throttle_mutex)
+
+    bool use_cli = false;
 
 ioa_addr cli_addr;
 int cli_addr_set = 0;
@@ -1244,9 +1248,16 @@ static void web_admin_input_handler(ioa_socket_handle s, int event_type, ioa_net
           proto = "HTTPS";
           set_ioa_socket_app_type(s, HTTPS_CLIENT_SOCKET);
 
-          TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: %s (%s %s) request: %s\n", __FUNCTION__, proto,
-                        get_ioa_socket_cipher(s), get_ioa_socket_ssl_method(s),
-                        (char *)ioa_network_buffer_data(in_buffer->nbh));
+          /* Suppress logging of the raw request when it carries credentials
+           * (the logon POST body contains "pwd="), mirroring handle_https(). */
+          if (strstr((char *)ioa_network_buffer_data(in_buffer->nbh), "pwd")) {
+            TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: %s (%s %s) request (body redacted: contains credentials)\n",
+                          __FUNCTION__, proto, get_ioa_socket_cipher(s), get_ioa_socket_ssl_method(s));
+          } else {
+            TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: %s (%s %s) request: %s\n", __FUNCTION__, proto,
+                          get_ioa_socket_cipher(s), get_ioa_socket_ssl_method(s),
+                          (char *)ioa_network_buffer_data(in_buffer->nbh));
+          }
 
           TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s socket to be detached: %p, st=%d, sat=%d\n", __FUNCTION__, s,
                         get_ioa_socket_type(s), get_ioa_socket_app_type(s));
@@ -1335,6 +1346,7 @@ static int send_socket_to_admin_server(ioa_engine_handle e, struct message_to_re
 }
 
 void setup_admin_thread(void) {
+  TURN_MUTEX_INIT(&admin_logon_throttle_mutex);
   adminserver.event_base = turn_event_base_new();
   super_memory_t *sm = new_super_memory_region();
   adminserver.e = create_ioa_engine(sm, adminserver.event_base, turn_params.listener.tp, turn_params.relay_ifname,
@@ -3327,10 +3339,103 @@ static void handle_update_request(ioa_socket_handle s, struct http_request *hr) 
   }
 }
 
+/* ---- HTTPS admin logon brute-force throttle (per source IP) ----
+ * The HTTPS admin interface authenticates per TLS connection, so without a
+ * cross-connection control an attacker can attempt unlimited password guesses
+ * by opening a fresh connection per attempt. This bounds the guess rate per
+ * source IP. State lives in a small fixed table; on overflow the
+ * least-recently-seen entry is evicted (worst case an attacker evicts their own
+ * lockout, which only resets them to the start of the failure window). All
+ * access happens on the single admin thread, but the mutex keeps it safe if
+ * that ever changes. */
+#define ADMIN_LOGON_THROTTLE_SIZE (256)
+#define ADMIN_LOGON_MAX_FAILURES (5)
+#define ADMIN_LOGON_LOCKOUT_SECS (30)
+#define ADMIN_LOGON_WINDOW_SECS (60)
+
+struct admin_logon_throttle_entry {
+  ioa_addr addr;
+  bool used;
+  int failures;
+  turn_time_t window_start;
+  turn_time_t lockout_until;
+  turn_time_t last_seen;
+};
+
+static struct admin_logon_throttle_entry admin_logon_throttle[ADMIN_LOGON_THROTTLE_SIZE];
+
+/* Find or (re)allocate the entry for addr. Caller must hold the mutex. */
+static struct admin_logon_throttle_entry *admin_logon_throttle_lookup(const ioa_addr *addr, turn_time_t now) {
+  struct admin_logon_throttle_entry *lru = &admin_logon_throttle[0];
+  for (size_t i = 0; i < ADMIN_LOGON_THROTTLE_SIZE; ++i) {
+    struct admin_logon_throttle_entry *e = &admin_logon_throttle[i];
+    if (e->used && addr_eq_no_port(&e->addr, addr)) {
+      return e;
+    }
+    if (!e->used) {
+      if (lru->used) {
+        lru = e; /* prefer any free slot */
+      }
+    } else if (lru->used && turn_time_before(e->last_seen, lru->last_seen)) {
+      lru = e;
+    }
+  }
+  memset(lru, 0, sizeof(*lru));
+  addr_cpy(&lru->addr, addr);
+  lru->used = true;
+  lru->window_start = now;
+  return lru;
+}
+
+static bool admin_logon_is_locked(const ioa_addr *addr) {
+  if (!addr) {
+    return false;
+  }
+  const turn_time_t now = turn_time();
+  TURN_MUTEX_LOCK(&admin_logon_throttle_mutex);
+  struct admin_logon_throttle_entry *e = admin_logon_throttle_lookup(addr, now);
+  const bool locked = (e->lockout_until != 0) && turn_time_before(now, e->lockout_until);
+  TURN_MUTEX_UNLOCK(&admin_logon_throttle_mutex);
+  return locked;
+}
+
+static void admin_logon_record_failure(const ioa_addr *addr) {
+  if (!addr) {
+    return;
+  }
+  const turn_time_t now = turn_time();
+  TURN_MUTEX_LOCK(&admin_logon_throttle_mutex);
+  struct admin_logon_throttle_entry *e = admin_logon_throttle_lookup(addr, now);
+  if (!turn_time_before(now, e->window_start + ADMIN_LOGON_WINDOW_SECS)) {
+    e->failures = 0;
+    e->window_start = now;
+  }
+  e->failures++;
+  e->last_seen = now;
+  if (e->failures >= ADMIN_LOGON_MAX_FAILURES) {
+    e->lockout_until = now + ADMIN_LOGON_LOCKOUT_SECS;
+    e->failures = 0;
+    e->window_start = now;
+  }
+  TURN_MUTEX_UNLOCK(&admin_logon_throttle_mutex);
+}
+
+static void admin_logon_record_success(const ioa_addr *addr) {
+  if (!addr) {
+    return;
+  }
+  const turn_time_t now = turn_time();
+  TURN_MUTEX_LOCK(&admin_logon_throttle_mutex);
+  struct admin_logon_throttle_entry *e = admin_logon_throttle_lookup(addr, now);
+  memset(e, 0, sizeof(*e)); /* clear counters/lockout on a successful logon */
+  TURN_MUTEX_UNLOCK(&admin_logon_throttle_mutex);
+}
+
 static void handle_logon_request(ioa_socket_handle s, struct http_request *hr) {
   if (s && hr) {
     const char *uname = get_http_header_value(hr, HR_USERNAME, NULL);
     const char *pwd = get_http_header_value(hr, HR_PASSWORD, NULL);
+    const ioa_addr *src = get_remote_addr_from_ioa_socket(s);
 
     struct admin_session *as = (struct admin_session *)s->special_session;
     if (!as) {
@@ -3343,6 +3448,11 @@ static void handle_logon_request(ioa_socket_handle s, struct http_request *hr) {
     }
 
     if (!(as->as_ok) && uname && is_secure_string((const uint8_t *)uname, 1) && pwd) {
+      if (admin_logon_is_locked(src)) {
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
+                      "%s: HTTPS admin logon rejected: too many failed attempts from source address\n", __FUNCTION__);
+        return;
+      }
       const turn_dbdriver_t *dbd = get_dbdriver();
       if (dbd && dbd->get_admin_user) {
         password_t password;
@@ -3356,6 +3466,11 @@ static void handle_logon_request(ioa_socket_handle s, struct http_request *hr) {
             as->number_of_user_sessions = DEFAULT_CLI_MAX_OUTPUT_SESSIONS;
           }
         }
+      }
+      if (as->as_ok) {
+        admin_logon_record_success(src);
+      } else {
+        admin_logon_record_failure(src);
       }
     }
   }

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -732,7 +732,8 @@ int add_static_user_account(char *user) {
 
   char *s = strstr(user, ":");
   if (!s || (s == user) || (strlen(s) < 2)) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong user account: %s\n", user);
+    /* Do not log the value: it contains the password component. */
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong user account: missing or malformed ':' separator\n");
     return -1;
   }
 
@@ -750,7 +751,8 @@ int add_static_user_account(char *user) {
   usname[ulen] = 0;
 
   if (!SASLprep((uint8_t *)usname)) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong user name: %s\n", user);
+    /* Log the username only, never the trailing password/key component. */
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong user name: %s\n", usname);
     free(usname);
     return -1;
   }
@@ -766,7 +768,8 @@ int add_static_user_account(char *user) {
     char *keysource = s + 2;
     const size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
     if (strlen(keysource) < sz * 2) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format: %s\n", s);
+      /* Do not log the key material itself; identify by username. */
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format for user: %s\n", usname);
     }
     convert_string_key_to_binary(keysource, *key, sz);
   } else {

--- a/src/apps/uclient/mainuclient.c
+++ b/src/apps/uclient/mainuclient.c
@@ -36,6 +36,8 @@
 #include "session.h"
 #include "uclient.h"
 
+#include <event2/thread.h>
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -229,6 +231,18 @@ int main(int argc, char **argv) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "WSAStartup failed with error: %d\n", err);
     return 1;
   }
+#endif
+
+  /* Enable libevent thread support before any event_base is created. The
+   * threaded uclient modes (--listener-threads / --sender-threads > 0, also
+   * auto-enabled at high -m) register events on a worker thread's event_base
+   * from the main thread while that worker runs event_base_dispatch(), so the
+   * base's internal structures (and the epoll changelist) are accessed cross-
+   * thread. libevent only locks them when threading was enabled up front. */
+#if defined(WINDOWS)
+  evthread_use_windows_threads();
+#else
+  evthread_use_pthreads();
 #endif
 
   set_logfile("stdout");

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -371,14 +371,25 @@ static bool encrypted_password(const char *pin, unsigned char *salt) {
   return false;
 }
 
+/* Length-checked constant-time string compare. The length comparison can leak
+ * the length of the secret, but the byte content is compared in constant time
+ * via CRYPTO_memcmp so no per-byte timing oracle remains. */
+static bool const_time_str_equal(const char *a, const char *b) {
+  const size_t la = strlen(a);
+  if (la != strlen(b)) {
+    return false;
+  }
+  return CRYPTO_memcmp(a, b, la) == 0;
+}
+
 bool check_password_equal(const char *pin, const char *pwd) {
   unsigned char salt[PWD_SALT_SIZE];
   if (!encrypted_password(pwd, salt)) {
-    return 0 == strcmp(pin, pwd);
+    return const_time_str_equal(pin, pwd);
   }
   char enc_pin[257];
   generate_enc_password(pin, enc_pin, salt);
-  return 0 == strcmp(enc_pin, pwd);
+  return const_time_str_equal(enc_pin, pwd);
 }
 
 /////////////////////////////////////////////////////////////////

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -2490,8 +2490,23 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
 
     size_t len = 0;
 
+    if ((size_t)outl < sizeof(uint16_t)) {
+      OAUTH_ERROR("%s: decoded token too small: %d\n", __FUNCTION__, (int)outl);
+      return false;
+    }
     dtoken->enc_block.key_length = nswap16(*((uint16_t *)(decoded_field + len)));
-    len += 2;
+    len += sizeof(uint16_t);
+
+    if (dtoken->enc_block.key_length > sizeof(dtoken->enc_block.mac_key)) {
+      OAUTH_ERROR("%s: mac key length too large: %u > %u\n", __FUNCTION__, (unsigned)dtoken->enc_block.key_length,
+                  (unsigned)sizeof(dtoken->enc_block.mac_key));
+      return false;
+    }
+
+    if ((size_t)outl < len + dtoken->enc_block.key_length + sizeof(uint64_t) + sizeof(uint32_t)) {
+      OAUTH_ERROR("%s: decoded token truncated: %d\n", __FUNCTION__, (int)outl);
+      return false;
+    }
 
     memcpy(dtoken->enc_block.mac_key, decoded_field + len, dtoken->enc_block.key_length);
     len += dtoken->enc_block.key_length;

--- a/src/server/ns_turn_allocation.c
+++ b/src/server/ns_turn_allocation.c
@@ -379,6 +379,24 @@ ch_info *get_turn_channel(turn_permission_info *tinfo, ioa_addr *addr) {
 
 turn_permission_hashtable *allocation_get_turn_permission_hashtable(allocation *a) { return &(a->addr_to_perm); }
 
+static size_t allocation_count_permissions(const turn_permission_hashtable *map) {
+  size_t count = 0;
+  for (size_t b = 0; b < TURN_PERMISSION_HASHTABLE_SIZE; ++b) {
+    const turn_permission_array *parray = &(map->table[b]);
+    for (size_t i = 0; i < TURN_PERMISSION_ARRAY_SIZE; ++i) {
+      if (parray->main_slots[i].info.allocated) {
+        ++count;
+      }
+    }
+    for (size_t i = 0; i < parray->extra_sz; ++i) {
+      if (parray->extra_slots[i] && parray->extra_slots[i]->info.allocated) {
+        ++count;
+      }
+    }
+  }
+  return count;
+}
+
 turn_permission_info *allocation_add_permission(allocation *a, const ioa_addr *addr) {
   if (!a || !addr) {
     return NULL;
@@ -417,6 +435,12 @@ turn_permission_info *allocation_add_permission(allocation *a, const ioa_addr *a
     }
 
     if (!slot) {
+      /* A new slot can only be created once every existing slot is in use, so
+       * enforcing the per-allocation cap here bounds total permission growth
+       * without penalizing reuse of freed slots. */
+      if (allocation_count_permissions(map) >= TURN_MAX_PERMISSIONS_PER_ALLOCATION) {
+        return NULL;
+      }
       size_t old_sz_mem = old_sz * sizeof(turn_permission_slot *);
       turn_permission_slot **new_slots =
           (turn_permission_slot **)realloc(parray->extra_slots, old_sz_mem + sizeof(turn_permission_slot *));

--- a/src/server/ns_turn_allocation.h
+++ b/src/server/ns_turn_allocation.h
@@ -113,6 +113,14 @@ typedef struct _tcp_connection_list {
 #define TURN_PERMISSION_HASHTABLE_SIZE (0x8)
 #define TURN_PERMISSION_ARRAY_SIZE (0x3)
 
+/* Upper bound on the number of concurrent permissions a single allocation may
+ * hold. Permissions are created on demand (CreatePermission / ChannelBind) and
+ * the backing storage grows one slot at a time, so without a cap an
+ * authenticated client can drive unbounded heap and timer growth by covering a
+ * large set of distinct peer addresses. RFC 5766 does not bound this; the cap
+ * is generous so legitimate clients are unaffected. */
+#define TURN_MAX_PERMISSIONS_PER_ALLOCATION (1024)
+
 typedef struct _ch_info {
   uint16_t chnum;
   bool allocated;


### PR DESCRIPTION
## Summary

A batch of independent security-hardening fixes across the relay, admin interface, client library, and load-test client. Each addresses a concrete attack surface; they are grouped here because none is large enough to warrant its own PR.

## Fixes

### 1. Strict port parsing (`src/apps/relay/mainrelay.c`)
All port options previously used `atoi()`, which silently truncates out-of-range input into a `uint16_t` (e.g. `65536` → `0`, turning a listener into an OS-assigned ephemeral port) and treats non-numeric input as `0`. New `get_port_value()` validates `0–65535`, rejects non-numeric/negative/out-of-range with an error and exits. Applied to `-p`, TLS/alt/alt-TLS ports, TCP proxy, min/max relay ports, CLI, web-admin, and Prometheus ports.

### 2. HTTPS admin logon brute-force throttle (`src/apps/relay/turn_admin_server.c`)
The HTTPS admin interface authenticates per TLS connection, so an attacker could attempt unlimited password guesses by reconnecting per attempt. Added a per-source-IP failure throttle (fixed 256-entry table, LRU eviction, `5` failures → `30 s` lockout within a `60 s` window). Successful logon clears the counters. Guarded by a mutex initialized in `setup_admin_thread()`. Also redacts the request body from `INFO` logging when it contains credentials (`pwd=`), mirroring `handle_https()`.

### 3. Credential redaction in static-user errors (`src/apps/relay/userdb.c`)
`add_static_user_account()` logged the raw `user:password`/`user:key` value on parse errors, leaking secrets to the log. Now logs only a description or the username, never the password/key component.

### 4. Constant-time password comparison (`src/client/ns_turn_msg.c`)
`check_password_equal()` used `strcmp()`, a per-byte timing oracle. Replaced with `const_time_str_equal()` (length check + `CRYPTO_memcmp`).

### 5. OAuth token decode bounds checking (`src/client/ns_turn_msg.c`)
`decode_oauth_token_gcm()` read `key_length` and `memcpy`'d `mac_key` from the decoded buffer without validating the decoded length or that `key_length` fits `mac_key`. Added explicit bounds checks for the length prefix, the `key_length` against `sizeof(mac_key)`, and total truncation before the copy — preventing out-of-bounds read / buffer overflow from a malformed token.

### 6. Per-allocation permission cap (`src/server/ns_turn_allocation.{c,h}`)
RFC 5766 places no bound on permissions per allocation, so an authenticated client could drive unbounded heap and timer growth by covering many distinct peer addresses. Added `TURN_MAX_PERMISSIONS_PER_ALLOCATION` (`1024`, generous enough not to affect legitimate clients), enforced only when a new backing slot would be allocated so freed-slot reuse is unpenalized.

### 7. uclient libevent threading init (`src/apps/uclient/mainuclient.c`)
Enable `evthread_use_pthreads()`/`evthread_use_windows_threads()` before any `event_base` is created. The threaded uclient modes register events on a worker's `event_base` cross-thread; libevent only locks its internal structures (and the epoll changelist) when threading is enabled up front, so this closes a data race in the load-test client.

## Notes for reviewers

- The admin throttle table and per-allocation cap are fixed-size by design (no dynamic growth on the abuse path).
- The constant-time compare still leaks secret *length* via the length check — documented inline; the byte content is compared in constant time.
- Commit messages on the branch are terse; this body is the authoritative description.
