### PR TITLE
Deny link-local / ULA / site-local relay peers by default

### DIFF
--- a/src/client/ns_turn_ioaddr.c
+++ b/src/client/ns_turn_ioaddr.c
@@ -630,6 +630,41 @@ int ioa_addr_is_zero(ioa_addr *addr) {
   return 0;
 }
 
+int ioa_addr_is_internal_deny_default(ioa_addr *addr) {
+  if (!addr) {
+    return 0;
+  }
+  /* Canonicalize any IPv4-in-IPv6 encoding first so e.g. ::ffff:169.254.169.254
+   * or a NAT64/6to4 form of a link-local address is classified too. */
+  ioa_addr embedded;
+  if (ioa_addr_get_embedded_ipv4(addr, &embedded)) {
+    addr = &embedded;
+  }
+  if (addr->ss.sa_family == AF_INET) {
+    const uint8_t *u = ((const uint8_t *)&(addr->s4.sin_addr));
+    /* IPv4 link-local 169.254.0.0/16 -- includes the 169.254.169.254 cloud
+     * metadata service, a classic SSRF target that is never a valid relay peer. */
+    if (u[0] == 169 && u[1] == 254) {
+      return 1;
+    }
+  } else if (addr->ss.sa_family == AF_INET6) {
+    const uint8_t *u = ((const uint8_t *)&(addr->s6.sin6_addr));
+    /* IPv6 link-local fe80::/10 */
+    if (u[0] == 0xfe && (u[1] & 0xc0) == 0x80) {
+      return 1;
+    }
+    /* IPv6 unique-local address (ULA) fc00::/7 -- fc00::/8 and fd00::/8 */
+    if ((u[0] & 0xfe) == 0xfc) {
+      return 1;
+    }
+    /* IPv6 site-local (deprecated, RFC 3879) fec0::/10 */
+    if (u[0] == 0xfe && (u[1] & 0xc0) == 0xc0) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
 /////// Map "public" address to "private" address //////////////
 
 // Must be called only in a single-threaded context,

--- a/src/client/ns_turn_ioaddr.h
+++ b/src/client/ns_turn_ioaddr.h
@@ -123,6 +123,14 @@ bool ioa_addr_get_embedded_ipv4(const ioa_addr *addr, ioa_addr *embedded);
 
 int ioa_addr_is_multicast(ioa_addr *a);
 int ioa_addr_is_loopback(ioa_addr *addr);
+
+/* Returns true for address scopes that must never be used as a relay peer
+ * regardless of the configured denied-peer-ip ranges: IPv4 link-local
+ * (169.254.0.0/16, incl. the 169.254.169.254 cloud metadata service), IPv6
+ * link-local (fe80::/10), IPv6 unique-local (fc00::/7) and IPv6 site-local
+ * (fec0::/10). Loopback is intentionally excluded -- it keeps its own
+ * allow-loopback-peers gate. IPv4-in-IPv6 encodings are canonicalized first. */
+int ioa_addr_is_internal_deny_default(ioa_addr *addr);
 int ioa_addr_is_zero(ioa_addr *addr);
 
 /////// Map "public" address to "private" address //////////////

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -302,6 +302,20 @@ static int good_peer_addr(turn_turnserver *server, const char *realm, ioa_addr *
     if (ioa_addr_is_zero(peer_addr)) {
       return 0;
     }
+    /* Secure default: never relay to link-local / unique-local / site-local
+     * scopes (incl. the 169.254.169.254 cloud metadata service), regardless of
+     * denied-peer-ip. An IPv4 denied-peer-ip range cannot even express an IPv6
+     * internal target, so this closes the native-IPv6 SSRF path to internal
+     * services such as a ULA-hosted database. */
+    if (ioa_addr_is_internal_deny_default(peer_addr)) {
+      char saddr[MAX_IOA_ADDR_STRING] = "";
+      addr_to_string_no_port(peer_addr, saddr);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
+                    "session %018llu: A peer IP %s denied: link-local/unique-local/site-local scope is not a "
+                    "permitted relay peer in server %d \n",
+                    (unsigned long long)session_id, saddr, server_id);
+      return 0;
+    }
 
     if (server->ip_whitelist) {
       // White listing of addr ranges

--- a/tests/test_ioaddr.c
+++ b/tests/test_ioaddr.c
@@ -193,6 +193,40 @@ static void test_is_multicast_and_zero_through_nat64(void) {
   TEST_ASSERT_TRUE(ioa_addr_is_zero(&zero));
 }
 
+/* ---- Secure-default internal-scope deny ---- */
+
+static void test_internal_deny_default_flags_internal_scopes(void) {
+  const char *internal[] = {
+      "169.254.169.254",        /* IPv4 link-local / cloud metadata */
+      "169.254.1.1",            /* IPv4 link-local                  */
+      "::ffff:169.254.169.254", /* mapped metadata                  */
+      "64:ff9b::a9fe:a9fe",     /* NAT64 metadata 169.254.169.254   */
+      "fe80::1",                /* IPv6 link-local                  */
+      "fc00::1",                /* IPv6 ULA (fc00::/8)              */
+      "fd12:3456::99",          /* IPv6 ULA (fd00::/8)              */
+      "fec0::1",                /* IPv6 site-local (deprecated)     */
+  };
+  for (size_t i = 0; i < sizeof(internal) / sizeof(internal[0]); ++i) {
+    ioa_addr a = {0};
+    make_addr(internal[i], &a);
+    TEST_ASSERT_TRUE_MESSAGE(ioa_addr_is_internal_deny_default(&a), internal[i]);
+  }
+}
+
+/* Loopback and RFC1918 must NOT be flagged here: loopback keeps its own
+ * allow-loopback-peers gate, and private ranges stay relayable for legitimate
+ * LAN/enterprise TURN deployments. */
+static void test_internal_deny_default_allows_other_scopes(void) {
+  const char *other[] = {
+      "8.8.8.8", "10.0.0.5", "172.16.0.1", "192.168.1.1", "100.64.0.1", "::1", "127.0.0.1", "2001:db8::1",
+  };
+  for (size_t i = 0; i < sizeof(other) / sizeof(other[0]); ++i) {
+    ioa_addr a = {0};
+    make_addr(other[i], &a);
+    TEST_ASSERT_FALSE_MESSAGE(ioa_addr_is_internal_deny_default(&a), other[i]);
+  }
+}
+
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_make_ioa_addr_ipv4_sets_family_and_port);
@@ -214,5 +248,7 @@ int main(void) {
   RUN_TEST(test_in_range_native_ipv6_not_matched_by_ipv4_range);
   RUN_TEST(test_is_loopback_all_ipv4_in_ipv6_encodings);
   RUN_TEST(test_is_multicast_and_zero_through_nat64);
+  RUN_TEST(test_internal_deny_default_flags_internal_scopes);
+  RUN_TEST(test_internal_deny_default_allows_other_scopes);
   return UNITY_END();
 }


### PR DESCRIPTION
good_peer_addr() denies loopback, multicast and zero peers by default, but had no guard for other internal address scopes, and a denied-peer-ip list is IPv4-only in typical deployments — an IPv4 range cannot even express an IPv6 internal target. An authenticated TURN user could therefore drive the RFC 6062 TCP CONNECT relay to a native-IPv6 internal service (e.g. a ULA-hosted Redis/SQL backend) or to the 169.254.169.254 cloud metadata service, none of which an IPv4 denied-peer-ip covers.

Add `ioa_addr_is_internal_deny_default()` and reject these scopes in `good_peer_addr()` unconditionally:

- IPv4 link-local `169.254.0.0/16` (incl. the `169.254.169.254` cloud metadata service)
- IPv6 link-local `fe80::/10`
- IPv6 unique-local (ULA) `fc00::/7`
- IPv6 site-local `fec0::/10`

IPv4-in-IPv6 canonicalization is applied first, so encoded forms (e.g. `::ffff:169.254.169.254`) are caught too. Loopback is intentionally excluded so it keeps its existing `--allow-loopback-peers` gate; RFC1918 / CGNAT stay relayable so legitimate LAN and enterprise TURN deployments are unaffected.

Adds unit tests covering each denied scope and confirming loopback / RFC1918 / public addresses are not flagged.