### PR TITLE
Add out-of-tree patch to restore deprecated OpenSSL 1.1.1 support

### DIFF
--- a/patches/openssl-1.1.1/0001-restore-openssl-1.1.1-support.patch
+++ b/patches/openssl-1.1.1/0001-restore-openssl-1.1.1-support.patch
@@ -1,0 +1,186 @@
+From c1110e6816c9c76668e6986efd282b9f57ef4fde Mon Sep 17 00:00:00 2001
+From: Robert Scheck <robert@fedoraproject.org>
+Date: Thu, 16 Apr 2026 01:49:25 +0200
+Subject: [PATCH] Restore support for OpenSSL >= 1.1.1 (for
+ AlmaLinux/RHEL/Rocky Linux 8)
+
+Conditionalize changes from commit 4c674289a8a288dd310e87490334684b05d61381
+to support building using OpenSSL 1.1.1 in AlmaLinux/RHEL/Rocky Linux 8.
+While OpenSSL 3.5 is in EPEL 8 it unfortunately can not be used, because
+other (to be linked) libraries (libevent_openssl, libmariadb and libpq)
+in RHEL 8 are built and linked against OpenSSL 1.1.1 from RHEL 8.
+---
+ src/apps/relay/mainrelay.c | 60 +++++++++++++++++++++++++++++++++++++-
+ src/apps/relay/mainrelay.h |  4 +++
+ 2 files changed, 63 insertions(+), 1 deletion(-)
+
+diff --git a/src/apps/relay/mainrelay.c b/src/apps/relay/mainrelay.c
+index b18b269f6..974575d6d 100644
+--- a/src/apps/relay/mainrelay.c
++++ b/src/apps/relay/mainrelay.c
+@@ -3503,8 +3503,12 @@ static void adjust_key_file_names(void) {
+     adjust_key_file_name(turn_params.dh_file, "DH key", 0);
+   }
+ }
+-static EVP_PKEY *get_dh566(void) {
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++static EVP_PKEY *get_dh566(void) {
++#else
++static DH *get_dh566(void) {
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+   unsigned char dh566_p[] = {0x36, 0x53, 0xA8, 0x9C, 0x3C, 0xF1, 0xD1, 0x1B, 0x2D, 0xA2, 0x64, 0xDE, 0x59, 0x3B, 0xE3,
+                              0x8C, 0x27, 0x74, 0xC2, 0xBE, 0x9B, 0x6D, 0x56, 0xE7, 0xDF, 0xFF, 0x67, 0x6A, 0xD2, 0x0C,
+                              0xE8, 0x9E, 0x52, 0x00, 0x05, 0xB3, 0x53, 0xF7, 0x1C, 0x41, 0xB2, 0xAC, 0x38, 0x16, 0x32,
+@@ -3518,6 +3522,7 @@ static EVP_PKEY *get_dh566(void) {
+ 
+   unsigned char dh566_g[] = {0x05};
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+   BIGNUM *p = BN_bin2bn(dh566_p, sizeof(dh566_p), NULL);
+   BIGNUM *g = BN_bin2bn(dh566_g, sizeof(dh566_g), NULL);
+   if (!p || !g) {
+@@ -3541,9 +3546,22 @@ static EVP_PKEY *get_dh566(void) {
+   EVP_PKEY_CTX_free(pctx);
+   OSSL_PARAM_free(params);
+   return pkey;
++#else
++  DH *dh;
++
++  if ((dh = DH_new()) == NULL) {
++    return (NULL);
++  }
++  DH_set0_pqg(dh, BN_bin2bn(dh566_p, sizeof(dh566_p), NULL), NULL, BN_bin2bn(dh566_g, sizeof(dh566_g), NULL));
++  return (dh);
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+ }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+ static EVP_PKEY *get_dh1066(void) {
++#else
++static DH *get_dh1066(void) {
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+ 
+   unsigned char dh1066_p[] = {0x02, 0x0E, 0x26, 0x6F, 0xAA, 0x9F, 0xA8, 0xE5, 0x3F, 0x70, 0x88, 0xF1, 0xA9, 0x29, 0xAE,
+                               0x1A, 0x2B, 0xA8, 0x2F, 0xE8, 0xE5, 0x0E, 0x81, 0x78, 0xD7, 0x12, 0x41, 0xDC, 0xE2, 0xD5,
+@@ -3563,6 +3581,7 @@ static EVP_PKEY *get_dh1066(void) {
+ 
+   unsigned char dh1066_g[] = {0x02};
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+   BIGNUM *p = BN_bin2bn(dh1066_p, sizeof(dh1066_p), NULL);
+   BIGNUM *g = BN_bin2bn(dh1066_g, sizeof(dh1066_g), NULL);
+   if (!p || !g) {
+@@ -3586,9 +3605,22 @@ static EVP_PKEY *get_dh1066(void) {
+   EVP_PKEY_CTX_free(pctx);
+   OSSL_PARAM_free(params);
+   return pkey;
++#else
++  DH *dh;
++
++  if ((dh = DH_new()) == NULL) {
++    return (NULL);
++  }
++  DH_set0_pqg(dh, BN_bin2bn(dh1066_p, sizeof(dh1066_p), NULL), NULL, BN_bin2bn(dh1066_g, sizeof(dh1066_g), NULL));
++  return (dh);
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+ }
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+ static EVP_PKEY *get_dh2066(void) {
++#else
++static DH *get_dh2066(void) {
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+ 
+   unsigned char dh2066_p[] = {
+       0x03, 0x31, 0x77, 0x20, 0x58, 0xA6, 0x69, 0xA3, 0x9D, 0x2D, 0x5E, 0xE0, 0x5C, 0x46, 0x82, 0x0F, 0x9E, 0x80, 0xF0,
+@@ -3617,6 +3649,7 @@ static EVP_PKEY *get_dh2066(void) {
+ 
+   unsigned char dh2066_g[] = {0x05};
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+   BIGNUM *p = BN_bin2bn(dh2066_p, sizeof(dh2066_p), NULL);
+   BIGNUM *g = BN_bin2bn(dh2066_g, sizeof(dh2066_g), NULL);
+   if (!p || !g) {
+@@ -3640,6 +3673,15 @@ static EVP_PKEY *get_dh2066(void) {
+   EVP_PKEY_CTX_free(pctx);
+   OSSL_PARAM_free(params);
+   return pkey;
++#else
++  DH *dh;
++
++  if ((dh = DH_new()) == NULL) {
++    return (NULL);
++  }
++  DH_set0_pqg(dh, BN_bin2bn(dh2066_p, sizeof(dh2066_p), NULL), NULL, BN_bin2bn(dh2066_g, sizeof(dh2066_g), NULL));
++  return (dh);
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+ }
+ 
+ static int pem_password_func(char *buf, int size, int rwflag, void *password) {
+@@ -3791,12 +3833,17 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
+ 
+   { // DH algorithms:
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+     EVP_PKEY *dh = NULL;
++#else
++    DH *dh = NULL;
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+     if (turn_params.dh_file[0]) {
+       FILE *paramfile = fopen(turn_params.dh_file, "r");
+       if (!paramfile) {
+         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot open DH file: %s\n", strerror(errno));
+       } else {
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+         OSSL_DECODER_CTX *dctx =
+             OSSL_DECODER_CTX_new_for_pkey(&dh, "PEM", NULL, "DH", EVP_PKEY_KEY_PARAMETERS, NULL, NULL);
+         if (dctx) {
+@@ -3805,6 +3852,9 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
+           }
+           OSSL_DECODER_CTX_free(dctx);
+         }
++#else
++        dh = PEM_read_DHparams(paramfile, NULL, NULL, NULL);
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+         fclose(paramfile);
+         if (dh) {
+           turn_params.dh_key_size = DH_CUSTOM;
+@@ -3826,11 +3876,19 @@ static void set_ctx(SSL_CTX **out, const char *protocol, const SSL_METHOD *metho
+       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: cannot allocate DH suite\n", __FUNCTION__);
+       err = 1;
+     } else {
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+       if (1 != SSL_CTX_set0_tmp_dh_pkey(ctx, dh)) {
++#else
++      if (1 != SSL_CTX_set_tmp_dh(ctx, dh)) {
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+         TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: ERROR: cannot set DH\n", __FUNCTION__);
+         err = 1;
+       }
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+       // No EVP_PKEY_free: SSL_CTX_set0_tmp_dh_pkey always takes ownership
++#else
++      DH_free(dh);
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+     }
+   }
+ 
+diff --git a/src/apps/relay/mainrelay.h b/src/apps/relay/mainrelay.h
+index 55ce93613..e1ef3583f 100644
+--- a/src/apps/relay/mainrelay.h
++++ b/src/apps/relay/mainrelay.h
+@@ -88,9 +88,13 @@
+ #include "ns_ioalib_impl.h"
+ 
+ #include <openssl/aes.h>
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+ #include <openssl/decoder.h>
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+ #include <openssl/err.h>
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+ #include <openssl/param_build.h>
++#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
+ #include <openssl/pem.h>
+ #include <openssl/ssl.h>
+ 

--- a/patches/openssl-1.1.1/README.md
+++ b/patches/openssl-1.1.1/README.md
@@ -1,0 +1,66 @@
+# Restore build support for (deprecated) OpenSSL 1.1.1
+
+This folder vendors an **out-of-tree patch** that brings back the ability to
+build coturn against **OpenSSL 1.1.1**. It is *not* applied to the coturn
+sources — it is provided for downstream packagers and operators who are forced
+to link against OpenSSL 1.1.1 and need a one-command way to restore that build.
+
+> [!WARNING]
+> **OpenSSL 1.1.1 is deprecated and end-of-life** (upstream EOL: 11 September
+> 2023; no further public security fixes). coturn targets OpenSSL 3.x, and this
+> patch exists only as a compatibility bridge for environments that cannot yet
+> move off 1.1.1. Use it at your own risk and migrate to OpenSSL 3.x as soon as
+> your platform allows.
+
+## What it does
+
+Commit `4c674289` ("OpenSSL: migrate to modern API for DH param", #1809) moved
+the DH-parameter handling in `src/apps/relay/mainrelay.c` to the OpenSSL 3.x
+`EVP_PKEY` / `OSSL_PARAM` API, which does not exist in OpenSSL 1.1.1. As a
+result, current coturn no longer compiles against 1.1.1.
+
+The patch conditionalizes those changes behind
+`OPENSSL_VERSION_NUMBER >= 0x30000000L`, keeping the modern path for OpenSSL 3.x
+while restoring the legacy `get_dh*()` / `DH_*` implementation for
+OpenSSL >= 1.1.1. It touches only `src/apps/relay/mainrelay.c` and
+`src/apps/relay/mainrelay.h`.
+
+## Why it is needed
+
+On AlmaLinux / RHEL / Rocky Linux 8, OpenSSL 3.5 is available in EPEL 8 but
+cannot be used in practice: the other libraries coturn links against
+(`libevent_openssl`, `libmariadb`, `libpq`) ship in RHEL 8 built and linked
+against the system OpenSSL 1.1.1. Mixing two OpenSSL major versions in one
+process is not viable, so coturn must also build against 1.1.1 on those
+distributions.
+
+## Source
+
+- Upstream pull request: <https://github.com/coturn/coturn/pull/1817>
+  ("Restore support for OpenSSL >= 1.1.1 (for AlmaLinux/RHEL/Rocky Linux 8)")
+- Author: Robert Scheck
+- Upstream commit: `c1110e6816c9c76668e6986efd282b9f57ef4fde`
+
+## How to apply
+
+From the repository root, choose one of:
+
+```bash
+# Preserve the original authorship as a real commit:
+git am patches/openssl-1.1.1/0001-restore-openssl-1.1.1-support.patch
+
+# Or apply to the working tree without committing:
+git apply patches/openssl-1.1.1/0001-restore-openssl-1.1.1-support.patch
+
+# Or with plain patch(1):
+patch -p1 < patches/openssl-1.1.1/0001-restore-openssl-1.1.1-support.patch
+```
+
+Then configure and build as usual; the legacy code path is selected
+automatically when it detects an OpenSSL version older than 3.0.
+
+## Verification
+
+The patch applies cleanly with `git apply --check` against the `master` commit
+it was vendored at (`e2735cf0`). If a later change to `mainrelay.c` causes it to
+no longer apply, regenerate it from the upstream pull request above.


### PR DESCRIPTION
Vendor the patch from upstream PR #1817 (Robert Scheck) under patches/openssl-1.1.1/, together with a README explaining that it brings back the ability to build coturn against the deprecated, end-of-life OpenSSL 1.1.1.

coturn targets OpenSSL 3.x; commit 4c674289 (#1809) migrated DH-param handling to the OpenSSL 3.x EVP_PKEY/OSSL_PARAM API, which does not exist in 1.1.1. The patch conditionalizes that behind
OPENSSL_VERSION_NUMBER >= 0x30000000L so the legacy path is restored for OpenSSL >= 1.1.1 -- needed on AlmaLinux/RHEL/Rocky Linux 8, where the libraries coturn links against (libevent_openssl, libmariadb, libpq) are built against the system OpenSSL 1.1.1.

The patch is not applied to the tree; it is provided for downstream packagers who must build against 1.1.1. It applies cleanly via git am / git apply / patch -p1 and is verified with git apply --check against the current master.