### PR TITLE
Update to 4.14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 # TODO: Modify this when the version is released
-SET(BUILD_VERSION "4.13.1")
+SET(BUILD_VERSION "4.14.0")
 
 # Find Git Version Patch
 IF(EXISTS "${CMAKE_SOURCE_DIR}/.git")

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,28 @@
+Release 4.14.0
+
+Changelist:
+- Add multiplex-peer tagging to share one peer IP:port across sessions (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Add per-source rate-limiting of UDP 401 Unauthorized responses (#1957) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Fix realm quota data race and warnings (#1958) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Prom https (#1956) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Build Prometheus exporter from vendored local sources (#1955) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- fix signed-char index out-of-bounds read in base64_decode (#1950) (alhuda <50839256+alhudz@users.noreply.github.com>)
+- Flush prometheus hot-path counters once per second to kill lock contention (#1954) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Fix relay threads override (#1953) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Add optional TLS transport for Redis connections (#1951) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Add out-of-tree patch to restore deprecated OpenSSL 1.1.1 support (#1952) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- validate hmackey length in sqlite_get_user_key before hex decode (#1948) (alhuda <50839256+alhudz@users.noreply.github.com>)
+- Upgrade Docker image to 4.13.1 Coturn version (Kai Ren <tyranron@gmail.com>)
+- Upgrade Docker image to 4.13.0 Coturn version (Kai Ren <tyranron@gmail.com>)
+- Upgrade Alpine 3.24 version in Docker image (Kai Ren <tyranron@gmail.com>)
+- Update Debian "trixie" to 20260610 snapshot in Docker image (Kai Ren <tyranron@gmail.com>)
+
+Contributors:
+- Kai Ren <tyranron@gmail.com>
+- Pavel Punsky <eakraly@users.noreply.github.com>
+- alhuda <50839256+alhudz@users.noreply.github.com>
+- dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+
 Release 4.13.1
 
 Changelist:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,9 @@
 Release 4.14.0
 
 Changelist:
-- Add multiplex-peer tagging to share one peer IP:port across sessions (Pavel Punsky <eakraly@users.noreply.github.com>)
-- Add per-source rate-limiting of UDP 401 Unauthorized responses (#1957) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Experimental: Add per-source rate-limiting of UDP 401 Unauthorized responses (#1957) (Pavel Punsky <eakraly@users.noreply.github.com>)
+- Experimental: Prom https (#1956) (Pavel Punsky <eakraly@users.noreply.github.com>)
 - Fix realm quota data race and warnings (#1958) (Pavel Punsky <eakraly@users.noreply.github.com>)
-- Prom https (#1956) (Pavel Punsky <eakraly@users.noreply.github.com>)
 - Build Prometheus exporter from vendored local sources (#1955) (Pavel Punsky <eakraly@users.noreply.github.com>)
 - fix signed-char index out-of-bounds read in base64_decode (#1950) (alhuda <50839256+alhudz@users.noreply.github.com>)
 - Flush prometheus hot-path counters once per second to kill lock contention (#1954) (Pavel Punsky <eakraly@users.noreply.github.com>)
@@ -12,16 +11,11 @@ Changelist:
 - Add optional TLS transport for Redis connections (#1951) (Pavel Punsky <eakraly@users.noreply.github.com>)
 - Add out-of-tree patch to restore deprecated OpenSSL 1.1.1 support (#1952) (Pavel Punsky <eakraly@users.noreply.github.com>)
 - validate hmackey length in sqlite_get_user_key before hex decode (#1948) (alhuda <50839256+alhudz@users.noreply.github.com>)
-- Upgrade Docker image to 4.13.1 Coturn version (Kai Ren <tyranron@gmail.com>)
-- Upgrade Docker image to 4.13.0 Coturn version (Kai Ren <tyranron@gmail.com>)
-- Upgrade Alpine 3.24 version in Docker image (Kai Ren <tyranron@gmail.com>)
-- Update Debian "trixie" to 20260610 snapshot in Docker image (Kai Ren <tyranron@gmail.com>)
 
 Contributors:
 - Kai Ren <tyranron@gmail.com>
 - Pavel Punsky <eakraly@users.noreply.github.com>
 - alhuda <50839256+alhudz@users.noreply.github.com>
-- dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 
 Release 4.13.1
 

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -35,7 +35,7 @@
 #ifndef __IOADEFS__
 #define __IOADEFS__
 
-#define TURN_SERVER_VERSION "4.13.1"
+#define TURN_SERVER_VERSION "4.14.0"
 #define TURN_SERVER_VERSION_NAME "Gorst"
 #ifndef TURN_SERVER_BUILD_INFO
 #define TURN_SERVER_BUILD_INFO ""


### PR DESCRIPTION
Changelist:
- **Experimental**: Add per-source rate-limiting of UDP 401 Unauthorized responses (#1957) 
- **Experimental**: Prom https (#1956)
- Fix realm quota data race and warnings (#1958)
- Build Prometheus exporter from vendored local sources (#1955) 
- fix signed-char index out-of-bounds read in base64_decode (#1950)
- Flush prometheus hot-path counters once per second to kill lock contention (#1954)
- Fix relay threads override (#1953)
- Add optional TLS transport for Redis connections (#1951)
- Add out-of-tree patch to restore deprecated OpenSSL 1.1.1 support (#1952) 
- validate hmackey length in sqlite_get_user_key before hex decode (#1948) 