### PR TITLE
fix off-by-one write past realm buffer in redis_list_admin_users

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_redis.c
+++ b/src/apps/relay/dbdrivers/dbd_redis.c
@@ -1325,7 +1325,7 @@ static int redis_list_admin_users(int no_print) {
   for (isz = 0; isz < keys.sz; ++isz) {
     char *s = keys.secrets[isz];
     s += strlen("turn/admin_user/");
-    uint8_t realm[STUN_MAX_REALM_SIZE];
+    uint8_t realm[STUN_MAX_REALM_SIZE + 1];
     password_t pwd;
     if (redis_get_admin_user((const uint8_t *)s, realm, pwd) == 0) {
       ++ret;


### PR DESCRIPTION
1. `redis_list_admin_users` declares `realm[STUN_MAX_REALM_SIZE]` (127 bytes, valid indices `0..126`) and hands it to `redis_get_admin_user`.
2. for an `admin_user` hash carrying a `realm` field that callee runs `strncpy(realm, val, STUN_MAX_REALM_SIZE)` then `realm[STUN_MAX_REALM_SIZE] = '\0'`, writing index `127` one byte past the array.

`password_t pwd` next to it, and every other `realm` buffer in the tree, is already `STUN_MAX_REALM_SIZE + 1`; the other four drivers build their listing straight from query rows and never pass an undersized stack buffer, so redis is the only site. Sized this one to match.

ASan before: `stack-buffer-overflow WRITE of size 1` at `realm[127]`. After: runs clean.