### PR TITLE
fix: remove unreachable null-deref branch in lm_map_put

### DIFF
--- a/src/server/ns_turn_maps.c
+++ b/src/server/ns_turn_maps.c
@@ -223,26 +223,12 @@ bool lm_map_put(lm_map *map, ur_map_key_type key, ur_map_value_type value) {
     for (size_t i = 0; i < esz; ++i) {
       ur_map_key_type *keyp = a->extra_keys[i];
       ur_map_value_type *valuep = a->extra_values[i];
-      if (keyp && valuep) {
-        if (!(*keyp) || !(*valuep)) {
-          *keyp = key;
-          *valuep = value;
-          return true;
-        }
-      } else {
-        if (!(*keyp)) {
-          a->extra_keys[i] = (ur_map_key_type *)turn_malloc(sizeof(ur_map_key_type));
-          keyp = a->extra_keys[i];
-        }
-        if (!(*valuep)) {
-          a->extra_values[i] = (ur_map_value_type *)turn_malloc(sizeof(ur_map_value_type));
-          valuep = a->extra_values[i];
-        }
-        assert(keyp);
-        assert(valuep);
+      // Every slot below extra_sz has both pointers allocated; deletion only
+      // zeroes the pointed-to values, so an empty slot is (!*keyp || !*valuep).
+      if (keyp && valuep && (!(*keyp) || !(*valuep))) {
         *keyp = key;
         *valuep = value;
-        return false;
+        return true;
       }
     }
   }


### PR DESCRIPTION
Static analysis (issue #1764) flagged the else branch in lm_map_put's extra-slot scan: it is entered when keyp or valuep is NULL, yet its first statements dereference them (!(*keyp) / !(*valuep)), and it returns false even after storing the pair.

The branch is unreachable: extra_sz is only incremented after both slot pointers are allocated, lm_map_del zeroes the pointed-to values but never the slot pointers, and lm_map_clean resets the whole map. Every slot below extra_sz therefore always has both pointers non-NULL. Delete the dead branch and keep the reuse path.

Fixes #1764