### PR TITLE
Flush prometheus hot-path counters once per second to kill lock contention

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -877,8 +877,7 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
       }
       udp_sendmmsg_batch_end();
 
-      prom_inc_packet_dropped(packets_dropped);
-      prom_inc_packet_processed(packets_processed);
+      ioa_engine_record_packets(server->e, packets_processed, packets_dropped);
       FUNCEND;
       return;
     }
@@ -890,14 +889,12 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
         ioa_engine_record_udp_recvmmsg_unavailable(server->e);
         turn_params.udp_recvmmsg = false;
       } else if (would_block()) {
-        prom_inc_packet_dropped(packets_dropped);
-        prom_inc_packet_processed(packets_processed);
+        ioa_engine_record_packets(server->e, packets_processed, packets_dropped);
         FUNCEND;
         return;
       } else if (is_connreset()) {
         reopen_server_socket(server, fd);
-        prom_inc_packet_dropped(packets_dropped);
-        prom_inc_packet_processed(packets_processed);
+        ioa_engine_record_packets(server->e, packets_processed, packets_dropped);
         FUNCEND;
         return;
       }
@@ -1025,8 +1022,7 @@ start_udp_cycle:
   ioa_network_buffer_delete(server->e, elem);
   elem = NULL;
 
-  prom_inc_packet_dropped(packets_dropped);
-  prom_inc_packet_processed(packets_processed);
+  ioa_engine_record_packets(server->e, packets_processed, packets_dropped);
 
   FUNCEND;
 }

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -535,6 +535,16 @@ void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src
 
 /************** ENGINE *************************/
 
