### PR TITLE
feat: RFC 8016 graceful dual-5-tuple mobility handoff

### DIFF
--- a/docs/mobility-rfc8016.md
+++ b/docs/mobility-rfc8016.md
@@ -1,0 +1,185 @@
+# RFC 8016 Mobility Conformance
+
+This document describes coturn's implementation of TURN mobility
+([RFC 8016](https://datatracker.ietf.org/doc/html/rfc8016), "Mobility with
+Traversal Using Relays around NAT (TURN)"), the gaps between the historical
+coturn behavior and the RFC, and the changes made to close them.
+
+Mobility is enabled with `--mobility` (config `mobility`) and is off by
+default.
+
+## Background
+
+RFC 8016 lets a TURN client keep an allocation alive when its client-side
+transport address (IP and/or port — the "5-tuple") changes, e.g. when a
+mobile device roams between networks. Without mobility the client would have
+to re-`ALLOCATE` and re-install every permission and channel. With mobility
+the server issues an opaque `MOBILITY-TICKET`; after a network change the
+client presents the ticket in a `REFRESH` from its new address and the server
+moves the existing allocation to the new client path.
+
+## Protocol summary (RFC 8016)
+
+| Phase | Behavior |
+|---|---|
+| Allocate | Client sends a **zero-length** `MOBILITY-TICKET` to request mobility. Server marks the allocation mobile and returns a ticket in the success response. |
+| Refresh (no move) | Client MUST NOT include `MOBILITY-TICKET`. |
+| Refresh (after move) | Client sends the ticket from its new 5-tuple. Server looks the allocation up **by ticket**, not by packet 5-tuple. |
+| Authorization | Server MUST run MESSAGE-INTEGRITY to confirm the resume comes from **the same user that created the allocation**; otherwise reject with **441**. |
+| Handoff | Server updates state with the new address but **does not discard the old 5-tuple**. It **MUST keep receiving on** and **transmitting to** the old 5-tuple until it sees a `Send`/`ChannelData` from the client on the **new** 5-tuple (or a close), then discards the old 5-tuple/ticket and moves relay egress to the new path. |
+| Ticket rotation | The ticket returned in the Refresh success response MUST differ from the old one. |
+
+## Gap analysis (pre-change coturn)
+
+| RFC item | Historical coturn | Status |
+|---|---|---|
+| Zero-length ticket requests mobility; non-zero → 400 | Implemented | ✅ |
+| 405 when mobility disabled | Implemented | ✅ |
+| Look up allocation by ticket | `get_session_from_mobile_map()` | ✅ |
+| Resume authorized as the **original owner** (441 on mismatch) | Adopted original creds only when the resuming session was unauthenticated; an already-authenticated session was validated against its own identity | ❌ fixed separately (owner-binding fix) |
+| Ticket differs on rotation | id is zeroed then regenerated on resume | ✅ |
+| **Graceful dual-5-tuple handoff** | **Immediate hard switch at Refresh time; old socket closed at once** | ❌ **this change** |
+| Unknown ticket → **437** | Returned **404** | ❌ **this change** |
+| Ticket "strong entropy / authenticated + encrypted" | 56-bit random handle (8-bit server-id prefix), cleartext on non-TLS | ⚠️ see "Ticket hardening" |
+
+## Change 1 — Graceful dual-5-tuple handoff
+
+### Design
+
+coturn's session model gives each `ts_ur_super_session` a single
+`client_socket`. Rather than merge the resuming socket into the original
+allocation immediately (the old behavior), the resume now enters a bounded
+**transition** in which both client paths exist:
+
+- The **original** session (`orig_ss`) keeps its allocation and its old
+  `client_socket`. Peer→client relayed traffic keeps flowing to the **old**
+  5-tuple, satisfying "MUST continue transmitting on the old 5-tuple."
+- The **resuming** session (`ss`, on the new 5-tuple) is kept alive and
+  linked to `orig_ss` as a *pending mobile resume* instead of being torn
+  down. The old path keeps being received and processed on `orig_ss` (which
+  still owns the allocation), satisfying "MUST continue receiving on the old
+  5-tuple"; the new path's first packet is what promotes the allocation onto
+  it (see below).
+- The Refresh success response (carrying the **new**, rotated ticket) is sent
+  on the new socket.
+
+The transition ends in one of two ways:
+
+1. **Promote (the client shows up on the new path).** The client's **first
+   packet** on the new 5-tuple completes the handoff: the new socket is moved
+   onto the allocation session (`attach_socket_to_session`), which closes the
+   old client socket and thereby discards the old 5-tuple; the packet is then
+   processed against the allocation. Peer→client egress reverts to the new
+   socket from this point.
+
+   RFC 8016 names the trigger as the client's first `Send`/`ChannelData` on the
+   new path. coturn promotes on the first packet of **any** type, because
+   control requests a roaming client issues from the new address
+   (`CreatePermission`, `ChannelBind`, a subsequent `Refresh`) must be served by
+   the allocation, not by the allocation-less pending session. The
+   make-before-break guarantee that matters — that relayed peer→client data
+   keeps flowing to the old path across the handoff gap — is preserved: egress
+   stays on the old socket for the whole interval between the Refresh response
+   and that first new-path packet.
+
+2. **Abort (the client never shows up).** If the transition stays open past a
+   bounded deadline (`MOBILITY_TRANSITION_TIMEOUT`, 30 s) with no packet on the
+   new path, the per-session sweep abandons it: the allocation stays on the
+   original/old path and the pending session is reaped. This is the
+   conservative choice (keep the last known-good path); a client that really
+   moved will have sent on the new path — and thus promoted — long before the
+   deadline, and can always re-`Refresh` to reopen a transition.
+
+Promotion reuses the original socket-transfer logic, factored into
+`mobile_complete_transition()`.
+
+### State (added to `ts_ur_super_session`)
+
+- `mobile_resume_target` — on the pending session: id of the allocation session,
+- `mobile_pending_resume` — on the allocation session: id of the pending session,
+- `mobile_transition_deadline` — on the allocation session: abort-by time.
+
+Session **ids** (not pointers) are stored so a session freed mid-transition
+never leaves a dangling reference; `shutdown_client_connection()` also unlinks a
+transition partner when either side is torn down.
+
+### Helpers (`ns_turn_server.c`, near `handle_turn_refresh`)
+
+- `mobile_begin_transition()` — links the two sessions, sets the deadline,
+  removes the pending session's stray mobile-map entry, and disarms its
+  un-allocated watchdog so it is not reaped while it legitimately holds no
+  allocation.
+- `mobile_complete_transition()` — promotes (moves the socket, closes the old
+  one, tears down the pending session) and returns the allocation session.
+- `mobile_abort_transition()` — clears the link and reaps the pending session,
+  keeping the allocation on the old path.
+
+### Interception points
+
+- `read_client_connection()` — before normal processing, if the receiving
+  session is a pending resume, promote and continue as the allocation session.
+- `sweep_session_cb()` (the 1 s per-session tick) — abort transitions past the
+  deadline. It only sets `to_be_closed` / clears links, so it is safe during map
+  iteration.
+
+### Note on quota
+
+During the (sub-second in practice, ≤30 s worst case) transition both sessions
+hold one quota unit for the same user; the pending session's unit is released
+when it is torn down at promotion/abort. This transient over-count is bounded by
+the deadline and is not persistent.
+
+## Change 2 — Error-code conformance
+
+- Unknown/stale ticket on resume now returns **437 (Allocation Mismatch)**, as
+  required by RFC 8016, instead of the previous non-standard 404.
+- Wrong-user resume returns **441 (Wrong Credentials)** — this follows from the
+  owner-binding fix: the resuming request's `USERNAME` is compared against the
+  adopted original owner and mismatches yield 441.
+
+## Ticket hardening (design note)
+
+The RFC requires the ticket to have "strong entropy" and to be "authenticated
+and encrypted." coturn's ticket is an **opaque, stateless-to-the-client random
+handle** into a server-side map — it carries no server state, so "modification"
+is a non-issue (a tampered value simply misses the map) and the residual risk
+is eavesdropping, which is addressed by (a) running mobility over `turns:` and
+(b) the owner-binding credential re-check. The remaining letter-of-the-RFC gap
+is entropy: the id is 64 bits with an 8-bit server-routing prefix, i.e. 56
+random bits.
+
+Raising this to a 128-bit ticket is specified but **not** bundled here because
+the mobile id is also passed **between coturn processes** as a 64-bit value on
+the cross-server resume path (`send_socket_to_relay` / `RMT_MOBILE_SOCKET`);
+widening it changes that inter-process wire format and, for true "encryption,"
+would require a cluster-shared key that coturn does not currently manage. It is
+tracked as a separate hardening item to avoid coupling a wire-format/key-mgmt
+change to the protocol-behavior work here.
+
+## Testing
+
+`examples/run_tests_mobile.sh` starts the server with `--mobility` and drives
+`turnutils_uclient -M` (UDP/TCP, legacy and threaded worker pools). The `-M`
+flow allocates, obtains a ticket, reopens on a fresh 5-tuple, and resumes with a
+`REFRESH` — so every run exercises the new path end-to-end: `handle_turn_refresh`
+opens a transition (`mobile_begin_transition`) and the client's next packet on
+the new socket drives `mobile_complete_transition`.
+
+The script then asserts, from the server log, that the handoff actually
+executed — it greps for the `mobility handoff completed` marker emitted by
+`mobile_complete_transition()`. This distinguishes "the transition machinery
+ran and promoted the allocation" from merely "a resume response was returned,"
+so a regression that skipped or broke the handoff fails the test rather than
+silently falling back.
+
+The transition helpers are tightly coupled to the live IO engine, sockets, and
+session maps, so they are validated at this integration level rather than as
+isolated unit tests. The suite is wired into the Linux CI workflows alongside
+the other `run_tests_*` scripts.
+
+An end-to-end assertion of the *make-before-break* property specifically (that
+peer→client data keeps arriving on the old 5-tuple during the transition window)
+would require a custom client that holds both 5-tuples open simultaneously;
+`turnutils_uclient` closes/reopens instead, so that aspect is covered by design
+review rather than an automated assertion. This is called out here so the gap is
+explicit.

--- a/examples/run_tests_mobile.sh
+++ b/examples/run_tests_mobile.sh
@@ -54,11 +54,9 @@ if [ "$(uname -s)" = "Linux" ]; then
 fi
 
 echo 'Running turnserver (--mobility)'
-if [ $IS_DARWIN -eq 1 ]; then
-    $BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --mobility --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > /dev/null &
-else
-    $BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --mobility --log-file=stdout --simple-log $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
-fi
+# Always capture the server log (both platforms): the handoff assertion below
+# greps it for the RFC 8016 dual-5-tuple transition marker.
+$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --mobility --log-file=stdout --simple-log $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"
 
 echo 'Running peer client'
@@ -131,9 +129,30 @@ run_uclient() {
     fi
 }
 
+# Assert the RFC 8016 dual-5-tuple handoff actually executed on the server. Each
+# -M resume drives handle_turn_refresh into the transition path, and the client's
+# first packet on the new 5-tuple promotes the allocation, emitting this marker.
+# Its presence proves the handoff code ran end-to-end, not merely that a resume
+# response was returned.
+assert_handoff() {
+    echo "Checking mobility handoff marker"
+    local n
+    n=$(grep -c "mobility handoff completed" "$TURNSERVER_LOG" 2>/dev/null)
+    if [ "${n:-0}" -ge 1 ]; then
+        echo "OK (mobility handoff x$n)"
+    else
+        echo "FAIL: no 'mobility handoff completed' marker in server log"
+        echo "--- turnserver log (mobility lines) ---"
+        grep -iE "mobil|handoff|refresh" "$TURNSERVER_LOG" 2>/dev/null | tail -20
+        exit 1
+    fi
+}
+
 # Legacy single-threaded uclient.
 run_uclient "mobile turn client UDP"
 run_uclient "mobile turn client TCP" -t
+
+assert_handoff
 
 if [ $IS_DARWIN -eq 1 ]; then
     # macOS loopback is unreliable for the mobility reopen beyond plain UDP;

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -143,6 +143,10 @@ static inline void log_method(ts_ur_super_session *ss, const char *method, int e
 
 static int attach_socket_to_session(turn_turnserver *server, ioa_socket_handle s, ts_ur_super_session *ss);
 
+/* RFC 8016 mobility handoff helpers (defined near handle_turn_refresh). */
+static ts_ur_super_session *mobile_complete_transition(turn_turnserver *server, ts_ur_super_session *pending_ss);
+static void mobile_abort_transition(turn_turnserver *server, ts_ur_super_session *orig_ss);
+
 static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stun_tid *tid, int *resp_constructed,
                            int *err_code, const uint8_t **reason, ioa_net_data *in_buffer,
                            ioa_network_buffer_handle nbh, uint16_t method, int *message_integrity, int *postpone_reply,
@@ -1066,6 +1070,13 @@ static bool sweep_session_cb(ur_map_key_type key, ur_map_value_type value, void 
   if (value) {
     ts_ur_super_session *ss = (ts_ur_super_session *)value;
     turn_turnserver *server = (turn_turnserver *)arg;
+    /* RFC 8016: if a mobility handoff has been open past its deadline without the
+     * client sending on the new path, abandon it — keep the allocation on the
+     * old path and reap the pending session. Only marks sessions to_be_closed /
+     * clears links, so it is safe during map iteration. */
+    if (ss->mobile_pending_resume && !turn_time_before(server->ctime, ss->mobile_transition_deadline)) {
+      mobile_abort_transition(server, ss);
+    }
     sweep_allocation_timed_events(server, get_allocation_ss(ss));
   }
   return false; /* keep iterating all sessions */
@@ -1633,6 +1644,102 @@ static void copy_auth_parameters(ts_ur_super_session *orig_ss, ts_ur_super_sessi
   }
 }
 
+/* RFC 8016 graceful dual-5-tuple mobility handoff.
+ *
+ * A mobility resume does not hard-switch the allocation onto the new client
+ * path at REFRESH time. Instead the allocation stays on the original session
+ * (peer->client keeps flowing to the old 5-tuple) and the resuming session is
+ * kept alive and linked as "pending". The allocation is promoted onto the new
+ * socket on the first client->peer datagram (Send indication / ChannelData) on
+ * the new path, or aborted back to the old path if a bounded deadline elapses
+ * with no such datagram. See docs/mobility-rfc8016.md. */
+
+/* Seconds to keep the dual-5-tuple transition open waiting for the client to
+ * send on the new path before conservatively abandoning it (keeping the old
+ * path). The RFC-conformant trigger is the client's first Send/ChannelData on
+ * the new 5-tuple, which in practice arrives well within this window. */
+#define MOBILITY_TRANSITION_TIMEOUT (30)
+
+/* Link a resuming session (new client path) to its allocation session and open
+ * the transition window. orig_ss keeps the allocation and the old client
+ * socket; pending_ss keeps the new client socket and is kept alive for the
+ * window (its un-allocated watchdog is disarmed and its stray mobile-map entry
+ * removed, since it owns no allocation of its own). */
+static void mobile_begin_transition(turn_turnserver *server, ts_ur_super_session *orig_ss,
+                                    ts_ur_super_session *pending_ss) {
+  /* A pending session must never itself be resumable. */
+  delete_session_from_mobile_map(pending_ss);
+  /* Do not let the un-allocated watchdog reap the pending session; it owns no
+   * allocation until (and unless) it is promoted. */
+  IOA_EVENT_DEL(pending_ss->to_be_allocated_timeout_ev);
+
+  orig_ss->mobile_pending_resume = pending_ss->id;
+  orig_ss->mobile_transition_deadline = server->ctime + MOBILITY_TRANSITION_TIMEOUT;
+  pending_ss->mobile_resume_target = orig_ss->id;
+
+  if (server->verbose) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
+                  "session %018llu: mobility handoff started (dual-5-tuple transition to session %018llu)\n",
+                  (unsigned long long)orig_ss->id, (unsigned long long)pending_ss->id);
+  }
+}
+
+/* Promote the allocation onto the pending session's new client socket: move the
+ * socket into the original allocation session, close the old client socket
+ * (discarding the old 5-tuple), tear down the now-spent pending session, and
+ * return the allocation session (now living on the new path). Returns NULL on
+ * failure or if the allocation session no longer exists. */
+static ts_ur_super_session *mobile_complete_transition(turn_turnserver *server, ts_ur_super_session *pending_ss) {
+  ts_ur_super_session *orig_ss = get_session_from_map(server, pending_ss->mobile_resume_target);
+
+  /* Clear the link regardless of outcome so we never promote twice. */
+  pending_ss->mobile_resume_target = 0;
+  if (!orig_ss) {
+    return NULL;
+  }
+  orig_ss->mobile_pending_resume = 0;
+  orig_ss->mobile_transition_deadline = 0;
+
+  ioa_socket_handle s = detach_ioa_socket(pending_ss->client_socket);
+  pending_ss->to_be_closed = 1;
+  if (!s) {
+    return NULL;
+  }
+
+  if (attach_socket_to_session(server, s, orig_ss) < 0) {
+    if (orig_ss->client_socket != s) {
+      IOA_CLOSE_SOCKET(s);
+    }
+    return NULL;
+  }
+
+  /* Carry the resuming session's (refreshed) auth context onto the allocation
+   * session; both hold the same owner credentials after the resume. The pending
+   * session's quota unit is released when it is torn down (to_be_closed above ->
+   * shutdown_client_connection -> dec_quota), so we do not release it here. */
+  if (pending_ss->hmackey_set) {
+    copy_auth_parameters(pending_ss, orig_ss);
+  }
+
+  TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
+                "session %018llu: mobility handoff completed (allocation moved to new client path)\n",
+                (unsigned long long)orig_ss->id);
+
+  return orig_ss;
+}
+
+/* Abandon a transition that timed out (or whose pending session died): keep the
+ * allocation on the original/old path and reap the pending session. */
+static void mobile_abort_transition(turn_turnserver *server, ts_ur_super_session *orig_ss) {
+  ts_ur_super_session *pending_ss = get_session_from_map(server, orig_ss->mobile_pending_resume);
+  orig_ss->mobile_pending_resume = 0;
+  orig_ss->mobile_transition_deadline = 0;
+  if (pending_ss && pending_ss->mobile_resume_target == orig_ss->id) {
+    pending_ss->mobile_resume_target = 0;
+    pending_ss->to_be_closed = 1;
+  }
+}
+
 static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss, stun_tid *tid, int *resp_constructed,
                                int *err_code, const uint8_t **reason, uint16_t *unknown_attrs, uint16_t *ua_num,
                                ioa_net_data *in_buffer, ioa_network_buffer_handle nbh, int message_integrity,
