### PR TITLE
reset reused udp recv buffer offset in dtls listener

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -999,7 +999,11 @@ start_udp_cycle:
   }
 
   if (keep_elem) {
-    /* buffer was not consumed downstream, reuse it on the next iteration */
+    /* buffer was not consumed downstream, reuse it on the next iteration.
+     * Reset offset/len first (as the recvmmsg path does): recvfrom()/ssl_read()
+     * write at buf + offset with a fixed capacity, so a stale offset left by a
+     * kept DTLS packet accumulates and eventually walks past the buffer. */
+    ioa_network_buffer_reset(elem);
     server->sm.m.sm.nd.nbh = NULL;
   } else {
     /* buffer was consumed (and freed) downstream, need a fresh one next time */


### PR DESCRIPTION
Repro: on a non-Linux build (or Linux with `--udp-recvmmsg=false`), give a DTLS client an allocation with a per-session `bps` cap, then send several back-to-back near-max-size DTLS data records that overrun the jiffie bandwidth budget.

Cause: the legacy UDP receive loop in `udp_server_input_handler` reuses the same `elem` across datagrams but only nulls `nd.nbh`; it never calls `ioa_network_buffer_reset(elem)`. A kept (rate-limited) DTLS packet leaves `buf.offset` advanced by `ssl_read` via `ioa_network_buffer_add_offset_size`, and both `recvfrom()` and `ssl_read()` write at `ioa_network_buffer_data() == buf + offset` with the fixed `UDP_STUN_BUFFER_SIZE` capacity, so the offset accumulates (`0 -> 16384 -> 32768`).

Expected: a reused receive buffer starts at `offset == 0`, as it does on the `recvmmsg` path.

Actual: the third kept DTLS packet decrypts to `buf + 49152`, and `SSL_read` writes up to `UDP_STUN_BUFFER_SIZE` bytes past the 65507-byte `stun_buffer.buf`, corrupting the buffer metadata and adjacent heap.

Fix: reset the buffer before reuse, matching the `recvmmsg` sibling which already calls `ioa_network_buffer_reset`.
