### PR TITLE
Add per-source rate-limiting of UDP 401 Unauthorized responses

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -63,6 +63,8 @@ jobs:
 
       - run: ./run_tests.sh
         working-directory: examples/
+      - run: ./run_tests_ratelimit_401.sh
+        working-directory: examples/
       - run: ./run_tests_conf.sh
         working-directory: examples/
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,5 +42,7 @@ jobs:
 
       - run: ./run_tests.sh
         working-directory: examples/
+      - run: ./run_tests_ratelimit_401.sh
+        working-directory: examples/
       - run: ./run_tests_conf.sh
         working-directory: examples/

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,6 +63,8 @@ jobs:
 
       - run: ./run_tests.sh
         working-directory: examples/
+      - run: ./run_tests_ratelimit_401.sh
+        working-directory: examples/
       - run: ./run_tests_conf.sh
         working-directory: examples/
       - run: ./run_tests_prom.sh

--- a/Makefile.in
+++ b/Makefile.in
@@ -12,9 +12,9 @@ LIBCLIENTTURN_MODS = src/client/ns_turn_ioaddr.c src/client/ns_turn_msg_addr.c s
 LIBCLIENTTURN_DEPS = ${LIBCLIENTTURN_HEADERS} ${MAKE_DEPS}
 LIBCLIENTTURN_OBJS = build/obj/ns_turn_ioaddr.o build/obj/ns_turn_msg_addr.o build/obj/ns_turn_msg.o
 
-SERVERTURN_HEADERS = src/ns_turn_atomic.h src/server/ns_turn_allocation.h src/server/ns_turn_ioalib.h src/server/ns_turn_khash.h src/server/ns_turn_maps_rtcp.h src/server/ns_turn_maps.h src/server/ns_turn_server.h src/server/ns_turn_session.h 
+SERVERTURN_HEADERS = src/ns_turn_atomic.h src/server/ns_turn_allocation.h src/server/ns_turn_ioalib.h src/server/ns_turn_khash.h src/server/ns_turn_maps_rtcp.h src/server/ns_turn_maps.h src/server/ns_turn_server.h src/server/ns_turn_session.h  src/server/ns_turn_ratelimit.h
 SERVERTURN_DEPS = ${LIBCLIENTTURN_HEADERS} ${SERVERTURN_HEADERS} ${MAKE_DEPS}
-SERVERTURN_MODS = ${LIBCLIENTTURN_MODS} src/server/ns_turn_allocation.c src/server/ns_turn_maps_rtcp.c src/server/ns_turn_maps.c src/server/ns_turn_server.c
+SERVERTURN_MODS = ${LIBCLIENTTURN_MODS} src/server/ns_turn_allocation.c src/server/ns_turn_maps_rtcp.c src/server/ns_turn_maps.c src/server/ns_turn_server.c src/server/ns_turn_ratelimit.c
 
 COMMON_HEADERS = src/apps/common/apputils.h src/apps/common/ns_turn_openssl.h src/apps/common/ns_turn_utils.h src/apps/common/stun_buffer.h
 COMMON_MODS = src/apps/common/apputils.c src/apps/common/ns_turn_utils.c src/apps/common/stun_buffer.c

--- a/README.turnserver
+++ b/README.turnserver
@@ -696,7 +696,10 @@ Options with values:
 --no-rfc5780	DEPRECATED and now the default behaviour. See --rfc5780.
 
 --stun-backward-compatibility		Enable handling old STUN Binding requests using MAPPED-ADDRESS attribute in binding response (instead of XOR-MAPPED-ADDRESS).
-
+--unauthorized-ratelimit		Enable per-source rate-limiting of 401 Unauthorized responses on UDP. Mitigates
+			reflection/amplification abuse where attackers spoof a victim's source address to
+			bounce 401 challenges off the server. Off by default; opt in explicitly.
+--unauthorized-ratelimit-rps=<count>		Maximum number of 401 Unauthorized responses to send per source IP per second. Default 10.
 
 ==================================
 

--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -191,6 +191,17 @@ lt-cred-mech
 #
 #no-auth
 
+# Mitigate UDP reflection/amplification through 401 Unauthorized challenges.
+# When enabled, only this many UDP 401 responses are sent per source IP
+# each second. Drop and collision diagnostics are each bounded to one log
+# line per bucket/second.
+# This protection is disabled by default.
+#
+#unauthorized-ratelimit
+#
+# Maximum UDP 401 Unauthorized responses per source IP per second (Default: 10).
+#unauthorized-ratelimit-rps=10
+
 # Enable prometheus exporter
 # If enabled the turnserver will expose an endpoint with stats on a prometheus format
 # this endpoint is listening on a different port to not conflict with other configurations.