@@ -1797,8 +1904,9 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
 
           ts_ur_super_session *orig_ss = get_session_from_mobile_map(server, mid);
           if (!orig_ss || orig_ss->to_be_closed || ioa_socket_tobeclosed(orig_ss->client_socket)) {
-            *err_code = 404;
-            *reason = (const uint8_t *)"Allocation not found";
+            /* RFC 8016: an unusable/unknown ticket is an Allocation Mismatch. */
+            *err_code = 437;
+            *reason = (const uint8_t *)"Allocation Mismatch";
           } else if (orig_ss == ss) {
             *err_code = 437;
             *reason = (const uint8_t *)"Invalid allocation";
@@ -1865,78 +1973,63 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
 
               } else {
 
-                // Transfer socket:
+                // RFC 8016 graceful handoff: keep the allocation on orig_ss so
+                // peer->client traffic keeps flowing to the old 5-tuple, and open
+                // a dual-5-tuple transition rather than hard-switching now. The
+                // allocation is promoted onto this new socket on the client's
+                // first Send/ChannelData on the new path (see read_client_connection),
+                // or abandoned back to the old path after a bounded deadline (see
+                // the per-session sweep).
 
-                ioa_socket_handle s = detach_ioa_socket(ss->client_socket);
+                // Rotate the mobility ticket (the new ticket MUST differ from the
+                // old) and re-key orig_ss in the mobile map under the new id.
+                delete_session_from_mobile_map(orig_ss);
+                put_session_into_mobile_map(orig_ss);
+                orig_ss->old_mobile_id = mid;
 
-                ss->to_be_closed = 1;
+                mobile_begin_transition(server, orig_ss, ss);
 
-                if (!s) {
-                  *err_code = 500;
-                } else {
+                turn_report_allocation_set(&(orig_ss->alloc), lifetime, 1);
 
-                  if (attach_socket_to_session(server, s, orig_ss) < 0) {
-                    if (orig_ss->client_socket != s) {
-                      IOA_CLOSE_SOCKET(s);
-                    }
-                    *err_code = 500;
-                  } else {
+                // Build the REFRESH success response carrying the new ticket. It
+                // is sent on the resuming session's new socket (ss is left as the
+                // pending session), so the roaming client learns the allocation
+                // survived the move.
+                nbh = ioa_network_buffer_allocate(server->e);
+                size_t len = ioa_network_buffer_get_size(nbh);
 
-                    if (ss->hmackey_set) {
-                      copy_auth_parameters(ss, orig_ss);
-                    }
+                stun_init_success_response_str(STUN_METHOD_REFRESH, ioa_network_buffer_data(nbh), &len, tid);
+                uint32_t lt = nswap32(lifetime);
 
-                    delete_session_from_mobile_map(ss);
-                    delete_session_from_mobile_map(orig_ss);
-                    put_session_into_mobile_map(orig_ss);
+                stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_LIFETIME, (const uint8_t *)&lt, 4);
+                ioa_network_buffer_set_size(nbh, len);
 
-                    // Use new buffer and redefine ss:
-                    nbh = ioa_network_buffer_allocate(server->e);
+                stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_MOBILITY_TICKET,
+                                  (uint8_t *)orig_ss->s_mobile_id, strlen(orig_ss->s_mobile_id));
+                ioa_network_buffer_set_size(nbh, len);
 
-                    dec_quota(ss);
-                    ss = orig_ss;
-                    inc_quota(ss, ss->username);
+                maybe_add_software_attribute(server, nbh);
 
-                    ss->old_mobile_id = mid;
-                    size_t len = ioa_network_buffer_get_size(nbh);
-
-                    turn_report_allocation_set(&(ss->alloc), lifetime, 1);
-
-                    stun_init_success_response_str(STUN_METHOD_REFRESH, ioa_network_buffer_data(nbh), &len, tid);
-                    uint32_t lt = nswap32(lifetime);
-
-                    stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_LIFETIME, (const uint8_t *)&lt,
-                                      4);
-                    ioa_network_buffer_set_size(nbh, len);
-
-                    stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_MOBILITY_TICKET,
-                                      (uint8_t *)ss->s_mobile_id, strlen(ss->s_mobile_id));
-                    ioa_network_buffer_set_size(nbh, len);
-
-                    maybe_add_software_attribute(server, nbh);
-
-                    if (message_integrity) {
-                      size_t len = ioa_network_buffer_get_size(nbh);
-                      stun_attr_add_integrity_str(server->ct, ioa_network_buffer_data(nbh), &len, ss->hmackey, ss->pwd,
-                                                  SHATYPE_DEFAULT);
-                      ioa_network_buffer_set_size(nbh, len);
-                    }
-
-                    if ((server->fingerprint) || ss->enforce_fingerprints) {
-                      size_t len = ioa_network_buffer_get_size(nbh);
-                      if (!stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &len)) {
-                        *err_code = 500;
-                        ioa_network_buffer_delete(server->e, nbh);
-                        return -1;
-                      }
-                      ioa_network_buffer_set_size(nbh, len);
-                    }
-
-                    *no_response = 1;
-
-                    return write_client_connection(server, ss, nbh, TTL_IGNORE, TOS_IGNORE);
-                  }
+                if (message_integrity) {
+                  size_t ilen = ioa_network_buffer_get_size(nbh);
+                  stun_attr_add_integrity_str(server->ct, ioa_network_buffer_data(nbh), &ilen, ss->hmackey, ss->pwd,
+                                              SHATYPE_DEFAULT);
+                  ioa_network_buffer_set_size(nbh, ilen);
                 }