+void ioa_engine_record_packets(ioa_engine_handle e, uint32_t processed, uint32_t dropped) {
+  if (!e) {
+    return;
+  }
+  /* Lock-free: only ever touched by this engine's own relay thread. Flushed to
+   * the shared prometheus counters once per second by timer_handler. */
+  e->prom_packets_processed += processed;
+  e->prom_packets_dropped += dropped;
+}
+
 #if defined(__linux__)
 void ioa_engine_record_udp_recvmmsg_batch(ioa_engine_handle e, int rc) {
   if (!e || rc <= 0) {
@@ -549,8 +559,6 @@ void ioa_engine_record_udp_recvmmsg_batch(ioa_engine_handle e, int rc) {
   e->udp_recvmmsg_calls++;
   e->udp_recvmmsg_packets += (uint64_t)rc;
   e->udp_recvmmsg_hist[bucket]++;
-
-  prom_observe_udp_recvmmsg_batch((unsigned int)rc);
 }
 
 void ioa_engine_record_udp_recvmmsg_wouldblock(ioa_engine_handle e) {
@@ -614,7 +622,6 @@ void ioa_engine_record_udp_sendmmsg_flush(ioa_engine_handle e, unsigned int coun
     e->udp_sendmmsg_gso_flushes++;
     e->udp_sendmmsg_gso_datagrams += (uint64_t)gso_count;
   }
-  prom_observe_udp_sendmmsg_flush(count, gso_count);
 }
 
 static uint64_t udp_sendmmsg_hist_sum(const ioa_engine_handle e, unsigned int lo, unsigned int hi) {
@@ -651,6 +658,37 @@ static void maybe_log_udp_sendmmsg_stats(ioa_engine_handle e, turn_time_t now) {
 }
 #endif
 
+/* Flush this engine's lock-free per-thread counters into the shared prometheus
+ * counters as deltas. Called once per second from timer_handler so the global
+ * prom_counter locks are hit ~1x/sec/thread instead of per batch. */
+static void maybe_flush_prom_counters(ioa_engine_handle e) {
+  if (!turn_params.prometheus || !e) {
+    return;
+  }
+
+  struct prom_udp_counter_deltas d = {0};
+
+  d.packets_processed = e->prom_packets_processed - e->prom_packets_processed_flushed;
+  d.packets_dropped = e->prom_packets_dropped - e->prom_packets_dropped_flushed;
+  e->prom_packets_processed_flushed = e->prom_packets_processed;
+  e->prom_packets_dropped_flushed = e->prom_packets_dropped;
+
+#if defined(__linux__)
+  d.recvmmsg_calls = e->udp_recvmmsg_calls - e->udp_recvmmsg_calls_prom_flushed;
+  d.recvmmsg_packets = e->udp_recvmmsg_packets - e->udp_recvmmsg_packets_prom_flushed;
+  d.sendmmsg_flushes = e->udp_sendmmsg_flushes - e->udp_sendmmsg_flushes_prom_flushed;
+  d.sendmmsg_datagrams = e->udp_sendmmsg_datagrams - e->udp_sendmmsg_datagrams_prom_flushed;
+  d.sendmmsg_gso_datagrams = e->udp_sendmmsg_gso_datagrams - e->udp_sendmmsg_gso_datagrams_prom_flushed;
+  e->udp_recvmmsg_calls_prom_flushed = e->udp_recvmmsg_calls;
+  e->udp_recvmmsg_packets_prom_flushed = e->udp_recvmmsg_packets;
+  e->udp_sendmmsg_flushes_prom_flushed = e->udp_sendmmsg_flushes;
+  e->udp_sendmmsg_datagrams_prom_flushed = e->udp_sendmmsg_datagrams;
+  e->udp_sendmmsg_gso_datagrams_prom_flushed = e->udp_sendmmsg_gso_datagrams;
+#endif
+
+  prom_flush_udp_counters(&d);
+}
+
 static void timer_handler(ioa_engine_handle e, void *arg) {
 
   UNUSED_ARG(arg);
@@ -659,6 +697,8 @@ static void timer_handler(ioa_engine_handle e, void *arg) {
   turn_atomic_store_u32(&_log_time_value, now);
 
   e->jiffie = now;
+
+  maybe_flush_prom_counters(e);
 
 #if defined(__linux__)
   maybe_log_udp_recvmmsg_stats(e, now);

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -164,6 +164,14 @@ struct _ioa_engine {
   size_t relays_number;
   size_t relay_addr_counter;
   ioa_addr *relay_addrs;
+  /* Prometheus hot-path packet counters: accumulated lock-free per engine
+   * (relay thread) and flushed to the shared prom_counter_t objects once per
+   * second from timer_handler, to avoid per-batch lock contention. The
+   * *_flushed fields snapshot the last value pushed to prometheus. */
+  uint64_t prom_packets_processed;
+  uint64_t prom_packets_dropped;
+  uint64_t prom_packets_processed_flushed;
+  uint64_t prom_packets_dropped_flushed;
 #if defined(__linux__)
   struct ioa_socket_recvmmsg_state *udp_recvmmsg_state;
   uint64_t udp_recvmmsg_calls;
@@ -182,6 +190,12 @@ struct _ioa_engine {
   uint64_t udp_sendmmsg_hist[IOA_UDP_SENDMMSG_MAX_BATCH + 1]; /* per-flush occupancy histogram */
   uint64_t udp_sendmmsg_last_report_flushes;
   turn_time_t udp_sendmmsg_last_report_time;
+  /* Snapshots of the above batch counters last flushed to prometheus. */
+  uint64_t udp_recvmmsg_calls_prom_flushed;
+  uint64_t udp_recvmmsg_packets_prom_flushed;
+  uint64_t udp_sendmmsg_flushes_prom_flushed;
+  uint64_t udp_sendmmsg_datagrams_prom_flushed;
+  uint64_t udp_sendmmsg_gso_datagrams_prom_flushed;
 #endif
   redis_context_handle rch;
   /* multiplex-peer (zero-initialised = disabled) */
@@ -331,6 +345,10 @@ void ioa_init_recvmmsg_hdr(struct mmsghdr *msg, struct iovec *iov, ioa_addr *src
 #if !defined(_MSC_VER) && defined(CMSG_SPACE)
 void ioa_parse_udp_recvmsg_cmsg(struct msghdr *msg, int *ttl, int *tos, uint32_t *errcode);
 #endif
+
+/* Accumulate processed/dropped packet counts for prometheus, lock-free, on the
+ * owning relay thread. Flushed to the shared prom counters by timer_handler. */
+void ioa_engine_record_packets(ioa_engine_handle e, uint32_t processed, uint32_t dropped);
 
 #if defined(__linux__)
 void ioa_engine_record_udp_recvmmsg_batch(ioa_engine_handle e, int rc);

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -319,32 +319,30 @@ void prom_dec_allocation(SOCKET_TYPE type) {
   }
 }
 
-void prom_inc_packet_processed(int count) {
-  if (turn_params.prometheus) {
-    prom_counter_add(packet_processed, count, NULL);
+void prom_flush_udp_counters(const struct prom_udp_counter_deltas *d) {
+  if (!turn_params.prometheus || !d) {
+    return;
   }
-}
-
-void prom_inc_packet_dropped(int count) {
-  if (turn_params.prometheus) {
-    prom_counter_add(packet_dropped, count, NULL);
+  if (d->packets_processed) {
+    prom_counter_add(packet_processed, (double)d->packets_processed, NULL);
   }
-}
-
-void prom_observe_udp_recvmmsg_batch(unsigned int packets) {
-  if (turn_params.prometheus && packets > 0) {
-    prom_counter_add(turn_udp_recvmmsg_calls, 1, NULL);
-    prom_counter_add(turn_udp_recvmmsg_packets, (double)packets, NULL);
+  if (d->packets_dropped) {
+    prom_counter_add(packet_dropped, (double)d->packets_dropped, NULL);
   }
-}
-
-void prom_observe_udp_sendmmsg_flush(unsigned int datagrams, unsigned int gso_datagrams) {
-  if (turn_params.prometheus && datagrams > 0) {
-    prom_counter_add(turn_udp_sendmmsg_flushes, 1, NULL);
-    prom_counter_add(turn_udp_sendmmsg_datagrams, (double)datagrams, NULL);
-    if (gso_datagrams > 0) {
-      prom_counter_add(turn_udp_sendmmsg_gso_datagrams, (double)gso_datagrams, NULL);
-    }
+  if (d->recvmmsg_calls) {
+    prom_counter_add(turn_udp_recvmmsg_calls, (double)d->recvmmsg_calls, NULL);
+  }
+  if (d->recvmmsg_packets) {
+    prom_counter_add(turn_udp_recvmmsg_packets, (double)d->recvmmsg_packets, NULL);
+  }
+  if (d->sendmmsg_flushes) {
+    prom_counter_add(turn_udp_sendmmsg_flushes, (double)d->sendmmsg_flushes, NULL);
+  }
+  if (d->sendmmsg_datagrams) {
+    prom_counter_add(turn_udp_sendmmsg_datagrams, (double)d->sendmmsg_datagrams, NULL);
+  }
+  if (d->sendmmsg_gso_datagrams) {
+    prom_counter_add(turn_udp_sendmmsg_gso_datagrams, (double)d->sendmmsg_gso_datagrams, NULL);
   }
 }
 
@@ -404,15 +402,6 @@ void prom_inc_allocation(SOCKET_TYPE type) { UNUSED_ARG(type); }
 
 void prom_dec_allocation(SOCKET_TYPE type) { UNUSED_ARG(type); }
 
-void prom_inc_packet_processed(int count) { UNUSED_ARG(count); }
-
-void prom_inc_packet_dropped(int count) { UNUSED_ARG(count); }
-
-void prom_observe_udp_recvmmsg_batch(unsigned int packets) { UNUSED_ARG(packets); }
-
-void prom_observe_udp_sendmmsg_flush(unsigned int datagrams, unsigned int gso_datagrams) {
-  UNUSED_ARG(datagrams);
-  UNUSED_ARG(gso_datagrams);
-}
+void prom_flush_udp_counters(const struct prom_udp_counter_deltas *d) { UNUSED_ARG(d); }
 
 #endif /* TURN_NO_PROMETHEUS */

--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -116,12 +116,22 @@ void prom_set_finished_traffic(const char *realm, const char *user, unsigned lon
 
 void prom_inc_allocation(SOCKET_TYPE type);
 void prom_dec_allocation(SOCKET_TYPE type);
-void prom_inc_packet_processed(int count);
-void prom_inc_packet_dropped(int count);
 
-/* Record one Linux recvmmsg/sendmmsg syscall and the datagrams it carried.
- * No-ops when prometheus is disabled or compiled out. */
-void prom_observe_udp_recvmmsg_batch(unsigned int packets);
-void prom_observe_udp_sendmmsg_flush(unsigned int datagrams, unsigned int gso_datagrams);
+/* Per-engine deltas accumulated lock-free on the relay hot path and flushed
+ * into the shared prometheus counters once per second (see timer_handler).
+ * Defined unconditionally so callers compile regardless of TURN_NO_PROMETHEUS. */
+struct prom_udp_counter_deltas {
+  uint64_t packets_processed;
+  uint64_t packets_dropped;
+  uint64_t recvmmsg_calls;
+  uint64_t recvmmsg_packets;
+  uint64_t sendmmsg_flushes;
+  uint64_t sendmmsg_datagrams;
+  uint64_t sendmmsg_gso_datagrams;
+};
+
+/* Add the given non-zero deltas to the shared prometheus counters.
+ * No-op when prometheus is disabled or compiled out. */
+void prom_flush_udp_counters(const struct prom_udp_counter_deltas *d);
 
 #endif /* __PROM_SERVER_H__ */


### PR DESCRIPTION
## Summary

The per-packet/per-batch prometheus counters were updated on the relay hot path by **every** relay thread:

- `prom_inc_packet_processed/dropped` — per receive batch in `udp_server_input_handler`
- the recvmmsg/sendmmsg batch observers — per syscall

Each call went through prometheus-client-c's `prom_counter_add()`, which takes a per-metric lock on a single process-wide counter object. With many relay threads those shared locks serialize the threads and show up as a futex storm: `native_queued_spin_lock_slowpath` consumed ~36% CPU under load (`futex_wait → futex_q_lock → _raw_spin_lock`).

This change accumulates the counts **lock-free** in per-engine (per-thread) fields and flushes the deltas into the shared `prom_counter_t` objects **once per second** from the engine's existing `timer_handler`. The global counter lock goes from per-batch to ~1×/sec/thread, removing the contention while keeping every metric exact and monotonic (`delta = current − last_flushed`, always ≥ 0).

Behaviour with `--prometheus` off or compiled out (`TURN_NO_PROMETHEUS`) is unchanged.

## Changes

- **ns_ioalib_impl.h**: add per-engine `prom_packets_processed/_dropped` accumulators (cross-platform) and `*_prom_flushed` snapshots for the existing recvmmsg/sendmmsg counters (Linux); declare `ioa_engine_record_packets()`.
- **ns_ioalib_engine_impl.c**: add lock-free `ioa_engine_record_packets()`, drop the two `prom_observe_*` hot-path calls, add `maybe_flush_prom_counters()` and call it from `timer_handler`.
- **dtls_listener.c**: replace the four `prom_inc_packet_*` call sites with `ioa_engine_record_packets(server->e, processed, dropped)`.
- **prom_server.{c,h}**: replace `prom_inc_packet_processed/dropped` and `prom_observe_udp_recvmmsg_batch/sendmmsg_flush` with a single batched `prom_flush_udp_counters(struct prom_udp_counter_deltas *)`, plus a `TURN_NO_PROMETHEUS` no-op stub.

## Validation

- **macOS** (stub path): build, unit tests (8/8), `run_tests.sh` / `run_tests_conf.sh` / `run_tests_multiplex_peer.sh`, fuzzing ASan targets 0 & 1.
- **Linux / Docker** (stub path): clean build, unit tests (7/7), `run_tests.sh` / `run_tests_conf.sh` / `run_tests_multiplex_peer.sh` all pass.
- **Prometheus-enabled** path (`run_tests_prom.sh` + live metrics scrape): on Linux with prometheus built.