--- a/docs/401-ratelimit.md
+++ b/docs/401-ratelimit.md
@@ -1,0 +1,277 @@
+# 401 Unauthorized rate-limiting
+
+This document describes the per-source rate-limit on `401 Unauthorized`
+responses. It covers what the feature defends
+against, how it is implemented, how to operate it, expected performance, and
+its known weaknesses.
+
+## Why
+
+TURN/STUN long-term authentication is a challenge/response flow: the first
+request from a client arrives without valid credentials, and the server
+answers with `401 Unauthorized` carrying a `REALM` and a `NONCE`. This is
+normal — the legitimate client then retries with credentials derived from the
+nonce.
+
+The problem is on UDP. UDP source addresses are trivially spoofable, and a
+`401` response is larger than the request that triggers it (it carries
+`REALM`, `NONCE`, `SOFTWARE`, and message-integrity material). An attacker can
+therefore:
+
+- **Reflect**: send authentication requests with the *victim's* IP forged as
+  the source, so the server bounces `401` responses at the victim, and
+- **Amplify**: each small spoofed request produces a larger `401`, multiplying
+  the attacker's outbound bandwidth at the victim.
+
+The server is an unwitting reflector/amplifier. The mitigation is to cap how
+many `401` responses the server will emit toward any single source address per
+unit time. Past the cap, the server simply stays silent — it does not send the
+`401`, denying the attacker both the reflection and the amplification.
+
+The feature is **off by default** and opt-in, because suppressing `401`
+responses changes a protocol-visible behavior and only matters for operators
+exposed to UDP reflection abuse.
+
+## What it does
+
+When enabled, for every request that *would* produce a `401`:
+
+1. Only `UDP` client sockets are considered. TCP/TLS can't be spoofed for
+   reflection (the handshake forces a real return path), so they are never
+   rate-limited.
+2. The source IP (port stripped) is looked up in a fixed bucket table and its
+   counter for the current window is incremented.
+3. If the count is within the limit, the `401` is sent as normal.
+4. If the count is over the limit, `no_response` is set: the `401` is silently
+   suppressed for the rest of the window.
+5. The first suppression in each window emits exactly one log line; further
+   drops in the same window are silent (no log-write amplification).
+
+Counting is **consume-on-401**: only requests that actually result in a `401`
+spend a token. Successful or otherwise-errored requests don't touch the table.
+
+## How it works
+
+### Components
+
+| File | Role |
+|---|---|
+| [src/ns_turn_atomic.h](../src/ns_turn_atomic.h) | Portable 32-bit atomics (load/store/fetch_add/CAS) over C11 `<stdatomic.h>` and, on MSVC, the `Interlocked*` intrinsics. |
+| [src/server/ns_turn_ratelimit.h](../src/server/ns_turn_ratelimit.h) / [.c](../src/server/ns_turn_ratelimit.c) | The lock-free rate-limit table and its two entry points. |
+| [src/server/ns_turn_server.c](../src/server/ns_turn_server.c) | The consume call site inside `handle_turn_command`. |
+| [src/apps/relay/mainrelay.c](../src/apps/relay/mainrelay.c) | CLI flags, defaults, and one-time `ratelimit_init()`. |
+| [src/apps/relay/prom_server.c](../src/apps/relay/prom_server.c) | Prometheus counters for UDP `401` decisions. |
+| [examples/run_tests_ratelimit_401.sh](../examples/run_tests_ratelimit_401.sh) | End-to-end positive/negative system test. |
+
+### The table
+
+```c
+#define RATELIMIT_BUCKETS 4096u    // power of two
+typedef struct {
+  turn_atomic_u32 tag;             // hash of source IP (port stripped); 0 = empty
+  turn_atomic_u32 window_start;    // turn_time() when the current window opened
+  turn_atomic_u32 count;           // requests counted in this window
+  turn_atomic_u32 logged;          // 1 once a drop has been logged this window
+  turn_atomic_u32 collision_logged;// 1 once a collision has been logged this window
+} ratelimit_bucket;
+static ratelimit_bucket ratelimit_table[RATELIMIT_BUCKETS];
+```
+
+A single statically-allocated, zero-initialized table of 4096 buckets, 20
+bytes each (~80 KiB resident). No `malloc`/`free` on the hot path, no growth,
+no eviction list.
+
+It is a **direct-mapped** structure: `bucket = hash(addr) & (RATELIMIT_BUCKETS-1)`.
+There is exactly one active budget per bucket. An address that collides with
+an unexpired bucket shares that existing budget; it cannot replace the bucket
+owner and get a fresh response allowance.
+
+- IPv4 keys are hashed with a splitmix-style 32-bit finalizer over
+  `sin_addr.s_addr`.
+- IPv6 keys are hashed with FNV-1a over the 16 address bytes.
+- The hash is forced non-zero so `0` can mean "empty bucket".
+- The **port is deliberately excluded** from the key, so an attacker cannot
+  evade the limit by rotating the source port.
+
+### The consume algorithm ([ns_turn_ratelimit.c](../src/server/ns_turn_ratelimit.c))
+
+`ratelimit_consume_address(addr, max_per_sec, &first_drop, &first_collision)`
+returns `true` when the current request is *over* the limit (caller should
+suppress). The window is a fixed 1 second, so `max_per_sec` is the allowed
+number of responses per source per second:
+
+1. Hash the address, index the bucket, read `now = (uint32_t)turn_time()`.
+2. Read the bucket's `tag` and `window_start`.
+3. **Reset path** — if the bucket is empty or the 1-second window has expired
+   (`now - window_start >= 1`): atomically store a fresh `window_start`,
+   clear the log latches, set `count = 1`, and finally store the new `tag`.
+   Returns `false` (this request is the first in a fresh window).
+4. **Collision path** — if an unexpired bucket has another tag, retain the
+   bucket owner and count the new request against the same budget. The first
+   such event sets `first_collision` for one bounded diagnostic log line.
+5. **Count path** — `fetch_add(count, 1)` returns the pre-increment
+   value `prev`. If `prev < max`, allow (`false`). Otherwise this is the
+   `(max+1)`-th request: it's over the limit, return `true`.
+6. **First-drop logging** — on an over-limit request, `CAS(logged, 0 -> 1)`.
+   The single winner of that CAS gets `*first_drop = true`; everyone else in
+   the window is silent.
+
+### Lock-free design and its tradeoffs
+
+There is no mutex. All bucket fields are sequentially-consistent atomics, and
+the design accepts small, bounded races by construction rather than locking
+them out:
+
+- Two threads resetting the same bucket concurrently: the second store wins;
+  both observe `count == 1` by the time the `tag` store lands. Worst case the
+  effective count is off by a request or two at a window boundary.
+- The window-expiry check and the increment are not one transaction, so a
+  request landing exactly at the boundary may be counted in the old or the new
+  window. Bounded and harmless for a rate-limit.
+
+This is acceptable because the goal is *coarse abuse mitigation*, not exact
+accounting. Most importantly, active collisions share a budget instead of
+granting additional reflected responses.
+
+### Why a dedicated atomics header
+
+The earlier shim typed the on/off flag as `bool` instead of `bool *` in
+`init_turn_server()`, which truncated the parameter pointer and left the
+feature effectively always-on. The fix makes both tunables pointers into
+`turn_params` (so every relay thread sees live CLI values without per-thread
+copies) and centralizes the atomic primitives in
+[src/ns_turn_atomic.h](../src/ns_turn_atomic.h). That header gates on
+`_MSC_VER` (not the project `WINDOWS` macro) because only MSVC lacks usable C11
+atomics — MinGW is a GCC toolchain and takes the `<stdatomic.h>` path. The
+`Interlocked*` intrinsics and the non-explicit C11 atomics are both
+sequentially consistent, so callers never reason about per-platform ordering.
+
+## Configuration
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--unauthorized-ratelimit` | off | Enable per-source 401 rate-limiting on UDP. |
+| `--unauthorized-ratelimit-rps=<count>` | `10` | Max 401 responses per source IP per second. |
+
+A non-positive value for the threshold is rejected with a warning and falls
+back to the default. The default (10 per second) is well above any legitimate
+client's challenge/retry rate, so normal traffic is never affected.
+
+Example:
+
+```bash
+turnserver --use-auth-secret --static-auth-secret=secret --realm=north.gov \
+  --unauthorized-ratelimit --unauthorized-ratelimit-rps=10
+```
+
+When the limit is first crossed for a source in a window the server logs:
+
+```
+401 rate-limit exceeded from <ip>, suppressing responses for this window
+```
+
+If a different address first collides with an active bucket in a window, the
+server also logs one diagnostic line for that bucket and window:
+
+```
+401 rate-limit bucket collision from <ip>, sharing active bucket budget for this window
+```
+
+When Prometheus is enabled, these metrics describe the UDP `401` reflection
+surface:
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `turn_unauthenticated_401_requests` | counter | Requests that required a UDP `401` response. |
+| `turn_unauthenticated_401_responses` | counter | UDP `401` responses emitted. |
+| `turn_unauthenticated_401_dropped_responses` | counter | UDP `401` responses suppressed by this mitigation. |
+
+A second group describes the health of the bucket table itself:
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `turn_ratelimit_hash_collisions` | counter | Total requests whose source hashed to a bucket already owned by a different live address. A rising rate means distinct sources are sharing budgets — the false-positive surface for the mitigation. |
+| `turn_ratelimit_occupied_buckets` | gauge | Buckets currently holding a live (non-expired) window. |
+| `turn_ratelimit_total_buckets` | gauge | Table capacity in buckets (the compile-time constant). |
+
+`turn_ratelimit_occupied_buckets / turn_ratelimit_total_buckets` is the table
+utilization; as it approaches 1, the birthday-paradox collision probability
+climbs, so a sustained high ratio (or a climbing `turn_ratelimit_hash_collisions`
+rate) is the signal to enlarge `RATELIMIT_BUCKETS`. These two are refreshed
+lazily when Prometheus scrapes `/metrics`: the collision counter is a single
+atomic incremented only on the collision branch, and occupancy is a one-pass
+scan of the table performed at scrape time, so neither adds cost to the request
+path.
+
+## Performance
+
+The feature is built to be effectively free on the data path:
+
+- **Per-request cost**: one hash (a few multiplies/xors over 4 or 16 bytes),
+  one array index, and a handful of atomic operations on a single bucket. No
+  allocation, no syscall, no lock, no list traversal — O(1) with a tiny
+  constant. It only runs on requests that already reached the `401` branch, so
+  it adds nothing to authenticated relay traffic (the throughput the load tests
+  in [CLAUDE.md](../CLAUDE.md) measure).
+- **Memory**: a single static `ratelimit_table` of `4096 * 20 B ≈ 80 KiB` (five
+  32-bit atomic fields per bucket), fixed for the life of the process and
+  shared across all relay threads.
+- **Cache/contention**: one bucket is one cache line's worth of atomics.
+  Distinct attacker addresses hit distinct buckets, so there is no central
+  contention point; a single hot source serializes only on its own bucket.
+- **Log amplification**: drop and collision diagnostics each have a
+  once-per-(bucket, window) CAS latch.
+
+No microbenchmark numbers are committed for this path; the cost is dominated by
+the existing `401` message construction it guards, not by the table operation.
+The DigitalOcean load-test harness in [CLAUDE.md](../CLAUDE.md) measures relay
+throughput, which this feature does not touch.
+
+## Weaknesses and limitations
+
+- **UDP only by design.** TCP/TLS/DTLS `401`s are never rate-limited. That is
+  correct for the reflection threat (those transports can't be spoofed), but it
+  means this is not a general brute-force-auth throttle.
+- **Hash collisions share a bucket.** Two unrelated addresses mapping to the
+  same of 4096 buckets consume one shared budget while its window is live. This
+  prevents a collision from increasing reflected output, but a flood can cause
+  incidental suppression of a colliding legitimate source's `401`s.
+- **Fixed table size.** 4096 buckets is a compile-time constant
+  (`RATELIMIT_BUCKETS`); there is no runtime sizing. A very large, highly-distributed
+  spoof set will cycle buckets faster, but the table never grows.
+- **Per-process, in-memory, non-persistent.** State is per `turnserver`
+  process and resets on restart. There is no coordination across a cluster of
+  servers behind a load balancer; each instance rate-limits independently.
+- **Coarse accounting.** The lock-free design tolerates off-by-a-few counts at
+  window boundaries and under concurrent resets. It is an abuse limiter, not an
+  exact quota.
+- **Granularity is whole-IP.** Because the port is stripped, all clients behind
+  a single NAT/CGNAT public IP share one bucket. With many legitimate clients
+  behind one address plus a tuned-down `--unauthorized-ratelimit-rps`, legitimate
+  challenges could be suppressed. Keep the threshold comfortably above
+  aggregate legitimate challenge rates for shared egress IPs.
+- **Time source resolution.** The window and timestamps use `turn_time()` at
+  1-second granularity stored in 32 bits; this matches the per-second limit but
+  is not suitable for sub-second limiting.
+
+## Testing
+
+[examples/run_tests_ratelimit_401.sh](../examples/run_tests_ratelimit_401.sh)
+runs two end-to-end cases against a real `turnserver` with bad credentials:
+
+- **Positive** (`--unauthorized-ratelimit-rps=1`): a single `turnutils_uclient`
+  session retries the `401` challenge enough times to cross the threshold, so
+  exactly one `401 rate-limit exceeded` line must appear.
+- **Negative** (`--unauthorized-ratelimit-rps=100000`): the same traffic stays
+  far below the threshold, so the line must *not* appear.
+
+It is split out of `run_tests.sh` so the rate-limit server fixture can't mask
+or be masked by the protocol suite's flags. It is **skipped on macOS** (loopback
+UDP relay is intermittently lossy there, making the log-line accounting flaky);
+Linux CI is the canonical target.
+
+[tests/test_ratelimit.c](../tests/test_ratelimit.c) finds a colliding source
+address and verifies that a live collision remains suppressed and emits its
+collision signal only once. [examples/run_tests_prom.sh](../examples/run_tests_prom.sh)
+drives a low-limit unauthorized flow and verifies all three Prometheus counters
+are non-zero in Linux CI.

--- a/docs/Prometheus.md
+++ b/docs/Prometheus.md
@@ -82,3 +82,40 @@ turnserver --prometheus-tls \
 Then scrape with `https://<host>:9641/metrics`. If `--prometheus-tls` is set
 but no certificate/key can be loaded, the exporter logs an error and does not
 start.
