### PR TITLE
Fix test_redis_format link failure

### DIFF
--- a/src/apps/common/CMakeLists.txt
+++ b/src/apps/common/CMakeLists.txt
@@ -89,6 +89,12 @@ message("COMMON_LIBS:${COMMON_LIBS}")
 add_library(${PROJECT_NAME} STATIC ${SOURCE_FILES} ${HEADER_FILES})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC ${COMMON_LIBS})
+# turncommon and turnclient are mutually dependent static libraries:
+# stun_buffer.c and ns_turn_utils.c call stun_*/addr_* from turnclient, while
+# turnclient calls the logging functions here. Declaring the cycle makes CMake
+# repeat both archives on the link line so single-pass linkers (GNU ld) can
+# resolve symbols regardless of which library is scanned first.
+target_link_libraries(${PROJECT_NAME} PUBLIC turnclient)
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${COMMON_DEFINED})
 target_compile_options(${PROJECT_NAME} PUBLIC
 	$<$<C_COMPILER_ID:GNU>:-Wno-deprecated-declarations>


### PR DESCRIPTION

libturncommon.a and libturnclient.a are mutually dependent static libraries: stun_buffer.c and ns_turn_utils.c (turncommon) call stun_*/addr_* functions defined in turnclient, while turnclient calls the logging functions in turncommon. CMake only modeled the one-way edge turnclient -> turncommon, so the link line ordered the archives as libturnclient.a libturncommon.a once each.

GNU ld scans static archives in a single left-to-right pass, so any binary that pulls an object from libturncommon.a needing a turnclient symbol that no earlier object referenced fails to link. tests/test_redis_format is the first such binary - it references only the logging code, so ns_turn_utils.c.o's call to addr_any_no_port (src/client/ns_turn_ioaddr.c) goes unresolved:

  /usr/bin/ld: ../lib/libturncommon.a(ns_turn_utils.c.o): in function
  'addr_debug_print': undefined reference to 'addr_any_no_port'

This has been failing the CMake CI workflow on master since the merge that added test_redis_format; it is independent of any one branch.

Declare the back-edge turncommon -> turnclient. CMake's documented handling of cyclic dependencies between static libraries repeats both archives on the link line, which lets single-pass linkers resolve the symbols regardless of scan order.

Validated: Linux (Docker, gcc) full build + ctest 7/7 passed including the previously failing test_redis_format link; macOS build + ctest 8/8 passed; examples/run_tests.sh in Docker all OK; fuzzing smoke tests ASan 0/1 passed.