### PR TITLE
release list mutex when del_alt_server removes the last entry

### DIFF
--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -275,15 +275,20 @@ static void del_alt_server(const char *saddr, uint16_t default_port, turn_server
 
       if (i < list->size) {
 
-        ioa_addr *new_addrs = (ioa_addr *)turn_malloc(sizeof(ioa_addr) * (list->size - 1));
-        if (!new_addrs) {
-          return;
-        }
-        for (size_t j = 0; j < i; ++j) {
-          addr_cpy(&(new_addrs[j]), &(list->addrs[j]));
-        }
-        for (size_t j = i; j < list->size - 1; ++j) {
-          addr_cpy(&(new_addrs[j]), &(list->addrs[j + 1]));
+        /* Removing the last entry means shrinking to zero elements. Requesting
+         * turn_malloc(0) would return NULL (the fail-fast wrappers only ever
+         * return NULL for a zero-size request), and NULL-checking a wrapper
+         * result is not allowed, so only allocate when there is something left
+         * to keep. */
+        ioa_addr *new_addrs = NULL;
+        if (list->size > 1) {
+          new_addrs = (ioa_addr *)turn_malloc(sizeof(ioa_addr) * (list->size - 1));
+          for (size_t j = 0; j < i; ++j) {
+            addr_cpy(&(new_addrs[j]), &(list->addrs[j]));
+          }
+          for (size_t j = i; j < list->size - 1; ++j) {
+            addr_cpy(&(new_addrs[j]), &(list->addrs[j + 1]));
+          }
         }
 
         free(list->addrs);


### PR DESCRIPTION
`del_alt_server` in `src/apps/relay/netengine.c` shrinks the list by allocating a smaller array under `list->m`, copying the survivors, and swapping it in. When the list holds a single entry and it matches, `list->size - 1` is `0`, so the allocation is `turn_malloc(0)`, which returns `NULL` for a zero-size request, and the `if (!new_addrs) return;` returns with `list->m` still held and the entry not removed. From there the next `add`/`del` on that list and the `300 ALTERNATE-SERVER` response path (which locks the same `list->m` in `set_alternate_server`) block forever; it is reachable through the CLI `del-alternate-server` family when the last configured server is removed.

NULL-checking a `turn_malloc` result is not permitted by the allocation contract (the wrappers only return `NULL` for a zero-size request), and this path regressed when #1981 swapped `malloc` for `turn_malloc`. Keeping the release next to the allocation, only allocate when more than one entry remains and drop the check, so removing the last entry frees the old array, leaves `list->addrs == NULL` and `size == 0`, and always reaches the `TURN_MUTEX_UNLOCK`.