+
+## UDP 401 mitigation metrics
+
+When the optional UDP 401 response rate limit is enabled, use:
+
+```
+unauthorized-ratelimit
+unauthorized-ratelimit-rps=10
+prometheus
+```
+
+The rate limit is disabled by default. It applies only to UDP `401 Unauthorized`
+responses, which can otherwise be used in spoofed-source reflection attacks.
+
+When Prometheus is enabled, the exporter provides the following counters for
+this path whether or not mitigation is enabled. The dropped response counter
+increments only when `unauthorized-ratelimit` suppresses responses.
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `turn_unauthenticated_401_requests` | counter | UDP requests requiring a `401 Unauthorized` response. |
+| `turn_unauthenticated_401_responses` | counter | UDP `401 Unauthorized` responses emitted. |
+| `turn_unauthenticated_401_dropped_responses` | counter | UDP `401` responses suppressed by the rate limit. |
+
+The rate-limit hash table is also instrumented. These values are computed
+lazily when Prometheus scrapes `/metrics`, so they add no cost to the hot path:
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `turn_ratelimit_hash_collisions` | counter | Requests whose source hashed to a bucket already owned by a different live address (distinct sources sharing a budget — the mitigation's false-positive surface). |
+| `turn_ratelimit_occupied_buckets` | gauge | Buckets currently holding a live (non-expired) window. |
+| `turn_ratelimit_total_buckets` | gauge | Table capacity in buckets. |
+
+`turn_ratelimit_occupied_buckets / turn_ratelimit_total_buckets` is the table
+load factor; a sustained high ratio or a climbing `turn_ratelimit_hash_collisions`
+rate means distinct attackers are colliding into shared buckets. See
+[docs/401-ratelimit.md](401-ratelimit.md) for the full design.

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -241,6 +241,17 @@
 #
 #no-auth
 
+# Mitigate UDP reflection/amplification through 401 Unauthorized challenges.
+# When enabled, only this many UDP 401 responses are sent per source IP
+# each second. Drop and collision diagnostics are each bounded to one log
+# line per bucket/second.
+# This protection is disabled by default.
+#
+#unauthorized-ratelimit
+#
+# Maximum UDP 401 Unauthorized responses per source IP per second (Default: 10).
+#unauthorized-ratelimit-rps=10
+
 # Enable prometheus exporter
 # If enabled the turnserver will expose an endpoint with stats on a prometheus format
 # this endpoint is listening on a different port to not conflict with other configurations.

--- a/examples/loadtest/401_response_flood.c
+++ b/examples/loadtest/401_response_flood.c
@@ -1,0 +1,342 @@
+/*
+ * Saturating UDP generator for the TURN 401 Unauthorized challenge path.
+ *
+ * Build:
+ *   cc -O3 -pthread -Wall -Wextra -o 401_response_flood 401_response_flood.c
+ *
+ * Run:
+ *   ./401_response_flood --host 10.116.0.2 --duration 30 --threads 4
+ *
+ * Each worker continuously sends valid unauthenticated Allocate requests.
+ * With long-term authentication enabled, turnserver replies with 401 until
+ * its optional 401 response rate-limit suppresses the response. A dedicated
+ * generator avoids measuring successful allocations or relay traffic.
+ */
+
+#define _GNU_SOURCE
+
+#if !defined(__linux__)
+#error "401_response_flood is Linux-only because it uses sendmmsg/recvmmsg"
+#endif
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#define STUN_ALLOCATE_REQUEST 0x0003u
+#define STUN_ERROR_CODE 0x0009u
+#define STUN_REQUESTED_TRANSPORT 0x0019u
+#define STUN_COOKIE 0x2112A442u
+#define STUN_REQUEST_BYTES 28u
+#define RESPONSE_BYTES_MAX 2048u
+#define DEFAULT_PORT 3478u
+#define DEFAULT_DURATION 30u
+#define DEFAULT_THREADS 4u
+#define DEFAULT_BATCH 64u
+#define MAX_BATCH 1024u
+
+typedef struct {
+  struct sockaddr_in destination;
+  double finish_at;
+  uint32_t worker_id;
+  uint32_t batch;
+  uint64_t sent_packets;
+  uint64_t sent_bytes;
+  uint64_t recv_packets;
+  uint64_t recv_bytes;
+  uint64_t responses_401;
+  uint64_t send_wouldblock;
+  int error;
+} worker_state;
+
+static volatile sig_atomic_t stop_requested = 0;
+
+static void stop_handler(int sig) {
+  (void)sig;
+  stop_requested = 1;
+}
+
+static double monotonic_seconds(void) {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+    return 0.0;
+  }
+  return (double)ts.tv_sec + ((double)ts.tv_nsec / 1000000000.0);
+}
+
+static void put_u16(uint8_t *p, uint16_t value) {
+  uint16_t n = htons(value);
+  memcpy(p, &n, sizeof(n));
+}
+
+static void put_u32(uint8_t *p, uint32_t value) {
+  uint32_t n = htonl(value);
+  memcpy(p, &n, sizeof(n));
+}
+
+static void make_allocate_request(uint8_t request[STUN_REQUEST_BYTES], uint32_t worker_id, uint64_t sequence) {
+  memset(request, 0, STUN_REQUEST_BYTES);
+  put_u16(request, STUN_ALLOCATE_REQUEST);
+  put_u16(request + 2, 8u);
+  put_u32(request + 4, STUN_COOKIE);
+  put_u32(request + 8, worker_id);
+  put_u32(request + 12, (uint32_t)(sequence >> 32));
+  put_u32(request + 16, (uint32_t)sequence);
+  put_u16(request + 20, STUN_REQUESTED_TRANSPORT);
+  put_u16(request + 22, 4u);
+  request[24] = 17u; /* UDP requested transport. */
+}
+
+static bool response_is_401(const uint8_t *response, size_t length) {
+  if (length < 20u) {
+    return false;
+  }
+  size_t attr_offset = 20u;
+  while (attr_offset + 4u <= length) {
+    uint16_t type;
+    uint16_t attr_length;
+    memcpy(&type, response + attr_offset, sizeof(type));
+    memcpy(&attr_length, response + attr_offset + 2u, sizeof(attr_length));
+    type = ntohs(type);
+    attr_length = ntohs(attr_length);
+    if (attr_offset + 4u + attr_length > length) {
+      return false;
+    }
+    if (type == STUN_ERROR_CODE && attr_length >= 4u) {
+      unsigned int code =
+          ((unsigned int)(response[attr_offset + 6u] & 0x07u) * 100u) + (unsigned int)response[attr_offset + 7u];
+      return code == 401u;
+    }
+    attr_offset += 4u + ((attr_length + 3u) & ~3u);
+  }
+  return false;
+}
+
+static void drain_responses(int fd, worker_state *state, struct mmsghdr *messages, struct iovec *iovecs,
+                            uint8_t *buffers) {
+  for (;;) {
+    if (stop_requested || monotonic_seconds() >= state->finish_at) {
+      return;
+    }
+    for (uint32_t i = 0; i < state->batch; ++i) {
+      memset(&messages[i], 0, sizeof(messages[i]));
+      iovecs[i].iov_base = buffers + (i * RESPONSE_BYTES_MAX);
+      iovecs[i].iov_len = RESPONSE_BYTES_MAX;
+      messages[i].msg_hdr.msg_iov = &iovecs[i];
+      messages[i].msg_hdr.msg_iovlen = 1;
+    }
+    int received = recvmmsg(fd, messages, state->batch, MSG_DONTWAIT, NULL);
+    if (received <= 0) {
+      if (received < 0 && errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
+        state->error = errno;
+      }
+      return;
+    }
+    state->recv_packets += (uint64_t)received;
+    for (int i = 0; i < received; ++i) {
+      state->recv_bytes += messages[i].msg_len;
+      if (response_is_401((const uint8_t *)iovecs[i].iov_base, messages[i].msg_len)) {
+        state->responses_401++;
+      }
+    }
+  }
+}
+
+static void *run_worker(void *opaque) {
+  worker_state *state = (worker_state *)opaque;
+  int fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+  if (fd < 0) {
+    state->error = errno;
+    return NULL;
+  }
+  int buffer_bytes = 16 * 1024 * 1024;
+  (void)setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &buffer_bytes, sizeof(buffer_bytes));
+  (void)setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &buffer_bytes, sizeof(buffer_bytes));
+  if (connect(fd, (const struct sockaddr *)&state->destination, sizeof(state->destination)) != 0) {
+    state->error = errno;
+    close(fd);
+    return NULL;
+  }
+
+  struct mmsghdr *send_messages = calloc(state->batch, sizeof(*send_messages));
+  struct iovec *send_iovecs = calloc(state->batch, sizeof(*send_iovecs));
+  uint8_t *requests = calloc(state->batch, STUN_REQUEST_BYTES);
+  struct mmsghdr *recv_messages = calloc(state->batch, sizeof(*recv_messages));
+  struct iovec *recv_iovecs = calloc(state->batch, sizeof(*recv_iovecs));
+  uint8_t *responses = calloc(state->batch, RESPONSE_BYTES_MAX);
+  if (!send_messages || !send_iovecs || !requests || !recv_messages || !recv_iovecs || !responses) {
+    state->error = ENOMEM;
+    goto out;
+  }
+
+  uint64_t sequence = 0;
+  while (!stop_requested && monotonic_seconds() < state->finish_at && state->error == 0) {
+    for (uint32_t i = 0; i < state->batch; ++i) {
+      uint8_t *request = requests + (i * STUN_REQUEST_BYTES);
+      make_allocate_request(request, state->worker_id, sequence++);
+      memset(&send_messages[i], 0, sizeof(send_messages[i]));
+      send_iovecs[i].iov_base = request;
+      send_iovecs[i].iov_len = STUN_REQUEST_BYTES;
+      send_messages[i].msg_hdr.msg_iov = &send_iovecs[i];
+      send_messages[i].msg_hdr.msg_iovlen = 1;
+    }
+    int sent = sendmmsg(fd, send_messages, state->batch, MSG_DONTWAIT);
+    if (sent > 0) {
+      state->sent_packets += (uint64_t)sent;
+      state->sent_bytes += (uint64_t)sent * STUN_REQUEST_BYTES;
+    } else if (sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+      state->send_wouldblock++;
+    } else if (sent < 0 && errno != EINTR) {
+      state->error = errno;
+    }
+    drain_responses(fd, state, recv_messages, recv_iovecs, responses);
+  }
+
+  /* Collect responses already queued at the end without extending the test. */
+  drain_responses(fd, state, recv_messages, recv_iovecs, responses);
+
+out:
+  free(send_messages);
+  free(send_iovecs);
+  free(requests);
+  free(recv_messages);
+  free(recv_iovecs);
+  free(responses);
+  close(fd);
+  return NULL;
+}
+
+static void usage(const char *program) {
+  fprintf(stderr,
+          "Usage: %s --host <ipv4> [--port N] [--duration S] [--threads N] [--batch N]\n"
+          "Send valid unauthenticated UDP Allocate requests and count TURN 401 responses.\n",
+          program);
+}
+
+static uint32_t parse_u32(const char *value, const char *name, uint32_t min, uint32_t max) {
+  char *end = NULL;
+  unsigned long parsed = strtoul(value, &end, 10);
+  if (!value[0] || (end && *end) || parsed < min || parsed > max) {
+    fprintf(stderr, "Invalid %s: %s\n", name, value);
+    exit(2);
+  }
+  return (uint32_t)parsed;
+}
+
+int main(int argc, char **argv) {
+  const char *host = NULL;
+  uint32_t port = DEFAULT_PORT;
+  uint32_t duration = DEFAULT_DURATION;
+  uint32_t threads = DEFAULT_THREADS;
+  uint32_t batch = DEFAULT_BATCH;
+  const struct option options[] = {{"host", required_argument, NULL, 'H'},
+                                   {"port", required_argument, NULL, 'p'},
+                                   {"duration", required_argument, NULL, 'd'},
+                                   {"threads", required_argument, NULL, 't'},
+                                   {"batch", required_argument, NULL, 'b'},
+                                   {"help", no_argument, NULL, 'h'},
+                                   {NULL, 0, NULL, 0}};
+  int option;
+  while ((option = getopt_long(argc, argv, "H:p:d:t:b:h", options, NULL)) != -1) {
+    switch (option) {
+    case 'H':
+      host = optarg;
+      break;
+    case 'p':
+      port = parse_u32(optarg, "port", 1u, 65535u);
+      break;
+    case 'd':
+      duration = parse_u32(optarg, "duration", 1u, 86400u);
+      break;
+    case 't':
+      threads = parse_u32(optarg, "threads", 1u, 256u);
+      break;
+    case 'b':
+      batch = parse_u32(optarg, "batch", 1u, MAX_BATCH);
+      break;
+    default:
+      usage(argv[0]);
+      return option == 'h' ? 0 : 2;
+    }
+  }
+  if (!host) {
+    usage(argv[0]);
+    return 2;
+  }
+
+  struct sockaddr_in destination = {.sin_family = AF_INET, .sin_port = htons((uint16_t)port)};
+  if (inet_pton(AF_INET, host, &destination.sin_addr) != 1) {
+    fprintf(stderr, "Invalid IPv4 destination: %s\n", host);
+    return 2;
+  }
+
+  signal(SIGINT, stop_handler);
+  signal(SIGTERM, stop_handler);
+  pthread_t *thread_ids = calloc(threads, sizeof(*thread_ids));
+  worker_state *workers = calloc(threads, sizeof(*workers));
+  if (!thread_ids || !workers) {
+    fprintf(stderr, "Cannot allocate worker state\n");
+    return 1;
+  }
+
+  const double started = monotonic_seconds();
+  const double finish_at = started + duration;
+  for (uint32_t i = 0; i < threads; ++i) {
+    workers[i].destination = destination;
+    workers[i].finish_at = finish_at;
+    workers[i].worker_id = i + 1u;
+    workers[i].batch = batch;
+    int create_error = pthread_create(&thread_ids[i], NULL, run_worker, &workers[i]);
+    if (create_error != 0) {
+      workers[i].error = create_error;
+      stop_requested = 1;
+      threads = i;
+      break;
+    }
+  }
+  for (uint32_t i = 0; i < threads; ++i) {
+    pthread_join(thread_ids[i], NULL);
+  }
+  const double elapsed = monotonic_seconds() - started;
+
+  uint64_t sent_packets = 0;
+  uint64_t sent_bytes = 0;
+  uint64_t recv_packets = 0;
+  uint64_t recv_bytes = 0;
+  uint64_t responses_401 = 0;
+  uint64_t send_wouldblock = 0;
+  int error = 0;
+  for (uint32_t i = 0; i < threads; ++i) {
+    sent_packets += workers[i].sent_packets;
+    sent_bytes += workers[i].sent_bytes;
+    recv_packets += workers[i].recv_packets;
+    recv_bytes += workers[i].recv_bytes;
+    responses_401 += workers[i].responses_401;
+    send_wouldblock += workers[i].send_wouldblock;
+    if (workers[i].error && !error) {
+      error = workers[i].error;
+    }
+  }
+  printf("duration_seconds=%.3f threads=%" PRIu32 " batch=%" PRIu32 "\n", elapsed, threads, batch);
+  printf("sent_packets=%" PRIu64 " sent_pps=%.0f sent_bytes=%" PRIu64 " sent_mbps=%.3f\n", sent_packets,
+         (double)sent_packets / elapsed, sent_bytes, ((double)sent_bytes * 8.0) / elapsed / 1000000.0);
+  printf("recv_packets=%" PRIu64 " recv_pps=%.0f recv_bytes=%" PRIu64 " recv_mbps=%.3f responses_401=%" PRIu64
+         " response_ratio=%.6f\n",
+         recv_packets, (double)recv_packets / elapsed, recv_bytes, ((double)recv_bytes * 8.0) / elapsed / 1000000.0,
+         responses_401, sent_packets ? (double)responses_401 / (double)sent_packets : 0.0);
+  printf("send_wouldblock=%" PRIu64 " worker_error=%d\n", send_wouldblock, error);
+  free(thread_ids);
+  free(workers);
+  return error ? 1 : 0;
+}

