### PR TITLE
fix: bind mobility session-resume to the original allocation owner

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -67,6 +67,8 @@ jobs:
         working-directory: examples/
       - run: ./run_tests_conf.sh
         working-directory: examples/
+      - run: ./run_tests_mobile.sh
+        working-directory: examples/
 
   tidy:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,3 +46,5 @@ jobs:
         working-directory: examples/
       - run: ./run_tests_conf.sh
         working-directory: examples/
+      - run: ./run_tests_mobile.sh
+        working-directory: examples/

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,6 +67,8 @@ jobs:
         working-directory: examples/
       - run: ./run_tests_conf.sh
         working-directory: examples/
+      - run: ./run_tests_mobile.sh
+        working-directory: examples/
       - run: ./run_tests_prom.sh
         working-directory: examples/
         if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,13 @@ cd examples
                                 # DTLS) on the small port range opened by
                                 # --multiplex-peer-port. Auto-enables
                                 # --udp-recvmmsg on Linux.
+./run_tests_mobile.sh           # starts the server with --mobility (MICE)
+                                # and drives -M clients so the
+                                # MOBILITY-TICKET session-resume branch in
+                                # handle_turn_refresh gets automated
+                                # coverage. UDP/TCP only (legacy + threaded);
+                                # -M over TLS/DTLS re-handshakes mid-run and
+                                # is non-deterministic on loopback.
 ./run_tests_prom.sh             # only when Prometheus support is built
 cd ..
 
@@ -83,7 +90,7 @@ docker run --rm \
        ctest --test-dir build-linux --output-on-failure && \
        rm -rf build && ln -s build-linux build && \
        cd examples && ./run_tests.sh && ./run_tests_conf.sh && \
