### PR TITLE
Canonicalize all IPv4-in-IPv6 encodings before peer-IP checks

### DIFF
--- a/src/client/ns_turn_ioaddr.c
+++ b/src/client/ns_turn_ioaddr.c
@@ -469,26 +469,65 @@ int addr_less_eq(const ioa_addr *addr1, const ioa_addr *addr2) {
   }
 }
 
+bool ioa_addr_get_embedded_ipv4(const ioa_addr *addr, ioa_addr *embedded) {
+  if (!addr || !embedded || addr->ss.sa_family != AF_INET6) {
+    return false;
+  }
+
+  const uint8_t *u = (const uint8_t *)&(addr->s6.sin6_addr);
+  const uint8_t *v4 = NULL;
+
+  if (u[0] == 0 && u[1] == 0 && u[2] == 0 && u[3] == 0 && u[4] == 0 && u[5] == 0 && u[6] == 0 && u[7] == 0 &&
+      u[8] == 0 && u[9] == 0 && u[10] == 0xff && u[11] == 0xff) {
+    /* IPv4-mapped: ::ffff:a.b.c.d (::ffff:0:0/96) */
+    v4 = u + 12;
+  } else if (u[0] == 0x20 && u[1] == 0x02) {
+    /* 6to4: 2002:AABB:CCDD::/16 -> embedded IPv4 is bytes 2..5 */
+    v4 = u + 2;
+  } else if (u[0] == 0x00 && u[1] == 0x64 && u[2] == 0xff && u[3] == 0x9b && u[4] == 0 && u[5] == 0 && u[6] == 0 &&
+             u[7] == 0 && u[8] == 0 && u[9] == 0 && u[10] == 0 && u[11] == 0) {
+    /* NAT64 well-known prefix: 64:ff9b::/96 -> embedded IPv4 is bytes 12..15 */
+    v4 = u + 12;
+  } else if (u[0] == 0 && u[1] == 0 && u[2] == 0 && u[3] == 0 && u[4] == 0 && u[5] == 0 && u[6] == 0 && u[7] == 0 &&
+             u[8] == 0 && u[9] == 0 && u[10] == 0 && u[11] == 0) {
+    /* IPv4-compatible: ::a.b.c.d (::/96). Intentionally skip :: (unspecified)
+     * and ::1 (IPv6 loopback) -- those are handled natively by ioa_addr_is_zero
+     * and ioa_addr_is_loopback and must not be reduced to a 0.0.0.x IPv4. */
+    if (!(u[12] == 0 && u[13] == 0 && u[14] == 0 && (u[15] == 0 || u[15] == 1))) {
+      v4 = u + 12;
+    }
+  }
+
+  if (!v4) {
+    return false;
+  }
+
+  memset(embedded, 0, sizeof(*embedded));
+  embedded->s4.sin_family = AF_INET;
+  memcpy(&(embedded->s4.sin_addr), v4, 4);
+  embedded->s4.sin_port = addr->s6.sin6_port;
+  return true;
+}
+
 int ioa_addr_in_range(const ioa_addr_range *range, const ioa_addr *addr) {
 
   if (range && addr) {
-#if !defined(WINDOWS)
-    /* If the range is AF_INET and addr is an IPv4-mapped IPv6 address
-     * (::ffff:x.x.x.x), extract the embedded IPv4 so the comparison works. */
-    ioa_addr addr4;
+    /* Reduce every IPv4-in-IPv6 encoding (IPv4-mapped, IPv4-compatible, 6to4,
+     * NAT64) to its embedded IPv4 before comparing against an AF_INET range, so
+     * an attacker cannot dodge an IPv4 denied-peer-ip range by re-encoding the
+     * same target address. */
+    ioa_addr embedded;
     if (addr->ss.sa_family == AF_INET6) {
-      sa_family_t range_family = range->min.ss.sa_family;
+      /* int, not sa_family_t: this path is now compiled on Windows too, where
+       * MinGW does not define sa_family_t. */
+      int range_family = range->min.ss.sa_family;
       if (range_family == 0) {
         range_family = range->max.ss.sa_family;
       }
-      if (range_family == AF_INET && IN6_IS_ADDR_V4MAPPED(&addr->s6.sin6_addr)) {
-        memset(&addr4, 0, sizeof(addr4));
-        addr4.s4.sin_family = AF_INET;
-        memcpy(&addr4.s4.sin_addr, addr->s6.sin6_addr.s6_addr + 12, 4);
-        addr = &addr4;
+      if (range_family == AF_INET && ioa_addr_get_embedded_ipv4(addr, &embedded)) {
+        addr = &embedded;
       }
     }
-#endif
     if (addr_any(&(range->min)) || addr_less_eq(&(range->min), addr)) {
       if (addr_any(&(range->max))) {
         return 1;
@@ -512,15 +551,18 @@ void ioa_addr_range_cpy(ioa_addr_range *dest, const ioa_addr_range *src) {
 
 int ioa_addr_is_multicast(ioa_addr *addr) {
   if (addr) {
+    /* Canonicalize any IPv4-in-IPv6 encoding to its embedded IPv4 first, so the
+     * IPv4 multicast test applies regardless of how the address was encoded. */
+    ioa_addr embedded;
+    if (ioa_addr_get_embedded_ipv4(addr, &embedded)) {
+      addr = &embedded;
+    }
     if (addr->ss.sa_family == AF_INET) {
       const uint8_t *u = ((const uint8_t *)&(addr->s4.sin_addr));
       return (u[0] > 223);
     } else if (addr->ss.sa_family == AF_INET6) {
       const uint8_t *u = ((const uint8_t *)&(addr->s6.sin6_addr));
-      /* IPv4-mapped IPv6: ::ffff:x.x.x.x — check embedded IPv4 multicast range */
-      if (IN6_IS_ADDR_V4MAPPED(&addr->s6.sin6_addr)) {
-        return (u[12] > 223);
-      }
+      /* Native IPv6 multicast: ff00::/8 */
       return (u[0] == 255);
     }
   }
@@ -529,17 +571,19 @@ int ioa_addr_is_multicast(ioa_addr *addr) {
 
 int ioa_addr_is_loopback(ioa_addr *addr) {
   if (addr) {
+    /* Canonicalize any IPv4-in-IPv6 encoding to its embedded IPv4 first. This
+     * covers ::ffff:127.0.0.1 / ::127.0.0.1 / 64:ff9b::7f00:1 / 2002:7f00:1::1 encodings of the
+     * IPv4 loopback range. The native ::1 literal is left for the branch below. */
+    ioa_addr embedded;
+    if (ioa_addr_get_embedded_ipv4(addr, &embedded)) {
+      addr = &embedded;
+    }
     if (addr->ss.sa_family == AF_INET) {
       const uint8_t *u = ((const uint8_t *)&(addr->s4.sin_addr));
       return (u[0] == 127);
     } else if (addr->ss.sa_family == AF_INET6) {
       const uint8_t *u = ((const uint8_t *)&(addr->s6.sin6_addr));
-      /* IPv4-mapped IPv6: ::ffff:x.x.x.x — check before the ::1 literal branch,
-       * otherwise ::ffff:127.0.0.1 (u[15] == 1) falls into the ::1 path and is
-       * misclassified as non-loopback (GHSA-w4hf-cr3w-6h79). */
-      if (IN6_IS_ADDR_V4MAPPED(&addr->s6.sin6_addr)) {
-        return (u[12] == 127);
-      }
+      /* Native IPv6 loopback: ::1 */
       if (u[15] == 1) {
         int i;
         for (i = 0; i < 15; ++i) {
@@ -562,15 +606,18 @@ To avoid any trouble we match the whole 0.0.0.0/8 that defined in RFC6890 as loc
 */
 int ioa_addr_is_zero(ioa_addr *addr) {
   if (addr) {
+    /* Canonicalize any IPv4-in-IPv6 encoding to its embedded IPv4 first so the
+     * 0.0.0.0/8 test applies regardless of encoding (e.g. ::ffff:0.0.0.0). The
+     * bare :: (unspecified) literal is not reduced and is caught natively. */
+    ioa_addr embedded;
+    if (ioa_addr_get_embedded_ipv4(addr, &embedded)) {
+      addr = &embedded;
+    }
     if (addr->ss.sa_family == AF_INET) {
       const uint8_t *u = ((const uint8_t *)&(addr->s4.sin_addr));
       return (u[0] == 0);
     } else if (addr->ss.sa_family == AF_INET6) {
       const uint8_t *u = ((const uint8_t *)&(addr->s6.sin6_addr));
-      /* IPv4-mapped IPv6: ::ffff:0.0.0.0 */
-      if (IN6_IS_ADDR_V4MAPPED(&addr->s6.sin6_addr)) {
-        return (u[12] == 0 && u[13] == 0 && u[14] == 0 && u[15] == 0);
-      }
       int i;
       for (i = 0; i <= 15; ++i) {
         if (u[i]) {

--- a/src/client/ns_turn_ioaddr.h
+++ b/src/client/ns_turn_ioaddr.h
@@ -37,6 +37,7 @@
 
 #include "ns_turn_defs.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -109,6 +110,14 @@ void ioa_addr_range_set(ioa_addr_range *range, const ioa_addr *addr_min, const i
 int addr_less_eq(const ioa_addr *addr1, const ioa_addr *addr2);
 int ioa_addr_in_range(const ioa_addr_range *range, const ioa_addr *addr);
 void ioa_addr_range_cpy(ioa_addr_range *dest, const ioa_addr_range *src);
+
+/* If addr is an IPv6 address that embeds an IPv4 address in one of the
+ * transition encodings an attacker can use to dodge an IPv4 ACL (IPv4-mapped
+ * ::ffff:0:0/96, IPv4-compatible ::/96, 6to4 2002::/16, NAT64 64:ff9b::/96),
+ * write the embedded IPv4 (with the original port) into *embedded and return
+ * true. The :: and ::1 literals are deliberately NOT treated as embedded IPv4.
+ * Returns false (leaving *embedded untouched) for any other address. */
+bool ioa_addr_get_embedded_ipv4(const ioa_addr *addr, ioa_addr *embedded);
 
 /////// Check whether this is a good address //////////////
 

--- a/tests/test_ioaddr.c
+++ b/tests/test_ioaddr.c
@@ -97,6 +97,102 @@ static void test_is_zero_mapped_any(void) {
   TEST_ASSERT_TRUE(ioa_addr_is_zero(&addr));
 }
 
+/* ---- IPv4-in-IPv6 canonicalization ---- */
+
+static void make_addr(const char *s, ioa_addr *a) {
+  memset(a, 0, sizeof(*a));
+  TEST_ASSERT_EQUAL_INT(0, make_ioa_addr((const uint8_t *)s, 0, a));
+}
+
+static void make_v4_range(ioa_addr_range *r, const char *lo, const char *hi) {
+  ioa_addr a = {0}, b = {0};
+  make_addr(lo, &a);
+  make_addr(hi, &b);
+  ioa_addr_range_set(r, &a, &b);
+}
+
+/* ioa_addr_get_embedded_ipv4 must reduce every IPv4-in-IPv6 encoding of
+ * 10.0.0.5 to the bare IPv4, and refuse non-embedding addresses. */
+static void test_embedded_ipv4_all_encodings(void) {
+  const char *encodings[] = {
+      "::ffff:10.0.0.5", /* IPv4-mapped   */
+      "::10.0.0.5",      /* IPv4-compat   */
+      "2002:a00:5::",    /* 6to4          */
+      "64:ff9b::a00:5",  /* NAT64         */
+  };
+  ioa_addr expected = {0};
+  make_addr("10.0.0.5", &expected);
+  for (size_t i = 0; i < sizeof(encodings) / sizeof(encodings[0]); ++i) {
+    ioa_addr in = {0}, out = {0};
+    make_addr(encodings[i], &in);
+    TEST_ASSERT_TRUE_MESSAGE(ioa_addr_get_embedded_ipv4(&in, &out), encodings[i]);
+    TEST_ASSERT_EQUAL_INT(AF_INET, out.ss.sa_family);
+    TEST_ASSERT_TRUE_MESSAGE(addr_eq_no_port(&out, &expected), encodings[i]);
+  }
+}
+
+static void test_embedded_ipv4_rejects_non_embedding(void) {
+  const char *non[] = {"::1", "::", "2001:db8::1", "fc00::1", "8.8.8.8"};
+  for (size_t i = 0; i < sizeof(non) / sizeof(non[0]); ++i) {
+    ioa_addr in = {0}, out = {0};
+    make_addr(non[i], &in);
+    TEST_ASSERT_FALSE_MESSAGE(ioa_addr_get_embedded_ipv4(&in, &out), non[i]);
+  }
+}
+
+/* The core ACL bypass: a denied IPv4 range must match every IPv4-in-IPv6
+ * encoding of an address inside it, not just the ::ffff: form. */
+static void test_in_range_matches_all_ipv4_in_ipv6_encodings(void) {
+  ioa_addr_range denied = {0};
+  make_v4_range(&denied, "10.0.0.0", "10.255.255.255");
+
+  const char *encodings[] = {
+      "::ffff:10.0.0.5",
+      "::10.0.0.5",
+      "2002:a00:5::",
+      "64:ff9b::a00:5",
+  };
+  for (size_t i = 0; i < sizeof(encodings) / sizeof(encodings[0]); ++i) {
+    ioa_addr peer = {0};
+    make_addr(encodings[i], &peer);
+    TEST_ASSERT_TRUE_MESSAGE(ioa_addr_in_range(&denied, &peer), encodings[i]);
+  }
+}
+
+/* A native IPv6 peer with no embedded IPv4 must not spuriously match an IPv4
+ * range (no false positives from the canonicalization). */
+static void test_in_range_native_ipv6_not_matched_by_ipv4_range(void) {
+  ioa_addr_range denied = {0};
+  make_v4_range(&denied, "10.0.0.0", "10.255.255.255");
+  ioa_addr peer = {0};
+  make_addr("2001:db8::a00:5", &peer);
+  TEST_ASSERT_FALSE(ioa_addr_in_range(&denied, &peer));
+}
+
+/* Loopback must be detected through every IPv4-in-IPv6 encoding of 127.x. */
+static void test_is_loopback_all_ipv4_in_ipv6_encodings(void) {
+  const char *encodings[] = {
+      "::ffff:127.0.0.1",
+      "::127.0.0.1",
+      "2002:7f00:1::",
+      "64:ff9b::7f00:1",
+  };
+  for (size_t i = 0; i < sizeof(encodings) / sizeof(encodings[0]); ++i) {
+    ioa_addr addr = {0};
+    make_addr(encodings[i], &addr);
+    TEST_ASSERT_TRUE_MESSAGE(ioa_addr_is_loopback(&addr), encodings[i]);
+  }
+}
+
+/* Multicast and zero must likewise be detected through a non-::ffff: encoding. */
+static void test_is_multicast_and_zero_through_nat64(void) {
+  ioa_addr mc = {0}, zero = {0};
+  make_addr("64:ff9b::e000:1", &mc); /* 224.0.0.1 */
+  TEST_ASSERT_TRUE(ioa_addr_is_multicast(&mc));
+  make_addr("64:ff9b::0:0", &zero); /* 0.0.0.0 */
+  TEST_ASSERT_TRUE(ioa_addr_is_zero(&zero));
+}
+
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_make_ioa_addr_ipv4_sets_family_and_port);
@@ -112,5 +208,11 @@ int main(void) {
   RUN_TEST(test_is_loopback_non_loopback);
   RUN_TEST(test_is_loopback_mapped_non_loopback);
   RUN_TEST(test_is_zero_mapped_any);
+  RUN_TEST(test_embedded_ipv4_all_encodings);
+  RUN_TEST(test_embedded_ipv4_rejects_non_embedding);
+  RUN_TEST(test_in_range_matches_all_ipv4_in_ipv6_encodings);
+  RUN_TEST(test_in_range_native_ipv6_not_matched_by_ipv4_range);
+  RUN_TEST(test_is_loopback_all_ipv4_in_ipv6_encodings);
+  RUN_TEST(test_is_multicast_and_zero_through_nat64);
   return UNITY_END();
 }


### PR DESCRIPTION
ioa_addr_in_range and the ioa_addr_is_loopback/multicast/zero guards only special-cased the IPv4-mapped form (::ffff:a.b.c.d). Other encodings of the same address — IPv4-compatible ::a.b.c.d, 6to4 2002::/16, and the NAT64 well-known prefix 64:ff9b::/96 — were compared full-16-bytes against an IPv4 range and never matched, so a denied-peer-ip range could be dodged by re-encoding the target.

Add ioa_addr_get_embedded_ipv4(), which reduces any of these encodings to its embedded IPv4 (deliberately excluding the :: and ::1 literals, which are handled natively), and apply it in ioa_addr_in_range, ioa_addr_is_loopback, ioa_addr_is_multicast and ioa_addr_is_zero before the IPv4 logic runs. This also extends the previously Linux-only extraction in ioa_addr_in_range to all platforms (range_family is typed int rather than sa_family_t, which MinGW does not define).

Add ioaddr unit tests covering every encoding for range membership, loopback, multicast and zero, plus a native-IPv6 no-false-positive case.