### PR TITLE
fix misaligned value reads in three stun attribute accessors

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1396,7 +1396,9 @@ uint16_t stun_attr_get_channel_number(stun_attr_ref attr) {
   if (attr) {
     const uint8_t *value = stun_attr_get_value(attr);
     if (value && (stun_attr_get_len(attr) >= 2)) {
-      const uint16_t cn = nswap16(((const uint16_t *)value)[0]);
+      uint16_t raw_cn;
+      memcpy(&raw_cn, value, sizeof(raw_cn));
+      const uint16_t cn = nswap16(raw_cn);
       if (STUN_VALID_CHANNEL(cn)) {
         return cn;
       }
@@ -1409,7 +1411,9 @@ band_limit_t stun_attr_get_bandwidth(stun_attr_ref attr) {
   if (attr) {
     const uint8_t *value = stun_attr_get_value(attr);
     if (value && (stun_attr_get_len(attr) >= 4)) {
-      const uint32_t bps = nswap32(((const uint32_t *)value)[0]);
+      uint32_t raw_bps;
+      memcpy(&raw_bps, value, sizeof(raw_bps));
+      const uint32_t bps = nswap32(raw_bps);
       return (band_limit_t)(bps << 7);
     }
   }
@@ -2053,7 +2057,9 @@ int stun_attr_get_response_port_str(stun_attr_ref attr) {
   if (stun_attr_get_len(attr) >= 2) {
     const uint8_t *value = stun_attr_get_value(attr);
     if (value) {
-      return nswap16(((const uint16_t *)value)[0]);
+      uint16_t raw_port;
+      memcpy(&raw_port, value, sizeof(raw_port));
+      return nswap16(raw_port);
     }
   }
   return -1;

--- a/tests/test_stun_msg.c
+++ b/tests/test_stun_msg.c
@@ -339,6 +339,52 @@ static void test_attr_accessors_survive_misaligned_pointer(void) {
   TEST_ASSERT_EQUAL_INT(STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV4, stun_get_requested_address_family(attr));
 }
 
+static void test_value_accessors_survive_misaligned_pointer(void) {
+  /* stun_attr_get_channel_number/get_bandwidth/get_response_port_str read a
+   * uint16/uint32 straight out of the attribute value via a cast to a wider
+   * integer pointer, the same construct the type/len/value accessors were
+   * moved off. On a misaligned base (an attribute one byte off an aligned
+   * origin) that is undefined behavior and SIGBUS on strict-alignment
+   * architectures such as ARM64. Drive each accessor from a misaligned
+   * attribute and confirm it still decodes the field correctly.
+   */
+  {
+    uint8_t raw[1 + 8] = {0};
+    uint8_t *attr = raw + 1;
+    attr[0] = (STUN_ATTRIBUTE_CHANNEL_NUMBER >> 8) & 0xFF;
+    attr[1] = STUN_ATTRIBUTE_CHANNEL_NUMBER & 0xFF;
+    attr[2] = 0x00;
+    attr[3] = 0x04; // length = 4
+    attr[4] = 0x40; // channel 0x4000 (valid)
+    attr[5] = 0x00;
+    stun_attr_ref sar = attr;
+    TEST_ASSERT_EQUAL_UINT16(0x4000, stun_attr_get_channel_number(sar));
+  }
+  {
+    uint8_t raw[1 + 8] = {0};
+    uint8_t *attr = raw + 1;
+    attr[0] = (STUN_ATTRIBUTE_BANDWIDTH >> 8) & 0xFF;
+    attr[1] = STUN_ATTRIBUTE_BANDWIDTH & 0xFF;
+    attr[2] = 0x00;
+    attr[3] = 0x04; // length = 4
+    attr[7] = 0x01; // 1 -> get_bandwidth returns 1 << 7
+    stun_attr_ref sar = attr;
+    TEST_ASSERT_EQUAL_UINT64(128, (uint64_t)stun_attr_get_bandwidth(sar));
+  }
+  {
+    uint8_t raw[1 + 8] = {0};
+    uint8_t *attr = raw + 1;
+    attr[0] = (STUN_ATTRIBUTE_RESPONSE_PORT >> 8) & 0xFF;
+    attr[1] = STUN_ATTRIBUTE_RESPONSE_PORT & 0xFF;
+    attr[2] = 0x00;
+    attr[3] = 0x04; // length = 4
+    attr[4] = 0x30; // port 12345
+    attr[5] = 0x39;
+    stun_attr_ref sar = attr;
+    TEST_ASSERT_EQUAL_INT(12345, stun_attr_get_response_port_str(sar));
+  }
+}
+
 static void test_http_message_len_handles_non_null_terminated_buffer(void) {
   uint8_t buf[] = {'G', 'E', 'T', ' ', '/', ' ', 'H', 'T', 'T', 'P', '/', '1', '.', '1', '\r', '\n', '\r', '\n'};
   size_t app_len = 0;
@@ -367,6 +413,7 @@ int main(void) {
   RUN_TEST(test_rfc5780_padding_roundtrip);
   RUN_TEST(test_rfc5780_other_address_and_response_origin_roundtrip);
   RUN_TEST(test_attr_accessors_survive_misaligned_pointer);
+  RUN_TEST(test_value_accessors_survive_misaligned_pointer);
   RUN_TEST(test_http_message_len_handles_non_null_terminated_buffer);
   return UNITY_END();
 }


### PR DESCRIPTION
Repro: build a caller with `-fsanitize=alignment` and hand it a `CHANNEL-NUMBER`, `BANDWIDTH` or `RESPONSE-PORT` attribute sitting one byte off an aligned base (`raw + 1`). `stun_attr_get_channel_number`, `stun_attr_get_bandwidth` and `stun_attr_get_response_port_str` report `load of misaligned address ... which requires 2/4 byte alignment` at `ns_turn_msg.c:1399/1412/2056` and abort, which is a `SIGBUS` on strict-alignment targets like ARM64.
Cause: those three still cast the wire `value` pointer to `const uint16_t *`/`const uint32_t *` and dereference it, unlike `stun_attr_get_type`/`get_len`/`get_value`/`get_requested_address_family`/`get_reservation_token_value`, which already read the field through `memcpy` (the case `test_attr_accessors_survive_misaligned_pointer` pins).
Fix: copy the field out with `memcpy` before the byte swap so the read is alignment-safe, matching the siblings, and extend the misaligned-pointer test to cover the three accessors. Aligned inputs decode identically.