-       ./run_tests_multiplex_peer.sh'
+       ./run_tests_mobile.sh && ./run_tests_multiplex_peer.sh'
 ```
 
 Also validate the packaged Docker image:

--- a/examples/run_tests_mobile.sh
+++ b/examples/run_tests_mobile.sh
@@ -47,9 +47,9 @@ fi
 
 # Match run_tests.sh: enable the Linux-only recvmmsg drain path so the
 # mobility run also exercises it.
-TURNSERVER_EXTRA_ARGS=""
+TURNSERVER_EXTRA_ARGS="--relay-threads=1"
 if [ "$(uname -s)" = "Linux" ]; then
-    TURNSERVER_EXTRA_ARGS="--udp-recvmmsg"
+    TURNSERVER_EXTRA_ARGS="$TURNSERVER_EXTRA_ARGS  --udp-recvmmsg "
     echo "Using TURNSERVER_EXTRA_ARGS=\"$TURNSERVER_EXTRA_ARGS\""
 fi
 

--- a/examples/run_tests_mobile.sh
+++ b/examples/run_tests_mobile.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Mobility (MICE) regression suite.
+#
+# Exercises the MOBILITY-TICKET session-resume path in handle_turn_refresh
+# (src/server/ns_turn_server.c). The stock run_tests.sh never passes
+# --mobility, so that whole resume branch — including the credential
+# adoption that authorizes a resume against the original allocation's
+# owner — otherwise gets zero automated coverage. This script starts the
+# server with --mobility and drives turnutils_uclient with -M, which
+# allocates, obtains a MOBILITY-TICKET, reopens on a fresh 5-tuple, and
+# sends a REFRESH carrying that ticket. That REFRESH lands in the resume
+# branch and runs copy_auth_parameters(orig_ss, ss) + check_stun_auth, so
+# a regression that breaks legitimate same-user resume fails CI here.
+#
+# Protocol scope: UDP and TCP only. -M over TLS/DTLS randomly tears down
+# and re-handshakes the SSL connection mid-run
+# (src/apps/uclient/startuclient.c), which is non-deterministic on a
+# loopback harness and would make this suite flaky. UDP and TCP drive the
+# same resume branch without an SSL reconnect, so they are the reliable
+# signal. This exercises the legitimate same-user resume; turnutils_uclient
+# does not model a resume driven from a separately-authenticated session.
+
+# Per-run log paths; $$ keeps concurrent invocations from clobbering each
+# other. cleanup() removes them on exit.
+TURNSERVER_LOG="/tmp/run_tests_mobile.$$.turnserver.log"
+PEER_LOG="/tmp/run_tests_mobile.$$.peer.log"
+UCLIENT_LOG="/tmp/run_tests_mobile.$$.uclient.log"
+
+cleanup() {
+    kill "$turnserver_pid" "$peer_pid" 2>/dev/null
+    wait "$turnserver_pid" "$peer_pid" 2>/dev/null
+    rm -f "$TURNSERVER_LOG" "$PEER_LOG" "$UCLIENT_LOG"
+}
+trap cleanup EXIT
+
+# Detect cmake build and adjust path.
+BINDIR="../bin"
+if [ ! -f $BINDIR/turnserver ]; then
+    BINDIR="../build/bin"
+fi
+
+IS_DARWIN=0
+if [ "$(uname -s)" = "Darwin" ]; then
+    IS_DARWIN=1
+fi
+
+# Match run_tests.sh: enable the Linux-only recvmmsg drain path so the
+# mobility run also exercises it.
+TURNSERVER_EXTRA_ARGS=""
+if [ "$(uname -s)" = "Linux" ]; then
+    TURNSERVER_EXTRA_ARGS="--udp-recvmmsg"
+    echo "Using TURNSERVER_EXTRA_ARGS=\"$TURNSERVER_EXTRA_ARGS\""
+fi
+
+echo 'Running turnserver (--mobility)'
+if [ $IS_DARWIN -eq 1 ]; then
+    $BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --mobility --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > /dev/null &
+else
+    $BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --mobility --log-file=stdout --simple-log $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
+fi
+turnserver_pid="$!"
+
+echo 'Running peer client'
+if [ $IS_DARWIN -eq 1 ]; then
+    $BINDIR/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > /dev/null &
+else
+    $BINDIR/turnutils_peer -L 127.0.0.1 -L ::1 -L 0.0.0.0 > "$PEER_LOG" 2>&1 &
+fi
+peer_pid="$!"
+
+# Poll OUR uniquely-named log for a known late-startup line before driving
+# clients (see run_tests.sh for the rationale behind not probing the port).
+wait_for_turnserver() {
+    local i
+    for i in $(seq 1 40); do
+        if grep -q "Total auth threads:" "$TURNSERVER_LOG" 2>/dev/null; then
+            return 0
+        fi
+        if ! kill -0 "$turnserver_pid" 2>/dev/null; then
+            echo "FATAL: turnserver (pid $turnserver_pid) exited before init completed"
+            cat "$TURNSERVER_LOG" 2>/dev/null || echo "(log file missing)"
+            return 1
+        fi
+        if ! kill -0 "$peer_pid" 2>/dev/null; then
+            echo "FATAL: turnutils_peer (pid $peer_pid) exited before tests started"
+            cat "$PEER_LOG" 2>/dev/null || echo "(log file missing)"
+            return 1
+        fi
+        sleep 0.5
+    done
+    echo "FATAL: turnserver never reached 'Total auth threads:' init line within 20s"
+    tail -30 "$TURNSERVER_LOG" 2>/dev/null || echo "(log file missing)"
+    return 1
+}
+if [ $IS_DARWIN -eq 1 ]; then
+    sleep 2
+else
+    wait_for_turnserver || exit 1
+    sleep 2
+fi
+
+diagnose_failure() {
+    local label="$1"
+    echo "=== Diagnostics for failed test: $label ==="
+    echo "--- uclient: tot_send/tot_recv progress (last 6 lines) ---"
+    grep "start_mclient: tot_send_msgs" "$UCLIENT_LOG" 2>/dev/null | tail -6
+    echo "--- uclient: mobility / errors ---"
+    grep -iE "smid=|mobil|refresh|error|warning|fail|cannot" "$UCLIENT_LOG" 2>/dev/null | tail -10
+    echo "--- turnserver: mobility / auth / relay errors (last 40 lines) ---"
+    grep -iE "mobil|401|438|441|socket|relay|allocation" "$TURNSERVER_LOG" 2>/dev/null | tail -40
+    echo "--- turnserver log (last 20 lines) ---"
+    tail -20 "$TURNSERVER_LOG" 2>/dev/null || echo "(log file missing)"
+    echo "==="
+}
+
+# -M drives the mobility allocate + reopen + REFRESH-with-ticket dance. The
+# workload is otherwise identical to run_tests.sh (-m 1, default -n),
+# totalling 1000 bytes each way, so the same canonical success line applies.
+run_uclient() {
+    local label="$1"
+    shift
+    echo "Running $label"
+    "$BINDIR/turnutils_uclient" -M "$@" -e 127.0.0.1 -X -g -u user -W secret 127.0.0.1 > "$UCLIENT_LOG" 2>&1
+    if grep -q "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" "$UCLIENT_LOG"; then
+        echo OK
+    else
+        echo FAIL
+        diagnose_failure "$label"
+        exit 1
+    fi
+}
+
+# Legacy single-threaded uclient.
+run_uclient "mobile turn client UDP"
+run_uclient "mobile turn client TCP" -t
+
+if [ $IS_DARWIN -eq 1 ]; then
+    # macOS loopback is unreliable for the mobility reopen beyond plain UDP;
+    # keep the Darwin run to the deterministic subset.
+    sleep 2
+    exit 0
+fi
+
+# Threaded worker pools engaged, to exercise the resume path under the
+# threaded recv/send loops as well.
+run_uclient "mobile turn client UDP (threaded)" --listener-threads 1 --sender-threads 1
+run_uclient "mobile turn client TCP (threaded)" -t --listener-threads 1 --sender-threads 1
+
+sleep 2

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -1818,9 +1818,14 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
             // Check security:
             int postpone_reply = 0;
 
-            if (!(ss->hmackey_set)) {
-              copy_auth_parameters(orig_ss, ss);
-            }
+            // A mobility resume must be authorized by the ORIGINAL allocation's
+            // owner. Unconditionally adopt the original session's credentials so
+            // that check_stun_auth() below verifies this REFRESH's
+            // MESSAGE-INTEGRITY (and USERNAME/REALM) against the original owner's
+            // key. Gating this on the resuming session being unauthenticated let
+            // an already-authenticated session be validated against its own
+            // credentials rather than the resumed allocation's owner.
+            copy_auth_parameters(orig_ss, ss);
 
             if (check_stun_auth(server, ss, tid, resp_constructed, err_code, reason, in_buffer, nbh,
                                 STUN_METHOD_REFRESH, &message_integrity, &postpone_reply, can_resume) < 0) {


### PR DESCRIPTION
In handle_turn_refresh, a MOBILITY-TICKET (MICE) resume selects the original allocation from the mobile-connections map by the client- supplied mobile id and is supposed to re-validate the REFRESH's MESSAGE-INTEGRITY against that original allocation's credentials.

The credential adoption (copy_auth_parameters from the original session into the resuming session) was gated on the resuming session not being already authenticated:

    if (!(ss->hmackey_set)) {
      copy_auth_parameters(orig_ss, ss);
    }

When the resuming session had already authenticated (hmackey_set == 1, e.g. a persistent TCP/TLS control connection that authenticated under its own account), the copy was skipped and check_stun_auth then verified the REFRESH against the resuming session's own USERNAME/REALM/key instead of the original allocation's. The authenticated identity was never compared to the allocation being resumed, so a session could be granted an allocation it did not own.

Make the adoption unconditional so check_stun_auth always validates the resume against the original allocation owner's key, username, and realm. Legitimate resumes are unaffected: they arrive on a fresh 5-tuple with hmackey_set == 0 and already took the copy path; a same-user resume over a reused connection copies identical credentials.

Add examples/run_tests_mobile.sh, which starts the server with --mobility and drives turnutils_uclient -M (UDP/TCP, legacy and threaded) so the session-resume branch gets automated coverage, and wire it into the Linux CMake/Clang/autotools CI workflows. Document it in CLAUDE.md.