### PR TITLE
fix signed-char index out-of-bounds read in base64_decode

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -1360,6 +1360,11 @@ unsigned char *base64_decode(const char *data, size_t input_length, size_t *outp
     return NULL;
   }
 
+  if (input_length == 0) {
+    *output_length = 0;
+    return NULL;
+  }
+
   *output_length = input_length / 4 * 3;
   if (data[input_length - 1] == '=') {
     (*output_length)--;
@@ -1377,10 +1382,10 @@ unsigned char *base64_decode(const char *data, size_t input_length, size_t *outp
   size_t j;
   for (i = 0, j = 0; i < (int)input_length;) {
 
-    const uint32_t sextet_a = data[i] == '=' ? 0 & i++ : decoding_table[(int)data[i++]];
-    const uint32_t sextet_b = data[i] == '=' ? 0 & i++ : decoding_table[(int)data[i++]];
-    const uint32_t sextet_c = data[i] == '=' ? 0 & i++ : decoding_table[(int)data[i++]];
-    const uint32_t sextet_d = data[i] == '=' ? 0 & i++ : decoding_table[(int)data[i++]];
+    const uint32_t sextet_a = data[i] == '=' ? 0 & i++ : decoding_table[(unsigned char)data[i++]];
+    const uint32_t sextet_b = data[i] == '=' ? 0 & i++ : decoding_table[(unsigned char)data[i++]];
+    const uint32_t sextet_c = data[i] == '=' ? 0 & i++ : decoding_table[(unsigned char)data[i++]];
+    const uint32_t sextet_d = data[i] == '=' ? 0 & i++ : decoding_table[(unsigned char)data[i++]];
 
     const uint32_t triple = (sextet_a << 3 * 6) + (sextet_b << 2 * 6) + (sextet_c << 1 * 6) + (sextet_d << 0 * 6);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ endfunction()
 
 coturn_add_test(test_ioaddr)
 coturn_add_test(test_stun_msg)
+coturn_add_test(test_base64)
 coturn_add_test(test_http_server ../src/apps/relay/http_buffer.c)
 
 # SQLite DB-driver interface test. Compiles the driver in isolation with a small

--- a/tests/test_base64.c
+++ b/tests/test_base64.c
@@ -1,0 +1,52 @@
+#include "apputils.h"
+
+#include <unity.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static void test_decode_roundtrips_ascii(void) {
+  size_t out_len = 0;
+  unsigned char *out = base64_decode("Zm9vYmFy", 8, &out_len); /* "foobar" */
+
+  TEST_ASSERT_NOT_NULL(out);
+  TEST_ASSERT_EQUAL_size_t(6, out_len);
+  TEST_ASSERT_EQUAL_MEMORY("foobar", out, 6);
+  free(out);
+}
+
+/* Bytes with the high bit set are not valid base64 characters. They must be
+   looked up as unsigned indices into the 256-entry decoding table (where they
+   map to 0), not sign-extended to a negative offset that reads before it. */
+static void test_decode_high_bit_bytes_are_not_oob(void) {
+  const char in[4] = {(char)0x80, (char)0xC0, (char)0xFF, (char)0x80};
+  size_t out_len = 0;
+  unsigned char *out = base64_decode(in, sizeof(in), &out_len);
+
+  TEST_ASSERT_NOT_NULL(out);
+  TEST_ASSERT_EQUAL_size_t(3, out_len);
+  TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+  TEST_ASSERT_EQUAL_UINT8(0, out[1]);
+  TEST_ASSERT_EQUAL_UINT8(0, out[2]);
+  free(out);
+}
+
+/* Empty input must not read data[-1]/data[-2] when probing for padding. */
+static void test_decode_empty_input_returns_null(void) {
+  size_t out_len = 123;
+  unsigned char *out = base64_decode("", 0, &out_len);
+
+  TEST_ASSERT_NULL(out);
+  TEST_ASSERT_EQUAL_size_t(0, out_len);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_decode_roundtrips_ascii);
+  RUN_TEST(test_decode_high_bit_bytes_are_not_oob);
+  RUN_TEST(test_decode_empty_input_returns_null);
+  return UNITY_END();
+}


### PR DESCRIPTION
`Repro:` with `--mobility` enabled, send a TURN Refresh carrying a `MOBILITY-TICKET` whose value is a 4-byte string with the high bit set (e.g. `\x80\x80\x80\x80`); the relay decodes it through `string_to_mobile_id` -> `base64_decode`.
`Cause:` `base64_decode` indexes `decoding_table[(int)data[i]]`, so a byte >= `0x80` sign-extends to a negative index and reads up to 128 bytes before the 256-byte table. `build_base64_decoding_table` already casts to `unsigned char` when filling it. Empty input also probes `data[input_length-1]`/`[-2]` before the buffer.
`Fix:` cast to `unsigned char` before the table lookup and reject empty input.

Added `tests/test_base64.c`; the high-bit case trips ASan (`heap-buffer-overflow` read in `base64_decode`) on the current tree and passes with the change.