### PR TITLE
feat: fail-fast allocation wrappers (log + abort on OOM)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,46 @@ Key style rules (LLVM-based):
 - Brace style: attach (K&R)
 - Zero-initialize stack buffers at declaration: `uint8_t buf[N] = {0}` or `SomeStruct s = {0}`
 
+## Memory allocation
+
+**MANDATORY.** All heap allocation in coturn-owned C code MUST go through the
+fail-fast wrappers declared in
+[ns_turn_utils.h](src/apps/common/ns_turn_utils.h):
+
+- `turn_malloc(size)`
+- `turn_calloc(number, size)`
+- `turn_realloc(ptr, size)`
+- `turn_strdup(str)`
+
+Raw `malloc` / `calloc` / `realloc` / `strdup` are **not allowed** — do not add
+them, and do not review/merge code that uses them. Any file that allocates must
+include `ns_turn_utils.h`. Release memory with plain `free()` (there is no
+`turn_free`; `free(NULL)` is a no-op).
+
+The wrappers log the failing call site and `abort()` on allocation failure; they
+**never return `NULL`** for a real failure. Therefore callers MUST NOT add a
+NULL/failure check on the result, and "fixing" an allocation by adding a NULL
+check is the wrong fix — route it through a wrapper instead. (`turn_malloc`,
+`turn_calloc`, `turn_realloc` return `NULL` only for a zero-size request;
+`turn_strdup` returns `NULL` only for a `NULL` argument.)
+
+Rationale: an allocation that fails mid-request cannot be recovered correctly in
+a long-running TURN server, so a controlled, logged abort is safer than a NULL
+dereference or a silently degraded process. The logger writes into a stack
+buffer (no heap allocation), so it stays usable when the heap is exhausted.
+
+The only permitted exceptions — do not convert these, and exclude them from any
+bare-allocator check:
+
+- [src/apps/relay/libtelnet.c](src/apps/relay/libtelnet.c) — vendored,
+  public-domain third-party code.
+- [src/prometheus/prom.c](src/prometheus/prom.c) — self-contained module with its
+  own `NULL`-return error contract; does not link `turncommon`.
+- [ns_turn_utils.c](src/apps/common/ns_turn_utils.c) — the wrapper implementation
+  itself, plus its `turn_mutex_*` helpers, which deliberately degrade (return an
+  error) rather than abort.
+- `fuzzing/`, `tests/`, and Windows-only shims.
+
 ## Tests
 
 ```bash

--- a/src/apps/common/apputils.c
+++ b/src/apps/common/apputils.c
@@ -921,7 +921,7 @@ static char *_WTA(__in wchar_t *pszInBuf, __in int nInSize, __out char **pszOutB
   // if MultiByteToWideChar is provided a length for the input, it does not add space for a nul-terminator
   // and we have to add space to the allocation ourselves.
   (*pnOutSize)++;
-  *pszOutBuf = malloc(*pnOutSize * sizeof(char));
+  *pszOutBuf = turn_malloc(*pnOutSize * sizeof(char));
   if (!pszOutBuf) {
     return NULL;
   }
@@ -1065,7 +1065,7 @@ void set_execdir(void) {
   _var = getenv("_");
 #endif
   if (_var && *_var) {
-    _var = strdup(_var);
+    _var = turn_strdup(_var);
     char *edir = _var;
     if (edir[0] != '.') {
       edir = strstr(edir, "/");
@@ -1078,7 +1078,7 @@ void set_execdir(void) {
     if (c_execdir) {
       free(c_execdir);
     }
-    c_execdir = strdup(edir);
+    c_execdir = turn_strdup(edir);
     free(_var);
   }
 }
@@ -1128,7 +1128,7 @@ char *find_config_file(const char *config_file) {
       FILE *f = fopen(config_file, "r");
       if (f) {
         fclose(f);
-        full_path_to_config_file = strdup(config_file);
+        full_path_to_config_file = turn_strdup(config_file);
       }
     } else {
       int i = 0;
@@ -1137,7 +1137,7 @@ char *find_config_file(const char *config_file) {
       while (config_file_search_dirs[i]) {
         const size_t dirlen = strlen(config_file_search_dirs[i]);
         size_t fnsz = sizeof(char) * (dirlen + cflen + 10);
-        char *fn = (char *)malloc(fnsz + 1);
+        char *fn = (char *)turn_malloc(fnsz + 1);
         snprintf(fn, fnsz + 1, "%s%s", config_file_search_dirs[i], config_file);
         FILE *f = fopen(fn, "r");
         if (f) {
@@ -1149,7 +1149,7 @@ char *find_config_file(const char *config_file) {
         if (config_file_search_dirs[i][0] != '/' && config_file_search_dirs[i][0] != '.' && c_execdir && c_execdir[0]) {
           const size_t celen = strlen(c_execdir);
           fnsz = sizeof(char) * (dirlen + cflen + celen + 10);
-          fn = (char *)malloc(fnsz + 1);
+          fn = (char *)turn_malloc(fnsz + 1);
           snprintf(fn, fnsz + 1, "%s/%s%s", c_execdir, config_file_search_dirs[i], config_file);
           if (strstr(fn, "//") != fn) {
             f = fopen(fn, "r");
@@ -1300,10 +1300,7 @@ char *base64_encode(const unsigned char *data, size_t input_length, size_t *outp
 
   *output_length = 4 * ((input_length + 2) / 3);
 
-  char *encoded_data = (char *)malloc(*output_length + 1);
-  if (encoded_data == NULL) {
-    return NULL;
-  }
+  char *encoded_data = (char *)turn_malloc(*output_length + 1);
 
   for (size_t i = 0, j = 0; i < input_length;) {
 
@@ -1330,7 +1327,7 @@ char *base64_encode(const unsigned char *data, size_t input_length, size_t *outp
 
 void build_base64_decoding_table(void) {
 
-  char *table = (char *)calloc(256, sizeof(char));
+  char *table = (char *)turn_calloc(256, sizeof(char));
 
   if (table) {
     for (size_t i = 0; i < 64; i++) {
@@ -1363,10 +1360,7 @@ unsigned char *base64_decode(const char *data, size_t input_length, size_t *outp
     (*output_length)--;
   }
 
-  unsigned char *decoded_data = (unsigned char *)malloc(*output_length);
-  if (decoded_data == NULL) {
-    return NULL;
-  }
+  unsigned char *decoded_data = (unsigned char *)turn_malloc(*output_length);
 
   int i;
   size_t j;

--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -643,6 +643,57 @@ void turn_log_func_default(const char *const file, const int line, const TURN_LO
   va_end(args);
 }
 
+///////////// MEMORY ///////////////////
+
+/*
+ * Fail-fast allocation wrappers. On allocation failure they log the failing
+ * call site and abort(): a TURN server that cannot allocate cannot correctly
+ * continue, and a controlled abort is preferable to a NULL dereference or a
+ * silently degraded process. The logger writes into a stack buffer (no heap
+ * allocation), so it remains usable when the heap is exhausted.
+ */
+
+static void turn_out_of_memory(const char *file, int line, const char *what, size_t sz) {
+  turn_log_func_default(file, line, TURN_LOG_LEVEL_ERROR, "FATAL: out of memory: %s(%lu) failed, aborting\n", what,
+                        (unsigned long)sz);
+  abort();
+}
+
+void *turn_malloc_impl(size_t sz, const char *file, int line) {
+  void *ptr = malloc(sz);
+  if (!ptr && sz) {
+    turn_out_of_memory(file, line, "malloc", sz);
+  }
+  return ptr;
+}
+
+void *turn_calloc_impl(size_t number, size_t size, const char *file, int line) {
+  void *ptr = calloc(number, size);
+  if (!ptr && number && size) {
+    turn_out_of_memory(file, line, "calloc", number * size);
+  }
+  return ptr;
+}
+
+void *turn_realloc_impl(void *ptr, size_t sz, const char *file, int line) {
+  void *newptr = realloc(ptr, sz);
+  if (!newptr && sz) {
+    turn_out_of_memory(file, line, "realloc", sz);
+  }
+  return newptr;
+}
+
+char *turn_strdup_impl(const char *s, const char *file, int line) {
+  if (!s) {
+    return NULL;
+  }
+  char *ptr = strdup(s);
+  if (!ptr) {
+    turn_out_of_memory(file, line, "strdup", strlen(s) + 1);
+  }
+  return ptr;
+}
+
 ///////////// ORIGIN ///////////////////
 
 int get_default_protocol_port(const char *scheme, size_t slen) {

--- a/src/apps/common/ns_turn_utils.h
+++ b/src/apps/common/ns_turn_utils.h
@@ -100,6 +100,24 @@ void set_logfile(const char *fn);
 void rollover_logfile(void);
 void set_log_file_line(int set);
 
+///////////////////////// MEMORY ///////////////////////
+
+/*
+ * Memory allocation wrappers with a fail-fast policy: on allocation failure
+ * they log the failing call site and abort() the process. They never return
+ * NULL, so callers must not check the result. Use these throughout coturn
+ * instead of malloc/calloc/realloc/strdup.
+ */
+void *turn_malloc_impl(size_t sz, const char *file, int line);
+void *turn_calloc_impl(size_t number, size_t size, const char *file, int line);
+void *turn_realloc_impl(void *ptr, size_t sz, const char *file, int line);
+char *turn_strdup_impl(const char *s, const char *file, int line);
+
+#define turn_malloc(sz) turn_malloc_impl((sz), __FILE__, __LINE__)
+#define turn_calloc(number, size) turn_calloc_impl((number), (size), __FILE__, __LINE__)
+#define turn_realloc(ptr, sz) turn_realloc_impl((ptr), (sz), __FILE__, __LINE__)
+#define turn_strdup(s) turn_strdup_impl((s), __FILE__, __LINE__)
+
 ///////////////////////////////////////////////////////
 
 int is_secure_string(const uint8_t *string, int sanitizesql);

--- a/src/apps/peer/mainudpserver.c
+++ b/src/apps/peer/mainudpserver.c
@@ -85,8 +85,8 @@ int main(int argc, char **argv) {
       port = atoi(optarg);
       break;
     case 'L':
-      local_addr_list = (char **)realloc(local_addr_list, ++las * sizeof(char *));
-      local_addr_list[las - 1] = strdup(optarg);
+      local_addr_list = (char **)turn_realloc(local_addr_list, ++las * sizeof(char *));
+      local_addr_list[las - 1] = turn_strdup(optarg);
       break;
     case 'v':
       verbose = TURN_VERBOSE_NORMAL;
@@ -98,10 +98,10 @@ int main(int argc, char **argv) {
   }
 
   if (las < 1) {
-    local_addr_list = (char **)realloc(local_addr_list, ++las * sizeof(char *));
-    local_addr_list[las - 1] = strdup("0.0.0.0");
-    local_addr_list = (char **)realloc(local_addr_list, ++las * sizeof(char *));
-    local_addr_list[las - 1] = strdup("::");
+    local_addr_list = (char **)turn_realloc(local_addr_list, ++las * sizeof(char *));
+    local_addr_list[las - 1] = turn_strdup("0.0.0.0");
+    local_addr_list = (char **)turn_realloc(local_addr_list, ++las * sizeof(char *));
+    local_addr_list[las - 1] = turn_strdup("::");
   }
 
   server_type *server = start_udp_server(verbose, ifname, local_addr_list, las, port);

--- a/src/apps/peer/udpserver.c
+++ b/src/apps/peer/udpserver.c
@@ -242,10 +242,7 @@ static int udp_create_server_socket(server_type *const server, const char *const
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Start\n");
   }
 
-  ioa_addr *server_addr = (ioa_addr *)malloc(sizeof(ioa_addr));
-  if (!server_addr) {
-    return -1;
-  }
+  ioa_addr *server_addr = (ioa_addr *)turn_malloc(sizeof(ioa_addr));
 
   STRCPY(server->ifname, ifname);
 
@@ -305,10 +302,7 @@ static server_type *init_server(int verbose, const char *ifname, char **local_ad
   if (port == USHRT_MAX) {
     return NULL;
   }
-  server_type *server = (server_type *)calloc(1, sizeof(server_type));
-  if (!server) {
-    return NULL;
-  }
+  server_type *server = (server_type *)turn_calloc(1, sizeof(server_type));
 
   server->verbose = verbose;
   server->event_base = turn_event_base_new();

--- a/src/apps/relay/dbdrivers/dbd_mongo.c
+++ b/src/apps/relay/dbdrivers/dbd_mongo.c
@@ -96,12 +96,7 @@ static MONGO *get_mongodb_connection(void) {
     mongoc_init();
     mongoc_log_set_handler(&mongo_logger, NULL);
 
-    mydbconnection = (MONGO *)calloc(1, sizeof(MONGO));
-
-    if (mydbconnection == NULL) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-      return NULL;
-    }
+    mydbconnection = (MONGO *)turn_calloc(1, sizeof(MONGO));
 
     mydbconnection->uri = mongoc_uri_new(pud->userdb);
 
@@ -906,10 +901,7 @@ static int mongo_set_realm_option_one(uint8_t *realm, unsigned long value, const
   bson_init(&doc);
 
   size_t klen = 9 + strlen(opt) + 1; /* "options." + opt + null */
-  char *_k = (char *)malloc(klen);
-  if (!_k) {
-    return -1;
-  }
+  char *_k = (char *)turn_malloc(klen);
   strcpy(_k, "options.");
   strcat(_k, opt);
 
@@ -1121,7 +1113,7 @@ static void mongo_reread_realms(secrets_list_t *realms_list) {
 
       if (bson_iter_init(&iter, item) && bson_iter_find(&iter, "realm") && BSON_ITER_HOLDS_UTF8(&iter)) {
 
-        char *_realm = strdup(bson_iter_utf8(&iter, &length));
+        char *_realm = turn_strdup(bson_iter_utf8(&iter, &length));
 
         get_realm(_realm);
 
@@ -1137,8 +1129,8 @@ static void mongo_reread_realms(secrets_list_t *realms_list) {
           if (bson_iter_init(&origin_iter, &origin_array)) {
             while (bson_iter_next(&origin_iter)) {
               if (BSON_ITER_HOLDS_UTF8(&origin_iter)) {
-                char *_origin = strdup(bson_iter_utf8(&origin_iter, &length));
-                char *rval = strdup(_realm);
+                char *_origin = turn_strdup(bson_iter_utf8(&origin_iter, &length));
+                char *rval = turn_strdup(_realm);
                 ur_string_map_value_type value = (ur_string_map_value_type)(rval);
                 ur_string_map_put(o_to_realm_new, (ur_string_map_key_type)_origin, value);
                 free(_origin);

--- a/src/apps/relay/dbdrivers/dbd_mysql.c
+++ b/src/apps/relay/dbdrivers/dbd_mysql.c
@@ -108,7 +108,7 @@ char *decryptPassword(char *in, const unsigned char *mykey) {
 
   char *out = NULL;
   if (newTotalSize > 0) {
-    out = (char *)malloc(newTotalSize + 1);
+    out = (char *)turn_malloc(newTotalSize + 1);
     if (out) {
       CRYPTO_ctr128_encrypt(encryptedText, (unsigned char *)out, newTotalSize, &key, state.ivec, state.ecount,
                             &state.num, (block128_f)AES_encrypt);
@@ -120,9 +120,9 @@ char *decryptPassword(char *in, const unsigned char *mykey) {
 }
 
 static Myconninfo *MyconninfoParse(char *userdb, char **errmsg) {
-  Myconninfo *co = (Myconninfo *)calloc(1, sizeof(Myconninfo));
+  Myconninfo *co = (Myconninfo *)turn_calloc(1, sizeof(Myconninfo));
   if (userdb) {
-    char *s0 = strdup(userdb);
+    char *s0 = turn_strdup(userdb);
     char *s = s0;
 
     while (s && *s) {
@@ -141,44 +141,44 @@ static Myconninfo *MyconninfoParse(char *userdb, char **errmsg) {
         MyconninfoFree(co);
         co = NULL;
         if (errmsg) {
-          *errmsg = strdup(s);
+          *errmsg = turn_strdup(s);
         }
         break;
       }
 
       *seq = 0;
       if (!strcmp(s, "host")) {
-        co->host = strdup(seq + 1);
+        co->host = turn_strdup(seq + 1);
       } else if (!strcmp(s, "ip")) {
-        co->host = strdup(seq + 1);
+        co->host = turn_strdup(seq + 1);
       } else if (!strcmp(s, "addr")) {
-        co->host = strdup(seq + 1);
+        co->host = turn_strdup(seq + 1);
       } else if (!strcmp(s, "ipaddr")) {
-        co->host = strdup(seq + 1);
+        co->host = turn_strdup(seq + 1);
       } else if (!strcmp(s, "hostaddr")) {
-        co->host = strdup(seq + 1);
+        co->host = turn_strdup(seq + 1);
       } else if (!strcmp(s, "dbname")) {
-        co->dbname = strdup(seq + 1);
+        co->dbname = turn_strdup(seq + 1);
       } else if (!strcmp(s, "db")) {
-        co->dbname = strdup(seq + 1);
+        co->dbname = turn_strdup(seq + 1);
       } else if (!strcmp(s, "database")) {
-        co->dbname = strdup(seq + 1);
+        co->dbname = turn_strdup(seq + 1);
       } else if (!strcmp(s, "user")) {
-        co->user = strdup(seq + 1);
+        co->user = turn_strdup(seq + 1);
       } else if (!strcmp(s, "uname")) {
-        co->user = strdup(seq + 1);
+        co->user = turn_strdup(seq + 1);
       } else if (!strcmp(s, "name")) {
-        co->user = strdup(seq + 1);
+        co->user = turn_strdup(seq + 1);
       } else if (!strcmp(s, "username")) {
-        co->user = strdup(seq + 1);
+        co->user = turn_strdup(seq + 1);
       } else if (!strcmp(s, "password")) {
-        co->password = strdup(seq + 1);
+        co->password = turn_strdup(seq + 1);
       } else if (!strcmp(s, "pwd")) {
-        co->password = strdup(seq + 1);
+        co->password = turn_strdup(seq + 1);
       } else if (!strcmp(s, "passwd")) {
-        co->password = strdup(seq + 1);
+        co->password = turn_strdup(seq + 1);
       } else if (!strcmp(s, "secret")) {
-        co->password = strdup(seq + 1);
+        co->password = turn_strdup(seq + 1);
       } else if (!strcmp(s, "port")) {
         co->port = (unsigned int)atoi(seq + 1);
       } else if (!strcmp(s, "p")) {
@@ -190,30 +190,30 @@ static Myconninfo *MyconninfoParse(char *userdb, char **errmsg) {
       } else if (!strcmp(s, "read_timeout")) {
         co->read_timeout = (unsigned int)atoi(seq + 1);
       } else if (!strcmp(s, "key")) {
-        co->key = strdup(seq + 1);
+        co->key = turn_strdup(seq + 1);
       } else if (!strcmp(s, "ssl-key")) {
-        co->key = strdup(seq + 1);
+        co->key = turn_strdup(seq + 1);
       } else if (!strcmp(s, "ca")) {
-        co->ca = strdup(seq + 1);
+        co->ca = turn_strdup(seq + 1);
       } else if (!strcmp(s, "ssl-ca")) {
-        co->ca = strdup(seq + 1);
+        co->ca = turn_strdup(seq + 1);
       } else if (!strcmp(s, "capath")) {
-        co->capath = strdup(seq + 1);
+        co->capath = turn_strdup(seq + 1);
       } else if (!strcmp(s, "ssl-capath")) {
-        co->capath = strdup(seq + 1);
+        co->capath = turn_strdup(seq + 1);
       } else if (!strcmp(s, "cert")) {
-        co->cert = strdup(seq + 1);
+        co->cert = turn_strdup(seq + 1);
       } else if (!strcmp(s, "ssl-cert")) {
-        co->cert = strdup(seq + 1);
+        co->cert = turn_strdup(seq + 1);
       } else if (!strcmp(s, "cipher")) {
-        co->cipher = strdup(seq + 1);
+        co->cipher = turn_strdup(seq + 1);
       } else if (!strcmp(s, "ssl-cipher")) {
-        co->cipher = strdup(seq + 1);
+        co->cipher = turn_strdup(seq + 1);
       } else {
         MyconninfoFree(co);
         co = NULL;
         if (errmsg) {
-          *errmsg = strdup(s);
+          *errmsg = turn_strdup(s);
         }
         break;
       }
@@ -226,16 +226,16 @@ static Myconninfo *MyconninfoParse(char *userdb, char **errmsg) {
 
   if (co) {
     if (!(co->dbname)) {
-      co->dbname = strdup("0");
+      co->dbname = turn_strdup("0");
     }
     if (!(co->host)) {
-      co->host = strdup("127.0.0.1");
+      co->host = turn_strdup("127.0.0.1");
     }
     if (!(co->user)) {
-      co->user = strdup("");
+      co->user = turn_strdup("");
     }
     if (!(co->password)) {
-      co->password = strdup("");
+      co->password = turn_strdup("");
     }
   }
 
@@ -866,7 +866,7 @@ static int mysql_get_ip_list(const char *kind, ip_range_list_t *list) {
 static void cb_origin_to_realm(char cols[][MY_COL_SZ], const unsigned long *lens, void *ctx) {
   (void)lens;
   ur_string_map *o_to_realm_new = (ur_string_map *)ctx;
-  char *rval = strdup(cols[1]);
+  char *rval = turn_strdup(cols[1]);
   get_realm(rval);
   if (!ur_string_map_put(o_to_realm_new, (ur_string_map_key_type)cols[0], (ur_string_map_value_type)rval)) {
     free(rval);

--- a/src/apps/relay/dbdrivers/dbd_pgsql.c
+++ b/src/apps/relay/dbdrivers/dbd_pgsql.c
@@ -792,7 +792,7 @@ static void pgsql_reread_realms(secrets_list_t *realms_list) {
             char *rval = PQgetvalue(res, i, 1);
             if (rval) {
               get_realm(rval);
-              ur_string_map_value_type value = strdup(rval);
+              ur_string_map_value_type value = turn_strdup(rval);
               if (!ur_string_map_put(o_to_realm_new, (ur_string_map_key_type)oval, value)) {
                 free(value);
               }

--- a/src/apps/relay/dbdrivers/dbd_redis.c
+++ b/src/apps/relay/dbdrivers/dbd_redis.c
@@ -1161,7 +1161,7 @@ static void redis_reread_realms(secrets_list_t *realms_list) {
             }
           } else {
             get_realm(rget->str);
-            ur_string_map_value_type value = strdup(rget->str);
+            ur_string_map_value_type value = turn_strdup(rget->str);
             ur_string_map_put(o_to_realm_new, (ur_string_map_key_type)origin, value);
           }
           turnFreeRedisReply(rget);

--- a/src/apps/relay/dbdrivers/dbd_redis_conninfo.c
+++ b/src/apps/relay/dbdrivers/dbd_redis_conninfo.c
@@ -35,6 +35,8 @@
 
 #include "dbd_redis_conninfo.h"
 
+#include "ns_turn_utils.h" // for turn_malloc, turn_calloc, turn_realloc, turn_strdup
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -60,17 +62,14 @@ static int ry_parse_bool(const char *v) {
 }
 
 Ryconninfo *RyconninfoParse(const char *userdb, char **errmsg) {
-  Ryconninfo *co = (Ryconninfo *)calloc(1, sizeof(Ryconninfo));
-  if (!co) {
-    return NULL;
-  }
+  Ryconninfo *co = (Ryconninfo *)turn_calloc(1, sizeof(Ryconninfo));
   /* Tri-state: -1 means "not specified", so the secure default (peer
    * verification on) can be applied without clobbering an explicit
    * "tls-verify=none". */
   co->tls_verify = -1;
 
   if (userdb) {
-    char *s0 = strdup(userdb);
+    char *s0 = turn_strdup(userdb);
     char *s = s0;
 
     while (s && *s) {
@@ -91,7 +90,7 @@ Ryconninfo *RyconninfoParse(const char *userdb, char **errmsg) {
           RyconninfoFree(co);
           co = NULL;
           if (errmsg) {
-            *errmsg = strdup(s);
+            *errmsg = turn_strdup(s);
           }
         }
         break;
@@ -100,52 +99,52 @@ Ryconninfo *RyconninfoParse(const char *userdb, char **errmsg) {
       *seq = 0;
       if (!strcmp(s, "host")) {
         free(co->host);
-        co->host = strdup(seq + 1);
+        co->host = turn_strdup(seq + 1);
       } else if (!strcmp(s, "ip")) {
         free(co->host);
-        co->host = strdup(seq + 1);
+        co->host = turn_strdup(seq + 1);
       } else if (!strcmp(s, "addr")) {
         free(co->host);
-        co->host = strdup(seq + 1);
+        co->host = turn_strdup(seq + 1);
       } else if (!strcmp(s, "ipaddr")) {
         free(co->host);
-        co->host = strdup(seq + 1);
+        co->host = turn_strdup(seq + 1);
       } else if (!strcmp(s, "hostaddr")) {
         free(co->host);
-        co->host = strdup(seq + 1);
+        co->host = turn_strdup(seq + 1);
       } else if (!strcmp(s, "dbname")) {
         free(co->dbname);
-        co->dbname = strdup(seq + 1);
+        co->dbname = turn_strdup(seq + 1);
       } else if (!strcmp(s, "db")) {
         free(co->dbname);
-        co->dbname = strdup(seq + 1);
+        co->dbname = turn_strdup(seq + 1);
       } else if (!strcmp(s, "database")) {
         free(co->dbname);
-        co->dbname = strdup(seq + 1);
+        co->dbname = turn_strdup(seq + 1);
       } else if (!strcmp(s, "user")) {
         free(co->user);
-        co->user = strdup(seq + 1);
+        co->user = turn_strdup(seq + 1);
       } else if (!strcmp(s, "uname")) {
         free(co->user);
-        co->user = strdup(seq + 1);
+        co->user = turn_strdup(seq + 1);
       } else if (!strcmp(s, "name")) {
         free(co->user);
-        co->user = strdup(seq + 1);
+        co->user = turn_strdup(seq + 1);
       } else if (!strcmp(s, "username")) {
         free(co->user);
-        co->user = strdup(seq + 1);
+        co->user = turn_strdup(seq + 1);
       } else if (!strcmp(s, "password")) {
         free(co->password);
-        co->password = strdup(seq + 1);
+        co->password = turn_strdup(seq + 1);
       } else if (!strcmp(s, "pwd")) {
         free(co->password);
-        co->password = strdup(seq + 1);
+        co->password = turn_strdup(seq + 1);
       } else if (!strcmp(s, "passwd")) {
         free(co->password);
-        co->password = strdup(seq + 1);
+        co->password = turn_strdup(seq + 1);
       } else if (!strcmp(s, "secret")) {
         free(co->password);
-        co->password = strdup(seq + 1);
+        co->password = turn_strdup(seq + 1);
       } else if (!strcmp(s, "port")) {
         co->port = (unsigned int)atoi(seq + 1);
       } else if (!strcmp(s, "p")) {
@@ -158,26 +157,26 @@ Ryconninfo *RyconninfoParse(const char *userdb, char **errmsg) {
         co->use_tls = ry_parse_bool(seq + 1);
       } else if (!strcmp(s, "tls-ca") || !strcmp(s, "ca") || !strcmp(s, "cacert")) {
         free(co->tls_ca);
-        co->tls_ca = strdup(seq + 1);
+        co->tls_ca = turn_strdup(seq + 1);
       } else if (!strcmp(s, "tls-capath") || !strcmp(s, "capath")) {
         free(co->tls_capath);
-        co->tls_capath = strdup(seq + 1);
+        co->tls_capath = turn_strdup(seq + 1);
       } else if (!strcmp(s, "tls-cert") || !strcmp(s, "cert")) {
         free(co->tls_cert);
-        co->tls_cert = strdup(seq + 1);
+        co->tls_cert = turn_strdup(seq + 1);
       } else if (!strcmp(s, "tls-key") || !strcmp(s, "clientkey")) {
         free(co->tls_key);
-        co->tls_key = strdup(seq + 1);
+        co->tls_key = turn_strdup(seq + 1);
       } else if (!strcmp(s, "tls-sni") || !strcmp(s, "sni") || !strcmp(s, "servername")) {
         free(co->tls_sni);
-        co->tls_sni = strdup(seq + 1);
+        co->tls_sni = turn_strdup(seq + 1);
       } else if (!strcmp(s, "tls-verify") || !strcmp(s, "verify")) {
         co->tls_verify = (!strcmp(seq + 1, "none") || !strcmp(seq + 1, "0") || !strcmp(seq + 1, "false")) ? 0 : 1;
       } else {
         RyconninfoFree(co);
         co = NULL;
         if (errmsg) {
-          *errmsg = strdup(s);
+          *errmsg = turn_strdup(s);
         }
         break;
       }
@@ -190,10 +189,10 @@ Ryconninfo *RyconninfoParse(const char *userdb, char **errmsg) {
 
   if (co) {
     if (!(co->dbname)) {
-      co->dbname = strdup("0");
+      co->dbname = turn_strdup("0");
     }
     if (!(co->host)) {
-      co->host = strdup("127.0.0.1");
+      co->host = turn_strdup("127.0.0.1");
     }
     if (co->tls_verify < 0) {
       co->tls_verify = 1; /* secure default: verify the server certificate */

--- a/src/apps/relay/dbdrivers/dbd_sqlite.c
+++ b/src/apps/relay/dbdrivers/dbd_sqlite.c
@@ -147,7 +147,7 @@ static void fix_user_directory(char *dir0) {
     }
     const size_t szh = strlen(home);
     const size_t sz = strlen(dir0) + 1 + szh;
-    char *dir_fixed = (char *)malloc(sz);
+    char *dir_fixed = (char *)turn_malloc(sz);
     strncpy(dir_fixed, home, szh);
     strncpy(dir_fixed + szh, dir + 1, (sz - szh - 1));
     strncpy(dir0, dir_fixed, sz);
@@ -1132,8 +1132,8 @@ static void sqlite_reread_realms(secrets_list_t *realms_list) {
         if (stepResult == SQLITE_ROW) {
 
           // TODO: Why does oval need to be strdup? It seems used read-only, non-owning?
-          char *oval = strdup((const char *)sqlite3_column_text(st, 0));
-          char *rval = strdup((const char *)sqlite3_column_text(st, 1));
+          char *oval = turn_strdup((const char *)sqlite3_column_text(st, 0));
+          char *rval = turn_strdup((const char *)sqlite3_column_text(st, 1));
 
           get_realm(rval);
           ur_string_map_value_type value = rval;
@@ -1193,7 +1193,7 @@ static void sqlite_reread_realms(secrets_list_t *realms_list) {
         if (stepResult == SQLITE_ROW) {
 
           // TODO: Why does rval need strdup? seems read-only non-owning.
-          char *rval = strdup((const char *)sqlite3_column_text(st, 0));
+          char *rval = turn_strdup((const char *)sqlite3_column_text(st, 0));
           const char *oval = (const char *)sqlite3_column_text(st, 1);
           const char *vval = (const char *)sqlite3_column_text(st, 2);
 

--- a/src/apps/relay/dbdrivers/dbdriver.c
+++ b/src/apps/relay/dbdrivers/dbdriver.c
@@ -112,7 +112,7 @@ char *sanitize_userdb_string(char *udb) {
   char *pend;
 
   /* host=localhost dbname=coturn user=turn password=turn connect_timeout=30 */
-  ret = strdup(udb);
+  ret = turn_strdup(udb);
   pstart = strstr(ret, "password=");
   if (pstart != NULL) {
     pstart += strlen("password=");

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -639,11 +639,7 @@ static int ensure_recvmmsg_state(dtls_listener_relay_server_type *server) {
   }
 
   server->recvmmsg_state =
-      (struct dtls_listener_recvmmsg_state *)calloc(1, sizeof(struct dtls_listener_recvmmsg_state));
-  if (!server->recvmmsg_state) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate recvmmsg scratch state\n", __FUNCTION__);
-    return -1;
-  }
+      (struct dtls_listener_recvmmsg_state *)turn_calloc(1, sizeof(struct dtls_listener_recvmmsg_state));
 
   for (unsigned int i = 0; i < MAX_RECVMMSG_BATCH; ++i) {
     ioa_init_recvmmsg_hdr(&(server->recvmmsg_state->msgs[i]), &(server->recvmmsg_state->iovecs[i]),
@@ -724,12 +720,7 @@ static int create_new_connected_udp_socket(dtls_listener_relay_server_type *serv
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Cannot bind udp server socket to device %s\n", (char *)(s->e->relay_ifname));
   }
 
-  ioa_socket_handle ret = (ioa_socket *)calloc(1, sizeof(ioa_socket));
-  if (!ret) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate new socket structure\n", __FUNCTION__);
-    socket_closesocket(udp_fd);
-    return -1;
-  }
+  ioa_socket_handle ret = (ioa_socket *)turn_calloc(1, sizeof(ioa_socket));
 
   ret->magic = SOCKET_MAGIC;
 

--- a/src/apps/relay/hiredis_libevent2.c
+++ b/src/apps/relay/hiredis_libevent2.c
@@ -264,21 +264,18 @@ redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int
   }
 
   /* Create container for context and r/w events */
-  struct redisLibeventEvents *e = (struct redisLibeventEvents *)calloc(1, sizeof(struct redisLibeventEvents));
-  if (!e) {
-    return NULL;
-  }
+  struct redisLibeventEvents *e = (struct redisLibeventEvents *)turn_calloc(1, sizeof(struct redisLibeventEvents));
 
   e->allocated = 1;
   e->context = ac;
   e->base = base;
-  e->ip = strdup(ip);
+  e->ip = turn_strdup(ip);
   e->port = port;
   if (user) {
-    e->user = strdup(user);
+    e->user = turn_strdup(user);
   }
   if (pwd) {
-    e->pwd = strdup(pwd);
+    e->pwd = turn_strdup(pwd);
   }
   e->db = db;
   e->ssl_ctx = ssl_ctx;

--- a/src/apps/relay/http_buffer.c
+++ b/src/apps/relay/http_buffer.c
@@ -46,15 +46,8 @@ struct str_buffer {
 };
 
 struct str_buffer *str_buffer_new(void) {
-  struct str_buffer *ret = (struct str_buffer *)calloc(1, sizeof(struct str_buffer));
-  if (!ret) {
-    return NULL;
-  }
-  ret->buffer = (char *)malloc(1);
-  if (!(ret->buffer)) {
-    free(ret);
-    return NULL;
-  }
+  struct str_buffer *ret = (struct str_buffer *)turn_calloc(1, sizeof(struct str_buffer));
+  ret->buffer = (char *)turn_malloc(1);
   ret->buffer[0] = 0;
   ret->capacity = 1;
   return ret;
@@ -75,10 +68,7 @@ void str_buffer_append(struct str_buffer *sb, const char *str) {
       }
 
       const size_t new_capacity = sb->capacity + growth;
-      char *new_buffer = (char *)realloc(sb->buffer, new_capacity);
-      if (!new_buffer) {
-        return;
-      }
+      char *new_buffer = (char *)turn_realloc(sb->buffer, new_capacity);
 
       sb->buffer = new_buffer;
       sb->capacity = new_capacity;

--- a/src/apps/relay/http_server.c
+++ b/src/apps/relay/http_server.c
@@ -127,16 +127,12 @@ static struct headers_list *post_parse(char *data, size_t data_len) {
     --data_len;
   }
   if (data_len) {
-    char *post_data = (char *)calloc(data_len + 1, sizeof(char));
+    char *post_data = (char *)turn_calloc(data_len + 1, sizeof(char));
     if (post_data != NULL) {
       memcpy(post_data, data, data_len);
       char *fmarker = NULL;
       char *fsplit = strtok_r(post_data, "&", &fmarker);
-      struct headers_list *list = (struct headers_list *)calloc(1, sizeof(struct headers_list));
-      if (list == NULL) {
-        free(post_data);
-        return NULL;
-      }
+      struct headers_list *list = (struct headers_list *)turn_calloc(1, sizeof(struct headers_list));
       while (fsplit != NULL) {
         char *vmarker = NULL;
         char *key = strtok_r(fsplit, "=", &vmarker);
@@ -155,9 +151,9 @@ static struct headers_list *post_parse(char *data, size_t data_len) {
             }
             p++;
           }
-          char **new_keys = (char **)realloc(list->keys, sizeof(char *) * (list->n + 1));
-          char **new_values = (char **)realloc(list->values, sizeof(char *) * (list->n + 1));
-          char *new_key = strdup(key);
+          char **new_keys = (char **)turn_realloc(list->keys, sizeof(char *) * (list->n + 1));
+          char **new_values = (char **)turn_realloc(list->values, sizeof(char *) * (list->n + 1));
+          char *new_key = turn_strdup(key);
           if (new_keys == NULL || new_values == NULL || new_key == NULL) {
             free(new_key);
             if (new_keys) {
@@ -205,7 +201,7 @@ static struct http_request *parse_http_request_1(struct http_request *ret, char 
 
         const char *query = evhttp_uri_get_query(uri);
         if (query) {
-          struct evkeyvalq *kv = (struct evkeyvalq *)calloc(1, sizeof(struct evkeyvalq));
+          struct evkeyvalq *kv = (struct evkeyvalq *)turn_calloc(1, sizeof(struct evkeyvalq));
           if (evhttp_parse_query_str(query, kv) < 0) {
             free(ret);
             ret = NULL;
@@ -214,14 +210,14 @@ static struct http_request *parse_http_request_1(struct http_request *ret, char 
               free(kv);
             }
           } else {
-            ret->headers = (struct http_headers *)calloc(1, sizeof(struct http_headers));
+            ret->headers = (struct http_headers *)turn_calloc(1, sizeof(struct http_headers));
             ret->headers->uri_headers = kv;
           }
         }
 
         const char *path = evhttp_uri_get_path(uri);
         if (path && ret) {
-          ret->path = strdup(path);
+          ret->path = turn_strdup(path);
         }
 
         evhttp_uri_free(uri);
@@ -230,7 +226,7 @@ static struct http_request *parse_http_request_1(struct http_request *ret, char 
           char *body = strstr(s + 1, "\r\n\r\n");
           if (body && body[0]) {
             if (!ret->headers) {
-              ret->headers = (struct http_headers *)calloc(1, sizeof(struct http_headers));
+              ret->headers = (struct http_headers *)turn_calloc(1, sizeof(struct http_headers));
             }
             ret->headers->post_headers = post_parse(body, strlen(body));
           }
@@ -250,12 +246,7 @@ struct http_request *parse_http_request(char *request) {
 
   if (request) {
 
-    ret = (struct http_request *)calloc(1, sizeof(struct http_request));
-
-    if (ret == NULL) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-      return NULL;
-    }
+    ret = (struct http_request *)turn_calloc(1, sizeof(struct http_request));
 
     if (strstr(request, "GET ") == request) {
       ret->rtype = HRT_GET;

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -328,7 +328,7 @@ static int make_local_listeners_list(void) {
 
   do {
 
-    pAddresses = (IP_ADAPTER_ADDRESSES *)malloc(outBufLen);
+    pAddresses = (IP_ADAPTER_ADDRESSES *)turn_malloc(outBufLen);
     if (pAddresses == NULL) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Memory allocation failed for IP_ADAPTER_ADDRESSES struct\n");
       return -1;
@@ -602,7 +602,7 @@ static int make_local_relays_list(int allow_local, int family) {
 
   do {
 
-    pAddresses = (IP_ADAPTER_ADDRESSES *)malloc(outBufLen);
+    pAddresses = (IP_ADAPTER_ADDRESSES *)turn_malloc(outBufLen);
     if (pAddresses == NULL) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Memory allocation failed for IP_ADAPTER_ADDRESSES struct\n");
       return -1;
@@ -787,7 +787,7 @@ int get_a_local_relay(int family, ioa_addr *relay_addr) {
   outBufLen = WORKING_BUFFER_SIZE;
 
   do {
-    pAddresses = (IP_ADAPTER_ADDRESSES *)malloc(outBufLen);
+    pAddresses = (IP_ADAPTER_ADDRESSES *)turn_malloc(outBufLen);
     if (pAddresses == NULL) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Memory allocation failed for IP_ADAPTER_ADDRESSES struct\n");
       return -1;
@@ -1924,13 +1924,13 @@ static void generate_aes_128_key(char *filePath, unsigned char *returnedKey) {
 unsigned char *base64decode(const void *b64_decode_this, int decode_this_many_bytes) {
   BIO *b64_bio, *mem_bio; // Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
   unsigned char *base64_decoded =
-      (unsigned char *)calloc((decode_this_many_bytes * 3) / 4 + 1, sizeof(char)); //+1 = null.
-  b64_bio = BIO_new(BIO_f_base64());                                               // Initialize our base64 filter BIO.
-  mem_bio = BIO_new(BIO_s_mem());                                                  // Initialize our memory source BIO.
-  BIO_write(mem_bio, b64_decode_this, decode_this_many_bytes);                     // Base64 data saved in source.
-  BIO_push(b64_bio, mem_bio);                     // Link the BIOs by creating a filter-source BIO chain.
-  BIO_set_flags(b64_bio, BIO_FLAGS_BASE64_NO_NL); // Don't require trailing newlines.
-  int decoded_byte_index = 0;                     // Index where the next base64_decoded byte should be written.
+      (unsigned char *)turn_calloc((decode_this_many_bytes * 3) / 4 + 1, sizeof(char)); //+1 = null.
+  b64_bio = BIO_new(BIO_f_base64());                           // Initialize our base64 filter BIO.
+  mem_bio = BIO_new(BIO_s_mem());                              // Initialize our memory source BIO.
+  BIO_write(mem_bio, b64_decode_this, decode_this_many_bytes); // Base64 data saved in source.
+  BIO_push(b64_bio, mem_bio);                                  // Link the BIOs by creating a filter-source BIO chain.
+  BIO_set_flags(b64_bio, BIO_FLAGS_BASE64_NO_NL);              // Don't require trailing newlines.
+  int decoded_byte_index = 0; // Index where the next base64_decoded byte should be written.
   while (0 < BIO_read(b64_bio, base64_decoded + decoded_byte_index, 1)) { // Read byte-by-byte.
     decoded_byte_index++; // Increment the index until read of BIO decoded data is complete.
   }                       // Once we're done reading decoded data, BIO_read returns -1 even though there's no error.
@@ -2274,7 +2274,7 @@ static void set_option(int c, char *value) {
     if (value) {
       char *div = strchr(value, '/');
       if (div) {
-        char *nval = strdup(value);
+        char *nval = turn_strdup(value);
         div = strchr(nval, '/');
         div[0] = 0;
         ++div;

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -218,7 +218,7 @@ static void add_aux_server_list(const char *saddr, turn_server_addrs_list_t *lis
     if (make_ioa_addr_from_full_string((const uint8_t *)saddr, 0, &addr) != 0) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong full address format: %s\n", saddr);
     } else {
-      list->addrs = (ioa_addr *)realloc(list->addrs, sizeof(ioa_addr) * (list->size + 1));
+      list->addrs = (ioa_addr *)turn_realloc(list->addrs, sizeof(ioa_addr) * (list->size + 1));
       addr_cpy(&(list->addrs[(list->size)++]), &addr);
       {
         char s[MAX_IOA_ADDR_STRING];
@@ -242,7 +242,7 @@ static void add_alt_server(const char *saddr, uint16_t default_port, turn_server
     if (make_ioa_addr_from_full_string((const uint8_t *)saddr, default_port, &addr) != 0) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong IP address format: %s\n", saddr);
     } else {
-      list->addrs = (ioa_addr *)realloc(list->addrs, sizeof(ioa_addr) * (list->size + 1));
+      list->addrs = (ioa_addr *)turn_realloc(list->addrs, sizeof(ioa_addr) * (list->size + 1));
       addr_cpy(&(list->addrs[(list->size)++]), &addr);
       {
         char s[MAX_IOA_ADDR_STRING];
@@ -275,7 +275,7 @@ static void del_alt_server(const char *saddr, uint16_t default_port, turn_server
 
       if (i < list->size) {
 
-        ioa_addr *new_addrs = (ioa_addr *)malloc(sizeof(ioa_addr) * (list->size - 1));
+        ioa_addr *new_addrs = (ioa_addr *)turn_malloc(sizeof(ioa_addr) * (list->size - 1));
         if (!new_addrs) {
           return;
         }
@@ -366,11 +366,7 @@ static void update_ssl_ctx(evutil_socket_t sock, short events, update_ssl_ctx_cb
 }
 
 void set_ssl_ctx(ioa_engine_handle e, turn_params_t *params) {
-  update_ssl_ctx_cb_args_t *args = (update_ssl_ctx_cb_args_t *)malloc(sizeof(update_ssl_ctx_cb_args_t));
-  if (args == NULL) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-    return;
-  }
+  update_ssl_ctx_cb_args_t *args = (update_ssl_ctx_cb_args_t *)turn_malloc(sizeof(update_ssl_ctx_cb_args_t));
   args->engine = e;
   args->params = params;
   args->next = NULL;
@@ -411,11 +407,11 @@ void add_listener_addr(const char *addr) {
     ++turn_params.listener.addrs_number;
     ++turn_params.listener.services_number;
     turn_params.listener.addrs =
-        (char **)realloc(turn_params.listener.addrs, sizeof(char *) * turn_params.listener.addrs_number);
-    turn_params.listener.addrs[turn_params.listener.addrs_number - 1] = strdup(sbaddr);
-    turn_params.listener.encaddrs =
-        (ioa_addr **)realloc(turn_params.listener.encaddrs, sizeof(ioa_addr *) * turn_params.listener.addrs_number);
-    turn_params.listener.encaddrs[turn_params.listener.addrs_number - 1] = (ioa_addr *)malloc(sizeof(ioa_addr));
+        (char **)turn_realloc(turn_params.listener.addrs, sizeof(char *) * turn_params.listener.addrs_number);
+    turn_params.listener.addrs[turn_params.listener.addrs_number - 1] = turn_strdup(sbaddr);
+    turn_params.listener.encaddrs = (ioa_addr **)turn_realloc(turn_params.listener.encaddrs,
+                                                              sizeof(ioa_addr *) * turn_params.listener.addrs_number);
+    turn_params.listener.encaddrs[turn_params.listener.addrs_number - 1] = (ioa_addr *)turn_malloc(sizeof(ioa_addr));
     addr_cpy(turn_params.listener.encaddrs[turn_params.listener.addrs_number - 1], &baddr);
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Listener address to use: %s\n", sbaddr);
   }
@@ -439,8 +435,9 @@ int add_relay_addr(const char *addr) {
     }
 
     ++turn_params.relays_number;
-    turn_params.relay_addrs = (char **)realloc(turn_params.relay_addrs, sizeof(char *) * turn_params.relays_number);
-    turn_params.relay_addrs[turn_params.relays_number - 1] = strdup(sbaddr);
+    turn_params.relay_addrs =
+        (char **)turn_realloc(turn_params.relay_addrs, sizeof(char *) * turn_params.relays_number);
+    turn_params.relay_addrs[turn_params.relays_number - 1] = turn_strdup(sbaddr);
 
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Relay address to use: %s\n", sbaddr);
     return 1;

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -375,7 +375,7 @@ static stun_buffer_list_elem *new_blist_elem(ioa_engine_handle e) {
   stun_buffer_list_elem *ret = get_elem_from_buffer_list(&(e->bufs));
 
   if (!ret) {
-    ret = (stun_buffer_list_elem *)malloc(sizeof(stun_buffer_list_elem));
+    ret = (stun_buffer_list_elem *)turn_malloc(sizeof(stun_buffer_list_elem));
   }
 
   if (ret) {
@@ -404,11 +404,7 @@ static inline void add_elem_to_buffer_list(stun_buffer_list *bufs, stun_buffer_l
 
 static void add_buffer_to_buffer_list(stun_buffer_list *bufs, char *buf, size_t len) {
   if (bufs && buf && (bufs->tsz < MAX_SOCKET_BUFFER_BACKLOG)) {
-    stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)malloc(sizeof(stun_buffer_list_elem));
-    if (buf_elem == NULL) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-      return;
-    }
+    stun_buffer_list_elem *buf_elem = (stun_buffer_list_elem *)turn_malloc(sizeof(stun_buffer_list_elem));
     memcpy(buf_elem->buf.buf, buf, len);
     buf_elem->buf.len = len;
     buf_elem->buf.offset = 0;
@@ -924,11 +920,7 @@ ioa_timer_handle set_ioa_timer(ioa_engine_handle e, int secs, int ms, ioa_timer_
 
   if (e && cb && secs > 0) {
 
-    timer_event *te = (timer_event *)malloc(sizeof(timer_event));
-    if (te == NULL) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-      return NULL;
-    }
+    timer_event *te = (timer_event *)turn_malloc(sizeof(timer_event));
 
     int flags = EV_TIMEOUT;
     if (persist) {
@@ -944,7 +936,7 @@ ioa_timer_handle set_ioa_timer(ioa_engine_handle e, int secs, int ms, ioa_timer_
       te->e = e;
       te->ev = ev;
       te->cb = cb;
-      te->txt = strdup(txt);
+      te->txt = turn_strdup(txt);
     }
 
     if (!ms) {
@@ -1278,12 +1270,7 @@ ioa_socket_handle create_unbound_relay_ioa_socket(ioa_engine_handle e, int famil
     return NULL;
   }
 
-  ret = (ioa_socket *)calloc(1, sizeof(ioa_socket));
-
-  if (ret == NULL) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-    return NULL;
-  }
+  ret = (ioa_socket *)turn_calloc(1, sizeof(ioa_socket));
 
   ret->magic = SOCKET_MAGIC;
 
@@ -2001,12 +1988,7 @@ ioa_socket_handle create_ioa_socket_from_fd(ioa_engine_handle e, ioa_socket_raw 
     return NULL;
   }
 
-  ret = (ioa_socket *)calloc(1, sizeof(ioa_socket));
-
-  if (ret == NULL) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-    return NULL;
-  }
+  ret = (ioa_socket *)turn_calloc(1, sizeof(ioa_socket));
 
   ret->magic = SOCKET_MAGIC;
   ret->fd = fd;
@@ -2272,7 +2254,7 @@ ioa_socket_handle detach_ioa_socket(ioa_socket_handle s) {
 
     ioa_network_buffer_delete(s->e, s->defer_nbh);
 
-    ret = (ioa_socket *)calloc(1, sizeof(ioa_socket));
+    ret = (ioa_socket *)turn_calloc(1, sizeof(ioa_socket));
     if (!ret) {
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: Cannot allocate new socket structure\n", __FUNCTION__);
       if (udp_fd >= 0) {
@@ -2738,11 +2720,7 @@ static int ensure_engine_recvmmsg_state(ioa_engine_handle e) {
     return 0;
   }
 
-  e->udp_recvmmsg_state = (struct ioa_socket_recvmmsg_state *)calloc(1, sizeof(struct ioa_socket_recvmmsg_state));
-  if (!e->udp_recvmmsg_state) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc\n", __FUNCTION__);
-    return -1;
-  }
+  e->udp_recvmmsg_state = (struct ioa_socket_recvmmsg_state *)turn_calloc(1, sizeof(struct ioa_socket_recvmmsg_state));
 
   return 0;
 }
@@ -4944,14 +4922,9 @@ struct _super_memory {
 
 static void init_super_memory_region(super_memory_t *r) {
   if (r) {
-    r->super_memory = (char **)malloc(sizeof(char *));
-    r->super_memory[0] = (char *)calloc(1, TURN_SM_SIZE);
-    r->sm_allocated = (size_t *)malloc(sizeof(size_t));
-
-    if (r->sm_allocated == NULL || r->super_memory == NULL) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-      return;
-    }
+    r->super_memory = (char **)turn_malloc(sizeof(char *));
+    r->super_memory[0] = (char *)turn_calloc(1, TURN_SM_SIZE);
+    r->sm_allocated = (size_t *)turn_malloc(sizeof(size_t));
 
     r->sm_allocated[0] = 0;
 
@@ -4967,7 +4940,7 @@ static void init_super_memory_region(super_memory_t *r) {
 void init_super_memory(void) { ; }
 
 super_memory_t *new_super_memory_region(void) {
-  super_memory_t *r = (super_memory_t *)calloc(1, sizeof(super_memory_t));
+  super_memory_t *r = (super_memory_t *)turn_calloc(1, sizeof(super_memory_t));
   init_super_memory_region(r);
   return r;
 }
@@ -4980,7 +4953,7 @@ void *allocate_super_memory_region_func(super_memory_t *r, size_t size, const ch
   void *ret = NULL;
 
   if (!r) {
-    ret = calloc(1, size);
+    ret = turn_calloc(1, size);
     return ret;
   }
 
@@ -5014,9 +4987,9 @@ void *allocate_super_memory_region_func(super_memory_t *r, size_t size, const ch
 
     if (!region) {
       r->sm_chunk += 1;
-      r->super_memory = (char **)realloc(r->super_memory, (r->sm_chunk + 1) * sizeof(char *));
-      r->super_memory[r->sm_chunk] = (char *)calloc(1, TURN_SM_SIZE);
-      r->sm_allocated = (size_t *)realloc(r->sm_allocated, (r->sm_chunk + 1) * sizeof(size_t));
+      r->super_memory = (char **)turn_realloc(r->super_memory, (r->sm_chunk + 1) * sizeof(char *));
+      r->super_memory[r->sm_chunk] = (char *)turn_calloc(1, TURN_SM_SIZE);
+      r->sm_allocated = (size_t *)turn_realloc(r->sm_allocated, (r->sm_chunk + 1) * sizeof(size_t));
       r->sm_allocated[r->sm_chunk] = 0;
       region = r->super_memory[r->sm_chunk];
       rsz = r->sm_allocated + r->sm_chunk;
@@ -5034,7 +5007,7 @@ void *allocate_super_memory_region_func(super_memory_t *r, size_t size, const ch
   }
 
   if (!ret) {
-    ret = calloc(1, size);
+    ret = turn_calloc(1, size);
   }
 
   return ret;

--- a/src/apps/relay/prom_server.c
+++ b/src/apps/relay/prom_server.c
@@ -168,7 +168,7 @@ static char *prom_read_file(const char *path) {
   if (fseek(f, 0, SEEK_END) == 0) {
     long size = ftell(f);
     if (size >= 0 && fseek(f, 0, SEEK_SET) == 0) {
-      buf = malloc((size_t)size + 1);
+      buf = turn_malloc((size_t)size + 1);
       if (buf != NULL) {
         if (fread(buf, 1, (size_t)size, f) != (size_t)size) {
           free(buf);

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -479,9 +479,9 @@ static bool print_session(ur_map_key_type key, ur_map_value_type value, void *ar
       if (!ur_string_map_get(csarg->users, (ur_string_map_key_type)(char *)tsi->username, &value)) {
         value = (ur_string_map_value_type)csarg->users_number;
         csarg->users_number += 1;
-        csarg->user_counters = (size_t *)realloc(csarg->user_counters, csarg->users_number * sizeof(size_t));
-        csarg->user_names = (char **)realloc(csarg->user_names, csarg->users_number * sizeof(char *));
-        csarg->user_names[(size_t)value] = strdup((char *)tsi->username);
+        csarg->user_counters = (size_t *)turn_realloc(csarg->user_counters, csarg->users_number * sizeof(size_t));
+        csarg->user_names = (char **)turn_realloc(csarg->user_names, csarg->users_number * sizeof(char *));
+        csarg->user_names[(size_t)value] = turn_strdup((char *)tsi->username);
         csarg->user_counters[(size_t)value] = 0;
         ur_string_map_put(csarg->users, (ur_string_map_key_type)(char *)tsi->username, value);
       }
@@ -948,7 +948,7 @@ static int run_cli_input(struct cli_session *cs, const char *buf0, unsigned int 
 
   if (cs && buf0 && cs->ts && cs->bev) {
 
-    char *buf = (char *)malloc(len + 1);
+    char *buf = (char *)turn_malloc(len + 1);
     memcpy(buf, buf0, len);
     buf[len] = 0;
 
@@ -1157,11 +1157,7 @@ static void cliserver_input_handler(struct evconnlistener *l, evutil_socket_t fd
 
   addr_debug_print(adminserver.verbose, (ioa_addr *)sa, "CLI connected to");
 
-  struct cli_session *clisession = (struct cli_session *)calloc(1, sizeof(struct cli_session));
-  if (clisession == NULL) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-    return;
-  }
+  struct cli_session *clisession = (struct cli_session *)turn_calloc(1, sizeof(struct cli_session));
 
   if (clisession) {
     clisession->rp = get_realm(NULL);
@@ -1434,11 +1430,7 @@ void setup_admin_thread(void) {
 void admin_server_receive_message(struct bufferevent *bev, void *ptr) {
   UNUSED_ARG(ptr);
 
-  struct turn_session_info *tsi = (struct turn_session_info *)calloc(1, sizeof(struct turn_session_info));
-  if (tsi == NULL) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-    return;
-  }
+  struct turn_session_info *tsi = (struct turn_session_info *)turn_calloc(1, sizeof(struct turn_session_info));
 
   int n = 0;
   struct evbuffer *input = bufferevent_get_input(bev);
@@ -1459,7 +1451,7 @@ void admin_server_receive_message(struct bufferevent *bev, void *ptr) {
 
     if (tsi->valid) {
       ur_map_put(adminserver.sessions, (ur_map_key_type)tsi->id, (ur_map_value_type)tsi);
-      tsi = (struct turn_session_info *)calloc(1, sizeof(struct turn_session_info));
+      tsi = (struct turn_session_info *)turn_calloc(1, sizeof(struct turn_session_info));
     } else {
       turn_session_info_clean(tsi);
     }
@@ -3412,10 +3404,7 @@ static void handle_logon_request(ioa_socket_handle s, struct http_request *hr) {
 
     struct admin_session *as = (struct admin_session *)s->special_session;
     if (!as) {
-      as = (struct admin_session *)calloc(1, sizeof(struct admin_session));
-      if (!as) {
-        return;
-      }
+      as = (struct admin_session *)turn_calloc(1, sizeof(struct admin_session));
       s->special_session = as;
       s->special_session_size = sizeof(struct admin_session);
     }

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -159,12 +159,8 @@ realm_params_t *get_realm(char *name) {
       unlock_realms();
       return (realm_params_t *)value;
     } else {
-      realm_params_t *ret = (realm_params_t *)malloc(sizeof(realm_params_t));
+      realm_params_t *ret = (realm_params_t *)turn_malloc(sizeof(realm_params_t));
       memcpy(ret, default_realm_params_ptr, sizeof(realm_params_t));
-      if (ret == NULL) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: error allocating memory\n", __FUNCTION__);
-        return default_realm_params_ptr;
-      }
       STRCPY(ret->options.name, name);
       value = (ur_string_map_value_type)ret;
       ur_string_map_put(realms, key, value);
@@ -189,7 +185,7 @@ int get_realm_options_by_origin(char *origin, realm_options_t *ro) {
   ur_string_map_value_type value = 0;
   TURN_MUTEX_LOCK(&o_to_realm_mutex);
   if (ur_string_map_get(o_to_realm, (ur_string_map_key_type)origin, &value) && value) {
-    char *realm = strdup((char *)value);
+    char *realm = turn_strdup((char *)value);
     TURN_MUTEX_UNLOCK(&o_to_realm_mutex);
     realm_params_t rp;
     get_realm_data(realm, &rp);
@@ -299,8 +295,8 @@ const char *get_secrets_list_elem(secrets_list_t *sl, size_t i) {
 
 void add_to_secrets_list(secrets_list_t *sl, const char *elem) {
   if (sl && elem) {
-    sl->secrets = (char **)realloc(sl->secrets, (sizeof(char *) * (sl->sz + 1)));
-    sl->secrets[sl->sz] = strdup(elem);
+    sl->secrets = (char **)turn_realloc(sl->secrets, (sizeof(char *) * (sl->sz + 1)));
+    sl->secrets[sl->sz] = turn_strdup(elem);
     sl->sz += 1;
   }
 }
@@ -389,7 +385,7 @@ static char *get_real_username(char *usname) {
           usname = col + 1;
         } else {
           *col = 0;
-          usname = strdup(usname);
+          usname = turn_strdup(usname);
           *col = turn_params.rest_api_separator;
           return usname;
         }
@@ -397,7 +393,7 @@ static char *get_real_username(char *usname) {
     }
   }
 
-  return strdup(usname);
+  return turn_strdup(usname);
 }
 
 /*
@@ -643,10 +639,7 @@ uint8_t *start_user_check(turnserver_id id, turn_credential_type ct, int in_oaut
                           int *postpone_reply) {
   *postpone_reply = 1;
 
-  struct auth_message *am = calloc(1, sizeof(*am));
-  if (!am) {
-    return NULL;
-  }
+  struct auth_message *am = turn_calloc(1, sizeof(*am));
   am->id = id;
   am->ct = ct;
   am->in_oauth = in_oauth;
@@ -666,7 +659,7 @@ uint8_t *start_user_check(turnserver_id id, turn_credential_type ct, int in_oaut
 int check_new_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
   int ret = 0;
   if (user || oauth) {
-    uint8_t *username = oauth ? (uint8_t *)strdup("") : (uint8_t *)get_real_username((char *)user);
+    uint8_t *username = oauth ? (uint8_t *)turn_strdup("") : (uint8_t *)get_real_username((char *)user);
     realm_params_t *rp = get_realm((char *)realm);
     /* Snapshot the realm quota configuration under the realms lock. These
      * fields are written by reread_realms()/change_*_quota() while holding
@@ -706,7 +699,7 @@ int check_new_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
 
 void release_allocation_quota(uint8_t *user, int oauth, uint8_t *realm) {
   if (user) {
-    uint8_t *username = oauth ? (uint8_t *)strdup("") : (uint8_t *)get_real_username((char *)user);
+    uint8_t *username = oauth ? (uint8_t *)turn_strdup("") : (uint8_t *)get_real_username((char *)user);
     realm_params_t *rp = get_realm((char *)realm);
     ur_string_map_lock(rp->status.alloc_counters);
     if (username[0]) {
@@ -749,10 +742,7 @@ int add_static_user_account(char *user) {
   // TODO: TURN usernames should be length limited by the RFC.
   // are user account names as well? If so, we can avoid allocating
   // and instead use a stack buffer.
-  char *usname = (char *)malloc(ulen + 1);
-  if (!usname) {
-    return -1;
-  }
+  char *usname = (char *)turn_malloc(ulen + 1);
 
   strncpy(usname, user, ulen);
   usname[ulen] = 0;
@@ -765,7 +755,7 @@ int add_static_user_account(char *user) {
   }
   s = skip_blanks(s + 1);
 
-  hmackey_t *key = (hmackey_t *)malloc(sizeof(hmackey_t));
+  hmackey_t *key = (hmackey_t *)turn_malloc(sizeof(hmackey_t));
   if (!key) {
     free(usname);
     return -1;
@@ -1122,10 +1112,10 @@ static ip_range_list_t *ipblacklist = NULL;
 
 void init_dynamic_ip_lists(void) {
 #if !defined(TURN_NO_RWLOCK)
-  whitelist_rwlock = (pthread_rwlock_t *)malloc(sizeof(pthread_rwlock_t));
+  whitelist_rwlock = (pthread_rwlock_t *)turn_malloc(sizeof(pthread_rwlock_t));
   pthread_rwlock_init(whitelist_rwlock, NULL);
 
-  blacklist_rwlock = (pthread_rwlock_t *)malloc(sizeof(pthread_rwlock_t));
+  blacklist_rwlock = (pthread_rwlock_t *)turn_malloc(sizeof(pthread_rwlock_t));
   pthread_rwlock_init(blacklist_rwlock, NULL);
 #else
   TURN_MUTEX_INIT(&whitelist_mutex);
@@ -1192,7 +1182,7 @@ const ip_range_list_t *ioa_get_blacklist(ioa_engine_handle e) {
 }
 
 ip_range_list_t *get_ip_list(const char *kind) {
-  ip_range_list_t *ret = (ip_range_list_t *)calloc(1, sizeof(ip_range_list_t));
+  ip_range_list_t *ret = (ip_range_list_t *)turn_calloc(1, sizeof(ip_range_list_t));
 
   const turn_dbdriver_t *dbd = get_dbdriver();
   if (dbd && dbd->get_ip_list && !turn_params.no_dynamic_ip_list) {
@@ -1235,7 +1225,7 @@ void update_white_and_black_lists(void) {
 /////////////// add ACL record ///////////////////
 
 int add_ip_list_range(const char *range0, const char *realm, ip_range_list_t *list) {
-  char *range = strdup(range0);
+  char *range = turn_strdup(range0);
 
   char *separator = strchr(range, '-');
 
@@ -1267,7 +1257,7 @@ int add_ip_list_range(const char *range0, const char *realm, ip_range_list_t *li
   }
 
   ++(list->ranges_number);
-  list->rs = (ip_range_t *)realloc(list->rs, sizeof(ip_range_t) * list->ranges_number);
+  list->rs = (ip_range_t *)turn_realloc(list->rs, sizeof(ip_range_t) * list->ranges_number);
   STRCPY(list->rs[list->ranges_number - 1].str, range);
   if (realm) {
     STRCPY(list->rs[list->ranges_number - 1].realm, realm);
@@ -1281,7 +1271,7 @@ int add_ip_list_range(const char *range0, const char *realm, ip_range_list_t *li
 }
 
 int check_ip_list_range(const char *range0) {
-  char *range = strdup(range0);
+  char *range = turn_strdup(range0);
 
   char *separator = strchr(range, '-');
 

--- a/src/apps/uclient/startuclient.c
+++ b/src/apps/uclient/startuclient.c
@@ -409,13 +409,8 @@ static int clnet_allocate(bool verbose, app_ur_conn_info *clnet_info, ioa_addr *
   bool allocate_finished;
 
   int ret = 0;
-  stun_buffer *request_message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  stun_buffer *response_message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  if (!request_message || !response_message) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot allocate STUN message buffers\n", __FUNCTION__);
-    ret = -1;
-    goto done;
-  }
+  stun_buffer *request_message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
+  stun_buffer *response_message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
 
 beg_allocate:
 
@@ -826,13 +821,8 @@ done:
 static int turn_channel_bind(bool verbose, uint16_t *chn, app_ur_conn_info *clnet_info, ioa_addr *peer_addr) {
 
   int ret = 0;
-  stun_buffer *request_message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  stun_buffer *response_message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  if (!request_message || !response_message) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot allocate STUN message buffers\n", __FUNCTION__);
-    ret = -1;
-    goto done;
-  }
+  stun_buffer *request_message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
+  stun_buffer *response_message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
 
 beg_bind:
 
@@ -938,13 +928,8 @@ static int turn_create_permission(bool verbose, app_ur_conn_info *clnet_info, io
   }
 
   int ret = 0;
-  stun_buffer *request_message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  stun_buffer *response_message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  if (!request_message || !response_message) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot allocate STUN message buffers\n", __FUNCTION__);
-    ret = -1;
-    goto done;
-  }
+  stun_buffer *request_message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
+  stun_buffer *response_message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
 
 beg_cp:
 
@@ -1040,13 +1025,8 @@ done:
 int turn_refresh_allocation(bool verbose, app_ur_conn_info *clnet_info, uint32_t lifetime) {
 
   int ret = 0;
-  stun_buffer *request_message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  stun_buffer *response_message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  if (!request_message || !response_message) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot allocate STUN message buffers\n", __FUNCTION__);
-    ret = -1;
-    goto done;
-  }
+  stun_buffer *request_message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
+  stun_buffer *response_message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
 
 beg_refresh:
 
@@ -1633,12 +1613,7 @@ int start_c2c_connection(uint16_t clnet_remote_port0, const char *remote_address
 
 int turn_tcp_connect(bool verbose, app_ur_conn_info *clnet_info, ioa_addr *peer_addr) {
   int ret = 0;
-  stun_buffer *message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  if (!message) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot allocate STUN message buffer\n", __FUNCTION__);
-    ret = -1;
-    goto done;
-  }
+  stun_buffer *message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
 
   {
     bool cp_sent = false;
@@ -1681,13 +1656,8 @@ done:
 static int turn_tcp_connection_bind(int verbose, app_ur_conn_info *clnet_info, app_tcp_conn_info *atc, int errorOK) {
 
   int ret = 0;
-  stun_buffer *request_message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  stun_buffer *response_message = (stun_buffer *)calloc(1, sizeof(stun_buffer));
-  if (!request_message || !response_message) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: cannot allocate STUN message buffers\n", __FUNCTION__);
-    ret = -1;
-    goto done;
-  }
+  stun_buffer *request_message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
+  stun_buffer *response_message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
 
 beg_cb:
 
@@ -1810,14 +1780,9 @@ again:
 
   ++elem->pinfo.tcp_conn_number;
   const int i = (int)(elem->pinfo.tcp_conn_number - 1);
-  elem->pinfo.tcp_conn =
-      (app_tcp_conn_info **)realloc(elem->pinfo.tcp_conn, elem->pinfo.tcp_conn_number * sizeof(app_tcp_conn_info *));
-  elem->pinfo.tcp_conn[i] = (app_tcp_conn_info *)calloc(1, sizeof(app_tcp_conn_info));
-
-  if (elem->pinfo.tcp_conn[i] == NULL) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "%s: failure in call to calloc \n", __FUNCTION__);
-    return;
-  }
+  elem->pinfo.tcp_conn = (app_tcp_conn_info **)turn_realloc(elem->pinfo.tcp_conn,
+                                                            elem->pinfo.tcp_conn_number * sizeof(app_tcp_conn_info *));
+  elem->pinfo.tcp_conn[i] = (app_tcp_conn_info *)turn_calloc(1, sizeof(app_tcp_conn_info));
 
   elem->pinfo.tcp_conn[i]->tcp_data_fd = clnet_fd;
   elem->pinfo.tcp_conn[i]->cid = cid;

--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -338,12 +338,7 @@ static int start_listener_threads(void) {
     num_listener_threads = UCLIENT_MAX_LISTENER_THREADS;
   }
 
-  listeners = (uclient_listener *)calloc((size_t)num_listener_threads, sizeof(uclient_listener));
-  if (!listeners) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "uclient: cannot allocate listener pool\n");
-    num_listener_threads = 0;
-    return -1;
-  }
+  listeners = (uclient_listener *)turn_calloc((size_t)num_listener_threads, sizeof(uclient_listener));
   for (int i = 0; i < num_listener_threads; ++i) {
     listeners[i].id = i;
     listeners[i].event_base = turn_event_base_new();
@@ -815,12 +810,7 @@ static int start_sender_threads(void) {
                   UCLIENT_MAX_SENDER_THREADS);
     num_sender_threads = UCLIENT_MAX_SENDER_THREADS;
   }
-  senders = (uclient_sender *)calloc((size_t)num_sender_threads, sizeof(uclient_sender));
-  if (!senders) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "uclient: cannot allocate sender pool\n");
-    num_sender_threads = 0;
-    return -1;
-  }
+  senders = (uclient_sender *)turn_calloc((size_t)num_sender_threads, sizeof(uclient_sender));
   for (int i = 0; i < num_sender_threads; ++i) {
     senders[i].id = i;
     senders[i].event_base = turn_event_base_new();
@@ -1035,7 +1025,7 @@ static app_ur_session *init_app_session(app_ur_session *ss) {
 
 static app_ur_session *create_new_ss(void) {
   ++current_clients_number;
-  app_ur_session *ss = init_app_session((app_ur_session *)malloc(sizeof(app_ur_session)));
+  app_ur_session *ss = init_app_session((app_ur_session *)turn_malloc(sizeof(app_ur_session)));
   if (ss) {
     /* Sender pool routing: when the pool is engaged, round-robin assign
      * this session to a sender thread. -1 keeps the legacy single-thread
@@ -2669,11 +2659,7 @@ void start_mclient(const char *remote_address, uint16_t port, const unsigned cha
     }
   }
 
-  elems = (app_ur_session **)malloc(sizeof(app_ur_session) * ((mclient * 2) + 1) + sizeof(void *));
-  if (elems == NULL) {
-    TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "!!! %s: failure in call to malloc !!!\n", __FUNCTION__);
-    return;
-  }
+  elems = (app_ur_session **)turn_malloc(sizeof(app_ur_session) * ((mclient * 2) + 1) + sizeof(void *));
 
   __turn_getMSTime();
   uint32_t stime = current_time;

--- a/src/client/ns_turn_ioaddr.c
+++ b/src/client/ns_turn_ioaddr.c
@@ -34,7 +34,8 @@
 
 #include "ns_turn_ioaddr.h"
 
-#include "ns_turn_defs.h" // for nswap16, nswap32, STRCPY
+#include "ns_turn_defs.h"  // for nswap16, nswap32, STRCPY
+#include "ns_turn_utils.h" // for turn_malloc, turn_calloc, turn_realloc, turn_strdup
 
 #include <stdio.h>  // for snprintf, fprintf, stderr
 #include <stdlib.h> // for atoi, malloc, realloc, free
@@ -343,7 +344,7 @@ int make_ioa_addr_from_full_string(const uint8_t *saddr, uint16_t default_port, 
 
   int ret = -1;
   uint16_t port = 0;
-  char *s = strdup((const char *)saddr);
+  char *s = turn_strdup((const char *)saddr);
   char *sa = get_addr_string_and_port(s, &port);
   if (sa) {
     if (port < 1) {
@@ -677,10 +678,10 @@ static size_t msz = 0;
 
 void ioa_addr_add_mapping(ioa_addr *apub, ioa_addr *apriv) {
   const size_t new_size = msz + sizeof(ioa_addr *);
-  public_addrs = (ioa_addr **)realloc(public_addrs, new_size);
-  private_addrs = (ioa_addr **)realloc(private_addrs, new_size);
-  public_addrs[mcount] = (ioa_addr *)malloc(sizeof(ioa_addr));
-  private_addrs[mcount] = (ioa_addr *)malloc(sizeof(ioa_addr));
+  public_addrs = (ioa_addr **)turn_realloc(public_addrs, new_size);
+  private_addrs = (ioa_addr **)turn_realloc(private_addrs, new_size);
+  public_addrs[mcount] = (ioa_addr *)turn_malloc(sizeof(ioa_addr));
+  private_addrs[mcount] = (ioa_addr *)turn_malloc(sizeof(ioa_addr));
   addr_cpy(public_addrs[mcount], apub);
   addr_cpy(private_addrs[mcount], apriv);
   ++mcount;

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -219,14 +219,7 @@ bool stun_produce_integrity_key_str(const uint8_t *uname, const uint8_t *realm, 
   const size_t plen = strlen((const char *)upwd);
   const size_t sz = ulen + 1 + rlen + 1 + plen + 1 + 10;
   const size_t strl = ulen + 1 + rlen + 1 + plen;
-  uint8_t *str = (uint8_t *)malloc(sz + 1);
-  if (str == NULL) {
-    return false;
-  }
-
-  if (!str) {
-    return false;
-  }
+  uint8_t *str = (uint8_t *)turn_malloc(sz + 1);
 
   strncpy((char *)str, (const char *)uname, sz);
   str[ulen] = ':';

--- a/src/server/ns_turn_allocation.c
+++ b/src/server/ns_turn_allocation.c
@@ -443,17 +443,11 @@ turn_permission_info *allocation_add_permission(allocation *a, const ioa_addr *a
       }
       size_t old_sz_mem = old_sz * sizeof(turn_permission_slot *);
       turn_permission_slot **new_slots =
-          (turn_permission_slot **)realloc(parray->extra_slots, old_sz_mem + sizeof(turn_permission_slot *));
-      if (!new_slots) {
-        return NULL;
-      }
+          (turn_permission_slot **)turn_realloc(parray->extra_slots, old_sz_mem + sizeof(turn_permission_slot *));
       parray->extra_slots = new_slots;
       slots = parray->extra_slots;
       parray->extra_sz = old_sz + 1;
-      slot = (turn_permission_slot *)malloc(sizeof(turn_permission_slot));
-      if (!slot) {
-        return NULL;
-      }
+      slot = (turn_permission_slot *)turn_malloc(sizeof(turn_permission_slot));
       slots[old_sz] = slot;
     }
   }
@@ -504,18 +498,9 @@ ch_info *ch_map_get(ch_map *const map, const uint16_t chnum, const int new_chn) 
 
   if (new_chn) {
     const size_t old_sz_mem = old_sz * sizeof(ch_info *);
-    ch_info **const pTmp = (ch_info **)realloc(a->extra_chns, old_sz_mem + sizeof(ch_info *));
-    if (!pTmp) {
-      return NULL;
-    }
+    ch_info **const pTmp = (ch_info **)turn_realloc(a->extra_chns, old_sz_mem + sizeof(ch_info *));
     a->extra_chns = pTmp;
-    a->extra_chns[old_sz] = (ch_info *)calloc(1, sizeof(ch_info));
-    if (!a->extra_chns[old_sz]) {
-      // if the realloc succeeds, but the calloc fails, we don't attempt to shrink the realloc back down
-      // by not recording the change to the size, we allow the next call to this function to realloc the
-      // block to presumably the same size it already is, which should be fine and not result in any leaks.
-      return NULL;
-    }
+    a->extra_chns[old_sz] = (ch_info *)turn_calloc(1, sizeof(ch_info));
 
     a->extra_sz += 1;
     return a->extra_chns[old_sz];
@@ -596,10 +581,7 @@ tcp_connection *create_tcp_connection(uint8_t server_id, allocation *a, stun_tid
     }
   }
 
-  tcp_connection *tc = (tcp_connection *)calloc(1, sizeof(tcp_connection));
-  if (!tc) {
-    return NULL;
-  }
+  tcp_connection *tc = (tcp_connection *)turn_calloc(1, sizeof(tcp_connection));
   addr_cpy(&(tc->peer_addr), peer_addr);
   if (tid) {
     memcpy(&(tc->tid), tid, sizeof(stun_tid));
@@ -620,11 +602,7 @@ tcp_connection *create_tcp_connection(uint8_t server_id, allocation *a, stun_tid
 
   if (!found) {
     size_t old_sz_mem = a->tcs.sz * sizeof(tcp_connection *);
-    tcp_connection **new_elems = realloc(a->tcs.elems, old_sz_mem + sizeof(tcp_connection *));
-    if (!new_elems) {
-      free(tc);
-      return NULL;
-    }
+    tcp_connection **new_elems = turn_realloc(a->tcs.elems, old_sz_mem + sizeof(tcp_connection *));
     a->tcs.elems = new_elems;
     a->tcs.elems[a->tcs.sz] = tc;
     a->tcs.sz += 1;
@@ -744,12 +722,7 @@ void add_unsent_buffer(unsent_buffer *ub, ioa_network_buffer_handle nbh) {
     ioa_network_buffer_delete(NULL, nbh);
   } else {
     ioa_network_buffer_handle *new_bufs =
-        (ioa_network_buffer_handle *)realloc(ub->bufs, sizeof(ioa_network_buffer_handle) * (ub->sz + 1));
-    if (!new_bufs) {
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Memory allocation failed in add_unsent_buffer\n");
-      ioa_network_buffer_delete(NULL, nbh);
-      return;
-    }
+        (ioa_network_buffer_handle *)turn_realloc(ub->bufs, sizeof(ioa_network_buffer_handle) * (ub->sz + 1));
     ub->bufs = new_bufs;
     ub->bufs[ub->sz] = nbh;
     ub->sz += 1;

--- a/src/server/ns_turn_maps.c
+++ b/src/server/ns_turn_maps.c
@@ -35,6 +35,7 @@
 #include "ns_turn_maps.h"
 
 #include "ns_turn_ioalib.h"
+#include "ns_turn_utils.h" // for turn_malloc, turn_calloc, turn_realloc, turn_strdup
 
 #include "ns_turn_khash.h"
 
@@ -65,7 +66,7 @@ static bool ur_map_init(ur_map *map) {
 #define ur_map_valid(map) ((map) && ((map)->h) && ((map)->magic == MAGIC_HASH))
 
 ur_map *ur_map_create(void) {
-  ur_map *map = (ur_map *)malloc(sizeof(ur_map));
+  ur_map *map = (ur_map *)turn_malloc(sizeof(ur_map));
   if (!ur_map_init(map)) {
     free(map);
     return NULL;
@@ -230,11 +231,11 @@ bool lm_map_put(lm_map *map, ur_map_key_type key, ur_map_value_type value) {
         }
       } else {
         if (!(*keyp)) {
-          a->extra_keys[i] = (ur_map_key_type *)malloc(sizeof(ur_map_key_type));
+          a->extra_keys[i] = (ur_map_key_type *)turn_malloc(sizeof(ur_map_key_type));
           keyp = a->extra_keys[i];
         }
         if (!(*valuep)) {
-          a->extra_values[i] = (ur_map_value_type *)malloc(sizeof(ur_map_value_type));
+          a->extra_values[i] = (ur_map_value_type *)turn_malloc(sizeof(ur_map_value_type));
           valuep = a->extra_values[i];
         }
         assert(keyp);
@@ -248,15 +249,15 @@ bool lm_map_put(lm_map *map, ur_map_key_type key, ur_map_value_type value) {
 
   const size_t old_sz = esz;
   size_t old_sz_mem = esz * sizeof(ur_map_key_type *);
-  a->extra_keys = (ur_map_key_type **)realloc(a->extra_keys, old_sz_mem + sizeof(ur_map_key_type *));
+  a->extra_keys = (ur_map_key_type **)turn_realloc(a->extra_keys, old_sz_mem + sizeof(ur_map_key_type *));
   assert(a->extra_keys);
-  a->extra_keys[old_sz] = (ur_map_key_type *)malloc(sizeof(ur_map_key_type));
+  a->extra_keys[old_sz] = (ur_map_key_type *)turn_malloc(sizeof(ur_map_key_type));
   *(a->extra_keys[old_sz]) = key;
 
   old_sz_mem = esz * sizeof(ur_map_value_type *);
-  a->extra_values = (ur_map_value_type **)realloc(a->extra_values, old_sz_mem + sizeof(ur_map_value_type *));
+  a->extra_values = (ur_map_value_type **)turn_realloc(a->extra_values, old_sz_mem + sizeof(ur_map_value_type *));
   assert(a->extra_values);
-  a->extra_values[old_sz] = (ur_map_value_type *)malloc(sizeof(ur_map_value_type));
+  a->extra_values[old_sz] = (ur_map_value_type *)turn_malloc(sizeof(ur_map_value_type));
   if (a->extra_values[old_sz] != NULL) {
     *(a->extra_values[old_sz]) = value;
     a->extra_sz += 1;
@@ -509,7 +510,7 @@ static void addr_list_add(addr_list_header *slh, const ioa_addr *key, ur_addr_ma
   if (!elem) {
     const size_t old_sz = slh->extra_sz;
     const size_t old_sz_mem = old_sz * sizeof(addr_elem);
-    slh->extra_list = (addr_elem *)realloc(slh->extra_list, old_sz_mem + sizeof(addr_elem));
+    slh->extra_list = (addr_elem *)turn_realloc(slh->extra_list, old_sz_mem + sizeof(addr_elem));
     assert(slh->extra_list);
     elem = &(slh->extra_list[old_sz]);
     slh->extra_sz += 1;
@@ -901,17 +902,10 @@ static string_list *string_list_add(string_list *sl, const ur_string_map_key_typ
   if (!key) {
     return sl;
   }
-  string_elem *elem = (string_elem *)malloc(sizeof(string_elem));
-  if (!elem) {
-    return sl;
-  }
+  string_elem *elem = (string_elem *)turn_malloc(sizeof(string_elem));
   elem->list.next = sl;
   elem->key_size = strlen(key) + 1;
-  elem->key = (char *)malloc(elem->key_size);
-  if (!elem->key) {
-    free(elem);
-    return sl;
-  }
+  elem->key = (char *)turn_malloc(elem->key_size);
   memcpy(elem->key, key, elem->key_size);
   elem->value = value;
   return &(elem->list);
@@ -999,7 +993,7 @@ static bool ur_string_map_init(ur_string_map *map) {
 #define ur_string_map_valid(map) ((map) && ((map)->magic == MAGIC_HASH))
 
 ur_string_map *ur_string_map_create(ur_string_map_func del_value_func) {
-  ur_string_map *map = (ur_string_map *)malloc(sizeof(ur_string_map));
+  ur_string_map *map = (ur_string_map *)turn_malloc(sizeof(ur_string_map));
   if (map == NULL) {
     return NULL;
   } else if (!ur_string_map_init(map)) {

--- a/src/server/ns_turn_maps_rtcp.c
+++ b/src/server/ns_turn_maps_rtcp.c
@@ -34,7 +34,8 @@
 
 #include "ns_turn_maps_rtcp.h"
 
-#include "ns_turn_defs.h" // for NULL, UNUSED_ARG, size_t, turn_time,
+#include "ns_turn_defs.h"  // for NULL, UNUSED_ARG, size_t, turn_time,
+#include "ns_turn_utils.h" // for turn_malloc, turn_calloc, turn_realloc, turn_strdup
 
 #include <stdlib.h> // for free, calloc
 
@@ -177,7 +178,7 @@ static bool rtcp_map_init(rtcp_map *map, ioa_engine_handle e) {
 }
 
 rtcp_map *rtcp_map_create(ioa_engine_handle e) {
-  rtcp_map *map = (rtcp_map *)calloc(1, sizeof(rtcp_map));
+  rtcp_map *map = (rtcp_map *)turn_calloc(1, sizeof(rtcp_map));
   if (!rtcp_map_init(map, e)) {
     free(map);
     return NULL;
@@ -194,10 +195,7 @@ bool rtcp_map_put(rtcp_map *map, rtcp_token_type token, ioa_socket_handle s) {
   if (!rtcp_map_valid(map)) {
     return false;
   } else {
-    rtcp_alloc_type *value = (rtcp_alloc_type *)calloc(1, sizeof(rtcp_alloc_type));
-    if (!value) {
-      return false;
-    }
+    rtcp_alloc_type *value = (rtcp_alloc_type *)turn_calloc(1, sizeof(rtcp_alloc_type));
 
     value->s = s;
     value->t = turn_time() + RTCP_TIMEOUT;

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -471,11 +471,7 @@ void turn_session_info_add_peer(struct turn_session_info *tsi, ioa_addr *peer) {
     }
   }
 
-  addr_data *pTmp = (addr_data *)realloc(tsi->extra_peers_data, (tsi->extra_peers_size + 1) * sizeof(addr_data));
-  if (!pTmp) {
-    return;
-  }
-
+  addr_data *pTmp = (addr_data *)turn_realloc(tsi->extra_peers_data, (tsi->extra_peers_size + 1) * sizeof(addr_data));
   tsi->extra_peers_data = pTmp;
   addr_cpy(&(tsi->extra_peers_data[tsi->extra_peers_size].addr), peer);
   addr_to_string(&(tsi->extra_peers_data[tsi->extra_peers_size].addr),
@@ -854,10 +850,7 @@ static ts_ur_super_session *create_new_ss(turn_turnserver *server) {
   //
   // printf("%s: 111.111: session size=%lu\n",__FUNCTION__,(unsigned long)sizeof(ts_ur_super_session));
   //
-  ts_ur_super_session *ss = (ts_ur_super_session *)calloc(1, sizeof(ts_ur_super_session));
-  if (!ss) {
-    return NULL;
-  }
+  ts_ur_super_session *ss = (ts_ur_super_session *)turn_calloc(1, sizeof(ts_ur_super_session));
   ss->server = server;
   get_default_realm_options(&(ss->realm_options));
   put_session_into_map(ss);
@@ -3766,10 +3759,10 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
             const int sarlen = stun_attr_get_len(sar);
             if (sarlen > 0) {
               ++norigins;
-              char *o = (char *)malloc(sarlen + 1);
+              char *o = (char *)turn_malloc(sarlen + 1);
               memcpy(o, stun_attr_get_value(sar), sarlen);
               o[sarlen] = 0;
-              char *corigin = (char *)malloc(STUN_MAX_ORIGIN_SIZE + 1);
+              char *corigin = (char *)turn_malloc(STUN_MAX_ORIGIN_SIZE + 1);
               corigin[0] = 0;
               if (get_canonic_origin(o, corigin, STUN_MAX_ORIGIN_SIZE) < 0) {
                 TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "session %018llu: %s: Wrong origin format: %s\n",
@@ -3823,10 +3816,10 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
           if (stun_attr_get_type(sar) == STUN_ATTRIBUTE_ORIGIN) {
             const int sarlen = stun_attr_get_len(sar);
             if (sarlen > 0) {
-              char *o = (char *)malloc(sarlen + 1);
+              char *o = (char *)turn_malloc(sarlen + 1);
               memcpy(o, stun_attr_get_value(sar), sarlen);
               o[sarlen] = 0;
-              char *corigin = (char *)malloc(STUN_MAX_ORIGIN_SIZE + 1);
+              char *corigin = (char *)turn_malloc(STUN_MAX_ORIGIN_SIZE + 1);
               corigin[0] = 0;
               if (get_canonic_origin(o, corigin, STUN_MAX_ORIGIN_SIZE) < 0) {
                 TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "session %018llu: %s: Wrong origin format: %s\n",


### PR DESCRIPTION
## What

Introduce fail-fast heap-allocation wrappers and route every coturn-owned allocation through them. On allocation failure they **log the exact call site and `abort()`** instead of returning `NULL`.

```c
void *turn_malloc(size_t);
void *turn_calloc(size_t number, size_t size);
void *turn_realloc(void *ptr, size_t);
char *turn_strdup(const char *);
```

Macros capture `__FILE__`/`__LINE__` and forward to `*_impl` functions in `ns_turn_utils.{h,c}`. They never return `NULL` on a genuine allocation failure, so callers no longer check the result, and the now-dead failure branches are removed.

## Why

A NULL `malloc` result in a long-running TURN server is usually a *localized* condition (RLIMIT_AS / cgroup cap, overcommit off, a large or attacker-influenced request) rather than a dead machine. Leaving those results unchecked risks a NULL dereference, or worse, a wild write from code that keeps running — this is the class of bug behind the recent one-off fixes (#1727, #1977, #1978). A controlled, logged abort turns that into a deterministic, restartable failure. The logger writes into a stack buffer (no heap), so it stays usable when the heap is exhausted.

This replaces a scattering of inconsistent per-site NULL checks (roughly half the ~150 sites checked, half didn't) with one coherent policy.

## Scope

- **Converted:** all raw `malloc`/`calloc`/`realloc`/`strdup` in `src/server`, `src/client`, `src/apps/{common,relay,peer,uclient}` (28 files).
- **Excluded, deliberately:**
  - `src/apps/relay/libtelnet.c` — vendored public-domain third party.
  - `src/prometheus/prom.c` — self-contained module with its own NULL-return error contract; does not link `turncommon`.
  - `fuzzing/`, `tests/`, Windows shims.

Two latent bugs fixed as a side effect: `get_realm()` no longer `memcpy`s into the result before its NULL check, and the STUN `ORIGIN` allocations in `handle_turn_command()` (previously unchecked) are now abort-safe.

## Interaction with #1977

This supersedes the realloc leak-guards in #1977 (`add_unsent_buffer`, `create_tcp_connection`): under abort-on-failure the "leak on realloc failure" they guarded against cannot occur, so those checks are now dead and removed.

## Validation

- Clean build; unit tests **12/12** (macOS) and **11/11** (Linux/Docker).
- Example suites `run_tests` / `run_tests_conf` / `run_tests_mobile` / `run_tests_multiplex_peer` — all pass, 0 FAIL (macOS).
- `clang-format-15` clean; ASan fuzzing smoke (`FuzzStun` + `FuzzStunClient`) clean.
