### PR TITLE
fix size_t underflow in telnet _process data emit

### DIFF
--- a/src/apps/relay/libtelnet.c
+++ b/src/apps/relay/libtelnet.c
@@ -952,7 +952,7 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
       /* on an IAC byte, pass through all pending bytes and
        * switch states */
       if (byte == TELNET_IAC) {
-        if (i != start) {
+        if (start < i) {
           ev.type = TELNET_EV_DATA;
           ev.data.buffer = buffer + start;
           ev.data.size = i - start;
@@ -961,7 +961,7 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
         telnet->state = TELNET_STATE_IAC;
       } else if (byte == '\r' && (telnet->flags & TELNET_FLAG_NVT_EOL) &&
                  !(telnet->flags & TELNET_FLAG_RECEIVE_BINARY)) {
-        if (i != start) {
+        if (start < i) {
           ev.type = TELNET_EV_DATA;
           ev.data.buffer = buffer + start;
           ev.data.size = i - start;
@@ -1136,7 +1136,7 @@ static void _process(telnet_t *telnet, const char *buffer, size_t size) {
   }
 
   /* pass through any remaining bytes */
-  if (telnet->state == TELNET_STATE_DATA && i != start) {
+  if (telnet->state == TELNET_STATE_DATA && start < i) {
     ev.type = TELNET_EV_DATA;
     ev.data.buffer = buffer + start;
     ev.data.size = i - start;


### PR DESCRIPTION
Repro: send `IAC SB 85 WILL` (`FF FA 55 FB`) to the CLI/telnet port with the `WILL` as the final byte, or followed by `IAC`/`CR`.
Cause: the MCCPv1 discard branch in `_process` sets `start = i + 2` to skip the `WILL` and its expected trailing `SE`; with no `SE`, `start` lands one past the buffer, so the `i != start` emit guards still fire and `ev.data.size = i - start` (both `size_t`) underflows to `SIZE_MAX`. `run_cli_input` then truncates that into `unsigned int`, does `malloc(len + 1)` (wraps to `0`) then `memcpy(buf, buf0, len)`, before the CLI password check runs.
Fix: emit the pending bytes only when `start < i` at the three `_process` data-emit sites, so `[start, i)` is always a valid range. Valid data and valid MCCPv1 sequences parse identically.

Confirmed under ASan: `heap-buffer-overflow` read at `libtelnet.c:1143` on the unpatched tree, clean after.