--- a/examples/loadtest/401_response_flood.sh
+++ b/examples/loadtest/401_response_flood.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Build and run the Linux 401 Unauthorized response-path flood generator.
+# The separate compile step keeps this benchmark independent of turnserver's
+# installed targets while still making it easy to upload and run on a load host.
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+OUT="${TMPDIR:-/tmp}/coturn_401_response_flood"
+
+"${CC:-cc}" -O3 -pthread -Wall -Wextra -o "$OUT" "$SCRIPT_DIR/401_response_flood.c"
+exec "$OUT" "$@"

--- a/examples/run_tests_prom.sh
+++ b/examples/run_tests_prom.sh
@@ -185,11 +185,40 @@ start_turnserver --prometheus --prometheus-address="127.0.0.1" --prometheus-port
   --allow-loopback-peers --no-cli --listening-port=3479 \
   --unauthorized-ratelimit --unauthorized-ratelimit-rps=1
 assert_prom_response "http://127.0.0.1:8081/metrics"
-timeout 15s "$BINDIR/turnutils_uclient" \
-  -e 127.0.0.1 -X -g -u baduser -W wrongsecret -p 3479 127.0.0.1 \
-  > /dev/null 2>&1 || true
-sleep 1
-prom_metrics="$(wget --quiet --output-document=- --tries=1 "http://127.0.0.1:8081/metrics")"
+# The two 401-mitigation metric families have deliberately different exposure
+# timing, and a single bad-cred client run satisfies only one at a time:
+#   * turn_unauthenticated_401_* are per-thread accumulators flushed into the
+#     registry on the engine's 1 Hz timer, so they only appear ~1s AFTER traffic.
+#   * turn_ratelimit_occupied_buckets is computed live at scrape time and decays
+#     to 0 within RATELIMIT_WINDOW_SECS (1s) of the most recent 401.
+# turnutils_uclient emits its whole 401 burst in well under a second and then
+# idles, so right after a burst the gauge is live but the counters have not
+# flushed, and a second later the counters appear but the gauge has decayed.
+# Keep bad-cred traffic flowing continuously (a short-lived client restarted in a
+# loop) so a rate-limit window stays open across at least one counter-flush tick,
+# then poll until a single scrape shows both families non-zero.
+flood_stop="$(mktemp "${TMPDIR:-/tmp}/run_tests_prom_flood.XXXXXX")"
+(
+  while [ -e "$flood_stop" ]; do
+    timeout 1s "$BINDIR/turnutils_uclient" \
+      -e 127.0.0.1 -X -g -u baduser -W wrongsecret -p 3479 127.0.0.1 \
+      > /dev/null 2>&1
+  done
+) &
+flood_pid="$!"
+prom_metrics=""
+deadline=$((SECONDS + POLL_TIMEOUT))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  scrape="$(wget --quiet --output-document=- --tries=1 "http://127.0.0.1:8081/metrics" 2>/dev/null)"
+  if echo "$scrape" | grep -Eq "^turn_ratelimit_occupied_buckets [1-9][0-9]*(\\.[0-9]+)?$" &&
+     echo "$scrape" | grep -Eq "^turn_unauthenticated_401_requests(_total)? [1-9][0-9]*(\\.[0-9]+)?$"; then
+    prom_metrics="$scrape"
+    break
+  fi
+  sleep 0.2
+done
+rm -f "$flood_stop"
+wait "$flood_pid" 2>/dev/null
 assert_prom_metric_nonzero "turn_unauthenticated_401_requests" "$prom_metrics"
 assert_prom_metric_nonzero "turn_unauthenticated_401_responses" "$prom_metrics"
 assert_prom_metric_nonzero "turn_unauthenticated_401_dropped_responses" "$prom_metrics"

--- a/examples/run_tests_prom.sh
+++ b/examples/run_tests_prom.sh
@@ -125,6 +125,17 @@ function assert_prom_response_tls() {
   echo OK
 }
 
+function assert_prom_metric_nonzero() {
+  metric="$1"
+  body="$2"
+  if echo "$body" | grep -Eq "^${metric}(_total)? [1-9][0-9]*(\\.[0-9]+)?$"; then
+    echo OK
+  else
+    echo "FAIL: metric ${metric} was not non-zero"
+    exit 1
+  fi
+}
+
 echo "Running without prometheus"
 start_turnserver
 wait_for_prom_decision
@@ -165,4 +176,25 @@ start_turnserver --prometheus-tls \
   --prometheus-cert=/nonexistent/cert.pem --prometheus-key=/nonexistent/key.pem
 wait_for_prom_decision
 assert_prom_no_response "https://localhost:9641/metrics"
+stop_turnserver
+
+# COMMON_ARGS already supplies -L/-E 127.0.0.1 and --no-tls --no-dtls.
+echo "Running turnserver with prometheus 401 mitigation counters"
+start_turnserver --prometheus --prometheus-address="127.0.0.1" --prometheus-port="8081" \
+  --use-auth-secret --static-auth-secret=secret --realm=north.gov \
+  --allow-loopback-peers --no-cli --listening-port=3479 \
+  --unauthorized-ratelimit --unauthorized-ratelimit-rps=1
+assert_prom_response "http://127.0.0.1:8081/metrics"
+timeout 15s "$BINDIR/turnutils_uclient" \
+  -e 127.0.0.1 -X -g -u baduser -W wrongsecret -p 3479 127.0.0.1 \
+  > /dev/null 2>&1 || true
+sleep 1
+prom_metrics="$(wget --quiet --output-document=- --tries=1 "http://127.0.0.1:8081/metrics")"
+assert_prom_metric_nonzero "turn_unauthenticated_401_requests" "$prom_metrics"
+assert_prom_metric_nonzero "turn_unauthenticated_401_responses" "$prom_metrics"
+assert_prom_metric_nonzero "turn_unauthenticated_401_dropped_responses" "$prom_metrics"
+# The single bad-cred source occupies exactly one live bucket; capacity is the
+# fixed table size. (Collisions stay 0 with one source, so are not asserted here.)
+assert_prom_metric_nonzero "turn_ratelimit_occupied_buckets" "$prom_metrics"
+assert_prom_metric_nonzero "turn_ratelimit_total_buckets" "$prom_metrics"
 stop_turnserver

--- a/examples/run_tests_ratelimit_401.sh
+++ b/examples/run_tests_ratelimit_401.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# 401 rate-limit feature test.
+#
+# Exercises the --unauthorized-ratelimit / --unauthorized-ratelimit-rps
+# flags end-to-end:
+#
+#   positive: with --unauthorized-ratelimit-rps=1, drive one bounded
+#             turnutils_uclient session. The client retries the 401
+#             challenge several times within the same second, easily
+#             crossing the threshold of 1, so the server must emit
+#             exactly one "401 rate-limit exceeded" log line (the log
+#             is self-rate-limited to one message per (bucket, window)
+#             on purpose).
+#
+#   negative: same harness but --unauthorized-ratelimit-rps=100000. Same
+#             client traffic produces nowhere near 100000 401s/sec, so the
+#             "exceeded" log line must NOT appear.
+#
+# Split out of run_tests.sh so the rate-limit configuration is fully
+# isolated from the protocol-test server fixture in that script — a
+# regression in either suite must not be masked by the other's flags.
+
+# Per-run log path; $$ keeps two concurrent invocations from clobbering
+# each other.
+RATELIMIT_LOG="/tmp/run_tests_ratelimit_401.$$.log"
+turnserver_pid=""
+
+cleanup() {
+    if [ -n "$turnserver_pid" ]; then
+        kill "$turnserver_pid" 2>/dev/null
+        wait "$turnserver_pid" 2>/dev/null
+    fi
+    rm -f "$RATELIMIT_LOG"
+}
+trap cleanup EXIT
+
+# Detect cmake build and adjust path.
+BINDIR="../bin"
+if [ ! -f "$BINDIR/turnserver" ]; then
+    BINDIR="../build/bin"
+fi
+
+# macOS loopback drops UDP relay traffic intermittently and the
+# turnutils_uclient retry pattern there is different enough that the
+# log-line accounting becomes flaky. Linux CI is the canonical target
+# for this feature — skip on Darwin rather than emit false failures.
+if [ "$(uname -s)" = "Darwin" ]; then
+    echo "Skipping 401 rate-limit test on macOS"
+    exit 0
+fi
+
+# Block until turnserver has printed the line that follows relay-port
+# init and per-thread UDP listener setup. Cheaper and more reliable
+# than `sleep N`; mirrors the pattern in run_tests.sh.
+wait_for_turnserver() {
+    local i
+    for i in $(seq 1 40); do
+        if grep -q "Total auth threads:" "$RATELIMIT_LOG" 2>/dev/null; then
+            return 0
+        fi
+        if ! kill -0 "$turnserver_pid" 2>/dev/null; then
+            echo "FATAL: turnserver (pid $turnserver_pid) exited before init completed"
+            echo "--- turnserver log ---"
+            cat "$RATELIMIT_LOG" 2>/dev/null || echo "(log file missing)"
+            return 1
+        fi
+        sleep 0.5
+    done
+    echo "FATAL: turnserver never reached 'Total auth threads:' init line within 20s"
+    echo "--- turnserver log (last 30 lines) ---"
+    tail -30 "$RATELIMIT_LOG" 2>/dev/null || echo "(log file missing)"
+    return 1
+}
+
+# Start a fresh turnserver with --unauthorized-ratelimit + caller-supplied
+# threshold flag. The previous server (if any) is killed
+# first; the log file is truncated so each case sees a clean slate.
+run_ratelimit_server() {
+    if [ -n "$turnserver_pid" ]; then
+        kill "$turnserver_pid" 2>/dev/null
+        wait "$turnserver_pid" 2>/dev/null
+    fi
+    : > "$RATELIMIT_LOG"
+    "$BINDIR/turnserver" --use-auth-secret --static-auth-secret=secret --realm=north.gov \
+        --allow-loopback-peers --no-cli --no-tls --no-dtls \
+        --listening-ip=127.0.0.1 --relay-ip=127.0.0.1 \
+        --listening-port=3479 \
+        --log-file=stdout --simple-log \
+        "$@" > "$RATELIMIT_LOG" 2>&1 &
+    turnserver_pid="$!"
+    wait_for_turnserver
+}
+
+# turnutils_uclient with bad credentials. `timeout` caps the run so a
+# hung session can't stall CI; we don't care about its exit status —
+# all the assertions are against the server log.
+drive_bad_client() {
+    timeout 15s "$BINDIR/turnutils_uclient" \
+        -e 127.0.0.1 -X -g -u baduser -W wrongsecret -p 3479 127.0.0.1 \
+        > /dev/null 2>&1 || true
+    sleep 1
+}
+
+echo "Running 401 rate-limit (positive)"
+run_ratelimit_server --unauthorized-ratelimit --unauthorized-ratelimit-rps=1 || exit 1
+drive_bad_client
+
+if grep -q '401 rate-limit exceeded from' "$RATELIMIT_LOG"; then
+    echo OK
+else
+    echo "FAIL: rate-limit log line not emitted under attack"
+    echo "--- turnserver log (last 40 lines) ---"
+    tail -40 "$RATELIMIT_LOG"
+    exit 1
+fi
+
+echo "Running 401 rate-limit (negative: high threshold)"
+run_ratelimit_server --unauthorized-ratelimit --unauthorized-ratelimit-rps=100000 || exit 1
+drive_bad_client
+
+if grep -q '401 rate-limit exceeded from' "$RATELIMIT_LOG"; then
+    echo "FAIL: rate-limit triggered below threshold (--unauthorized-ratelimit-rps=100000)"
+    echo "--- turnserver log (last 40 lines) ---"
+    tail -40 "$RATELIMIT_LOG"
+    exit 1
+else
+    echo OK
+fi

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -1242,6 +1242,20 @@ DEPRECATED and now the default behaviour. See \-\-rfc5780.
 \fB\-\-stun\-backward\-compatibility\fP
 Enable handling old STUN Binding requests using MAPPED\-ADDRESS attribute in binding response (instead of XOR\-MAPPED\-ADDRESS).
 .RE
