### PR TITLE
zero channel-data padding in stun_init_channel_message_str

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -810,7 +810,11 @@ bool stun_init_channel_message_str(uint16_t chnumber, uint8_t *buf, size_t *len,
   ((uint16_t *)(buf))[1] = nswap16((uint16_t)length);
 
   if (do_padding && (rlen & 0x0003)) {
-    rlen = ((rlen >> 2) + 1) << 2;
+    const uint16_t padded = ((rlen >> 2) + 1) << 2;
+    // Zero the pad bytes so stale buffer contents are not leaked on the wire
+    // (matches the padding handling in stun_attr_add_str).
+    memset(buf + 4 + rlen, 0, (size_t)(padded - rlen));
+    rlen = padded;
   }
 
   *len = 4 + rlen;

--- a/tests/test_stun_msg.c
+++ b/tests/test_stun_msg.c
@@ -106,6 +106,29 @@ static void test_channel_message_roundtrip(void) {
   TEST_ASSERT_EQUAL_UINT16(channel, parsed_channel);
 }
 
+static void test_channel_message_zeroes_padding_bytes(void) {
+  uint8_t buf[1024];
+  // Prefill with a stale marker, mimicking a reused pooled buffer.
+  memset(buf, 0xAA, sizeof(buf));
+  size_t len = 0;
+  const uint16_t channel = 0x4001;
+  const int payload_len = 5; // not a multiple of 4 -> padding is added
+
+  for (int i = 0; i < payload_len; i++) {
+    buf[4 + i] = (uint8_t)(0x10 + i);
+  }
+
+  TEST_ASSERT_TRUE(stun_init_channel_message_str(channel, buf, &len, payload_len, true));
+
+  // 4 header + 5 payload rounded up to a 4-byte boundary.
+  TEST_ASSERT_EQUAL_size_t(12, len);
+
+  // The 3 pad bytes must be zeroed, not the stale 0xAA, so nothing leaks.
+  for (size_t i = (size_t)(4 + payload_len); i < len; i++) {
+    TEST_ASSERT_EQUAL_UINT8(0, buf[i]);
+  }
+}
+
 static void test_challenge_response_null_terminates_max_length_server_name(void) {
   uint8_t buf[MAX_STUN_MESSAGE_SIZE] = {0};
   size_t len = 0;
@@ -303,6 +326,7 @@ int main(void) {
   RUN_TEST(test_truncated_buffer_is_not_command_message);
   RUN_TEST(test_zeroed_buffer_is_not_command_message);
   RUN_TEST(test_channel_message_roundtrip);
+  RUN_TEST(test_channel_message_zeroes_padding_bytes);
   RUN_TEST(test_challenge_response_null_terminates_max_length_server_name);
   RUN_TEST(test_message_len_does_not_overflow_uint16);
   RUN_TEST(test_message_len_accepts_full_well_formed_message);


### PR DESCRIPTION
Repro: a client channel-binds over `TCP`/`TLS`, then a peer sends a `UDP` payload whose length is not a multiple of 4.
Cause: `stun_init_channel_message_str` rounds the `ChannelData` length up to a 4-byte boundary but leaves the pad bytes uninitialised, so the recycled relay buffer's stale tail (from an earlier packet) travels to the client. `stun_attr_add_str` already zeroes its attribute padding for the same reason.
Fix: `memset` the pad bytes to `0` before returning.