### PR TITLE
avoid leaks on realloc failure in tcp relay allocation

### DIFF
--- a/src/server/ns_turn_allocation.c
+++ b/src/server/ns_turn_allocation.c
@@ -622,6 +622,7 @@ tcp_connection *create_tcp_connection(uint8_t server_id, allocation *a, stun_tid
     size_t old_sz_mem = a->tcs.sz * sizeof(tcp_connection *);
     tcp_connection **new_elems = realloc(a->tcs.elems, old_sz_mem + sizeof(tcp_connection *));
     if (!new_elems) {
+      free(tc);
       return NULL;
     }
     a->tcs.elems = new_elems;
@@ -742,12 +743,14 @@ void add_unsent_buffer(unsent_buffer *ub, ioa_network_buffer_handle nbh) {
   if (!ub || (ub->sz >= MAX_UNSENT_BUFFER_SIZE)) {
     ioa_network_buffer_delete(NULL, nbh);
   } else {
-    ub->bufs = (ioa_network_buffer_handle *)realloc(ub->bufs, sizeof(ioa_network_buffer_handle) * (ub->sz + 1));
-    if (!ub->bufs) {
+    ioa_network_buffer_handle *new_bufs =
+        (ioa_network_buffer_handle *)realloc(ub->bufs, sizeof(ioa_network_buffer_handle) * (ub->sz + 1));
+    if (!new_bufs) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Memory allocation failed in add_unsent_buffer\n");
       ioa_network_buffer_delete(NULL, nbh);
       return;
     }
+    ub->bufs = new_bufs;
     ub->bufs[ub->sz] = nbh;
     ub->sz += 1;
   }


### PR DESCRIPTION
Repro: on the RFC 6062 TCP-relay path, queue a peer buffer via `add_unsent_buffer` (peer sends before the client `CONNECTION_BIND`s) with the growth `realloc` forced to fail via a fault-injecting allocator, then run `clear_unsent_buffer`.
Cause: `add_unsent_buffer` does `ub->bufs = realloc(ub->bufs, ...)`, so a failed `realloc` overwrites the sole pointer with `NULL` and orphans the old array plus every already-queued `ioa_network_buffer_handle` (up to `MAX_UNSENT_BUFFER_SIZE` relay buffers) — `clear_unsent_buffer`/`top`/`pop` all gate on `ub->bufs`, so those buffers are never reclaimed. `create_tcp_connection` has the same shape: it returns without freeing the just-`calloc`d `tc` when the `a->tcs.elems` growth `realloc` fails.
Fix: `realloc` into a temporary and only publish it once it succeeds (matching `allocation_add_permission` a few functions up in the same file), and free `tc` before the error return.