+
+.RS
+.TP
+.B
+\fB\-\-unauthorized\-ratelimit\fP
+Enable per\-source rate limiting of UDP 401 Unauthorized responses.
+This mitigates reflection and amplification attacks that spoof a victim's
+source address to receive authentication challenges. Disabled by default.
+.TP
+.B
+\fB\-\-unauthorized\-ratelimit\-rps\fP=<count>
+Maximum number of UDP 401 Unauthorized responses sent per source IP
+per second. Default is 10.
+.RE
 .PP
 
 .SH ==================================

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -37,6 +37,7 @@
 
 #include "dbdrivers/dbdriver.h"
 
+#include "ns_turn_ratelimit.h"
 #include "prom_server.h"
 #include <assert.h>
 #include <limits.h>
@@ -253,7 +254,11 @@ turn_params_t turn_params = {
 #endif
     false, /* include_reason_string */
     false, /* multiplex_peer */
-    0      /* multiplex_peer_base_port */
+    0,     /* multiplex_peer_base_port */
+
+    ///////// Ratelimit /////////
+    false,                                 /* unauthorized-ratelimit */
+    RATELIMIT_DEFAULT_MAX_REQUESTS_PER_SEC /* unauthorized-ratelimit-rps */
 };
 
 //////////////// OpenSSL Init //////////////////////
@@ -1409,6 +1414,13 @@ static char Usage[] =
     "						   By default, only the standard reason phrase for the error code is\n"
     "						   sent. Enabling this option adds detailed error descriptions which\n"
     "						   may aid debugging but can also leak internal server information.\n"
+    " --unauthorized-ratelimit                       Enable per-source rate-limiting of 401\n"
+    "                                                 Unauthorized responses on UDP. Mitigates\n"
+    "                                                 reflection/amplification abuse where attackers\n"
+    "                                                 spoof a victim's source address to bounce 401\n"
+    "                                                 challenges off the server. Off by default.\n"
+    " --unauthorized-ratelimit-rps=<count>           Max 401 Unauthorized responses to send per\n"
+    "                                                 source IP per second (default 10).\n"
     " --version					Print version (and exit).\n"
     " -h						Help\n"
     "\n";
@@ -1580,6 +1592,8 @@ enum EXTRA_OPTS {
   UDP_GSO_OPT,
 #endif
   VERSION_OPT,
+  RATELIMIT_OPT,
+  RATELIMIT_RPS_OPT,
   CPUS_OPT,
   INCLUDE_REASON_STRING_OPT,
   OPT_MULTIPLEX_PEER = 800,
@@ -1745,6 +1759,8 @@ static const struct myoption long_options[] = {
     {"version", optional_argument, NULL, VERSION_OPT},
     {"syslog-facility", required_argument, NULL, SYSLOG_FACILITY_OPT},
     {"cpus", required_argument, NULL, CPUS_OPT},
+    {"unauthorized-ratelimit", optional_argument, NULL, RATELIMIT_OPT},
+    {"unauthorized-ratelimit-rps", optional_argument, NULL, RATELIMIT_RPS_OPT},
     {NULL, no_argument, NULL, 0}};
 
 static const struct myoption admin_long_options[] = {
@@ -2612,6 +2628,21 @@ static void set_option(int c, char *value) {
       turn_params.cpus = (unsigned long)cpus;
       turn_params.cpus_configured = true;
     }
+  } break;
+  case RATELIMIT_OPT:
+    turn_params.ratelimit_unauthorized_requests = get_bool_value(value);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Unauthorized response rate-limiting: %s\n",
+                  turn_params.ratelimit_unauthorized_requests ? "enabled" : "disabled");
+    break;
+  case RATELIMIT_RPS_OPT: {
+    int v = get_int_value(value, (int)RATELIMIT_DEFAULT_MAX_REQUESTS_PER_SEC);
+    if (v <= 0) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "Invalid --unauthorized-ratelimit-rps=%d (must be > 0); using default %u\n",
+                    v, RATELIMIT_DEFAULT_MAX_REQUESTS_PER_SEC);
+      v = (int)RATELIMIT_DEFAULT_MAX_REQUESTS_PER_SEC;
+    }
+    turn_params.ratelimit_unauthorized_requests_per_sec = v;
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Unauthorized rate-limit threshold: %d responses per second\n", v);
   } break;
 
   /* these options have been already taken care of before: */
