### PR TITLE
Prom https

### DIFF
--- a/configure
+++ b/configure
@@ -850,9 +850,18 @@ if [ -z "${TURN_NO_PROMETHEUS}" ] ; then
     # coturn ships a vendored, self-contained Prometheus client under
     # src/prometheus (built from local sources). libmicrohttpd serves the
     # /metrics endpoint and is the only external dependency.
-    testlib microhttpd
-    ER=$?
-    if ! [ ${ER} -eq 0 ] ; then
+    #
+    # Prefer pkg-config so non-default install prefixes (e.g. Homebrew's
+    # /opt/homebrew) are picked up like libssl/libevent below; fall back to the
+    # bare -lmicrohttpd link probe for platforms without a .pc file.
+    MICROHTTPD_OK=0
+    if testpkg_common libmicrohttpd; then
+        MICROHTTPD_OK=1
+    else
+        testlib microhttpd
+        [ $? -ne 0 ] && MICROHTTPD_OK=1
+    fi
+    if [ ${MICROHTTPD_OK} -eq 1 ] ; then
         ${ECHO_CMD} "Microhttpd lib found; using vendored Prometheus client."
         OSCFLAGS="${OSCFLAGS} -Isrc/prometheus"
         # Adjustments for Debian

--- a/docker/coturn/alpine/Dockerfile
+++ b/docker/coturn/alpine/Dockerfile
@@ -4,10 +4,6 @@
 
 ARG alpine_ver=3.24
 
-# The Prometheus exporter is built from coturn's vendored client
-# (src/prometheus). libmicrohttpd is the only dependency it needs, and it is
-# installed in the build and runtime stages below.
-
 
 
 

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -4,10 +4,6 @@
 
 ARG debian_ver=trixie
 
-# The Prometheus exporter is built from coturn's vendored client
-# (src/prometheus). libmicrohttpd is the only dependency it needs, and it is
-# installed in the build and runtime stages below.
-
 
 
 

--- a/docs/Prometheus.md
+++ b/docs/Prometheus.md
@@ -57,3 +57,26 @@ install prefix, set `MicroHTTPD_ROOT`:
 cmake -S . -B build -DMicroHTTPD_ROOT=/path/to/libmicrohttpd/install
 cmake --build build
 ```
+
+The exporter is always compiled in (libmicrohttpd is a required build
+dependency); the runtime `--prometheus` flag controls whether it is started.
+
+## HTTPS (optional)
+
+By default the metrics endpoint is served over plain HTTP. To serve it over
+HTTPS instead, pass `--prometheus-tls` (requires libmicrohttpd built with TLS
+support). The certificate and key default to the server's own `--cert` /
+`--pkey`; override them with `--prometheus-cert` / `--prometheus-key`:
+
+```
+# Reuse the server's TLS material:
+turnserver --prometheus --prometheus-tls --cert server.pem --pkey server.key
+
+# Or use a dedicated certificate for the metrics endpoint:
+turnserver --prometheus --prometheus-tls \
+    --prometheus-cert metrics.pem --prometheus-key metrics.key
+```
+
+Then scrape with `https://<host>:9641/metrics`. If `--prometheus-tls` is set
+but no certificate/key can be loaded, the exporter logs an error and does not
+start.

--- a/docs/Prometheus.md
+++ b/docs/Prometheus.md
@@ -65,15 +65,17 @@ dependency); the runtime `--prometheus` flag controls whether it is started.
 
 By default the metrics endpoint is served over plain HTTP. To serve it over
 HTTPS instead, pass `--prometheus-tls` (requires libmicrohttpd built with TLS
-support). The certificate and key default to the server's own `--cert` /
-`--pkey`; override them with `--prometheus-cert` / `--prometheus-key`:
+support). `--prometheus-tls` implies `--prometheus`, so it enables the exporter
+on its own — there is no need to pass both. The certificate and key default to
+the server's own `--cert` / `--pkey`; override them with `--prometheus-cert` /
+`--prometheus-key`:
 
 ```
 # Reuse the server's TLS material:
-turnserver --prometheus --prometheus-tls --cert server.pem --pkey server.key
+turnserver --prometheus-tls --cert server.pem --pkey server.key
 
 # Or use a dedicated certificate for the metrics endpoint:
-turnserver --prometheus --prometheus-tls \
+turnserver --prometheus-tls \
     --prometheus-cert metrics.pem --prometheus-key metrics.key
 ```
 

--- a/examples/run_tests_prom.sh
+++ b/examples/run_tests_prom.sh
@@ -7,6 +7,67 @@ if [ ! -f $BINDIR/turnserver ]; then
     BINDIR="../build/bin"
 fi
 
