### PR TITLE
configure: detect hiredis_ssl for Redis TLS in autotools build

### DIFF
--- a/configure
+++ b/configure
@@ -969,6 +969,15 @@ fi
 if [ -z "${TURN_NO_HIREDIS}" ] ; then
     if testpkg_db hiredis; then
         ${ECHO_CMD} "Hiredis found."
+        # Optional TLS transport to Redis, provided by the separate
+        # hiredis_ssl library. Mirror the CMake build which defines
+        # TURN_HAVE_HIREDIS_SSL when this companion library is present.
+        if testpkg_db hiredis_ssl; then
+            ${ECHO_CMD} "Hiredis SSL found."
+            TURN_HAVE_HIREDIS_SSL="-DTURN_HAVE_HIREDIS_SSL"
+        else
+            ${ECHO_CMD} "Hiredis SSL not found. Building without Redis TLS support."
+        fi
     else
         ${ECHO_CMD} "Hiredis not found. Building without hiredis support."
         TURN_NO_HIREDIS="-DTURN_NO_HIREDIS"
@@ -1061,7 +1070,7 @@ ${ECHO_CMD} "LDFLAGS += ${OSLIBS}" >> Makefile
 ${ECHO_CMD} "DBLIBS += ${DBLIBS}" >> Makefile
 ${ECHO_CMD} "CFLAGS += ${OSCFLAGS}" >> Makefile
 ${ECHO_CMD} "CPPFLAGS = ${CPPFLAGS}" >> Makefile
-${ECHO_CMD} "DBCFLAGS += ${DBCFLAGS} ${TURN_NO_PQ} ${TURN_NO_MYSQL} ${TURN_NO_SQLITE} ${TURN_NO_MONGO} ${TURN_NO_HIREDIS} ${TURN_NO_SYSTEMD}" >> Makefile
+${ECHO_CMD} "DBCFLAGS += ${DBCFLAGS} ${TURN_NO_PQ} ${TURN_NO_MYSQL} ${TURN_NO_SQLITE} ${TURN_NO_MONGO} ${TURN_NO_HIREDIS} ${TURN_HAVE_HIREDIS_SSL} ${TURN_NO_SYSTEMD}" >> Makefile
 ${ECHO_CMD} "#" >> Makefile
 ${ECHO_CMD} "PORTNAME = ${PORTNAME}" >> Makefile
 ${ECHO_CMD} "PREFIX = ${PREFIX}" >> Makefile


### PR DESCRIPTION
## What

The CMake build defines `TURN_HAVE_HIREDIS_SSL` and links the separate `hiredis_ssl` companion library when present (see [src/apps/relay/CMakeLists.txt:136-140](https://github.com/coturn/coturn/blob/master/src/apps/relay/CMakeLists.txt#L136-L140)), enabling TLS transport to Redis. The autotools `configure` script lacked this probe, so Makefile-based builds always compiled with `TURN_HAVE_HIREDIS_SSL` undefined and silently dropped Redis TLS support.

## Change

Mirror the CMake behavior in `configure`:

- When hiredis itself is found, additionally probe for `hiredis_ssl` via `pkg-config` (`testpkg_db hiredis_ssl`), which wires its cflags/libs into `DBCFLAGS`/`DBLIBS`.
- Emit `-DTURN_HAVE_HIREDIS_SSL` into `DBCFLAGS` when the companion library is present; otherwise log that the build proceeds without Redis TLS support.

This brings the two build systems to parity — the `#if defined(TURN_HAVE_HIREDIS_SSL)` guards in `dbd_redis.c` and `hiredis_libevent2.c` are now reachable from the autotools build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)