### PR TITLE
fix: send SNI host name in turnutils_uclient TLS connections

### DIFF
--- a/src/apps/uclient/startuclient.c
+++ b/src/apps/uclient/startuclient.c
@@ -101,13 +101,25 @@ static int get_allocate_address_family(ioa_addr *relay_addr) {
 
 /////////////////////////////////////////
 
-static SSL *tls_connect(ioa_socket_raw fd, ioa_addr *remote_addr, bool *try_again, int connect_cycle) {
+static SSL *tls_connect(ioa_socket_raw fd, ioa_addr *remote_addr, const char *remote_host, bool *try_again,
+                        int connect_cycle) {
 
   const int ctxtype = (int)(((unsigned long)turn_random_number()) % root_tls_ctx_num);
 
   SSL *const ssl = SSL_new(root_tls_ctx[ctxtype]);
 
   SSL_set_alpn_protos(ssl, kALPNProtos, kALPNProtosLen);
+
+  /* RFC 6066 section 3: SNI carries DNS hostnames only, never IP literals. */
+  if (remote_host && remote_host[0]) {
+    struct in_addr v4;
+    struct in6_addr v6;
+    if (inet_pton(AF_INET, remote_host, &v4) != 1 && inet_pton(AF_INET6, remote_host, &v6) != 1) {
+      if (SSL_set_tlsext_host_name(ssl, remote_host) != 1) {
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "%s: cannot set SNI host name '%s'\n", __FUNCTION__, remote_host);
+      }
+    }
+  }
 
   if (use_tcp) {
     SSL_set_fd(ssl, fd);
@@ -328,7 +340,7 @@ start_socket:
 
   if (use_secure && clnet_info) {
     bool try_again = false;
-    clnet_info->ssl = tls_connect(clnet_info->fd, &remote_addr, &try_again, connect_cycle++);
+    clnet_info->ssl = tls_connect(clnet_info->fd, &remote_addr, remote_address, &try_again, connect_cycle++);
     if (!clnet_info->ssl) {
       if (try_again) {
         goto start_socket;
@@ -1778,7 +1790,8 @@ again:
   if (use_secure) {
     bool try_again = false;
     elem->pinfo.tcp_conn[i]->tcp_data_ssl =
-        tls_connect(elem->pinfo.tcp_conn[i]->tcp_data_fd, &(elem->pinfo.remote_addr), &try_again, connect_cycle++);
+        tls_connect(elem->pinfo.tcp_conn[i]->tcp_data_fd, &(elem->pinfo.remote_addr), elem->pinfo.rsaddr, &try_again,
+                    connect_cycle++);
     if (!(elem->pinfo.tcp_conn[i]->tcp_data_ssl)) {
       if (try_again) {
         --elem->pinfo.tcp_conn_number;


### PR DESCRIPTION
Fixes #1732.

## What changed

`turnutils_uclient` never called `SSL_set_tlsext_host_name()`, so its TLS ClientHello carried no `server_name` (SNI) extension. TLS-terminating proxies that route by SNI (e.g. Caddy in front of a TURN server on 443) could not identify the target host, while `openssl s_client` against the same endpoint worked.

`tls_connect()` in `src/apps/uclient/startuclient.c` now receives the original server string alongside the resolved address and sets it as the SNI host name before `SSL_connect()`:

- The main control connection passes the CLI server argument (`remote_address`), which is also preserved across reconnects via `clnet_info->rsaddr`.
- The RFC 6062 TCP data connections pass `elem->pinfo.rsaddr`, so `connection-bind` data streams send SNI too.
- IP literals are detected with `inet_pton()` and skipped, per RFC 6066 section 3 (SNI must carry DNS host names only) — connecting by address keeps today's no-SNI behavior.
- A failed `SSL_set_tlsext_host_name()` logs a warning and continues rather than aborting.

No new CLI flags; the positional server argument is the SNI value, matching `openssl s_client` behavior. The extension is also legal in DTLS ClientHello, so both TCP-TLS and DTLS paths set it.

## Validation

- Functional check against a local TLS server with an SNI callback: connecting by host name delivers `SNI='localhost'` and the handshake completes; connecting by `127.0.0.1` delivers no SNI and the handshake still completes.
- macOS: build, 12/12 unit tests, `examples/run_tests.sh`, `run_tests_conf.sh`, `run_tests_mobile.sh`, `run_tests_multiplex_peer.sh` — zero FAIL lines; fuzzing smoke tests (ASan targets 0 and 1).
- Linux (Docker): clean build, 11/11 unit tests, same four example suites — zero FAIL lines.