+# turnserver startup is near-instant on Linux but takes ~5s on macOS, where the
+# thread-barrier rendezvous in netengine.c degrades to a fixed sleep(5) because
+# libpthread lacks pthread_barrier_*. Rather than sleeping a fixed interval, the
+# helpers below poll for readiness (the metrics endpoint, or the server log) up
+# to this timeout.
+POLL_TIMEOUT=30
+
+TURNSERVER_LOG="$(mktemp "${TMPDIR:-/tmp}/run_tests_prom.XXXXXX")"
+turnserver_pid=""
+
+# Pin the TURN listeners to loopback and skip the TLS/DTLS listeners: this test
+# only exercises the Prometheus exporter (served independently by libmicrohttpd),
+# and leaving address auto-discovery on makes startup slow and flaky on hosts
+# with tentative/temporary IPv6 addresses (the DTLS/UDP bind retries with
+# sleep(1) until Duplicate Address Detection completes).
+COMMON_ARGS="-L 127.0.0.1 -E 127.0.0.1 --no-tls --no-dtls --log-file=stdout --simple-log"
+
+# stop_turnserver: stop the running turnserver and wait for it to exit so its
+# listening ports are released before the next instance binds them. SIGKILL is
+# used deliberately: graceful SIGTERM shutdown can take up to ~5s (the auth
+# housekeeping thread sleeps in 5s cycles), and this test does not care about a
+# clean drain.
+function stop_turnserver() {
+  if [ -n "$turnserver_pid" ]; then
+    kill -KILL "$turnserver_pid" 2>/dev/null
+    wait "$turnserver_pid" 2>/dev/null
+    turnserver_pid=""
+  fi
+}
+
+function cleanup() {
+  stop_turnserver
+  rm -f "$TURNSERVER_LOG"
+}
+trap cleanup EXIT
+
+# start_turnserver <args...>: launch turnserver in the background with its output
+# captured to TURNSERVER_LOG so the negative tests can poll for its decision.
+function start_turnserver() {
+  : > "$TURNSERVER_LOG"
+  # shellcheck disable=SC2086
+  "$BINDIR/turnserver" $COMMON_ARGS "$@" > "$TURNSERVER_LOG" 2>&1 &
+  turnserver_pid="$!"
+}
+
+# wait_for_prom_decision: block until turnserver has logged that it settled its
+# Prometheus startup decision (exporter started, or explicitly not started).
+# Used by the no-response tests, which cannot poll the (absent) endpoint.
+function wait_for_prom_decision() {
+  local deadline=$((SECONDS + POLL_TIMEOUT))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if grep -Eq "prometheus collector started successfully|prometheus collector disabled, not started|could not read certificate|without TLS support|no certificate/key is configured" "$TURNSERVER_LOG"; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "FAIL (turnserver did not settle its prometheus decision within ${POLL_TIMEOUT}s)"
+  cat "$TURNSERVER_LOG"
+  exit 1
+}
+
 function assert_prom_no_response() {
   wget --quiet --output-document=/dev/null --tries=1 "$1"
   status="$?"
@@ -19,27 +80,40 @@ function assert_prom_no_response() {
 }
 
 function assert_prom_response() {
-  # Match something that looks like the expected body
-  wget --quiet --output-document=- --tries=1 "$1" | grep 'TYPE\|HELP\|counter\|gauge' >/dev/null
-  status="$?"
-  if [ "$status" -eq 0 ]; then
-    echo OK
-  else
-    echo FAIL
-    exit "$status"
-  fi
+  # Poll until the endpoint returns something that looks like the expected body,
+  # or fail after POLL_TIMEOUT.
+  local deadline=$((SECONDS + POLL_TIMEOUT))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if wget --quiet --output-document=- --tries=1 "$1" 2>/dev/null |
+        grep -q 'TYPE\|HELP\|counter\|gauge'; then
+      echo OK
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo FAIL
+  cat "$TURNSERVER_LOG"
+  exit 1
 }
 
 function assert_prom_response_tls() {
   # Same as assert_prom_response but over HTTPS with a self-signed cert, so
   # certificate verification is disabled. A plaintext HTTP request to the same
   # URL must NOT succeed (the endpoint is TLS-only).
-  wget --no-check-certificate --quiet --output-document=- --tries=1 "$1" |
-    grep 'TYPE\|HELP\|counter\|gauge' >/dev/null
-  status="$?"
-  if [ "$status" -ne 0 ]; then
+  local deadline=$((SECONDS + POLL_TIMEOUT))
+  local ok=0
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if wget --no-check-certificate --quiet --output-document=- --tries=1 "$1" 2>/dev/null |
+        grep -q 'TYPE\|HELP\|counter\|gauge'; then
+      ok=1
+      break
+    fi
+    sleep 0.2
+  done
+  if [ "$ok" -ne 1 ]; then
     echo FAIL
-    exit "$status"
+    cat "$TURNSERVER_LOG"
+    exit 1
   fi
   # The HTTPS endpoint must reject a plaintext HTTP request on the same port.
   http_url="${1/https:/http:}"
@@ -52,59 +126,41 @@ function assert_prom_response_tls() {
 }
 
 echo "Running without prometheus"
-$BINDIR/turnserver  > /dev/null &
-turnserver_pid="$!"
-sleep 5
+start_turnserver
+wait_for_prom_decision
 assert_prom_no_response "http://localhost:9641/metrics"
-kill "$turnserver_pid"
-sleep 5
+stop_turnserver
 
 echo "Running turnserver with prometheus, using defaults"
-$BINDIR/turnserver --prometheus > /dev/null &
-turnserver_pid="$!"
-sleep 5
+start_turnserver --prometheus
 assert_prom_response "http://localhost:9641/metrics"
-kill "$turnserver_pid"
-sleep 5
+stop_turnserver
 
 echo "Running turnserver with prometheus, using custom address and port"
-$BINDIR/turnserver --prometheus --prometheus-address="127.0.0.1" --prometheus-port="8080" > /dev/null &
-turnserver_pid="$!"
-sleep 5
+start_turnserver --prometheus --prometheus-address="127.0.0.1" --prometheus-port="8080"
 assert_prom_response "http://127.0.0.1:8080/metrics"
-kill "$turnserver_pid"
-sleep 5
+stop_turnserver
 
 echo "Running turnserver with prometheus, using custom path"
-$BINDIR/turnserver --prometheus --prometheus-path="/coturn/metrics" > /dev/null &
-turnserver_pid="$!"
-sleep 5
+start_turnserver --prometheus --prometheus-path="/coturn/metrics"
 assert_prom_response "http://localhost:9641/coturn/metrics"
-kill "$turnserver_pid"
-sleep 5
+stop_turnserver
 
 echo "Running turnserver with prometheus over TLS, explicit --prometheus-cert/--prometheus-key"
-$BINDIR/turnserver --prometheus --prometheus-tls \
-  --prometheus-cert=etc/turn_server_cert.pem --prometheus-key=etc/turn_server_pkey.pem > /dev/null &
-turnserver_pid="$!"
-sleep 5
+start_turnserver --prometheus --prometheus-tls \
+  --prometheus-cert=etc/turn_server_cert.pem --prometheus-key=etc/turn_server_pkey.pem
 assert_prom_response_tls "https://localhost:9641/metrics"
-kill "$turnserver_pid"
-sleep 5
+stop_turnserver
 
 echo "Running turnserver with prometheus over TLS, cert/key inherited from server --cert/--pkey"
-$BINDIR/turnserver --prometheus --prometheus-tls \
-  --cert=etc/turn_server_cert.pem --pkey=etc/turn_server_pkey.pem > /dev/null &
-turnserver_pid="$!"
-sleep 5
+start_turnserver --prometheus --prometheus-tls \
+  --cert=etc/turn_server_cert.pem --pkey=etc/turn_server_pkey.pem
 assert_prom_response_tls "https://localhost:9641/metrics"
-kill "$turnserver_pid"
-sleep 5
+stop_turnserver
 
 echo "Running turnserver with prometheus TLS but an unreadable cert: endpoint must not start"
-$BINDIR/turnserver --prometheus --prometheus-tls \
-  --prometheus-cert=/nonexistent/cert.pem --prometheus-key=/nonexistent/key.pem > /dev/null &
-turnserver_pid="$!"
-sleep 5
+start_turnserver --prometheus --prometheus-tls \
+  --prometheus-cert=/nonexistent/cert.pem --prometheus-key=/nonexistent/key.pem
+wait_for_prom_decision
 assert_prom_no_response "https://localhost:9641/metrics"
-kill "$turnserver_pid"
+stop_turnserver

--- a/examples/run_tests_prom.sh
+++ b/examples/run_tests_prom.sh
@@ -67,21 +67,6 @@ assert_prom_response "http://localhost:9641/metrics"
 kill "$turnserver_pid"
 sleep 5
 
-echo "Running turnserver with prometheus, using custom address"
-$BINDIR/turnserver --prometheus --prometheus-address="127.0.0.1" > /dev/null &
-turnserver_pid="$!"
-sleep 5
-assert_prom_response "http://127.0.0.1:9641/metrics"
-kill "$turnserver_pid"
- 
-echo "Running turnserver with prometheus, using custom port"
-$BINDIR/turnserver --prometheus --prometheus-port="8080" > /dev/null &
-turnserver_pid="$!"
-sleep 5
-assert_prom_response "http://localhost:8080/metrics"
-kill "$turnserver_pid"
-sleep 5
-
 echo "Running turnserver with prometheus, using custom address and port"
 $BINDIR/turnserver --prometheus --prometheus-address="127.0.0.1" --prometheus-port="8080" > /dev/null &
 turnserver_pid="$!"

--- a/examples/run_tests_prom.sh
+++ b/examples/run_tests_prom.sh
@@ -146,20 +146,22 @@ start_turnserver --prometheus --prometheus-path="/coturn/metrics"
 assert_prom_response "http://localhost:9641/coturn/metrics"
 stop_turnserver
 
+# --prometheus-tls implies --prometheus, so the exporter is enabled without a
+# separate --prometheus flag below.
 echo "Running turnserver with prometheus over TLS, explicit --prometheus-cert/--prometheus-key"
-start_turnserver --prometheus --prometheus-tls \
+start_turnserver --prometheus-tls \
   --prometheus-cert=etc/turn_server_cert.pem --prometheus-key=etc/turn_server_pkey.pem
 assert_prom_response_tls "https://localhost:9641/metrics"
 stop_turnserver
 
 echo "Running turnserver with prometheus over TLS, cert/key inherited from server --cert/--pkey"
-start_turnserver --prometheus --prometheus-tls \
+start_turnserver --prometheus-tls \
   --cert=etc/turn_server_cert.pem --pkey=etc/turn_server_pkey.pem
 assert_prom_response_tls "https://localhost:9641/metrics"
 stop_turnserver
 
 echo "Running turnserver with prometheus TLS but an unreadable cert: endpoint must not start"
-start_turnserver --prometheus --prometheus-tls \
+start_turnserver --prometheus-tls \
   --prometheus-cert=/nonexistent/cert.pem --prometheus-key=/nonexistent/key.pem
 wait_for_prom_decision
 assert_prom_no_response "https://localhost:9641/metrics"

--- a/examples/run_tests_prom.sh
+++ b/examples/run_tests_prom.sh
@@ -30,6 +30,27 @@ function assert_prom_response() {
   fi
 }
 
+function assert_prom_response_tls() {
+  # Same as assert_prom_response but over HTTPS with a self-signed cert, so
+  # certificate verification is disabled. A plaintext HTTP request to the same
+  # URL must NOT succeed (the endpoint is TLS-only).
+  wget --no-check-certificate --quiet --output-document=- --tries=1 "$1" |
+    grep 'TYPE\|HELP\|counter\|gauge' >/dev/null
+  status="$?"
+  if [ "$status" -ne 0 ]; then
+    echo FAIL
+    exit "$status"
+  fi
+  # The HTTPS endpoint must reject a plaintext HTTP request on the same port.
+  http_url="${1/https:/http:}"
+  wget --quiet --output-document=/dev/null --tries=1 "$http_url"
+  if [ "$?" -eq 0 ]; then
+    echo "FAIL (plaintext HTTP accepted on TLS endpoint)"
+    exit 1
+  fi
+  echo OK
+}
+
 echo "Running without prometheus"
 $BINDIR/turnserver  > /dev/null &
 turnserver_pid="$!"
@@ -74,4 +95,31 @@ $BINDIR/turnserver --prometheus --prometheus-path="/coturn/metrics" > /dev/null 
 turnserver_pid="$!"
 sleep 5
 assert_prom_response "http://localhost:9641/coturn/metrics"
+kill "$turnserver_pid"
+sleep 5
+
+echo "Running turnserver with prometheus over TLS, explicit --prometheus-cert/--prometheus-key"
+$BINDIR/turnserver --prometheus --prometheus-tls \
+  --prometheus-cert=etc/turn_server_cert.pem --prometheus-key=etc/turn_server_pkey.pem > /dev/null &
+turnserver_pid="$!"
+sleep 5
+assert_prom_response_tls "https://localhost:9641/metrics"
+kill "$turnserver_pid"
+sleep 5
+
+echo "Running turnserver with prometheus over TLS, cert/key inherited from server --cert/--pkey"
+$BINDIR/turnserver --prometheus --prometheus-tls \
+  --cert=etc/turn_server_cert.pem --pkey=etc/turn_server_pkey.pem > /dev/null &
+turnserver_pid="$!"
+sleep 5
+assert_prom_response_tls "https://localhost:9641/metrics"
+kill "$turnserver_pid"
+sleep 5
+
+echo "Running turnserver with prometheus TLS but an unreadable cert: endpoint must not start"
+$BINDIR/turnserver --prometheus --prometheus-tls \
+  --prometheus-cert=/nonexistent/cert.pem --prometheus-key=/nonexistent/key.pem > /dev/null &
+turnserver_pid="$!"
+sleep 5
+assert_prom_no_response "https://localhost:9641/metrics"
 kill "$turnserver_pid"

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1171,7 +1171,7 @@ static char Usage[] =
     " --prometheus-path		<path>		Prometheus serve path (Default: /metrics).\n"
     " --prometheus-username-labels			When metrics are enabled, add labels with client usernames.\n"
     " --prometheus-tls				Serve the metrics endpoint over HTTPS instead of HTTP "
-    "(optional). Requires libmicrohttpd built with TLS support.\n"
+    "(optional). Implies --prometheus. Requires libmicrohttpd built with TLS support.\n"
     " --prometheus-cert		<file>		PEM certificate for the HTTPS metrics endpoint "
     "(Default: the server's --cert).\n"
     " --prometheus-key		<file>		PEM private key for the HTTPS metrics endpoint "
@@ -2391,6 +2391,11 @@ static void set_option(int c, char *value) {
     break;
   case PROMETHEUS_TLS_OPT:
     turn_params.prometheus_tls = get_bool_value(value);
+    if (turn_params.prometheus_tls) {
+      /* Serving the metrics endpoint over TLS implies enabling the exporter,
+       * so --prometheus-tls alone is enough (no separate --prometheus needed). */
+      turn_params.prometheus = true;
+    }
     break;
   case PROMETHEUS_CERT_OPT:
     STRCPY(turn_params.prometheus_cert_file, value);

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -220,6 +220,9 @@ turn_params_t turn_params = {
     "",                                 /* prometheus address */
     "/metrics",                         /* prometheus path */
     false, /* prometheus username labelling disabled by default when prometheus is enabled */
+    false, /* prometheus TLS (HTTPS) disabled by default */
+    "",    /* prometheus cert file (defaults to --cert) */
+    "",    /* prometheus key file (defaults to --pkey) */
 
     ///////////// Users DB //////////////
     {(TURN_USERDB_TYPE)0, {"\0", "\0"}, {0, NULL, {NULL, 0}}},
@@ -1167,6 +1170,12 @@ static char Usage[] =
     " --prometheus-address		<address>		Prometheus listening address (Default: any).\n"
     " --prometheus-path		<path>		Prometheus serve path (Default: /metrics).\n"
     " --prometheus-username-labels			When metrics are enabled, add labels with client usernames.\n"
+    " --prometheus-tls				Serve the metrics endpoint over HTTPS instead of HTTP "
+    "(optional). Requires libmicrohttpd built with TLS support.\n"
+    " --prometheus-cert		<file>		PEM certificate for the HTTPS metrics endpoint "
+    "(Default: the server's --cert).\n"
+    " --prometheus-key		<file>		PEM private key for the HTTPS metrics endpoint "
+    "(Default: the server's --pkey).\n"
 #endif
     " --use-auth-secret				TURN REST API flag.\n"
     "						Flag that sets a special authorization option that is based upon "
@@ -1495,6 +1504,9 @@ enum EXTRA_OPTS {
   PROMETHEUS_ADDRESS_OPT,
   PROMETHEUS_PATH_OPT,
   PROMETHEUS_ENABLE_USERNAMES_OPT,
+  PROMETHEUS_TLS_OPT,
+  PROMETHEUS_CERT_OPT,
+  PROMETHEUS_KEY_OPT,
   AUTH_SECRET_OPT,
   NO_AUTH_PINGS_OPT,
   NO_DYNAMIC_IP_LIST_OPT,
@@ -1629,6 +1641,9 @@ static const struct myoption long_options[] = {
     {"prometheus-address", optional_argument, NULL, PROMETHEUS_ADDRESS_OPT},
     {"prometheus-path", optional_argument, NULL, PROMETHEUS_PATH_OPT},
     {"prometheus-username-labels", optional_argument, NULL, PROMETHEUS_ENABLE_USERNAMES_OPT},
+    {"prometheus-tls", optional_argument, NULL, PROMETHEUS_TLS_OPT},
+    {"prometheus-cert", required_argument, NULL, PROMETHEUS_CERT_OPT},
+    {"prometheus-key", required_argument, NULL, PROMETHEUS_KEY_OPT},
 #endif
     {"use-auth-secret", optional_argument, NULL, AUTH_SECRET_OPT},
     {"static-auth-secret", required_argument, NULL, STATIC_AUTH_SECRET_VAL_OPT},
@@ -2373,6 +2388,15 @@ static void set_option(int c, char *value) {
     break;
   case PROMETHEUS_ENABLE_USERNAMES_OPT:
     turn_params.prometheus_username_labels = true;
+    break;
+  case PROMETHEUS_TLS_OPT:
+    turn_params.prometheus_tls = get_bool_value(value);
+    break;
+  case PROMETHEUS_CERT_OPT:
+    STRCPY(turn_params.prometheus_cert_file, value);
+    break;
+  case PROMETHEUS_KEY_OPT:
+    STRCPY(turn_params.prometheus_pkey_file, value);
     break;
   case AUTH_SECRET_OPT:
     turn_params.use_auth_secret_with_timestamp = 1;

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -321,6 +321,11 @@ typedef struct _turn_params_ {
   char prometheus_address[INET6_ADDRSTRLEN];
   char prometheus_path[1025];
   bool prometheus_username_labels;
+  bool prometheus_tls; /* serve the metrics endpoint over HTTPS */
+  /* PEM cert/key for the HTTPS metrics endpoint; empty means fall back to the
+   * server's main --cert / --pkey. */
+  char prometheus_cert_file[1025];
+  char prometheus_pkey_file[1025];
 
   /////// Users DB ///////////
 

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -44,11 +44,73 @@
 
 //////////// Barrier for the threads //////////////
 
-#if !defined(TURN_NO_THREAD_BARRIERS)
-static unsigned int barrier_count = 0;
-static pthread_barrier_t barrier;
-static pthread_barrier_t relay_setup_barrier;
+#if !defined(PTHREAD_BARRIER_SERIAL_THREAD)
+#define PTHREAD_BARRIER_SERIAL_THREAD (-1)
 #endif
+
+#if defined(TURN_NO_THREAD_BARRIERS)
+/* Portable thread barrier for platforms that lack pthread_barrier_* (e.g.
+ * macOS). Built on a mutex + condition variable, which are universally
+ * available. This replaces the former sleep(5) shim: it is both instant and
+ * race-free (the shim let threads proceed if any setup took longer than the
+ * fixed sleep). */
+typedef struct {
+  pthread_mutex_t mtx;
+  pthread_cond_t cond;
+  unsigned int threshold;  /* number of threads to rendezvous */
+  unsigned int count;      /* threads currently waiting */
+  unsigned int generation; /* bumped each time the barrier trips, guards reuse */
+} turn_barrier_t;
+
+static int turn_barrier_init(turn_barrier_t *b, unsigned int n) {
+  if (n == 0) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (pthread_mutex_init(&b->mtx, NULL) != 0) {
+    return -1;
+  }
+  if (pthread_cond_init(&b->cond, NULL) != 0) {
+    pthread_mutex_destroy(&b->mtx);
+    return -1;
+  }
+  b->threshold = n;
+  b->count = 0;
+  b->generation = 0;
+  return 0;
+}
+
+static int turn_barrier_wait(turn_barrier_t *b) {
+  pthread_mutex_lock(&b->mtx);
+  const unsigned int gen = b->generation;
+  if (++b->count == b->threshold) {
+    /* Last thread to arrive releases the rest and resets for reuse. */
+    b->generation++;
+    b->count = 0;
+    pthread_cond_broadcast(&b->cond);
+    pthread_mutex_unlock(&b->mtx);
+    return PTHREAD_BARRIER_SERIAL_THREAD;
+  }
+  /* The generation guard absorbs spurious condvar wakeups. */
+  while (gen == b->generation) {
+    pthread_cond_wait(&b->cond, &b->mtx);
+  }
+  pthread_mutex_unlock(&b->mtx);
+  return 0;
+}
+
+#define TURN_BARRIER turn_barrier_t
+#define TURN_BARRIER_INIT(b, n) turn_barrier_init((b), (n))
+#define TURN_BARRIER_WAIT(b) turn_barrier_wait((b))
+#else
+#define TURN_BARRIER pthread_barrier_t
+#define TURN_BARRIER_INIT(b, n) pthread_barrier_init((b), NULL, (n))
+#define TURN_BARRIER_WAIT(b) pthread_barrier_wait((b))
+#endif
+
+static unsigned int barrier_count = 0;
+static TURN_BARRIER barrier;
+static TURN_BARRIER relay_setup_barrier;
 
 ////////////// Auth Server ////////////////
 
@@ -84,26 +146,16 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
 
 /////////////// BARRIERS ///////////////////
 
-#if !defined(PTHREAD_BARRIER_SERIAL_THREAD)
-#define PTHREAD_BARRIER_SERIAL_THREAD (-1)
-#endif
-
 static void barrier_wait_func(const char *func, int line) {
-#if !defined(TURN_NO_THREAD_BARRIERS)
   int br = 0;
   do {
-    br = pthread_barrier_wait(&barrier);
+    br = TURN_BARRIER_WAIT(&barrier);
     if ((br < 0) && (br != PTHREAD_BARRIER_SERIAL_THREAD)) {
       const int err = socket_errno();
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "barrier wait: %s\n", strerror(errno));
       printf("%s:%s:%d: %d\n", __FUNCTION__, func, line, err);
     }
   } while (((br < 0) && (br != PTHREAD_BARRIER_SERIAL_THREAD)) && socket_eintr());
-#else
-  UNUSED_ARG(func);
-  UNUSED_ARG(line);
-  sleep(5);
-#endif
 }
 
 #define barrier_wait() barrier_wait_func(__FUNCTION__, __LINE__)
@@ -975,28 +1027,22 @@ static void setup_listener(void) {
 }
 
 static void setup_barriers(void) {
-#if !defined(TURN_NO_THREAD_BARRIERS)
-  if (pthread_barrier_init(&barrier, NULL, barrier_count) != 0) {
+  if (TURN_BARRIER_INIT(&barrier, barrier_count) != 0) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "barrier init: %s\n", strerror(errno));
   }
-#endif
 }
 
 static void setup_socket_per_thread_udp_listener_servers(void) {
   size_t i = 0;
   size_t relayindex = 0;
 
-  /* Wait for all relay threads to complete setup before accessing their state */
-#if !defined(TURN_NO_THREAD_BARRIERS)
-  pthread_barrier_wait(&relay_setup_barrier);
-#else
-  /* Fallback when barriers are disabled: spin-wait (racy, but preserved for compatibility) */
-  for (relayindex = 0; relayindex < get_real_general_relay_servers_number(); relayindex++) {
-    while (!(general_relay_servers[relayindex]->ioa_eng) || !(general_relay_servers[relayindex]->server.e)) {
-      sched_yield();
-    }
+  /* Wait for all relay threads to complete setup before accessing their state.
+   * When relays run inline on the main thread (general_relay_servers_number == 0)
+   * there is no separate thread to rendezvous with and the barrier is not
+   * initialized, so the wait is skipped. */
+  if (turn_params.general_relay_servers_number > 0) {
+    TURN_BARRIER_WAIT(&relay_setup_barrier);
   }
-#endif
 
   /* Aux UDP servers */
   for (i = 0; i < turn_params.aux_servers_list.size; i++) {
@@ -1347,9 +1393,7 @@ static void *run_general_relay_thread(void *arg) {
 
   setup_relay_server(rs, NULL, we_need_rfc5780);
 
-#if !defined(TURN_NO_THREAD_BARRIERS)
-  pthread_barrier_wait(&relay_setup_barrier);
-#endif
+  TURN_BARRIER_WAIT(&relay_setup_barrier);
 
   barrier_wait();
 
@@ -1363,14 +1407,11 @@ static void *run_general_relay_thread(void *arg) {
 static void setup_general_relay_servers(void) {
   size_t i = 0;
 
-#if !defined(TURN_NO_THREAD_BARRIERS)
   if (turn_params.general_relay_servers_number > 0) {
-    if (pthread_barrier_init(&relay_setup_barrier, NULL, (unsigned int)get_real_general_relay_servers_number() + 1) !=
-        0) {
+    if (TURN_BARRIER_INIT(&relay_setup_barrier, (unsigned int)get_real_general_relay_servers_number() + 1) != 0) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "relay_setup_barrier init: %s\n", strerror(errno));
     }
   }
-#endif
 
   for (i = 0; i < get_real_general_relay_servers_number(); i++) {
 
@@ -1508,14 +1549,10 @@ void setup_server(void) {
     authserver_number = MIN_AUTHSERVER_NUMBER;
   }
 
-#if !defined(TURN_NO_THREAD_BARRIERS)
-
   /* relay threads plus auth threads plus main listener thread */
   /* plus admin thread */
   /* udp address listener thread(s) will start later */
   barrier_count = turn_params.general_relay_servers_number + authserver_number + 1 + 1;
-
-#endif
 
 #if defined(__linux__)
   if (turn_params.multiplex_peer) {

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -35,6 +35,7 @@
 #include "prom_server.h"
 #include "mainrelay.h"
 #include "ns_turn_utils.h"
+#include <stdio.h>
 #if !defined(WINDOWS)
 #include <errno.h>
 #include <sys/socket.h>
@@ -127,6 +128,32 @@ static MHD_RESULT promhttp_handler(void *cls, struct MHD_Connection *connection,
     MHD_destroy_response(response);
   }
   return ret;
+}
+
+/* Read an entire file into a freshly malloc'd NUL-terminated buffer, or return
+ * NULL on error. Used to load the PEM cert/key for the HTTPS metrics endpoint. */
+static char *prom_read_file(const char *path) {
+  FILE *f = fopen(path, "rb");
+  if (f == NULL) {
+    return NULL;
+  }
+  char *buf = NULL;
+  if (fseek(f, 0, SEEK_END) == 0) {
+    long size = ftell(f);
+    if (size >= 0 && fseek(f, 0, SEEK_SET) == 0) {
+      buf = malloc((size_t)size + 1);
+      if (buf != NULL) {
+        if (fread(buf, 1, (size_t)size, f) != (size_t)size) {
+          free(buf);
+          buf = NULL;
+        } else {
+          buf[size] = '\0';
+        }
+      }
+    }
+  }
+  fclose(f);
+  return buf;
 }
 
 void start_prometheus_server(void) {
@@ -235,6 +262,42 @@ void start_prometheus_server(void) {
                                           "The exporter might be unreachable on highly used servers\n");
   }
 
+  // Optional HTTPS for the metrics endpoint. The cert/key buffers are kept for
+  // the daemon's (process) lifetime, as libmicrohttpd references them.
+  char *https_cert = NULL;
+  char *https_key = NULL;
+  if (turn_params.prometheus_tls) {
+    const char *cert_path =
+        turn_params.prometheus_cert_file[0] ? turn_params.prometheus_cert_file : turn_params.cert_file;
+    const char *key_path =
+        turn_params.prometheus_pkey_file[0] ? turn_params.prometheus_pkey_file : turn_params.pkey_file;
+    if (!cert_path[0] || !key_path[0]) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "prometheus TLS requested but no certificate/key is configured "
+                                          "(set --prometheus-cert/--prometheus-key or the server --cert/--pkey)\n");
+      return;
+    }
+#if MHD_VERSION >= 0x00095300
+    if (!MHD_is_feature_supported(MHD_FEATURE_TLS)) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "prometheus TLS requested but libmicrohttpd was built without TLS support\n");
+      return;
+    }
+#endif
+    https_cert = prom_read_file(cert_path);
+    https_key = prom_read_file(key_path);
+    if (https_cert == NULL || https_key == NULL) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "prometheus TLS: could not read certificate '%s' or key '%s'\n", cert_path,
+                    key_path);
+      free(https_cert);
+      free(https_key);
+      return;
+    }
+#if MHD_VERSION >= 0x00095300
+    flags |= MHD_USE_TLS;
+#else
+    flags |= MHD_USE_SSL;
+#endif
+  }
+
   ioa_addr server_addr;
   addr_set_any(&server_addr);
   if (turn_params.prometheus_address[0]) {
@@ -259,13 +322,22 @@ void start_prometheus_server(void) {
 
   char addr[MAX_IOA_ADDR_STRING] = "";
   addr_to_string(&server_addr, addr);
-  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "prometheus exporter server will listen on %s\n", addr);
+  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "prometheus exporter server will listen on %s (%s)\n", addr,
+                turn_params.prometheus_tls ? "https" : "http");
 
-  struct MHD_Daemon *daemon =
-      MHD_start_daemon(flags, 0, NULL, NULL, &promhttp_handler, NULL, MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
-                       MHD_OPTION_SOCK_ADDR, &server_addr, MHD_OPTION_END);
+  struct MHD_Daemon *daemon;
+  if (turn_params.prometheus_tls) {
+    daemon = MHD_start_daemon(flags, 0, NULL, NULL, &promhttp_handler, NULL, MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
+                              MHD_OPTION_SOCK_ADDR, &server_addr, MHD_OPTION_HTTPS_MEM_CERT, https_cert,
+                              MHD_OPTION_HTTPS_MEM_KEY, https_key, MHD_OPTION_END);
+  } else {
+    daemon = MHD_start_daemon(flags, 0, NULL, NULL, &promhttp_handler, NULL, MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
+                              MHD_OPTION_SOCK_ADDR, &server_addr, MHD_OPTION_END);
+  }
   if (daemon == NULL) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "could not start prometheus collector\n");
+    free(https_cert);
+    free(https_key);
     return;
   }
 


### PR DESCRIPTION
## Summary

Adds an optional **HTTPS mode for the Prometheus `/metrics` endpoint**, and bundles three supporting improvements that surfaced while building and testing it: more reliable `libmicrohttpd` detection, a fix for slow `turnserver` startup on macOS, and expanded/robust Prometheus tests.

## Changes

### 1. Optional HTTPS for the Prometheus exporter
The exporter previously served `/metrics` over plain HTTP only. It can now optionally serve over HTTPS via libmicrohttpd's TLS support.

- `--prometheus-tls` — serve the metrics endpoint over HTTPS instead of HTTP.
- `--prometheus-cert <file>` / `--prometheus-key <file>` — PEM cert/key for the endpoint; default to the server's own `--cert` / `--pkey` when unset.

`start_prometheus_server()` loads the cert/key into memory, enables `MHD_USE_TLS`, and passes `MHD_OPTION_HTTPS_MEM_CERT/KEY`. If TLS is requested but no cert/key can be loaded (or libmicrohttpd lacks TLS support), it logs an error and does not start. The startup log now notes the `(http)`/`(https)` scheme. `docs/Prometheus.md` documents the new flags.

*(`src/apps/relay/prom_server.c`, `mainrelay.c`, `mainrelay.h`, `docs/Prometheus.md`)*

### 2. Reliable `libmicrohttpd` detection in `configure`
The autotools `configure` probed libmicrohttpd with a bare `cc -lmicrohttpd` link test (no include/lib paths), so it failed to find Homebrew-installed libmicrohttpd on macOS and silently disabled Prometheus — even though OpenSSL/libevent (also Homebrew) were found via pkg-config. `configure` now detects libmicrohttpd via `pkg-config` first (matching how libssl/libevent are already detected), falling back to the bare link probe on platforms without a `.pc` file. `./configure && make` now builds the exporter on macOS without manual `CFLAGS`/`LDFLAGS`.

*(`configure`)*

### 3. Faster `turnserver` startup on macOS
macOS lacks `pthread_barrier_*`, so the thread-startup rendezvous in `netengine.c` degraded to a flat `sleep(5)` — adding ~5s to every startup (and it was racy: threads proceeded even if setup took longer than the fixed sleep). Replaced the shim with a real portable barrier built on a mutex + condition variable, behind a unified macro API: **native `pthread_barrier` is still used on Linux**, the portable barrier is used only where it is unavailable. The previous racy `sched_yield()` spin-wait fallback is removed as well.

*(`src/apps/relay/netengine.c`)*

### 4. Prometheus test coverage + robustness
`examples/run_tests_prom.sh` now also covers the HTTPS endpoint (explicit cert/key, cert/key inherited from `--cert`/`--pkey`, and a negative test that an unreadable cert keeps the endpoint down, including a check that the TLS endpoint rejects plaintext HTTP). Readiness is now detected by polling the endpoint / server log instead of fixed `sleep` intervals, making the suite both faster (~70s → ~2s) and less flaky.

*(`examples/run_tests_prom.sh`)*

## New flags

| Flag | Description |
|---|---|
| `--prometheus-tls` | Serve `/metrics` over HTTPS. Requires libmicrohttpd built with TLS support. |
| `--prometheus-cert <file>` | PEM certificate for the HTTPS endpoint (default: the server's `--cert`). |
| `--prometheus-key <file>` | PEM private key for the HTTPS endpoint (default: the server's `--pkey`). |

## Validation

- **macOS** (portable-barrier path): `clang-format` clean, 10/10 unit tests, and `run_tests.sh` / `run_tests_conf.sh` / `run_tests_multiplex_peer.sh` / `run_tests_prom.sh` all pass. Exporter now reachable at startup `t=0` (was `t=5`).
- **Linux** (Docker, native-`pthread_barrier` path): clean build, 9/9 unit tests, and all four system-test suites pass (TCP/TLS/UDP/DTLS).
