### PR TITLE
null-terminate http request buffer before verbose %s log

### DIFF
--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4741,6 +4741,7 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
   if (sat == HTTP_CLIENT_SOCKET) {
 
     if (server->verbose) {
+      ((char *)ioa_network_buffer_data(in_buffer->nbh))[ioa_network_buffer_get_size(in_buffer->nbh)] = 0;
       TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s: HTTP connection input: %s\n", __FUNCTION__,
                     (char *)ioa_network_buffer_data(in_buffer->nbh));
     }


### PR DESCRIPTION
Repro: send an HTTP request to a worker with web-admin enabled and `--verbose` so the socket becomes `HTTP_CLIENT_SOCKET`, then a follow-up request reaches the log in `read_client_connection`.

Cause: the `%s` prints `ioa_network_buffer_data()` directly, but the receive buffer holds `buf.len` bytes with no terminator, so it over-reads past the request into stale pooled-buffer bytes (and past the 65507-byte allocation when the region has no `NUL`). `handle_https` and `web_admin_input_handler` in `turn_admin_server.c` already terminate before their `%s`/`strstr`; this site did not.

Fix: write `data[get_size()] = 0` before the log, matching those sibling handlers.