### PR TITLE
Fix realm quota data race and warnings

### DIFF
--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -103,7 +103,7 @@ static MHD_RESULT promhttp_handler(void *cls, struct MHD_Connection *connection,
     status = MHD_HTTP_METHOD_NOT_ALLOWED;
     body = "method not allowed";
   } else if (strcmp(url, turn_params.prometheus_path) == 0) {
-    body = (char *)prom_collector_registry_bridge(PROM_COLLECTOR_REGISTRY_DEFAULT);
+    body = prom_collector_registry_bridge(PROM_COLLECTOR_REGISTRY_DEFAULT);
     if (body == NULL) {
       return MHD_NO;
     }

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -668,9 +668,16 @@ int check_new_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
   if (user || oauth) {
     uint8_t *username = oauth ? (uint8_t *)strdup("") : (uint8_t *)get_real_username((char *)user);
     realm_params_t *rp = get_realm((char *)realm);
+    /* Snapshot the realm quota configuration under the realms lock. These
+     * fields are written by reread_realms()/change_*_quota() while holding
+     * lock_realms(), so reading them under the per-realm alloc_counters lock
+     * below (a different mutex) would be a data race. */
+    lock_realms();
+    const vint total_quota = rp->options.perf_options.total_quota;
+    const vint user_quota = rp->options.perf_options.user_quota;
+    unlock_realms();
     ur_string_map_lock(rp->status.alloc_counters);
-    if (rp->options.perf_options.total_quota &&
-        (rp->status.total_current_allocs >= rp->options.perf_options.total_quota)) {
+    if (total_quota && (rp->status.total_current_allocs >= total_quota)) {
       ret = -1;
     } else if (username[0]) {
       ur_string_map_value_type value = 0;
@@ -679,7 +686,7 @@ int check_new_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
         ur_string_map_put(rp->status.alloc_counters, (ur_string_map_key_type)username, value);
         ++(rp->status.total_current_allocs);
       } else {
-        if ((rp->options.perf_options.user_quota) && ((size_t)value >= (size_t)(rp->options.perf_options.user_quota))) {
+        if ((user_quota) && ((size_t)value >= (size_t)user_quota)) {
           ret = -1;
         } else {
           value = (ur_string_map_value_type)(((size_t)value) + 1);

--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -566,7 +566,7 @@ static int uclient_tx_flush(void) {
   return sent;
 }
 
-void uclient_send_batch_begin(void) {
+static void uclient_send_batch_begin(void) {
   uclient_tx_state *st = &uclient_tx_batch;
   if (st->depth == 0) {
     st->count = 0;
@@ -577,7 +577,7 @@ void uclient_send_batch_begin(void) {
   ++st->depth;
 }
 
-void uclient_send_batch_end(void) {
+static void uclient_send_batch_end(void) {
   uclient_tx_state *st = &uclient_tx_batch;
   if (st->depth == 0) {
     return;
@@ -621,8 +621,8 @@ static bool uclient_tx_enqueue(evutil_socket_t fd, const void *data, size_t len)
   return true;
 }
 #else  /* !__linux__ */
-void uclient_send_batch_begin(void) {}
-void uclient_send_batch_end(void) {}
+static void uclient_send_batch_begin(void) {}
+static void uclient_send_batch_end(void) {}
 static bool uclient_tx_enqueue(evutil_socket_t fd, const void *data, size_t len) {
   (void)fd;
   (void)data;
@@ -1570,6 +1570,7 @@ recv_again:
  * Extracted from client_read() so the Linux recvmmsg batch path can reuse
  * the per-packet processing without going through recv_buffer() again. */
 static int process_received_buffer(app_ur_session *elem, int is_tcp_data, app_tcp_conn_info *atc, int rc) {
+  UNUSED_ARG(atc);
 
   app_ur_conn_info *clnet_info = &(elem->pinfo);
   int err_code = 0;

--- a/src/prometheus/prom.c
+++ b/src/prometheus/prom.c
@@ -435,7 +435,7 @@ static void prom_metric_render(prom_buf_t *b, prom_metric_t *m) {
   pthread_mutex_unlock(&m->mutex);
 }
 
-const char *prom_collector_registry_bridge(prom_collector_registry_t *registry) {
+char *prom_collector_registry_bridge(prom_collector_registry_t *registry) {
   if (registry == NULL) {
     return NULL;
   }

--- a/src/prometheus/prom.h
+++ b/src/prometheus/prom.h
@@ -75,7 +75,7 @@ prom_metric_t *prom_collector_registry_must_register_metric(prom_metric_t *metri
 /* Render every registered metric in Prometheus text-exposition format. Returns
  * a heap-allocated NUL-terminated string the caller must free(), or NULL on
  * allocation failure. */
-const char *prom_collector_registry_bridge(prom_collector_registry_t *registry);
+char *prom_collector_registry_bridge(prom_collector_registry_t *registry);
 
 /* Counters: monotonically increasing values. label_keys may be NULL when
  * label_key_count is 0. */


### PR DESCRIPTION
## Summary

Fixes a pre-existing data race on per-realm quota configuration, plus a small
compiler-warning cleanup in the same area. Both are independent of any feature
work — they were surfaced by a ThreadSanitizer CI run and the build's warning
flags respectively.

## 1. Data race on realm quota fields

`check_new_allocation_quota()` (called from relay threads on every allocation)
read `rp->options.perf_options.total_quota` and `user_quota` while holding only
the **per-realm `alloc_counters` map lock**. Those same fields are written by:

- `reread_realms()` — runs in the auth-server thread at startup and every 5s, and
- `change_total_quota()` / `change_user_quota()`

…all of which hold **`lock_realms()`** — a *different* mutex. The two sides
therefore touched the quota configuration with no common lock, a genuine data
race (ThreadSanitizer reports it in `reread_realms`, firing when the periodic
write overlaps a relay thread mid-allocation).

**Fix:** snapshot the two quota values under `lock_realms()` before taking the
`alloc_counters` lock, so the read is properly ordered against the writers. The
realms lock is released before the `alloc_counters` lock is taken, so no new lock
nesting is introduced. `max_bps` is unaffected — it is read either via atomics
(`get_max_bps()`) or from a per-session copy taken under `lock_realms()` at
allocation time.

**Validation:** ThreadSanitizer build (`-fsanitize=thread`) running
`examples/run_tests_conf.sh` repeatedly:

| | conf-test result | `reread_realms` races |
|---|---|---|
| before | all pass | **6** across the run |
| after  | all pass | **0** |

## 2. Compiler-warning cleanup

Clears the coturn-source warnings the CI build emits (`-Wcast-qual`,
`-Wmissing-prototypes`, `-Wunused-parameter`):

- **`prom_collector_registry_bridge()`** returns a heap buffer the caller owns and
  `free()`s (rendered into an `MHD_RESPMEM_MUST_FREE` response), but was typed
  `const char *`, forcing a const-discarding cast at its only call site. Returns
  `char *` now, matching the documented ownership transfer, and the cast is gone.
- **`uclient_send_batch_begin()` / `uclient_send_batch_end()`** are used only
  within `uclient.c`; both the Linux and the non-Linux stub definitions are now
  `static`.
- **`process_received_buffer()`**'s unused `atc` parameter is marked with
  `UNUSED_ARG`.

Verified by rebuilding with those three flags (warnings gone from the affected
files) and confirming the third-party-only `libbson` cast-qual warning is left
untouched.

## Testing

- Unit tests: all 11 pass (incl. `test_prometheus`, which exercises the changed
  bridge function).
- `examples/run_tests_conf.sh` passes under ThreadSanitizer with 0 `reread_realms`
  races (was 6).
- `clang-format` clean on all changed files.
