### PR TITLE
validate hmackey length in sqlite_get_user_key before hex decode

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_sqlite.c
+++ b/src/apps/relay/dbdrivers/dbd_sqlite.c
@@ -312,8 +312,14 @@ static int sqlite_get_user_key(uint8_t *usname, uint8_t *realm, hmackey_t key) {
     if (sqlite3_step(st) == SQLITE_ROW) {
       const char *const kval = (const char *)sqlite3_column_text(st, 0);
       const size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
-      convert_string_key_to_binary(kval, key, sz);
-      ret = 0;
+      if (!kval) {
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong hmackey data for user %s: NULL\n", usname);
+      } else if (strlen(kval) < sz * 2) {
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format: %s, user %s\n", kval, usname);
+      } else {
+        convert_string_key_to_binary(kval, key, sz);
+        ret = 0;
+      }
     }
   } else {
     const char *errmsg = sqlite3_errmsg(sqliteconnection);

--- a/tests/test_sqlite_dbd.c
+++ b/tests/test_sqlite_dbd.c
@@ -242,6 +242,20 @@ static void test_sql_injection_neutralized(void) {
                                 "del_secret realm parameter is SQL-injectable: unintended secret rows were deleted");
 }
 
+/* A short hmackey stored in turnusers_lt must be rejected, not fed to the
+ * hex->binary decoder. The decoder reads sz*2 chars unconditionally, so a row
+ * with fewer hex chars than the key size makes get_user_key over-read past the
+ * column buffer (visible under ASan). The sibling mysql/pgsql/redis drivers
+ * already length-check before decoding. */
+static void test_short_hmackey_rejected(void) {
+  exec_vfy("insert into turnusers_lt (realm,name,hmackey) values('north.gov','shorty','00112233')");
+  TEST_ASSERT_EQUAL_INT(1, count_rows("select count(*) from turnusers_lt where name='shorty'"));
+
+  hmackey_t key;
+  memset(key, 0, sizeof(key));
+  TEST_ASSERT_EQUAL_INT(-1, db->get_user_key((uint8_t *)"shorty", (uint8_t *)"north.gov", key));
+}
+
 ///////////////////////////// main /////////////////////////////
 
 int main(void) {
@@ -273,6 +287,7 @@ int main(void) {
   RUN_TEST(test_oauth_roundtrip);
   RUN_TEST(test_permission_ip_roundtrip);
   RUN_TEST(test_admin_user_roundtrip);
+  RUN_TEST(test_short_hmackey_rejected);
   RUN_TEST(test_sql_injection_neutralized);
   int rc = UNITY_END();
 


### PR DESCRIPTION
`Repro:` store a `turnusers_lt` row whose `hmackey` is shorter than the key size (e.g. `00112233`) and authenticate as that user; `test_short_hmackey_rejected` in `tests/test_sqlite_dbd.c` reproduces it.
`Cause:` `sqlite_get_user_key` hands the column straight to `convert_string_key_to_binary`, which reads `sz * 2` hex chars unconditionally (`sz == 16` for `SHATYPE_DEFAULT`), so a short value over-reads past the column buffer and a NULL column dereferences. The `mysql`/`pgsql`/`redis`/`mongo` drivers already length-check before decoding; the `sqlite` one didn't.
`Fix:` reject NULL and under-length keys before decoding, matching the `pgsql` driver.