### PR TITLE
Adapt .gitignore to allow files already in repo (#1935)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
 /Makefile
 /bin/
-*build*/
+/build
 include
 lib
 sqlite
 examples/ca/CA.pl
-.vscode
 .idea
 .vs/
 


### PR DESCRIPTION
.gitignore had `.vscode` in it although having it in the repo is desired.

The `*build*/` pattern wrongly matched subdirectories with that pattern so it was changed to only match the root `/build` artifact dir

Fixes #1935 and hopefully also building for Debian (https://salsa.debian.org/pkg-voip-team/coturn/-/merge_requests/2)