+
+                if ((server->fingerprint) || ss->enforce_fingerprints) {
+                  size_t flen = ioa_network_buffer_get_size(nbh);
+                  if (!stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &flen)) {
+                    *err_code = 500;
+                    ioa_network_buffer_delete(server->e, nbh);
+                    return -1;
+                  }
+                  ioa_network_buffer_set_size(nbh, flen);
+                }
+
+                *no_response = 1;
+
+                return write_client_connection(server, ss, nbh, TTL_IGNORE, TOS_IGNORE);
               }
             }
 
@@ -4346,6 +4439,27 @@ int shutdown_client_connection(turn_turnserver *server, ts_ur_super_session *ss,
     return 0;
   }
 
+  /* RFC 8016 mobility handoff: this session is being freed. If it is part of a
+   * transition, unlink its peer so a surviving allocation session doesn't wait
+   * on a dead pending resume (and vice versa). */
+  if (ss->mobile_resume_target) {
+    ts_ur_super_session *tgt = get_session_from_map(server, ss->mobile_resume_target);
+    if (tgt && tgt->mobile_pending_resume == ss->id) {
+      tgt->mobile_pending_resume = 0;
+      tgt->mobile_transition_deadline = 0;
+    }
+    ss->mobile_resume_target = 0;
+  }
+  if (ss->mobile_pending_resume) {
+    ts_ur_super_session *pend = get_session_from_map(server, ss->mobile_pending_resume);
+    if (pend && pend->mobile_resume_target == ss->id) {
+      pend->mobile_resume_target = 0;
+      pend->to_be_closed = 1;
+    }
+    ss->mobile_pending_resume = 0;
+    ss->mobile_transition_deadline = 0;
+  }
+
   if (eve(server->verbose)) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "closing session %p, client socket %p (socket session=%p)\n", ss,
                   ss->client_socket, get_ioa_socket_session(ss->client_socket));
