### PR TITLE
fix: log explicit error when configured tls-listening-port cannot start

### DIFF
--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -1107,7 +1107,11 @@ void print_abs_file_name(const char *msg1, const char *msg2, const char *fn) {
     }
   }
   if (absfn[0]) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s%s file found: %s\n", msg1, msg2, absfn);
+    if (access(absfn, R_OK) == 0) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "%s%s file found: %s\n", msg1, msg2, absfn);
+    } else {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "%s%s file not found or not readable: %s\n", msg1, msg2, absfn);
+    }
   }
 }
 

--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -60,6 +60,11 @@
 
 #if defined(_MSC_VER)
 #include <direct.h>
+#include <io.h>
+#ifndef R_OK
+#define R_OK 4 /* MSVC has no R_OK; 4 is the _access() read-permission mode */
+#endif
+#define access _access /* the POSIX name is deprecated in the MSVC CRT (C4996) */
 #else
 #include <unistd.h>
 #endif

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -143,6 +143,7 @@ turn_params_t turn_params = {
     DEFAULT_STUN_TLS_PORT, /* tls_listener_port */
     0,                     /* alt_listener_port */
     0,                     /* alt_tls_listener_port */
+    false,                 /* tls_port_configured */
     0,                     /* tcp_proxy_port */
     false,                 /* rfc5780 */
 
@@ -2205,12 +2206,14 @@ static void set_option(int c, char *value) {
     break;
   case TLS_PORT_OPT:
     turn_params.tls_listener_port = get_port_value(value);
+    turn_params.tls_port_configured = true;
     break;
   case ALT_PORT_OPT:
     turn_params.alt_listener_port = get_port_value(value);
     break;
   case ALT_TLS_PORT_OPT:
     turn_params.alt_tls_listener_port = get_port_value(value);
+    turn_params.tls_port_configured = true;
     break;
   case TCP_PROXY_PORT_OPT:
     turn_params.tcp_proxy_port = get_port_value(value);
@@ -4239,6 +4242,14 @@ static void openssl_setup(void) {
 
   if (!(turn_params.no_tls && turn_params.no_dtls)) {
     adjust_key_file_names();
+  }
+
+  if (turn_params.tls_port_configured && turn_params.no_tls && turn_params.no_dtls) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
+                  "tls-listening-port %d is configured, but the TLS and DTLS listeners are disabled "
+                  "(see the messages above). The server will NOT listen on that port. Set valid 'cert' and "
+                  "'pkey' files (readable by the turnserver process) to enable TLS/DTLS.\n",
+                  (int)turn_params.tls_listener_port);
   }
 
   openssl_load_certificates();

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -230,6 +230,7 @@ typedef struct _turn_params_ {
   uint16_t tls_listener_port;
   uint16_t alt_listener_port;
   uint16_t alt_tls_listener_port;
+  bool tls_port_configured;
   uint16_t tcp_proxy_port;
   bool rfc5780;
 


### PR DESCRIPTION
## What

When `tls-listening-port` (or `alt-tls-listening-port`) is explicitly configured but the TLS/DTLS listeners cannot be started (missing or unreadable `cert`/`pkey`), turnserver now logs an explicit startup ERROR naming the dead port:

```
ERROR: tls-listening-port 3443 is configured, but the TLS and DTLS listeners are disabled (see the messages above). The server will NOT listen on that port. Set valid 'cert' and 'pkey' files (readable by the turnserver process) to enable TLS/DTLS.
```

Also fixes `print_abs_file_name()` to check readability before logging `... file found:`; a missing/unreadable path now logs `WARNING: ... file not found or not readable: <absolute path>` instead of claiming the file was found.

## Why

Fixes #1775. Setting `tls-listening-port` without a usable cert/pkey pair silently downgrades to plain-only listeners: the only trace is a WARNING buried in the startup log, immediately contradicted by an INFO line claiming the (missing) certificate file was found. Operators restart after enabling the port, see nothing listening, and have no obvious lead — exactly the confusion in the issue report.

## Notes for reviewers

- This deliberately does **not** make the condition fatal. The shipped Docker config sets `tls-listening-port=5349` unconditionally with cert paths that only exist when mounted, so exiting would crash-loop existing plain-only Docker deployments. The new `tls_port_configured` flag keeps the ERROR scoped to configs that explicitly asked for a TLS port, so intentionally plain deployments that never set the option see no new noise.
- The absolute path in the new `not found or not readable` warning is the actionable detail for the common permissions trap (root-only Let's Encrypt directories after privilege drop).

## Validation

- macOS + Linux (Docker): clean build, all unit tests pass, `examples/run_tests.sh`, `run_tests_conf.sh`, `run_tests_mobile.sh`, `run_tests_multiplex_peer.sh` all pass with no FAIL lines; fuzzing smoke tests (ASan targets 0 and 1) pass; `clang-format` lint clean.
- Functional: without certs, the configured port stays unbound and the new ERROR appears; with a valid cert/pkey pair, the port binds and no new warnings/errors fire.
