### PR TITLE
bound mssp subnegotiation parse to the buffer end

### DIFF
--- a/src/apps/relay/libtelnet.c
+++ b/src/apps/relay/libtelnet.c
@@ -706,7 +706,9 @@ static int _mssp_telnet(telnet_t *telnet, char *buffer, size_t size) {
 
     /* remember our next type and increment c for next loop run */
     last = out;
-    next_type = *c++;
+    if (c < buffer + size) {
+      next_type = *c++;
+    }
   }
 
   /* invoke event with our arguments */


### PR DESCRIPTION
`_mssp_telnet` scans each MSSP field up to the next `VAR`/`VAL` marker, then reads that marker with `next_type = *c++` to type the following field. When the final field has no trailing marker (the normal case) the inner scan leaves `c` at `buffer + size`, so the read touches `buffer[size]`, one byte past the allocation. It is reachable pre-auth over the telnet CLI (`telnet_recv` -> `_process` -> `_subnegotiate` dispatches telopt 70 here); ASan reports a heap-buffer-overflow read when the subnegotiation payload exactly fills the 512-byte buffer bucket.

Guard the marker read with `c < buffer + size`, matching the inner scan and the sibling `_environ_telnet` parser, which already bound every `*c++`. Keeping the check on the read means a field that runs to the buffer end ends the loop instead of reading past it.