@@ -4713,6 +4827,21 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
       ioa_socket_tobeclosed(ss->client_socket)) {
     FUNCEND;
     return -1;
+  }
+
+  /* RFC 8016 mobility handoff: this is the client's first packet on the new
+   * 5-tuple after a resume. Complete the transition now — promote the allocation
+   * onto this socket and process the packet against the allocation session.
+   * Peer->client relayed traffic stayed on the old 5-tuple up to this point
+   * (make-before-break); the client's activity here is what ends that window
+   * (RFC 8016 uses the first Send/ChannelData as the trigger — we also promote
+   * on control requests such as CreatePermission/ChannelBind so they are served
+   * by the allocation rather than the pending session). */
+  if (ss->mobile_resume_target) {
+    ts_ur_super_session *promoted = mobile_complete_transition(server, ss);
+    if (promoted) {
+      ss = promoted;
+    }
   }
 
   const int ret = (int)ioa_network_buffer_get_size(in_buffer->nbh);

--- a/src/server/ns_turn_session.h
+++ b/src/server/ns_turn_session.h
@@ -121,6 +121,14 @@ struct _ts_ur_super_session {
   mobile_id_t mobile_id;
   mobile_id_t old_mobile_id;
   char s_mobile_id[33];
+  /* RFC 8016 mobility graceful handoff (dual-5-tuple transition state).
+   * During a resume the allocation stays on the original session while the
+   * resuming session (new client path) is kept alive and linked, so peer->client
+   * traffic keeps flowing on the old 5-tuple until the client sends on the new
+   * one (or a bounded deadline elapses). See docs/mobility-rfc8016.md. */
+  turnsession_id mobile_resume_target;    /* resuming session -> allocation session id being resumed */
+  turnsession_id mobile_pending_resume;   /* allocation session -> resuming session id */
+  turn_time_t mobile_transition_deadline; /* allocation session: promote/abort by this time */
   /* Bandwidth */
   band_limit_t bps;
 };