@@ -3686,6 +3717,10 @@ int main(int argc, char **argv) {
   /* Auto-deny coturn's own DB backend endpoints as relay peers (after all
    * config is parsed, before servers bind their copy of the blacklist). */
   deny_self_db_endpoints();
+
+  if (turn_params.ratelimit_unauthorized_requests) {
+    ratelimit_init();
+  }
 
   setup_server();
 

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -360,6 +360,9 @@ typedef struct _turn_params_ {
 
   bool multiplex_peer;               /* --multiplex-peer flag */
   uint16_t multiplex_peer_base_port; /* --multiplex-peer-port (default 3480) */
+
+  bool ratelimit_unauthorized_requests;
+  vint ratelimit_unauthorized_requests_per_sec;
 } turn_params_t;
 
 extern turn_params_t turn_params;

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -36,6 +36,7 @@
 #include <errno.h>
 
 #include "ns_turn_ioalib.h"
+#include "prom_server.h"
 
 //////////// Backward compatibility with OpenSSL 1.0.x //////////////
 #if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER <= 0x3040000fL
@@ -1359,7 +1360,11 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
       turn_params.server_relay, send_turn_session_info, send_https_socket, turn_params.sock_buf_size, allocate_bps,
       turn_params.oauth, turn_params.oauth_server_name, turn_params.acme_redirect,
       turn_params.allocation_default_address_family, &turn_params.log_binding, &turn_params.stun_backward_compatibility,
-      &turn_params.respond_http_unsupported, turn_params.include_reason_string);
+      &turn_params.respond_http_unsupported, turn_params.include_reason_string,
+      &turn_params.ratelimit_unauthorized_requests, &turn_params.ratelimit_unauthorized_requests_per_sec);
+  set_unauthenticated_401_metric_cbs(&(rs->server), prom_inc_unauthenticated_401_request,
+                                     prom_inc_unauthenticated_401_response,
+                                     prom_inc_unauthenticated_401_dropped_response);
   if (to_set_rfc5780) {
     set_rfc5780(&(rs->server), get_alt_addr, send_message_from_listener_to_client);
   }

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -687,6 +687,10 @@ static void maybe_flush_prom_counters(ioa_engine_handle e) {
 #endif
 
   prom_flush_udp_counters(&d);
+
+  /* Same once-per-second-per-thread flush for the 401 mitigation counters,
+   * which accumulate lock-free in _Thread_local storage on the relay hot path. */
+  prom_flush_401_counters();
 }
 
 static void timer_handler(ioa_engine_handle e, void *arg) {

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -34,6 +34,7 @@
 
 #include "prom_server.h"
 #include "mainrelay.h"
+#include "ns_turn_ratelimit.h"
 #include "ns_turn_utils.h"
 #include <stdio.h>
 #if !defined(WINDOWS)
@@ -50,6 +51,14 @@ prom_counter_t *packet_dropped;
 prom_counter_t *stun_binding_request;
 prom_counter_t *stun_binding_response;
 prom_counter_t *stun_binding_error;
+
+prom_counter_t *turn_unauthenticated_401_requests;
+prom_counter_t *turn_unauthenticated_401_responses;
+prom_counter_t *turn_unauthenticated_401_dropped_responses;
+
+prom_counter_t *turn_ratelimit_hash_collisions;
+prom_gauge_t *turn_ratelimit_occupied_buckets;
+prom_gauge_t *turn_ratelimit_total_buckets;
 
 prom_counter_t *turn_traffic_rcvp;
 prom_counter_t *turn_traffic_rcvb;
@@ -85,6 +94,22 @@ prom_counter_t *turn_udp_sendmmsg_gso_datagrams;
 #define MHD_RESULT int
 #endif
 
+// Pull the 401 rate-limit table's self-instrumented stats into Prometheus
+// metrics. Called only from the single MHD scrape thread, so the static delta
+// tracker below needs no locking. The whole-table scan in
+// ratelimit_count_occupied() touches the buckets once per scrape and never runs
+// on the data path, so this stays off the hot path entirely.
+static void prom_refresh_ratelimit_stats(void) {
+  static uint32_t last_collisions = 0;
+  uint32_t cur = ratelimit_get_collisions();
+  uint32_t delta = cur - last_collisions; // unsigned subtraction is correct across the 2^32 wrap
+  if (delta) {
+    prom_counter_add(turn_ratelimit_hash_collisions, (double)delta, NULL);
+    last_collisions = cur;
+  }
+  prom_gauge_set(turn_ratelimit_occupied_buckets, (double)ratelimit_count_occupied(), NULL);
+}
+
 static MHD_RESULT promhttp_handler(void *cls, struct MHD_Connection *connection, const char *url, const char *method,
                                    const char *version, const char *upload_data, size_t *upload_data_size,
                                    void **con_cls) {
@@ -103,7 +128,8 @@ static MHD_RESULT promhttp_handler(void *cls, struct MHD_Connection *connection,
     status = MHD_HTTP_METHOD_NOT_ALLOWED;
     body = "method not allowed";
   } else if (strcmp(url, turn_params.prometheus_path) == 0) {
-    body = prom_collector_registry_bridge(PROM_COLLECTOR_REGISTRY_DEFAULT);
+    prom_refresh_ratelimit_stats();
+    body = (char *)prom_collector_registry_bridge(PROM_COLLECTOR_REGISTRY_DEFAULT);
     if (body == NULL) {
       return MHD_NO;
     }
@@ -178,6 +204,26 @@ void start_prometheus_server(void) {
       prom_counter_new("stun_binding_response", "Outgoing STUN Binding responses", 0, NULL));
   stun_binding_error = prom_collector_registry_must_register_metric(
       prom_counter_new("stun_binding_error", "STUN Binding errors", 0, NULL));
+
+  turn_unauthenticated_401_requests = prom_collector_registry_must_register_metric(prom_counter_new(
+      "turn_unauthenticated_401_requests", "UDP requests requiring a 401 Unauthorized response", 0, NULL));
+  turn_unauthenticated_401_responses = prom_collector_registry_must_register_metric(
+      prom_counter_new("turn_unauthenticated_401_responses", "UDP 401 Unauthorized responses emitted", 0, NULL));
+  turn_unauthenticated_401_dropped_responses = prom_collector_registry_must_register_metric(prom_counter_new(
+      "turn_unauthenticated_401_dropped_responses", "UDP 401 responses suppressed by DDoS mitigation", 0, NULL));
+
+  // 401 rate-limit hash-table health. Refreshed lazily at scrape time from the
+  // lock-free table's self-instrumented counters (see prom_refresh_ratelimit_stats).
+  turn_ratelimit_hash_collisions = prom_collector_registry_must_register_metric(
+      prom_counter_new("turn_ratelimit_hash_collisions",
+                       "401 rate-limit hash-bucket collisions (a source sharing another's live bucket)", 0, NULL));
+  turn_ratelimit_occupied_buckets = prom_collector_registry_must_register_metric(prom_gauge_new(
+      "turn_ratelimit_occupied_buckets", "401 rate-limit buckets currently tracking a live window", 0, NULL));
+  turn_ratelimit_total_buckets = prom_collector_registry_must_register_metric(
+      prom_gauge_new("turn_ratelimit_total_buckets", "401 rate-limit hash table capacity in buckets", 0, NULL));
+  // Capacity is a compile-time constant; publish it once so occupancy can be
+  // read as a utilization ratio in PromQL.
+  prom_gauge_set(turn_ratelimit_total_buckets, (double)ratelimit_get_capacity(), NULL);
 
   // Create TURN traffic counter metrics
   turn_traffic_rcvp = prom_collector_registry_must_register_metric(
@@ -418,6 +464,54 @@ void prom_flush_udp_counters(const struct prom_udp_counter_deltas *d) {
   }
 }
 
+/* The 401 mitigation counters are bumped on the relay hot path (once per
+ * unauthenticated UDP request -- the reflection surface, and the busiest path
+ * under the very flood this feature mitigates). To keep the global prom_counter
+ * locks off that path, each relay thread accumulates into lock-free
+ * _Thread_local counters here and prom_flush_401_counters() pushes the deltas
+ * once per second from the engine timer -- mirroring the UDP packet counters
+ * (see prom_flush_udp_counters / maybe_flush_prom_counters). */
+static _Thread_local uint64_t tl_401_requests, tl_401_requests_flushed;
+static _Thread_local uint64_t tl_401_responses, tl_401_responses_flushed;
+static _Thread_local uint64_t tl_401_dropped, tl_401_dropped_flushed;
+
+void prom_inc_unauthenticated_401_request(void) {
+  if (turn_params.prometheus) {
+    tl_401_requests++;
+  }
+}
+
+void prom_inc_unauthenticated_401_response(void) {
+  if (turn_params.prometheus) {
+    tl_401_responses++;
+  }
+}
+
+void prom_inc_unauthenticated_401_dropped_response(void) {
+  if (turn_params.prometheus) {
+    tl_401_dropped++;
+  }
+}
+
+void prom_flush_401_counters(void) {
+  if (!turn_params.prometheus) {
+    return;
+  }
+  uint64_t d;
+  if ((d = tl_401_requests - tl_401_requests_flushed)) {
+    prom_counter_add(turn_unauthenticated_401_requests, (double)d, NULL);
+    tl_401_requests_flushed = tl_401_requests;
+  }
+  if ((d = tl_401_responses - tl_401_responses_flushed)) {
+    prom_counter_add(turn_unauthenticated_401_responses, (double)d, NULL);
+    tl_401_responses_flushed = tl_401_responses;
+  }
+  if ((d = tl_401_dropped - tl_401_dropped_flushed)) {
+    prom_counter_add(turn_unauthenticated_401_dropped_responses, (double)d, NULL);
+    tl_401_dropped_flushed = tl_401_dropped;
+  }
+}
+
 void prom_inc_stun_binding_request(void) {
   if (turn_params.prometheus) {
     prom_counter_add(stun_binding_request, 1, NULL);
@@ -475,5 +569,13 @@ void prom_inc_allocation(SOCKET_TYPE type) { UNUSED_ARG(type); }
 void prom_dec_allocation(SOCKET_TYPE type) { UNUSED_ARG(type); }
 
 void prom_flush_udp_counters(const struct prom_udp_counter_deltas *d) { UNUSED_ARG(d); }
+
+void prom_inc_unauthenticated_401_request(void) {}
+
+void prom_inc_unauthenticated_401_response(void) {}
+
+void prom_inc_unauthenticated_401_dropped_response(void) {}
+
+void prom_flush_401_counters(void) {}
 
 #endif /* TURN_NO_PROMETHEUS */

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -34,6 +34,7 @@
 
 #include "prom_server.h"
 #include "mainrelay.h"
+#include "ns_turn_atomic.h" // for TURN_THREAD_LOCAL (portable thread-local on MSVC)
 #include "ns_turn_ratelimit.h"
 #include "ns_turn_utils.h"
 #include <stdio.h>
@@ -468,12 +469,12 @@ void prom_flush_udp_counters(const struct prom_udp_counter_deltas *d) {
  * unauthenticated UDP request -- the reflection surface, and the busiest path
  * under the very flood this feature mitigates). To keep the global prom_counter
  * locks off that path, each relay thread accumulates into lock-free
- * _Thread_local counters here and prom_flush_401_counters() pushes the deltas
+ * thread-local counters here and prom_flush_401_counters() pushes the deltas
  * once per second from the engine timer -- mirroring the UDP packet counters
  * (see prom_flush_udp_counters / maybe_flush_prom_counters). */
-static _Thread_local uint64_t tl_401_requests, tl_401_requests_flushed;
-static _Thread_local uint64_t tl_401_responses, tl_401_responses_flushed;
-static _Thread_local uint64_t tl_401_dropped, tl_401_dropped_flushed;
+static TURN_THREAD_LOCAL uint64_t tl_401_requests, tl_401_requests_flushed;
+static TURN_THREAD_LOCAL uint64_t tl_401_responses, tl_401_responses_flushed;
+static TURN_THREAD_LOCAL uint64_t tl_401_dropped, tl_401_dropped_flushed;
 
 void prom_inc_unauthenticated_401_request(void) {
   if (turn_params.prometheus) {

--- a/src/apps/relay/prom_server.h
+++ b/src/apps/relay/prom_server.h
@@ -68,6 +68,14 @@ extern prom_counter_t *stun_binding_request;
 extern prom_counter_t *stun_binding_response;
 extern prom_counter_t *stun_binding_error;
 
+extern prom_counter_t *turn_unauthenticated_401_requests;
+extern prom_counter_t *turn_unauthenticated_401_responses;
+extern prom_counter_t *turn_unauthenticated_401_dropped_responses;
+
+extern prom_counter_t *turn_ratelimit_hash_collisions;
+extern prom_gauge_t *turn_ratelimit_occupied_buckets;
+extern prom_gauge_t *turn_ratelimit_total_buckets;
+
 extern prom_counter_t *turn_new_allocation;
 extern prom_counter_t *turn_refreshed_allocation;
 extern prom_counter_t *turn_deleted_allocation;
@@ -118,6 +126,9 @@ void prom_set_finished_traffic(const char *realm, const char *user, unsigned lon
 
 void prom_inc_allocation(SOCKET_TYPE type);
 void prom_dec_allocation(SOCKET_TYPE type);
+void prom_inc_unauthenticated_401_request(void);
+void prom_inc_unauthenticated_401_response(void);
+void prom_inc_unauthenticated_401_dropped_response(void);
 
 /* Per-engine deltas accumulated lock-free on the relay hot path and flushed
  * into the shared prometheus counters once per second (see timer_handler).
@@ -135,5 +146,10 @@ struct prom_udp_counter_deltas {
 /* Add the given non-zero deltas to the shared prometheus counters.
  * No-op when prometheus is disabled or compiled out. */
 void prom_flush_udp_counters(const struct prom_udp_counter_deltas *d);
+
+/* Flush this thread's lock-free 401 mitigation counters into the shared
+ * prometheus counters. Called once per second per relay thread from the engine
+ * timer. No-op when prometheus is disabled or compiled out. */
+void prom_flush_401_counters(void);
 
 #endif /* __PROM_SERVER_H__ */

--- a/src/ns_turn_atomic.h
+++ b/src/ns_turn_atomic.h
@@ -100,4 +100,19 @@ static inline bool turn_atomic_cas_u32(turn_atomic_u32 *p, uint32_t expected, ui
 
 #endif
 
+/*
+ * Thread-local storage-class specifier. MSVC spells it __declspec(thread) and
+ * rejects the C11 _Thread_local keyword on the toolsets we build against;
+ * GCC/Clang/MinGW take _Thread_local. Callers that keep per-thread accumulators
+ * (e.g. the lock-free relay-thread counters flushed into Prometheus) use this
+ * instead of a per-file shim, and get true thread-local storage on every
+ * platform. Gated on _MSC_VER (the compiler), not WINDOWS: MinGW is GCC and
+ * uses the _Thread_local path even though WINDOWS is defined for it.
+ */
+#if defined(_MSC_VER)
+#define TURN_THREAD_LOCAL __declspec(thread)
+#else
+#define TURN_THREAD_LOCAL _Thread_local
+#endif
+
 #endif //__TURN_ATOMIC__

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCE_FILES
     ns_turn_allocation.c
     ns_turn_maps_rtcp.c
     ns_turn_maps.c
+    ns_turn_ratelimit.c
     ns_turn_server.c
     )
 
@@ -47,6 +48,7 @@ set(HEADER_FILES
     ns_turn_khash.h
     ns_turn_maps_rtcp.h
     ns_turn_maps.h
+    ns_turn_ratelimit.h
     ns_turn_server.h
     ns_turn_session.h
     )

--- a/src/server/ns_turn_ratelimit.c
+++ b/src/server/ns_turn_ratelimit.c
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * https://opensource.org/license/bsd-3-clause
+ *
+ * Copyright (C) 2011, 2012, 2013 Citrix Systems
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the project nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "ns_turn_ratelimit.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "ns_turn_atomic.h" // for turn_atomic_* portable atomics
+#include "ns_turn_defs.h"   // for turn_time_t / turn_time()
+
+/* Power-of-two bucket count. 4096 buckets * 20 B/bucket = ~80 KiB resident.
+ * Increasing this lowers hash-collision probability for legit traffic. Live
+ * collisions share the existing budget so they cannot expand 401 output. */
+#define RATELIMIT_BUCKETS 4096u
+#define RATELIMIT_MASK (RATELIMIT_BUCKETS - 1u)
+
+/* The limit is expressed per second, so the window is a fixed 1 second. */
+#define RATELIMIT_WINDOW_SECS 1u
+
+typedef struct {
+  turn_atomic_u32 tag;              /* hash of source IP (port stripped); 0 = empty */
+  turn_atomic_u32 window_start;     /* turn_time() value when the current window opened */
+  turn_atomic_u32 count;            /* requests counted in this window */
+  turn_atomic_u32 logged;           /* 1 once we've logged a drop in this window */
+  turn_atomic_u32 collision_logged; /* 1 once we've logged a collision in this window */
+} ratelimit_bucket;
+
+static ratelimit_bucket ratelimit_table[RATELIMIT_BUCKETS];
+
+/* Monotonic count of hash-bucket collisions: requests whose source hashed to
+ * a bucket currently owned by a different address. A single global atomic,
+ * touched only on the (rare) collision branch of the 401 path, so it adds no
+ * cost to the common case. Read at scrape time via ratelimit_get_collisions().
+ * Wraps at 2^32; the exporter recovers the increment via unsigned subtraction. */
+static turn_atomic_u32 ratelimit_collisions;
+
+/* 32-bit hash over the address bytes, ignoring port. Returns a value
+ * != 0 so we can reserve 0 as the "empty bucket" tag. */
+static uint32_t ratelimit_hash(const ioa_addr *a) {
+  uint32_t h;
+  if (a->ss.sa_family == AF_INET6) {
+    /* FNV-1a 32-bit over the 16-byte v6 address. */
+    const uint8_t *b = (const uint8_t *)&a->s6.sin6_addr;
+    h = 2166136261u;
+    for (int i = 0; i < 16; i++) {
+      h ^= b[i];
+      h *= 16777619u;
+    }
+  } else {
+    /* splitmix-style finalizer on the 32-bit v4 address. */
+    h = (uint32_t)a->s4.sin_addr.s_addr;
+    h ^= h >> 16;
+    h *= 0x7feb352du;
+    h ^= h >> 15;
+    h *= 0x846ca68bu;
+    h ^= h >> 16;
+  }
+  return h ? h : 1u;
+}
+
+void ratelimit_init(void) {
+  /* Static storage is zero-initialized; this is here so the symbol
+   * exists for callers and the intent is explicit. */
+  memset(ratelimit_table, 0, sizeof(ratelimit_table));
+  turn_atomic_store_u32(&ratelimit_collisions, 0u);
+}
+
+bool ratelimit_consume_address(const ioa_addr *address, uint32_t max_requests_per_sec, bool *first_drop,
+                               bool *first_collision) {
+  if (first_drop) {
+    *first_drop = false;
+  }
+  if (first_collision) {
+    *first_collision = false;
+  }
+  if (!address || max_requests_per_sec == 0) {
+    return false;
+  }
+
+  const uint32_t h = ratelimit_hash(address);
+  ratelimit_bucket *b = &ratelimit_table[h & RATELIMIT_MASK];
+  const uint32_t now = (uint32_t)turn_time();
+
+  const uint32_t tag = turn_atomic_load_u32(&b->tag);
+  const uint32_t ws = turn_atomic_load_u32(&b->window_start);
+
+  if (tag == 0u || (now - ws) >= RATELIMIT_WINDOW_SECS) {
+    /* Empty bucket or expired window: establish a fresh owner.
+     * Two concurrent resets are fine: the second one wins, and both
+     * see count == 1 by the time the store on the tag lands. */
+    turn_atomic_store_u32(&b->window_start, now);
+    turn_atomic_store_u32(&b->logged, 0u);
+    turn_atomic_store_u32(&b->collision_logged, 0u);
+    turn_atomic_store_u32(&b->count, 1u);
+    turn_atomic_store_u32(&b->tag, h);
+    return false;
+  }
+
+  if (tag != h) {
+    /* A colliding source landed on a live bucket owned by another address.
+     * Count every collision for telemetry; the diagnostic log line is still
+     * latched to once per (bucket, window) via collision_logged. */
+    turn_atomic_fetch_add_u32(&ratelimit_collisions, 1u);
+    if (first_collision && turn_atomic_cas_u32(&b->collision_logged, 0u, 1u)) {
+      *first_collision = true;
+    }
+  }
+
+  /* A live collision uses the existing bucket budget. Replacing the owner
+   * here would let alternating colliders repeatedly obtain a fresh allowance. */
+  /* fetch_add returns the value BEFORE the increment, so prev == max
+   * means this request is exactly the (max+1)-th in the window — the
+   * first that crosses the threshold. */
+  const uint32_t prev = turn_atomic_fetch_add_u32(&b->count, 1u);
+  if (prev < max_requests_per_sec) {
+    return false;
+  }
+
+  if (first_drop) {
+    /* Emit a single log line per (bucket, window) by CAS'ing the
+     * `logged` flag from 0 to 1. Subsequent drops in the same window
+     * silently increment the counter but don't log. */
+    if (turn_atomic_cas_u32(&b->logged, 0u, 1u)) {
+      *first_drop = true;
+    }
+  }
+  return true;
+}
+
+uint32_t ratelimit_get_collisions(void) { return turn_atomic_load_u32(&ratelimit_collisions); }
+
+uint32_t ratelimit_get_capacity(void) { return RATELIMIT_BUCKETS; }
+
+uint32_t ratelimit_count_occupied(void) {
+  /* Whole-table scan: cheap (one pass over RATELIMIT_BUCKETS atomic loads) and
+   * intended to run only at metrics-scrape time, never on the data path. A
+   * bucket counts as occupied when it holds a tag and its window has not yet
+   * expired, mirroring the liveness test in ratelimit_consume_address(). */
+  const uint32_t now = (uint32_t)turn_time();
+  uint32_t occupied = 0u;
+  for (uint32_t i = 0; i < RATELIMIT_BUCKETS; i++) {
+    ratelimit_bucket *b = &ratelimit_table[i];
+    if (turn_atomic_load_u32(&b->tag) != 0u && (now - turn_atomic_load_u32(&b->window_start)) < RATELIMIT_WINDOW_SECS) {
+      occupied++;
+    }
+  }
+  return occupied;
+}

--- a/src/server/ns_turn_ratelimit.h
+++ b/src/server/ns_turn_ratelimit.h
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * https://opensource.org/license/bsd-3-clause
+ *
+ * Copyright (C) 2011, 2012, 2013 Citrix Systems
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the project nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef __TURN_RATE_LIMIT__
+#define __TURN_RATE_LIMIT__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "ns_turn_ioaddr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Default for the unauthorized rate-limit feature. The PR opts in via
+ * --unauthorized-ratelimit; once enabled, --unauthorized-ratelimit-rps
+ * tunes the per-second response threshold. */
+#define RATELIMIT_DEFAULT_MAX_REQUESTS_PER_SEC 10u
+
+/*
+ * Lock-free per-source-IP rate-limit, designed for the unauthorized-response
+ * reflection attack mitigation in handle_turn_command.
+ *
+ * Design:
+ *  - Fixed-size table of buckets (no malloc/free on the hot path).
+ *  - Each bucket holds a 32-bit tag derived from the source address,
+ *    the start of the current window, and a counter — all atomics.
+ *  - Direct-mapped hash: bucket = hash(addr_without_port) & MASK.
+ *  - An address colliding with a live bucket shares its response budget
+ *    until the window expires; it does not replace the current tag or
+ *    receive a fresh allowance.
+ *  - No global mutex, no list scan, no UAF surface: the address never
+ *    appears as a pointer, only as a tag.
+ *
+ * Caveats:
+ *  - Hash collisions cause two unrelated addresses to share a bucket;
+ *    this can suppress a colliding legitimate source when the shared
+ *    budget is exhausted, but cannot expand reflection output.
+ *  - The port is stripped from the key, so attackers cannot evade by
+ *    rotating the source port.
+ */
+
+/* Reset the rate-limit table. Called once at server startup. Safe to
+ * call multiple times; safe to skip (the table is zero-initialized at
+ * load time). */
+void ratelimit_init(void);
+
+/* Atomic bump. `max_requests_per_sec` is the allowed number of responses
+ * per source per second (the rate limit operates on a fixed 1-second
+ * window). Returns true if THIS request is OVER the limit, i.e. the caller
+ * should suppress the unauthorized response. The out parameter `first_drop`
+ * is set to true exactly once per (bucket, window) pair. `first_collision`
+ * is set to true exactly once when a live bucket is first shared by a
+ * colliding address during a window. Either may be NULL. */
+bool ratelimit_consume_address(const ioa_addr *address, uint32_t max_requests_per_sec, bool *first_drop,
+                               bool *first_collision);
+
+/* Telemetry accessors. All are cheap, read-only, and meant to be polled by the
+ * metrics exporter at scrape time — never from the data path.
+ *
+ * ratelimit_get_collisions(): monotonic count of hash-bucket collisions since
+ *   startup (wraps at 2^32; recover the increment with unsigned subtraction).
+ * ratelimit_get_capacity(): the fixed number of buckets in the table.
+ * ratelimit_count_occupied(): number of buckets currently holding a live,
+ *   non-expired (1-second) window. Scans the whole table, so call it at most
+ *   once per scrape. */
+uint32_t ratelimit_get_collisions(void);
+uint32_t ratelimit_get_capacity(void);
+uint32_t ratelimit_count_occupied(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //__TURN_RATE_LIMIT__

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -37,7 +37,9 @@
 #include "../apps/relay/ns_ioalib_impl.h"
 #include "ns_turn_allocation.h"
 #include "ns_turn_ioalib.h"
+#include "ns_turn_maps.h"
 #include "ns_turn_msg_defs.h" // for STUN_ATTRIBUTE_NONCE
+#include "ns_turn_ratelimit.h"
 #include "ns_turn_utils.h"
 
 #include "apputils.h" // for turn_random, base64_decode
@@ -4039,6 +4041,39 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
 
     *resp_constructed = 1;
   }
+  /* UDP 401 responses are the reflection surface. Metrics cover the
+   * response decision even when mitigation is disabled. */
+  if (err_code == 401 && get_ioa_socket_type(ss->client_socket) == UDP_SOCKET) {
+    if (server->unauthenticated_401_request_cb) {
+      server->unauthenticated_401_request_cb();
+    }
+    const ioa_addr *rate_limit_address = get_remote_addr_from_ioa_socket(ss->client_socket);
+    bool first_drop = false;
+    bool first_collision = false;
+    if (server->ratelimit_unauthorized_requests && *(server->ratelimit_unauthorized_requests) && rate_limit_address &&
+        ratelimit_consume_address(rate_limit_address, (uint32_t) * (server->ratelimit_unauthorized_requests_per_sec),
+                                  &first_drop, &first_collision)) {
+      no_response = 1;
+      if (server->unauthenticated_401_dropped_response_cb) {
+        server->unauthenticated_401_dropped_response_cb();
+      }
+      if (first_drop) {
+        char raddr[INET6_ADDRSTRLEN + 1] = {0};
+        addr_to_string_no_port(rate_limit_address, raddr);
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "401 rate-limit exceeded from %s, suppressing responses for this window\n",
+                      raddr);
+      }
+    }
+    if (first_collision) {
+      char raddr[INET6_ADDRSTRLEN + 1] = {0};
+      addr_to_string_no_port(rate_limit_address, raddr);
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
+                    "401 rate-limit bucket collision from %s, sharing active bucket budget for this window\n", raddr);
+    }
+    if (!no_response && server->unauthenticated_401_response_cb) {
+      server->unauthenticated_401_response_cb();
+    }
+  }
 
   if (!no_response) {
 
@@ -5129,7 +5164,8 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
                       int sock_buf_size, allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
                       const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family,
                       bool *log_binding, bool *stun_backward_compatibility, bool *respond_http_unsupported,
-                      bool include_reason_string) {
+                      bool include_reason_string, bool *ratelimit_unauthorized_requests,
+                      vintp ratelimit_unauthorized_requests_per_sec) {
 
   if (!server) {
     return;
@@ -5211,6 +5247,9 @@ void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, io
   server->include_reason_string = include_reason_string;
 
   server->is_draining = false;
+
+  server->ratelimit_unauthorized_requests = ratelimit_unauthorized_requests;
+  server->ratelimit_unauthorized_requests_per_sec = ratelimit_unauthorized_requests_per_sec;
 }
 
 ioa_engine_handle turn_server_get_engine(turn_turnserver *s) {
@@ -5222,6 +5261,16 @@ ioa_engine_handle turn_server_get_engine(turn_turnserver *s) {
 
 void set_disconnect_cb(turn_turnserver *server, int (*disconnect)(ts_ur_super_session *)) {
   server->disconnect = disconnect;
+}
+
+void set_unauthenticated_401_metric_cbs(turn_turnserver *server, unauthenticated_401_metric_cb request_cb,
+                                        unauthenticated_401_metric_cb response_cb,
+                                        unauthenticated_401_metric_cb dropped_response_cb) {
+  if (server) {
+    server->unauthenticated_401_request_cb = request_cb;
+    server->unauthenticated_401_response_cb = response_cb;
+    server->unauthenticated_401_dropped_response_cb = dropped_response_cb;
+  }
 }
 
 //////////////////////////////////////////////////////////////////

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -112,6 +112,7 @@ typedef int (*send_turn_session_info_cb)(struct turn_session_info *tsi);
 typedef void (*send_https_socket_cb)(ioa_socket_handle s);
 
 typedef band_limit_t (*allocate_bps_cb)(band_limit_t bps, int positive);
+typedef void (*unauthenticated_401_metric_cb)(void);
 
 struct _turn_turnserver {
 
@@ -208,6 +209,18 @@ struct _turn_turnserver {
   bool is_draining;
 
   bool multiplex_peer_mode;
+
+  /* Both of these are pointers into turn_params so the CLI flags affect
+   * every relay thread without per-thread copies. The legacy version of
+   * this struct had `ratelimit_unauthorized_requests` typed as `bool`
+   * (not `bool *`), which silently truncated the parameter pointer in
+   * init_turn_server() and left the feature always-on. Keep them as
+   * pointers and dereference at use sites. */
+  bool *ratelimit_unauthorized_requests;
+  vintp ratelimit_unauthorized_requests_per_sec;
+  unauthenticated_401_metric_cb unauthenticated_401_request_cb;
+  unauthenticated_401_metric_cb unauthenticated_401_response_cb;
+  unauthenticated_401_metric_cb unauthenticated_401_dropped_response_cb;
 };
 
 const char *get_version(turn_turnserver *server);
@@ -227,7 +240,8 @@ void init_turn_server(
     int server_relay, send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
     int sock_buf_size, allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
     const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family, bool *log_binding,
-    bool *stun_backward_compatibility, bool *respond_http_unsupported, bool include_reason_string);
+    bool *stun_backward_compatibility, bool *respond_http_unsupported, bool include_reason_string,
+    bool *ratelimit_unauthorized_requests, vintp ratelimit_unauthorized_requests_per_sec);
 
 ioa_engine_handle turn_server_get_engine(turn_turnserver *s);
 
@@ -240,6 +254,9 @@ void set_rfc5780(turn_turnserver *server, get_alt_addr_cb cb, send_message_cb sm
 int open_client_connection_session(turn_turnserver *server, struct socket_message *sm);
 int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss, int force, const char *reason);
 void set_disconnect_cb(turn_turnserver *server, int (*disconnect)(ts_ur_super_session *));
+void set_unauthenticated_401_metric_cbs(turn_turnserver *server, unauthenticated_401_metric_cb request_cb,
+                                        unauthenticated_401_metric_cb response_cb,
+                                        unauthenticated_401_metric_cb dropped_response_cb);
 
 int turnserver_accept_tcp_client_data_connection(turn_turnserver *server, tcp_connection_id tcid, stun_tid *tid,
                                                  ioa_socket_handle s, int message_integrity, ioa_net_data *nd,

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -211,11 +211,10 @@ struct _turn_turnserver {
   bool multiplex_peer_mode;
 
   /* Both of these are pointers into turn_params so the CLI flags affect
-   * every relay thread without per-thread copies. The legacy version of
-   * this struct had `ratelimit_unauthorized_requests` typed as `bool`
-   * (not `bool *`), which silently truncated the parameter pointer in
-   * init_turn_server() and left the feature always-on. Keep them as
-   * pointers and dereference at use sites. */
+   * every relay thread without per-thread copies. They must stay pointers
+   * (not a `bool`/value copy): the server dereferences them live at the use
+   * sites, so a value copy would snapshot the flag at struct-init time and
+   * ignore later updates. */
   bool *ratelimit_unauthorized_requests;
   vintp ratelimit_unauthorized_requests_per_sec;
   unauthenticated_401_metric_cb unauthenticated_401_request_cb;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,9 +20,9 @@ coturn_add_test(test_ioaddr)
 coturn_add_test(test_stun_msg)
 coturn_add_test(test_base64)
 coturn_add_test(test_http_server ../src/apps/relay/http_buffer.c)
-# Redis connection-string parser (incl. TLS options). The parser unit is
-# dependency-free, so it is compiled straight into the test with no hiredis lib.
 coturn_add_test(test_redis_conninfo ../src/apps/relay/dbdrivers/dbd_redis_conninfo.c)
+coturn_add_test(test_ratelimit ../src/server/ns_turn_ratelimit.c)
+target_include_directories(test_ratelimit PRIVATE ../src/server ../src)
 
 # SQLite DB-driver interface test. Compiles the driver in isolation with a small
 # support/stub layer, so it needs the same include set the relay build uses.

--- a/tests/test_ratelimit.c
+++ b/tests/test_ratelimit.c
@@ -1,0 +1,115 @@
+#include "ns_turn_ratelimit.h"
+
+#include <unity.h>
+
+#include <stdio.h>
+
+void setUp(void) { ratelimit_init(); }
+void tearDown(void) {}
+
+static void test_live_bucket_collision_shares_exhausted_budget(void) {
+  ioa_addr victim = {0};
+  ioa_addr collider = {0};
+  bool found_collision = false;
+
+  TEST_ASSERT_EQUAL_INT(0, make_ioa_addr((const uint8_t *)"203.0.113.9", 3478, &victim));
+
+  for (unsigned int i = 0; i < 65536 && !found_collision; ++i) {
+    char candidate[INET_ADDRSTRLEN] = {0};
+    bool first_drop = false;
+    bool first_collision = false;
+
+    snprintf(candidate, sizeof(candidate), "198.18.%u.%u", i >> 8, i & 0xffu);
+    TEST_ASSERT_EQUAL_INT(0, make_ioa_addr((const uint8_t *)candidate, 3478, &collider));
+
+    ratelimit_init();
+    TEST_ASSERT_FALSE(ratelimit_consume_address(&victim, 1u, NULL, NULL));
+    found_collision =
+        ratelimit_consume_address(&collider, 1u, &first_drop, &first_collision) && first_drop && first_collision;
+  }
+
+  TEST_ASSERT_TRUE_MESSAGE(found_collision, "failed to locate a bucket collision for regression coverage");
+
+  ratelimit_init();
+  TEST_ASSERT_FALSE(ratelimit_consume_address(&victim, 1u, NULL, NULL));
+
+  bool first_drop = false;
+  bool first_collision = false;
+  TEST_ASSERT_TRUE(ratelimit_consume_address(&collider, 1u, &first_drop, &first_collision));
+  TEST_ASSERT_TRUE(first_drop);
+  TEST_ASSERT_TRUE(first_collision);
+
+  first_drop = false;
+  first_collision = false;
+  TEST_ASSERT_TRUE(ratelimit_consume_address(&collider, 1u, &first_drop, &first_collision));
+  TEST_ASSERT_FALSE(first_drop);
+  TEST_ASSERT_FALSE(first_collision);
+
+  first_drop = false;
+  first_collision = false;
+  TEST_ASSERT_TRUE(ratelimit_consume_address(&victim, 1u, &first_drop, &first_collision));
+  TEST_ASSERT_FALSE(first_drop);
+  TEST_ASSERT_FALSE(first_collision);
+}
+
+static void test_capacity_is_nonzero_power_of_two(void) {
+  uint32_t cap = ratelimit_get_capacity();
+  TEST_ASSERT_GREATER_THAN_UINT32(0u, cap);
+  TEST_ASSERT_EQUAL_UINT32(0u, cap & (cap - 1u));
+}
+
+static void test_occupancy_tracks_live_buckets(void) {
+  ioa_addr a = {0};
+  TEST_ASSERT_EQUAL_INT(0, make_ioa_addr((const uint8_t *)"203.0.113.9", 3478, &a));
+
+  ratelimit_init();
+  TEST_ASSERT_EQUAL_UINT32(0u, ratelimit_count_occupied());
+
+  /* The first consume opens a window in exactly one bucket. */
+  TEST_ASSERT_FALSE(ratelimit_consume_address(&a, 5u, NULL, NULL));
+  TEST_ASSERT_EQUAL_UINT32(1u, ratelimit_count_occupied());
+}
+
+static void test_collision_counter_counts_every_collision(void) {
+  ioa_addr victim = {0};
+  ioa_addr collider = {0};
+  bool found_collision = false;
+
+  TEST_ASSERT_EQUAL_INT(0, make_ioa_addr((const uint8_t *)"203.0.113.9", 3478, &victim));
+
+  /* Locate an address that hashes into the victim's bucket. */
+  for (unsigned int i = 0; i < 65536 && !found_collision; ++i) {
+    char candidate[INET_ADDRSTRLEN] = {0};
+    bool first_collision = false;
+
+    snprintf(candidate, sizeof(candidate), "198.18.%u.%u", i >> 8, i & 0xffu);
+    TEST_ASSERT_EQUAL_INT(0, make_ioa_addr((const uint8_t *)candidate, 3478, &collider));
+
+    ratelimit_init();
+    TEST_ASSERT_FALSE(ratelimit_consume_address(&victim, 1u, NULL, NULL));
+    found_collision = ratelimit_consume_address(&collider, 1u, NULL, &first_collision) && first_collision;
+  }
+  TEST_ASSERT_TRUE_MESSAGE(found_collision, "failed to locate a bucket collision for counter coverage");
+
+  ratelimit_init();
+  TEST_ASSERT_EQUAL_UINT32(0u, ratelimit_get_collisions());
+
+  /* The bucket owner's own request is never a collision. */
+  TEST_ASSERT_FALSE(ratelimit_consume_address(&victim, 1u, NULL, NULL));
+  TEST_ASSERT_EQUAL_UINT32(0u, ratelimit_get_collisions());
+
+  /* Every colliding request is counted, not just the first one in the window. */
+  ratelimit_consume_address(&collider, 1u, NULL, NULL);
+  TEST_ASSERT_EQUAL_UINT32(1u, ratelimit_get_collisions());
+  ratelimit_consume_address(&collider, 1u, NULL, NULL);
+  TEST_ASSERT_EQUAL_UINT32(2u, ratelimit_get_collisions());
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_live_bucket_collision_shares_exhausted_budget);
+  RUN_TEST(test_capacity_is_nonzero_power_of_two);
+  RUN_TEST(test_occupancy_tracks_live_buckets);
+  RUN_TEST(test_collision_counter_counts_every_collision);
+  return UNITY_END();
+}


### PR DESCRIPTION
TURN/STUN long-term auth answers the first unauthenticated request with a 401 Unauthorized carrying REALM/NONCE. On UDP, where source addresses are spoofable and the 401 is larger than the request that triggers it, the server becomes a reflection/amplification vector: an attacker forges a victim's source IP and bounces amplified 401s at it.

This adds an opt-in mitigation that caps how many UDP 401 responses the server emits toward any single source IP per second. Past the cap the server stays silent, denying both the reflection and the amplification. Authenticated relay traffic is untouched — only requests that reach the 401 branch spend budget.

Flags (off by default):
  --unauthorized-ratelimit            Enable the mitigation (UDP only).
  --unauthorized-ratelimit-rps=<n>    Max 401 responses per source IP per second. Default 10.

Implementation:
- Lock-free, fixed 4096-bucket direct-mapped table (~80 KiB, no malloc/free, no lock, no list scan on the hot path); the source IP appears only as a 32-bit tag, never as a pointer. The port is stripped from the key so an attacker cannot evade the limit by rotating the source port. A fixed 1-second window backs the per-second limit.
- Colliding addresses share the live bucket budget instead of receiving a fresh allowance, so hash collisions can never expand reflected output.
- Drop and collision diagnostics are each latched to one log line per (bucket, window) to avoid log amplification.
- Portable 32-bit atomics over C11 <stdatomic.h> with an MSVC Interlocked* fallback; the on/off flag and the per-second threshold are pointers into turn_params so every relay thread sees live CLI values without per-thread copies.

Observability (Prometheus):
- turn_unauthenticated_401_{requests,responses,dropped_responses}
- turn_ratelimit_{hash_collisions,occupied_buckets,total_buckets}

Tests & docs:
- Unity unit test (tests/test_ratelimit.c) covering live-bucket collisions, occupancy tracking, and the collision counter.
- End-to-end positive/negative system test (run_tests_ratelimit_401.sh) and a Prometheus counter test (run_tests_prom.sh).
- A 401-response-flood load harness under examples/loadtest/.
- docs/401-ratelimit.md design note, plus man page, README, Prometheus docs, and the example/Docker turnserver.conf entries.