### PR DESCRIPTION
Historically a MOBILITY-TICKET resume hard-switched the allocation onto the new client socket at REFRESH time and closed the old socket immediately. RFC 8016 instead requires the server to keep receiving on, and transmitting peer->client data to, the old 5-tuple until the client is active on the new one, and only then discard the old 5-tuple.

Implement that make-before-break handoff:

- handle_turn_refresh no longer transfers the socket. It rotates the mobility ticket, refreshes the allocation on the original session, and opens a bounded transition: the original session keeps the allocation and its old socket (peer->client egress stays on the old 5-tuple), while the resuming session is kept alive and linked as "pending" and the REFRESH success response is sent on the new socket.
- read_client_connection promotes the allocation onto the new socket on the client's first packet from the new 5-tuple (mobile_complete_transition): the socket is moved to the allocation session, which closes the old socket and discards the old 5-tuple, and the packet is then served by the allocation. RFC names the trigger as the first Send/ChannelData; we promote on any first packet so control requests (CreatePermission/ChannelBind/Refresh) a roaming client issues from the new address are served by the allocation.
- The per-session sweep aborts a transition left open past a 30s deadline, conservatively keeping the allocation on the old path and reaping the pending session. shutdown_client_connection unlinks a transition partner on teardown.

Transition state (session ids + deadline) is added to ts_ur_super_session; the pending session's un-allocated watchdog is disarmed and its stray mobile-map entry removed while it legitimately holds no allocation.

Also align resume error codes with RFC 8016: an unusable/unknown ticket now returns 437 (Allocation Mismatch) instead of the non-standard 404.

examples/run_tests_mobile.sh now asserts, from the server log, that the handoff actually executed (mobile_complete_transition emits a marker), so a regression that skipped or broke the transition fails the test. docs/mobility-rfc8016.md documents the design, the trigger/deadline semantics, the quota note, and the deferred ticket-entropy hardening item.