### PR TITLE
Fix remaining misaligned wire-buffer accesses; add turn_read/write helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,8 @@ Key style rules (LLVM-based):
 - Pointer alignment: right (`int *p`)
 - Brace style: attach (K&R)
 - Zero-initialize stack buffers at declaration: `uint8_t buf[N] = {0}` or `SomeStruct s = {0}`
+- Prefix new identifiers (functions, types, macros) with `turn_`, not `ns_` — the `ns_` names are
+  legacy; do not add new ones
 
 ## Memory allocation
 
@@ -588,5 +590,12 @@ docs/              # Protocol notes and configuration docs
 - **Uninitialized structs**: use `= {0}` for stack-allocated address structs (e.g., `ioa_addr`)
 - **Counter overflow in `turn_ports.c`**: `_turnports` uses `uint32_t low/high` counters; comparisons must be overflow-safe (use subtraction, not `>=`)
 - **Port bounds checks**: use `<= USHRT_MAX` (not `< USHRT_MAX`) when validating that an `int` holds a valid port — port 65535 is valid
+- **Wire-format field access**: read/write multi-byte STUN/TURN wire fields with the alignment-safe
+  helpers in [src/ns_turn_defs.h](src/ns_turn_defs.h) — `turn_read_u16/u32/u64(field)` and
+  `turn_write_u16/u32/u64(field, value)` (memcpy + network-byte-order swap). Never cast a wire byte
+  pointer to `uint16_t *`/`uint32_t *`/`uint64_t *` and dereference it: attributes sit at arbitrary
+  offsets, so the cast is undefined behavior and a SIGBUS on strict-alignment targets. For fields
+  that are **not** byte-swapped (CONNECTION-ID's as-is encoding, values already in network order),
+  use a plain `memcpy`, not the swapping helpers
 - **Error handling**: check return values of all OpenSSL/libevent calls; use `ERR_clear_error()` before HMAC operations
 - **Logging**: use `TURN_LOG_FUNC` macros, not `fprintf`/`perror`

--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -1595,7 +1595,10 @@ static int process_received_buffer(app_ur_session *elem, int is_tcp_data, app_tc
         while (sar) {
           int attr_type = stun_attr_get_type(sar);
           if (attr_type == STUN_ATTRIBUTE_CONNECTION_ID) {
-            cid = *((const uint32_t *)stun_attr_get_value(sar));
+            const uint8_t *value = stun_attr_get_value(sar);
+            if (value && (stun_attr_get_len(sar) == 4)) {
+              memcpy(&cid, value, sizeof(cid));
+            }
             break;
           }
           sar = stun_attr_get_next_str(elem->in_buffer.buf, elem->in_buffer.len, sar);
@@ -1649,7 +1652,10 @@ static int process_received_buffer(app_ur_session *elem, int is_tcp_data, app_tc
         while (sar) {
           int attr_type = stun_attr_get_type(sar);
           if (attr_type == STUN_ATTRIBUTE_CONNECTION_ID) {
-            cid = *((const uint32_t *)stun_attr_get_value(sar));
+            const uint8_t *value = stun_attr_get_value(sar);
+            if (value && (stun_attr_get_len(sar) == 4)) {
+              memcpy(&cid, value, sizeof(cid));
+            }
             break;
           }
           sar = stun_attr_get_next_str(elem->in_buffer.buf, elem->in_buffer.len, sar);

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -152,17 +152,19 @@ static void generate_random_nonce(unsigned char *nonce, size_t sz) {
 }
 
 static void turn_random_tid_size(void *id) {
-  uint32_t *ar = (uint32_t *)id;
+  uint8_t *ar = (uint8_t *)id;
 #if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
   if (ar) {
     for (size_t i = 0; i < 3; ++i) {
-      ar[i] = (uint32_t)turn_random_number();
+      const uint32_t r = (uint32_t)turn_random_number();
+      memcpy(ar + i * sizeof(r), &r, sizeof(r));
     }
   }
 #else
   if (!RAND_bytes((unsigned char *)ar, 12)) {
     for (size_t i = 0; i < 3; ++i) {
-      ar[i] = (uint32_t)turn_random_number();
+      const uint32_t r = (uint32_t)turn_random_number();
+      memcpy(ar + i * sizeof(r), &r, sizeof(r));
     }
   }
 #endif
@@ -397,7 +399,9 @@ int stun_get_command_message_len_str(const uint8_t *buf, size_t len) {
   }
 
   /* Validate the size the buffer claims to be */
-  const size_t bufLen = (size_t)(nswap16(((const uint16_t *)(buf))[1]) + STUN_HEADER_LENGTH);
+  uint16_t raw_len;
+  memcpy(&raw_len, buf + 2, sizeof(raw_len));
+  const size_t bufLen = (size_t)(nswap16(raw_len) + STUN_HEADER_LENGTH);
   if (bufLen > len) {
     return -1;
   }
@@ -409,7 +413,8 @@ static bool stun_set_command_message_len_str(uint8_t *buf, int len) {
   if (len < STUN_HEADER_LENGTH) {
     return false;
   }
-  ((uint16_t *)buf)[1] = nswap16((uint16_t)(len - STUN_HEADER_LENGTH));
+  const uint16_t raw_len = nswap16((uint16_t)(len - STUN_HEADER_LENGTH));
+  memcpy(buf + 2, &raw_len, sizeof(raw_len));
   return true;
 }
 
@@ -425,7 +430,9 @@ uint16_t stun_get_method_str(const uint8_t *buf, size_t len) {
     return (uint16_t)-1;
   }
 
-  const uint16_t tt = nswap16(((const uint16_t *)buf)[0]);
+  uint16_t raw_tt;
+  memcpy(&raw_tt, buf, sizeof(raw_tt));
+  const uint16_t tt = nswap16(raw_tt);
 
   return (tt & 0x000F) | ((tt & 0x00E0) >> 1) | ((tt & 0x0E00) >> 2) | ((tt & 0x3000) >> 2);
 }
@@ -434,21 +441,34 @@ uint16_t stun_get_msg_type_str(const uint8_t *buf, size_t len) {
   if (!buf || len < 2) {
     return (uint16_t)-1;
   }
-  return ((nswap16(((const uint16_t *)buf)[0])) & 0x3FFF);
+  uint16_t raw_type;
+  memcpy(&raw_type, buf, sizeof(raw_type));
+  return (nswap16(raw_type) & 0x3FFF);
 }
 
 bool is_channel_msg_str(const uint8_t *buf, size_t blen) {
-  return (buf && blen >= 4 && STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0])));
+  if (!buf || blen < 4) {
+    return false;
+  }
+  uint16_t raw_chn;
+  memcpy(&raw_chn, buf, sizeof(raw_chn));
+  return STUN_VALID_CHANNEL(nswap16(raw_chn));
 }
 
 /////////////// message types /////////////////////////////////
 
 bool stun_is_command_message_str(const uint8_t *buf, size_t blen) {
   if (buf && blen >= STUN_HEADER_LENGTH) {
-    if (!STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0]))) {
+    uint16_t raw_chn;
+    memcpy(&raw_chn, buf, sizeof(raw_chn));
+    if (!STUN_VALID_CHANNEL(nswap16(raw_chn))) {
       if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0) {
-        if (nswap32(((const uint32_t *)(buf))[1]) == STUN_MAGIC_COOKIE) {
-          const uint16_t len = nswap16(((const uint16_t *)(buf))[1]);
+        uint32_t raw_cookie;
+        memcpy(&raw_cookie, buf + 4, sizeof(raw_cookie));
+        if (nswap32(raw_cookie) == STUN_MAGIC_COOKIE) {
+          uint16_t raw_len;
+          memcpy(&raw_len, buf + 2, sizeof(raw_len));
+          const uint16_t len = nswap16(raw_len);
           if ((len & 0x0003) == 0) {
             if ((size_t)(len + STUN_HEADER_LENGTH) == blen) {
               return true;
@@ -463,13 +483,19 @@ bool stun_is_command_message_str(const uint8_t *buf, size_t blen) {
 
 bool old_stun_is_command_message_str(const uint8_t *buf, size_t blen, uint32_t *cookie) {
   if (buf && blen >= STUN_HEADER_LENGTH) {
-    if (!STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0]))) {
+    uint16_t raw_chn;
+    memcpy(&raw_chn, buf, sizeof(raw_chn));
+    if (!STUN_VALID_CHANNEL(nswap16(raw_chn))) {
       if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0) {
-        if (nswap32(((const uint32_t *)(buf))[1]) != STUN_MAGIC_COOKIE) {
-          const uint16_t len = nswap16(((const uint16_t *)(buf))[1]);
+        uint32_t raw_cookie;
+        memcpy(&raw_cookie, buf + 4, sizeof(raw_cookie));
+        if (nswap32(raw_cookie) != STUN_MAGIC_COOKIE) {
+          uint16_t raw_len;
+          memcpy(&raw_len, buf + 2, sizeof(raw_len));
+          const uint16_t len = nswap16(raw_len);
           if ((len & 0x0003) == 0) {
             if ((size_t)(len + STUN_HEADER_LENGTH) == blen) {
-              *cookie = nswap32(((const uint32_t *)(buf))[1]);
+              *cookie = nswap32(raw_cookie);
               return true;
             }
           }
@@ -498,12 +524,14 @@ bool stun_is_command_message_full_check_str(const uint8_t *buf, size_t blen, int
   if (stun_attr_get_len(sar) != 4) {
     return false;
   }
-  const uint32_t *fingerprint = (const uint32_t *)stun_attr_get_value(sar);
+  const uint8_t *fingerprint = stun_attr_get_value(sar);
   if (!fingerprint) {
     return !must_check_fingerprint;
   }
-  const uint32_t crc32len = (uint32_t)((((const uint8_t *)fingerprint) - buf) - 4);
-  const bool ret = (*fingerprint == nswap32(ns_crc32(buf, crc32len) ^ ((uint32_t)FINGERPRINT_XOR)));
+  uint32_t raw_fingerprint;
+  memcpy(&raw_fingerprint, fingerprint, sizeof(raw_fingerprint));
+  const uint32_t crc32len = (uint32_t)((fingerprint - buf) - 4);
+  const bool ret = (raw_fingerprint == nswap32(ns_crc32(buf, crc32len) ^ ((uint32_t)FINGERPRINT_XOR)));
   if (ret && fingerprint_present) {
     *fingerprint_present = ret;
   }
@@ -647,18 +675,24 @@ void stun_init_buffer_str(uint8_t *buf, size_t *len) {
 void stun_init_command_str(uint16_t message_type, uint8_t *buf, size_t *len) {
   stun_init_buffer_str(buf, len);
   message_type &= (uint16_t)(0x3FFF);
-  ((uint16_t *)buf)[0] = nswap16(message_type);
-  ((uint16_t *)buf)[1] = 0;
-  ((uint32_t *)buf)[1] = nswap32(STUN_MAGIC_COOKIE);
+  const uint16_t raw_type = nswap16(message_type);
+  memcpy(buf, &raw_type, sizeof(raw_type));
+  buf[2] = 0;
+  buf[3] = 0;
+  const uint32_t raw_cookie = nswap32(STUN_MAGIC_COOKIE);
+  memcpy(buf + 4, &raw_cookie, sizeof(raw_cookie));
   stun_tid_generate_in_message_str(buf, NULL);
 }
 
 void old_stun_init_command_str(uint16_t message_type, uint8_t *buf, size_t *len, uint32_t cookie) {
   stun_init_buffer_str(buf, len);
   message_type &= (uint16_t)(0x3FFF);
-  ((uint16_t *)buf)[0] = nswap16(message_type);
-  ((uint16_t *)buf)[1] = 0;
-  ((uint32_t *)buf)[1] = nswap32(cookie);
+  const uint16_t raw_type = nswap16(message_type);
+  memcpy(buf, &raw_type, sizeof(raw_type));
+  buf[2] = 0;
+  buf[3] = 0;
+  const uint32_t raw_cookie = nswap32(cookie);
+  memcpy(buf + 4, &raw_cookie, sizeof(raw_cookie));
   stun_tid_generate_in_message_str(buf, NULL);
 }
 
@@ -806,8 +840,10 @@ bool stun_init_channel_message_str(uint16_t chnumber, uint8_t *buf, size_t *len,
   if (length < 0 || (MAX_STUN_MESSAGE_SIZE < (4 + length))) {
     return false;
   }
-  ((uint16_t *)(buf))[0] = nswap16(chnumber);
-  ((uint16_t *)(buf))[1] = nswap16((uint16_t)length);
+  const uint16_t raw_chn = nswap16(chnumber);
+  memcpy(buf, &raw_chn, sizeof(raw_chn));
+  const uint16_t raw_dlen = nswap16((uint16_t)length);
+  memcpy(buf + 2, &raw_dlen, sizeof(raw_dlen));
 
   if (do_padding && (rlen & 0x0003)) {
     const uint16_t padded = ((rlen >> 2) + 1) << 2;
@@ -830,7 +866,9 @@ bool stun_is_channel_message_str(const uint8_t *buf, size_t *blen, uint16_t *chn
     return false;
   }
 
-  const uint16_t chn = nswap16(((const uint16_t *)(buf))[0]);
+  uint16_t raw_chn;
+  memcpy(&raw_chn, buf, sizeof(raw_chn));
+  const uint16_t chn = nswap16(raw_chn);
   if (!STUN_VALID_CHANNEL(chn)) {
     return false;
   }
@@ -842,7 +880,7 @@ bool stun_is_channel_message_str(const uint8_t *buf, size_t *blen, uint16_t *chn
    * if the function later returns false (issue #1837). */
   const uint16_t blen16 = (*blen > (uint16_t)-1) ? (uint16_t)-1 : (uint16_t)*blen;
   datalen_actual = blen16 - 4;
-  datalen_header = ((const uint16_t *)buf)[1];
+  memcpy(&datalen_header, buf + 2, sizeof(datalen_header));
   datalen_header = nswap16(datalen_header);
 
   if (datalen_header > datalen_actual) {
@@ -956,15 +994,21 @@ int stun_get_message_len_str(uint8_t *buf, size_t blen, int padding, size_t *app
   if (buf && blen) {
     /* STUN request/response ? */
     if (buf && blen >= STUN_HEADER_LENGTH) {
-      if (!STUN_VALID_CHANNEL(nswap16(((const uint16_t *)buf)[0]))) {
+      uint16_t raw_chn;
+      memcpy(&raw_chn, buf, sizeof(raw_chn));
+      if (!STUN_VALID_CHANNEL(nswap16(raw_chn))) {
         if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0) {
-          if (nswap32(((const uint32_t *)(buf))[1]) == STUN_MAGIC_COOKIE) {
+          uint32_t raw_cookie;
+          memcpy(&raw_cookie, buf + 4, sizeof(raw_cookie));
+          if (nswap32(raw_cookie) == STUN_MAGIC_COOKIE) {
             /* Use uint32_t to avoid uint16_t truncation overflow when the body
              * length is near 0xFFFF: e.g. 65532 + STUN_HEADER_LENGTH (20) =
              * 65552, which wraps to 16 in uint16_t and lets the truncated value
              * pass the bounds check, desynchronizing TCP/TLS framing. Mirrors
              * the channel-data path below. */
-            uint32_t len = (uint32_t)nswap16(((const uint16_t *)(buf))[1]);
+            uint16_t raw_len;
+            memcpy(&raw_len, buf + 2, sizeof(raw_len));
+            uint32_t len = (uint32_t)nswap16(raw_len);
             if ((len & 0x0003u) == 0) {
               len += STUN_HEADER_LENGTH;
               if (len <= blen) {
@@ -988,13 +1032,17 @@ int stun_get_message_len_str(uint8_t *buf, size_t blen, int padding, size_t *app
 
     /* STUN channel ? */
     if (blen >= 4) {
-      const uint16_t chn = nswap16(((const uint16_t *)(buf))[0]);
+      uint16_t raw_chn;
+      memcpy(&raw_chn, buf, sizeof(raw_chn));
+      const uint16_t chn = nswap16(raw_chn);
       if (STUN_VALID_CHANNEL(chn)) {
 
         /* Use uint32_t to avoid uint16_t truncation overflow when data_len is
          * near 0xFFFF: 4 + 0xFFFF = 65539, which wraps to 3 in uint16_t and
          * causes TCP framing bypass (CVE candidate, issue #1837). */
-        uint32_t bret = 4u + (uint32_t)nswap16(((const uint16_t *)(buf))[1]);
+        uint16_t raw_dlen;
+        memcpy(&raw_dlen, buf + 2, sizeof(raw_dlen));
+        uint32_t bret = 4u + (uint32_t)nswap16(raw_dlen);
 
         *app_len = bret;
 
@@ -1553,13 +1601,13 @@ bool stun_attr_add_str(uint8_t *buf, size_t *len, uint16_t attr, const uint8_t *
 
   uint8_t *attr_start = buf + clen;
 
-  uint16_t *attr_start_16t = (uint16_t *)attr_start;
-
   stun_set_command_message_len_str(buf, newlen);
   *len = newlen;
 
-  attr_start_16t[0] = nswap16(attr);
-  attr_start_16t[1] = nswap16(alen);
+  const uint16_t raw_attr = nswap16(attr);
+  memcpy(attr_start, &raw_attr, sizeof(raw_attr));
+  const uint16_t raw_alen = nswap16((uint16_t)alen);
+  memcpy(attr_start + 2, &raw_alen, sizeof(raw_alen));
   if (alen > 0) {
     memcpy(attr_start + 4, avalue, alen);
   }
@@ -1726,7 +1774,8 @@ bool stun_attr_add_fingerprint_str(uint8_t *buf, size_t *len) {
     return false;
   }
   crc32 = ns_crc32(buf, (int)*len - 8);
-  *((uint32_t *)(buf + *len - 4)) = nswap32(crc32 ^ ((uint32_t)FINGERPRINT_XOR));
+  const uint32_t raw_fingerprint = nswap32(crc32 ^ ((uint32_t)FINGERPRINT_XOR));
+  memcpy(buf + *len - 4, &raw_fingerprint, sizeof(raw_fingerprint));
   return true;
 }
 ////////////// CRC ///////////////////////////////////////////////
@@ -2067,9 +2116,8 @@ int stun_attr_get_response_port_str(stun_attr_ref attr) {
 
 bool stun_attr_add_response_port_str(uint8_t *buf, size_t *len, uint16_t port) {
   uint8_t avalue[4] = {0, 0, 0, 0};
-  uint16_t *port_ptr = (uint16_t *)avalue;
-
-  *port_ptr = nswap16(port);
+  const uint16_t raw_port = nswap16(port);
+  memcpy(avalue, &raw_port, sizeof(raw_port));
 
   return stun_attr_add_str(buf, len, STUN_ATTRIBUTE_RESPONSE_PORT, avalue, 4);
 }
@@ -2336,13 +2384,15 @@ static bool encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_tok
 
     size_t len = 0;
 
-    *((uint16_t *)(orig_field + len)) = nswap16(OAUTH_GCM_NONCE_SIZE);
+    const uint16_t raw_nonce_len = nswap16(OAUTH_GCM_NONCE_SIZE);
+    memcpy(orig_field + len, &raw_nonce_len, sizeof(raw_nonce_len));
     len += 2;
 
     memcpy(orig_field + len, nonce, OAUTH_GCM_NONCE_SIZE);
     len += OAUTH_GCM_NONCE_SIZE;
 
-    *((uint16_t *)(orig_field + len)) = nswap16(dtoken->enc_block.key_length);
+    const uint16_t raw_key_length = nswap16(dtoken->enc_block.key_length);
+    memcpy(orig_field + len, &raw_key_length, sizeof(raw_key_length));
     len += 2;
 
     memcpy(orig_field + len, dtoken->enc_block.mac_key, dtoken->enc_block.key_length);
@@ -2352,7 +2402,8 @@ static bool encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_tok
     memcpy((orig_field + len), &ts, sizeof(ts));
     len += sizeof(ts);
 
-    *((uint32_t *)(orig_field + len)) = nswap32(dtoken->enc_block.lifetime);
+    const uint32_t raw_lifetime = nswap32(dtoken->enc_block.lifetime);
+    memcpy(orig_field + len, &raw_lifetime, sizeof(raw_lifetime));
     len += 4;
 
     const EVP_CIPHER *cipher = get_cipher_type(key->as_rs_alg);
@@ -2426,11 +2477,9 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
                                    oauth_token *dtoken) {
   if (server_name && etoken && key && dtoken) {
 
-    unsigned char snl[2];
-    memcpy(snl, (const unsigned char *)(etoken->token), 2);
-    const unsigned char *csnl = snl;
-
-    const uint16_t nonce_len = nswap16(*((const uint16_t *)csnl));
+    uint16_t raw_nonce_len;
+    memcpy(&raw_nonce_len, etoken->token, sizeof(raw_nonce_len));
+    const uint16_t nonce_len = nswap16(raw_nonce_len);
 
     if (nonce_len > OAUTH_MAX_NONCE_SIZE) {
       OAUTH_ERROR("%s: nonce length too large: %u > %u\n", __FUNCTION__, (unsigned)nonce_len,
@@ -2524,7 +2573,9 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
       OAUTH_ERROR("%s: decoded token too small: %d\n", __FUNCTION__, (int)outl);
       return false;
     }
-    dtoken->enc_block.key_length = nswap16(*((uint16_t *)(decoded_field + len)));
+    uint16_t raw_key_length;
+    memcpy(&raw_key_length, decoded_field + len, sizeof(raw_key_length));
+    dtoken->enc_block.key_length = nswap16(raw_key_length);
     len += sizeof(uint16_t);
 
     if (dtoken->enc_block.key_length > sizeof(dtoken->enc_block.mac_key)) {

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -399,9 +399,7 @@ int stun_get_command_message_len_str(const uint8_t *buf, size_t len) {
   }
 
   /* Validate the size the buffer claims to be */
-  uint16_t raw_len;
-  memcpy(&raw_len, buf + 2, sizeof(raw_len));
-  const size_t bufLen = (size_t)(nswap16(raw_len) + STUN_HEADER_LENGTH);
+  const size_t bufLen = (size_t)(turn_read_u16(buf + 2) + STUN_HEADER_LENGTH);
   if (bufLen > len) {
     return -1;
   }
@@ -413,8 +411,7 @@ static bool stun_set_command_message_len_str(uint8_t *buf, int len) {
   if (len < STUN_HEADER_LENGTH) {
     return false;
   }
-  const uint16_t raw_len = nswap16((uint16_t)(len - STUN_HEADER_LENGTH));
-  memcpy(buf + 2, &raw_len, sizeof(raw_len));
+  turn_write_u16(buf + 2, (uint16_t)(len - STUN_HEADER_LENGTH));
   return true;
 }
 
@@ -430,9 +427,7 @@ uint16_t stun_get_method_str(const uint8_t *buf, size_t len) {
     return (uint16_t)-1;
   }
 
-  uint16_t raw_tt;
-  memcpy(&raw_tt, buf, sizeof(raw_tt));
-  const uint16_t tt = nswap16(raw_tt);
+  const uint16_t tt = turn_read_u16(buf);
 
   return (tt & 0x000F) | ((tt & 0x00E0) >> 1) | ((tt & 0x0E00) >> 2) | ((tt & 0x3000) >> 2);
 }
@@ -441,34 +436,21 @@ uint16_t stun_get_msg_type_str(const uint8_t *buf, size_t len) {
   if (!buf || len < 2) {
     return (uint16_t)-1;
   }
-  uint16_t raw_type;
-  memcpy(&raw_type, buf, sizeof(raw_type));
-  return (nswap16(raw_type) & 0x3FFF);
+  return (turn_read_u16(buf) & 0x3FFF);
 }
 
 bool is_channel_msg_str(const uint8_t *buf, size_t blen) {
-  if (!buf || blen < 4) {
-    return false;
-  }
-  uint16_t raw_chn;
-  memcpy(&raw_chn, buf, sizeof(raw_chn));
-  return STUN_VALID_CHANNEL(nswap16(raw_chn));
+  return (buf && blen >= 4 && STUN_VALID_CHANNEL(turn_read_u16(buf)));
 }
 
 /////////////// message types /////////////////////////////////
 
 bool stun_is_command_message_str(const uint8_t *buf, size_t blen) {
   if (buf && blen >= STUN_HEADER_LENGTH) {
-    uint16_t raw_chn;
-    memcpy(&raw_chn, buf, sizeof(raw_chn));
-    if (!STUN_VALID_CHANNEL(nswap16(raw_chn))) {
+    if (!STUN_VALID_CHANNEL(turn_read_u16(buf))) {
       if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0) {
-        uint32_t raw_cookie;
-        memcpy(&raw_cookie, buf + 4, sizeof(raw_cookie));
-        if (nswap32(raw_cookie) == STUN_MAGIC_COOKIE) {
-          uint16_t raw_len;
-          memcpy(&raw_len, buf + 2, sizeof(raw_len));
-          const uint16_t len = nswap16(raw_len);
+        if (turn_read_u32(buf + 4) == STUN_MAGIC_COOKIE) {
+          const uint16_t len = turn_read_u16(buf + 2);
           if ((len & 0x0003) == 0) {
             if ((size_t)(len + STUN_HEADER_LENGTH) == blen) {
               return true;
@@ -483,19 +465,14 @@ bool stun_is_command_message_str(const uint8_t *buf, size_t blen) {
 
 bool old_stun_is_command_message_str(const uint8_t *buf, size_t blen, uint32_t *cookie) {
   if (buf && blen >= STUN_HEADER_LENGTH) {
-    uint16_t raw_chn;
-    memcpy(&raw_chn, buf, sizeof(raw_chn));
-    if (!STUN_VALID_CHANNEL(nswap16(raw_chn))) {
+    if (!STUN_VALID_CHANNEL(turn_read_u16(buf))) {
       if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0) {
-        uint32_t raw_cookie;
-        memcpy(&raw_cookie, buf + 4, sizeof(raw_cookie));
-        if (nswap32(raw_cookie) != STUN_MAGIC_COOKIE) {
-          uint16_t raw_len;
-          memcpy(&raw_len, buf + 2, sizeof(raw_len));
-          const uint16_t len = nswap16(raw_len);
+        const uint32_t msg_cookie = turn_read_u32(buf + 4);
+        if (msg_cookie != STUN_MAGIC_COOKIE) {
+          const uint16_t len = turn_read_u16(buf + 2);
           if ((len & 0x0003) == 0) {
             if ((size_t)(len + STUN_HEADER_LENGTH) == blen) {
-              *cookie = nswap32(raw_cookie);
+              *cookie = msg_cookie;
               return true;
             }
           }
@@ -528,10 +505,8 @@ bool stun_is_command_message_full_check_str(const uint8_t *buf, size_t blen, int
   if (!fingerprint) {
     return !must_check_fingerprint;
   }
-  uint32_t raw_fingerprint;
-  memcpy(&raw_fingerprint, fingerprint, sizeof(raw_fingerprint));
   const uint32_t crc32len = (uint32_t)((fingerprint - buf) - 4);
-  const bool ret = (raw_fingerprint == nswap32(ns_crc32(buf, crc32len) ^ ((uint32_t)FINGERPRINT_XOR)));
+  const bool ret = (turn_read_u32(fingerprint) == (ns_crc32(buf, crc32len) ^ ((uint32_t)FINGERPRINT_XOR)));
   if (ret && fingerprint_present) {
     *fingerprint_present = ret;
   }
@@ -675,24 +650,18 @@ void stun_init_buffer_str(uint8_t *buf, size_t *len) {
 void stun_init_command_str(uint16_t message_type, uint8_t *buf, size_t *len) {
   stun_init_buffer_str(buf, len);
   message_type &= (uint16_t)(0x3FFF);
-  const uint16_t raw_type = nswap16(message_type);
-  memcpy(buf, &raw_type, sizeof(raw_type));
-  buf[2] = 0;
-  buf[3] = 0;
-  const uint32_t raw_cookie = nswap32(STUN_MAGIC_COOKIE);
-  memcpy(buf + 4, &raw_cookie, sizeof(raw_cookie));
+  turn_write_u16(buf, message_type);
+  turn_write_u16(buf + 2, 0);
+  turn_write_u32(buf + 4, STUN_MAGIC_COOKIE);
   stun_tid_generate_in_message_str(buf, NULL);
 }
 
 void old_stun_init_command_str(uint16_t message_type, uint8_t *buf, size_t *len, uint32_t cookie) {
   stun_init_buffer_str(buf, len);
   message_type &= (uint16_t)(0x3FFF);
-  const uint16_t raw_type = nswap16(message_type);
-  memcpy(buf, &raw_type, sizeof(raw_type));
-  buf[2] = 0;
-  buf[3] = 0;
-  const uint32_t raw_cookie = nswap32(cookie);
-  memcpy(buf + 4, &raw_cookie, sizeof(raw_cookie));
+  turn_write_u16(buf, message_type);
+  turn_write_u16(buf + 2, 0);
+  turn_write_u32(buf + 4, cookie);
   stun_tid_generate_in_message_str(buf, NULL);
 }
 
@@ -840,10 +809,8 @@ bool stun_init_channel_message_str(uint16_t chnumber, uint8_t *buf, size_t *len,
   if (length < 0 || (MAX_STUN_MESSAGE_SIZE < (4 + length))) {
     return false;
   }
-  const uint16_t raw_chn = nswap16(chnumber);
-  memcpy(buf, &raw_chn, sizeof(raw_chn));
-  const uint16_t raw_dlen = nswap16((uint16_t)length);
-  memcpy(buf + 2, &raw_dlen, sizeof(raw_dlen));
+  turn_write_u16(buf, chnumber);
+  turn_write_u16(buf + 2, (uint16_t)length);
 
   if (do_padding && (rlen & 0x0003)) {
     const uint16_t padded = ((rlen >> 2) + 1) << 2;
@@ -866,9 +833,7 @@ bool stun_is_channel_message_str(const uint8_t *buf, size_t *blen, uint16_t *chn
     return false;
   }
 
-  uint16_t raw_chn;
-  memcpy(&raw_chn, buf, sizeof(raw_chn));
-  const uint16_t chn = nswap16(raw_chn);
+  const uint16_t chn = turn_read_u16(buf);
   if (!STUN_VALID_CHANNEL(chn)) {
     return false;
   }
@@ -880,8 +845,7 @@ bool stun_is_channel_message_str(const uint8_t *buf, size_t *blen, uint16_t *chn
    * if the function later returns false (issue #1837). */
   const uint16_t blen16 = (*blen > (uint16_t)-1) ? (uint16_t)-1 : (uint16_t)*blen;
   datalen_actual = blen16 - 4;
-  memcpy(&datalen_header, buf + 2, sizeof(datalen_header));
-  datalen_header = nswap16(datalen_header);
+  datalen_header = turn_read_u16(buf + 2);
 
   if (datalen_header > datalen_actual) {
     return false;
@@ -994,21 +958,15 @@ int stun_get_message_len_str(uint8_t *buf, size_t blen, int padding, size_t *app
   if (buf && blen) {
     /* STUN request/response ? */
     if (buf && blen >= STUN_HEADER_LENGTH) {
-      uint16_t raw_chn;
-      memcpy(&raw_chn, buf, sizeof(raw_chn));
-      if (!STUN_VALID_CHANNEL(nswap16(raw_chn))) {
+      if (!STUN_VALID_CHANNEL(turn_read_u16(buf))) {
         if ((((uint8_t)buf[0]) & ((uint8_t)(0xC0))) == 0) {
-          uint32_t raw_cookie;
-          memcpy(&raw_cookie, buf + 4, sizeof(raw_cookie));
-          if (nswap32(raw_cookie) == STUN_MAGIC_COOKIE) {
+          if (turn_read_u32(buf + 4) == STUN_MAGIC_COOKIE) {
             /* Use uint32_t to avoid uint16_t truncation overflow when the body
              * length is near 0xFFFF: e.g. 65532 + STUN_HEADER_LENGTH (20) =
              * 65552, which wraps to 16 in uint16_t and lets the truncated value
              * pass the bounds check, desynchronizing TCP/TLS framing. Mirrors
              * the channel-data path below. */
-            uint16_t raw_len;
-            memcpy(&raw_len, buf + 2, sizeof(raw_len));
-            uint32_t len = (uint32_t)nswap16(raw_len);
+            uint32_t len = (uint32_t)turn_read_u16(buf + 2);
             if ((len & 0x0003u) == 0) {
               len += STUN_HEADER_LENGTH;
               if (len <= blen) {
@@ -1032,17 +990,13 @@ int stun_get_message_len_str(uint8_t *buf, size_t blen, int padding, size_t *app
 
     /* STUN channel ? */
     if (blen >= 4) {
-      uint16_t raw_chn;
-      memcpy(&raw_chn, buf, sizeof(raw_chn));
-      const uint16_t chn = nswap16(raw_chn);
+      const uint16_t chn = turn_read_u16(buf);
       if (STUN_VALID_CHANNEL(chn)) {
 
         /* Use uint32_t to avoid uint16_t truncation overflow when data_len is
          * near 0xFFFF: 4 + 0xFFFF = 65539, which wraps to 3 in uint16_t and
          * causes TCP framing bypass (CVE candidate, issue #1837). */
-        uint16_t raw_dlen;
-        memcpy(&raw_dlen, buf + 2, sizeof(raw_dlen));
-        uint32_t bret = 4u + (uint32_t)nswap16(raw_dlen);
+        uint32_t bret = 4u + (uint32_t)turn_read_u16(buf + 2);
 
         *app_len = bret;
 
@@ -1391,27 +1345,21 @@ turn_time_t stun_adjust_allocate_lifetime(turn_time_t lifetime, turn_time_t max_
 
 int stun_attr_get_type(stun_attr_ref attr) {
   if (attr) {
-    uint16_t val;
-    memcpy(&val, attr, sizeof(val));
-    return (int)(nswap16(val));
+    return (int)turn_read_u16(attr);
   }
   return -1;
 }
 
 int stun_attr_get_len(stun_attr_ref attr) {
   if (attr) {
-    uint16_t val;
-    memcpy(&val, (const uint8_t *)attr + 2, sizeof(val));
-    return (int)(nswap16(val));
+    return (int)turn_read_u16((const uint8_t *)attr + 2);
   }
   return -1;
 }
 
 const uint8_t *stun_attr_get_value(stun_attr_ref attr) {
   if (attr) {
-    uint16_t val;
-    memcpy(&val, (const uint8_t *)attr + 2, sizeof(val));
-    const int len = (int)(nswap16(val));
+    const int len = (int)turn_read_u16((const uint8_t *)attr + 2);
     if (len < 1) {
       return NULL;
     }
@@ -1422,9 +1370,7 @@ const uint8_t *stun_attr_get_value(stun_attr_ref attr) {
 
 int stun_get_requested_address_family(stun_attr_ref attr) {
   if (attr) {
-    uint16_t raw_len;
-    memcpy(&raw_len, (const uint8_t *)attr + 2, sizeof(raw_len));
-    const int len = (int)(nswap16(raw_len));
+    const int len = (int)turn_read_u16((const uint8_t *)attr + 2);
     if (len != 4) {
       return STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_INVALID;
     }
@@ -1444,9 +1390,7 @@ uint16_t stun_attr_get_channel_number(stun_attr_ref attr) {
   if (attr) {
     const uint8_t *value = stun_attr_get_value(attr);
     if (value && (stun_attr_get_len(attr) >= 2)) {
-      uint16_t raw_cn;
-      memcpy(&raw_cn, value, sizeof(raw_cn));
-      const uint16_t cn = nswap16(raw_cn);
+      const uint16_t cn = turn_read_u16(value);
       if (STUN_VALID_CHANNEL(cn)) {
         return cn;
       }
@@ -1459,9 +1403,7 @@ band_limit_t stun_attr_get_bandwidth(stun_attr_ref attr) {
   if (attr) {
     const uint8_t *value = stun_attr_get_value(attr);
     if (value && (stun_attr_get_len(attr) >= 4)) {
-      uint32_t raw_bps;
-      memcpy(&raw_bps, value, sizeof(raw_bps));
-      const uint32_t bps = nswap32(raw_bps);
+      const uint32_t bps = turn_read_u32(value);
       return (band_limit_t)(bps << 7);
     }
   }
@@ -1472,9 +1414,7 @@ uint64_t stun_attr_get_reservation_token_value(stun_attr_ref attr) {
   if (attr) {
     const uint8_t *value = stun_attr_get_value(attr);
     if (value && (stun_attr_get_len(attr) == 8)) {
-      uint64_t token;
-      memcpy(&token, value, sizeof(uint64_t));
-      return nswap64(token);
+      return turn_read_u64(value);
     }
   }
   return 0;
@@ -1604,10 +1544,8 @@ bool stun_attr_add_str(uint8_t *buf, size_t *len, uint16_t attr, const uint8_t *
   stun_set_command_message_len_str(buf, newlen);
   *len = newlen;
 
-  const uint16_t raw_attr = nswap16(attr);
-  memcpy(attr_start, &raw_attr, sizeof(raw_attr));
-  const uint16_t raw_alen = nswap16((uint16_t)alen);
-  memcpy(attr_start + 2, &raw_alen, sizeof(raw_alen));
+  turn_write_u16(attr_start, attr);
+  turn_write_u16(attr_start + 2, (uint16_t)alen);
   if (alen > 0) {
     memcpy(attr_start + 4, avalue, alen);
   }
@@ -1774,8 +1712,7 @@ bool stun_attr_add_fingerprint_str(uint8_t *buf, size_t *len) {
     return false;
   }
   crc32 = ns_crc32(buf, (int)*len - 8);
-  const uint32_t raw_fingerprint = nswap32(crc32 ^ ((uint32_t)FINGERPRINT_XOR));
-  memcpy(buf + *len - 4, &raw_fingerprint, sizeof(raw_fingerprint));
+  turn_write_u32(buf + *len - 4, crc32 ^ ((uint32_t)FINGERPRINT_XOR));
   return true;
 }
 ////////////// CRC ///////////////////////////////////////////////
@@ -2106,9 +2043,7 @@ int stun_attr_get_response_port_str(stun_attr_ref attr) {
   if (stun_attr_get_len(attr) >= 2) {
     const uint8_t *value = stun_attr_get_value(attr);
     if (value) {
-      uint16_t raw_port;
-      memcpy(&raw_port, value, sizeof(raw_port));
-      return nswap16(raw_port);
+      return turn_read_u16(value);
     }
   }
   return -1;
@@ -2116,8 +2051,7 @@ int stun_attr_get_response_port_str(stun_attr_ref attr) {
 
 bool stun_attr_add_response_port_str(uint8_t *buf, size_t *len, uint16_t port) {
   uint8_t avalue[4] = {0, 0, 0, 0};
-  const uint16_t raw_port = nswap16(port);
-  memcpy(avalue, &raw_port, sizeof(raw_port));
+  turn_write_u16(avalue, port);
 
   return stun_attr_add_str(buf, len, STUN_ATTRIBUTE_RESPONSE_PORT, avalue, 4);
 }
@@ -2384,26 +2318,22 @@ static bool encode_oauth_token_gcm(const uint8_t *server_name, encoded_oauth_tok
 
     size_t len = 0;
 
-    const uint16_t raw_nonce_len = nswap16(OAUTH_GCM_NONCE_SIZE);
-    memcpy(orig_field + len, &raw_nonce_len, sizeof(raw_nonce_len));
+    turn_write_u16(orig_field + len, OAUTH_GCM_NONCE_SIZE);
     len += 2;
 
     memcpy(orig_field + len, nonce, OAUTH_GCM_NONCE_SIZE);
     len += OAUTH_GCM_NONCE_SIZE;
 
-    const uint16_t raw_key_length = nswap16(dtoken->enc_block.key_length);
-    memcpy(orig_field + len, &raw_key_length, sizeof(raw_key_length));
+    turn_write_u16(orig_field + len, dtoken->enc_block.key_length);
     len += 2;
 
     memcpy(orig_field + len, dtoken->enc_block.mac_key, dtoken->enc_block.key_length);
     len += dtoken->enc_block.key_length;
 
-    uint64_t ts = nswap64(dtoken->enc_block.timestamp);
-    memcpy((orig_field + len), &ts, sizeof(ts));
-    len += sizeof(ts);
+    turn_write_u64(orig_field + len, dtoken->enc_block.timestamp);
+    len += sizeof(uint64_t);
 
-    const uint32_t raw_lifetime = nswap32(dtoken->enc_block.lifetime);
-    memcpy(orig_field + len, &raw_lifetime, sizeof(raw_lifetime));
+    turn_write_u32(orig_field + len, dtoken->enc_block.lifetime);
     len += 4;
 
     const EVP_CIPHER *cipher = get_cipher_type(key->as_rs_alg);
@@ -2477,9 +2407,7 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
                                    oauth_token *dtoken) {
   if (server_name && etoken && key && dtoken) {
 
-    uint16_t raw_nonce_len;
-    memcpy(&raw_nonce_len, etoken->token, sizeof(raw_nonce_len));
-    const uint16_t nonce_len = nswap16(raw_nonce_len);
+    const uint16_t nonce_len = turn_read_u16(etoken->token);
 
     if (nonce_len > OAUTH_MAX_NONCE_SIZE) {
       OAUTH_ERROR("%s: nonce length too large: %u > %u\n", __FUNCTION__, (unsigned)nonce_len,
@@ -2573,9 +2501,7 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
       OAUTH_ERROR("%s: decoded token too small: %d\n", __FUNCTION__, (int)outl);
       return false;
     }
-    uint16_t raw_key_length;
-    memcpy(&raw_key_length, decoded_field + len, sizeof(raw_key_length));
-    dtoken->enc_block.key_length = nswap16(raw_key_length);
+    dtoken->enc_block.key_length = turn_read_u16(decoded_field + len);
     len += sizeof(uint16_t);
 
     if (dtoken->enc_block.key_length > sizeof(dtoken->enc_block.mac_key)) {
@@ -2592,15 +2518,11 @@ static bool decode_oauth_token_gcm(const uint8_t *server_name, const encoded_oau
     memcpy(dtoken->enc_block.mac_key, decoded_field + len, dtoken->enc_block.key_length);
     len += dtoken->enc_block.key_length;
 
-    uint64_t ts;
-    memcpy(&ts, (decoded_field + len), sizeof(ts));
-    dtoken->enc_block.timestamp = nswap64(ts);
-    len += sizeof(ts);
+    dtoken->enc_block.timestamp = turn_read_u64(decoded_field + len);
+    len += sizeof(uint64_t);
 
-    uint32_t lt;
-    memcpy(&lt, (decoded_field + len), sizeof(lt));
-    dtoken->enc_block.lifetime = nswap32(lt);
-    len += sizeof(lt);
+    dtoken->enc_block.lifetime = turn_read_u32(decoded_field + len);
+    len += sizeof(uint32_t);
 
     return true;
   }

--- a/src/client/ns_turn_msg_addr.c
+++ b/src/client/ns_turn_msg_addr.c
@@ -57,18 +57,22 @@ int stun_addr_encode(const ioa_addr *ca, uint8_t *cfield, int *clen, int xor_ed,
     if (xor_ed) {
 
       /* Port */
-      ((uint16_t *)cfield)[1] = (ca->s4.sin_port) ^ nswap16(mc >> 16);
+      const uint16_t port = (ca->s4.sin_port) ^ nswap16(mc >> 16);
+      memcpy(cfield + 2, &port, sizeof(port));
 
       /* Address */
-      ((uint32_t *)cfield)[1] = (ca->s4.sin_addr.s_addr) ^ nswap32(mc);
+      const uint32_t addr = (ca->s4.sin_addr.s_addr) ^ nswap32(mc);
+      memcpy(cfield + 4, &addr, sizeof(addr));
 
     } else {
 
       /* Port */
-      ((uint16_t *)cfield)[1] = ca->s4.sin_port;
+      const uint16_t port = ca->s4.sin_port;
+      memcpy(cfield + 2, &port, sizeof(port));
 
       /* Address */
-      ((uint32_t *)cfield)[1] = ca->s4.sin_addr.s_addr;
+      const uint32_t addr = ca->s4.sin_addr.s_addr;
+      memcpy(cfield + 4, &addr, sizeof(addr));
     }
 
   } else if (ca->ss.sa_family == AF_INET6) {
@@ -88,7 +92,8 @@ int stun_addr_encode(const ioa_addr *ca, uint8_t *cfield, int *clen, int xor_ed,
       uint32_t magic = nswap32(mc);
 
       /* Port */
-      ((uint16_t *)cfield)[1] = ca->s6.sin6_port ^ nswap16(mc >> 16);
+      const uint16_t port = ca->s6.sin6_port ^ nswap16(mc >> 16);
+      memcpy(cfield + 2, &port, sizeof(port));
 
       /* Address */
 
@@ -102,7 +107,8 @@ int stun_addr_encode(const ioa_addr *ca, uint8_t *cfield, int *clen, int xor_ed,
     } else {
 
       /* Port */
-      ((uint16_t *)cfield)[1] = ca->s6.sin6_port;
+      const uint16_t port = ca->s6.sin6_port;
+      memcpy(cfield + 2, &port, sizeof(port));
 
       /* Address */
       memcpy(((uint8_t *)cfield) + 4, &ca->s6.sin6_addr, 16);
@@ -146,10 +152,10 @@ int stun_addr_decode(ioa_addr *ca, const uint8_t *cfield, int len, int xor_ed, u
     /* IPv4 address */
 
     /* Port */
-    ca->s4.sin_port = ((const uint16_t *)cfield)[1];
+    memcpy(&ca->s4.sin_port, cfield + 2, sizeof(ca->s4.sin_port));
 
     /* Address */
-    ca->s4.sin_addr.s_addr = ((const uint32_t *)cfield)[1];
+    memcpy(&ca->s4.sin_addr.s_addr, cfield + 4, sizeof(ca->s4.sin_addr.s_addr));
 
     if (xor_ed) {
       ca->s4.sin_port ^= nswap16(mc >> 16);
@@ -165,7 +171,7 @@ int stun_addr_decode(ioa_addr *ca, const uint8_t *cfield, int len, int xor_ed, u
     }
 
     /* Port */
-    ca->s6.sin6_port = ((const uint16_t *)cfield)[1];
+    memcpy(&ca->s6.sin6_port, cfield + 2, sizeof(ca->s6.sin6_port));
 
     /* Address */
     memcpy(&ca->s6.sin6_addr, ((const uint8_t *)cfield) + 4, 16);

--- a/src/ns_turn_defs.h
+++ b/src/ns_turn_defs.h
@@ -115,6 +115,48 @@ static inline uint64_t _ioa_ntoh64(uint64_t v) {
 #define ioa_ntoh64 _ioa_ntoh64
 #define ioa_hton64 _ioa_ntoh64
 
+/* Alignment-safe access to network-order (big-endian) wire fields.
+ *
+ * STUN attributes and headers sit at arbitrary byte offsets inside receive
+ * buffers, so casting the byte pointer to a wider integer pointer and
+ * dereferencing it is undefined behavior (SIGBUS on strict-alignment
+ * architectures). These helpers go through memcpy — which compilers fold
+ * into a single load/store — and convert to/from host byte order.
+ * For fields that are NOT byte-swapped (e.g. values kept in network order
+ * or CONNECTION-ID's as-is encoding), use a plain memcpy instead. */
+static inline uint16_t turn_read_u16(const void *field) {
+  uint16_t v;
+  memcpy(&v, field, sizeof(v));
+  return nswap16(v);
+}
+
+static inline uint32_t turn_read_u32(const void *field) {
+  uint32_t v;
+  memcpy(&v, field, sizeof(v));
+  return nswap32(v);
+}
+
+static inline uint64_t turn_read_u64(const void *field) {
+  uint64_t v;
+  memcpy(&v, field, sizeof(v));
+  return nswap64(v);
+}
+
+static inline void turn_write_u16(void *field, uint16_t v) {
+  const uint16_t raw = nswap16(v);
+  memcpy(field, &raw, sizeof(raw));
+}
+
+static inline void turn_write_u32(void *field, uint32_t v) {
+  const uint32_t raw = nswap32(v);
+  memcpy(field, &raw, sizeof(raw));
+}
+
+static inline void turn_write_u64(void *field, uint64_t v) {
+  const uint64_t raw = nswap64(v);
+  memcpy(field, &raw, sizeof(raw));
+}
+
 #if defined(WINDOWS)
 static inline int socket_errno(void) { return WSAGetLastError(); }
 static inline int socket_enomem(void) { return socket_errno() == WSA_NOT_ENOUGH_MEMORY; }

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -1274,9 +1274,7 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
             *err_code = 400;
             *reason = (const uint8_t *)"Wrong Lifetime Data";
           } else {
-            uint32_t raw_lifetime;
-            memcpy(&raw_lifetime, value, sizeof(raw_lifetime));
-            lifetime = nswap32(raw_lifetime);
+            lifetime = turn_read_u32(value);
           }
         }
       } break;
@@ -1810,9 +1808,7 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
             *err_code = 400;
             *reason = (const uint8_t *)"Wrong lifetime field data";
           } else {
-            uint32_t raw_lifetime;
-            memcpy(&raw_lifetime, value, sizeof(raw_lifetime));
-            lifetime = nswap32(raw_lifetime);
+            lifetime = turn_read_u32(value);
             if (!lifetime) {
               to_delete = 1;
             }

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -1274,7 +1274,9 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
             *err_code = 400;
             *reason = (const uint8_t *)"Wrong Lifetime Data";
           } else {
-            lifetime = nswap32(*((const uint32_t *)value));
+            uint32_t raw_lifetime;
+            memcpy(&raw_lifetime, value, sizeof(raw_lifetime));
+            lifetime = nswap32(raw_lifetime);
           }
         }
       } break;
@@ -1808,7 +1810,9 @@ static int handle_turn_refresh(turn_turnserver *server, ts_ur_super_session *ss,
             *err_code = 400;
             *reason = (const uint8_t *)"Wrong lifetime field data";
           } else {
-            lifetime = nswap32(*((const uint32_t *)value));
+            uint32_t raw_lifetime;
+            memcpy(&raw_lifetime, value, sizeof(raw_lifetime));
+            lifetime = nswap32(raw_lifetime);
             if (!lifetime) {
               to_delete = 1;
             }
@@ -2612,7 +2616,7 @@ static int handle_turn_connection_bind(turn_turnserver *server, ts_ur_super_sess
             *err_code = 400;
             *reason = (const uint8_t *)"Wrong Connection ID field data";
           } else {
-            id = *((const uint32_t *)value); // AS-IS encoding, no conversion to/from network byte order
+            memcpy(&id, value, sizeof(id)); // AS-IS encoding, no conversion to/from network byte order
           }
         }
       } break;

--- a/tests/test_stun_msg.c
+++ b/tests/test_stun_msg.c
@@ -4,10 +4,18 @@
 
 #include <unity.h>
 
+#include <stdint.h>
 #include <string.h>
 
 void setUp(void) {}
 void tearDown(void) {}
+
+/* uint8_t arrays carry no alignment guarantee, so a fixed `raw + 1` is only
+ * misaligned when the array base happens to land on an even address. Pick the
+ * offset at runtime so the returned pointer always sits on an odd address and
+ * the misaligned-access regression tests below are deterministic. Callers
+ * must size `raw` with two bytes of headroom. */
+static uint8_t *misalign(uint8_t *raw) { return raw + 1 + ((uintptr_t)raw & 1); }
 
 static void test_init_request_produces_valid_stun_header(void) {
   uint8_t buf[1024] = {0};
@@ -317,8 +325,8 @@ static void test_attr_accessors_survive_misaligned_pointer(void) {
    * aligned base and confirm the accessors still decode it correctly
    * instead of crashing.
    */
-  uint8_t raw[1 + 8] = {0};
-  uint8_t *attr = raw + 1;
+  uint8_t raw[2 + 8] = {0};
+  uint8_t *attr = misalign(raw);
 
   attr[0] = (STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY >> 8) & 0xFF;
   attr[1] = STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY & 0xFF;
@@ -349,8 +357,8 @@ static void test_value_accessors_survive_misaligned_pointer(void) {
    * attribute and confirm it still decodes the field correctly.
    */
   {
-    uint8_t raw[1 + 8] = {0};
-    uint8_t *attr = raw + 1;
+    uint8_t raw[2 + 8] = {0};
+    uint8_t *attr = misalign(raw);
     attr[0] = (STUN_ATTRIBUTE_CHANNEL_NUMBER >> 8) & 0xFF;
     attr[1] = STUN_ATTRIBUTE_CHANNEL_NUMBER & 0xFF;
     attr[2] = 0x00;
@@ -361,8 +369,8 @@ static void test_value_accessors_survive_misaligned_pointer(void) {
     TEST_ASSERT_EQUAL_UINT16(0x4000, stun_attr_get_channel_number(sar));
   }
   {
-    uint8_t raw[1 + 8] = {0};
-    uint8_t *attr = raw + 1;
+    uint8_t raw[2 + 8] = {0};
+    uint8_t *attr = misalign(raw);
     attr[0] = (STUN_ATTRIBUTE_BANDWIDTH >> 8) & 0xFF;
     attr[1] = STUN_ATTRIBUTE_BANDWIDTH & 0xFF;
     attr[2] = 0x00;
@@ -372,8 +380,8 @@ static void test_value_accessors_survive_misaligned_pointer(void) {
     TEST_ASSERT_EQUAL_UINT64(128, (uint64_t)stun_attr_get_bandwidth(sar));
   }
   {
-    uint8_t raw[1 + 8] = {0};
-    uint8_t *attr = raw + 1;
+    uint8_t raw[2 + 8] = {0};
+    uint8_t *attr = misalign(raw);
     attr[0] = (STUN_ATTRIBUTE_RESPONSE_PORT >> 8) & 0xFF;
     attr[1] = STUN_ATTRIBUTE_RESPONSE_PORT & 0xFF;
     attr[2] = 0x00;
@@ -383,6 +391,124 @@ static void test_value_accessors_survive_misaligned_pointer(void) {
     stun_attr_ref sar = attr;
     TEST_ASSERT_EQUAL_INT(12345, stun_attr_get_response_port_str(sar));
   }
+}
+
+static void test_message_build_and_parse_survive_misaligned_buffer(void) {
+  /* The message builders and header parsers (stun_init_command_str,
+   * stun_attr_add_str, stun_attr_add_fingerprint_str, stun_get_method_str,
+   * stun_is_command_message_str, stun_get_message_len_str, ...) used to
+   * access the wire buffer through casts to wider integer pointers — the
+   * store-side twin of the attribute-accessor reads already pinned by the
+   * misaligned tests above. Build and re-parse a complete message on a buffer
+   * one byte off an aligned base and confirm every step still works.
+   */
+  uint8_t raw[2 + 1024] = {0};
+  uint8_t *buf = misalign(raw);
+  size_t len = 0;
+
+  stun_init_request_str(STUN_METHOD_BINDING, buf, &len);
+  TEST_ASSERT_EQUAL_size_t(STUN_HEADER_LENGTH, len);
+
+  const uint16_t rport = 12345;
+  TEST_ASSERT_TRUE(stun_attr_add_response_port_str(buf, &len, rport));
+  TEST_ASSERT_TRUE(stun_attr_add_fingerprint_str(buf, &len));
+
+  TEST_ASSERT_TRUE(stun_is_command_message_str(buf, len));
+  TEST_ASSERT_TRUE(stun_is_request_str(buf, len));
+  TEST_ASSERT_EQUAL_UINT16(STUN_METHOD_BINDING, stun_get_method_str(buf, len));
+  TEST_ASSERT_EQUAL_UINT16(stun_make_request(STUN_METHOD_BINDING), stun_get_msg_type_str(buf, len));
+  TEST_ASSERT_EQUAL_INT((int)len, stun_get_command_message_len_str(buf, len));
+  TEST_ASSERT_FALSE(is_channel_msg_str(buf, len));
+
+  int fingerprint_present = 0;
+  TEST_ASSERT_TRUE(stun_is_command_message_full_check_str(buf, len, 1, &fingerprint_present));
+  TEST_ASSERT_TRUE(fingerprint_present);
+
+  stun_attr_ref sar = stun_attr_get_first_by_type_str(buf, len, STUN_ATTRIBUTE_RESPONSE_PORT);
+  TEST_ASSERT_NOT_NULL(sar);
+  TEST_ASSERT_EQUAL_INT((int)rport, stun_attr_get_response_port_str(sar));
+
+  size_t app_len = 0;
+  TEST_ASSERT_EQUAL_INT((int)len, stun_get_message_len_str(buf, len, 0, &app_len));
+  TEST_ASSERT_EQUAL_size_t(len, app_len);
+
+  /* Old (RFC 3489) header path: cookie is read and reported through the same
+   * previously-misaligned loads. */
+  {
+    uint8_t raw_old[2 + 64] = {0};
+    uint8_t *obuf = misalign(raw_old);
+    size_t olen = 0;
+    const uint32_t old_cookie = 0x12345678;
+    old_stun_init_command_str(stun_make_request(STUN_METHOD_BINDING), obuf, &olen, old_cookie);
+    uint32_t parsed_cookie = 0;
+    TEST_ASSERT_TRUE(old_stun_is_command_message_str(obuf, olen, &parsed_cookie));
+    TEST_ASSERT_EQUAL_UINT32(old_cookie, parsed_cookie);
+  }
+}
+
+static void test_channel_message_survives_misaligned_buffer(void) {
+  /* Channel-data framing (stun_init_channel_message_str,
+   * stun_is_channel_message_str, is_channel_msg_str, and the channel branch of
+   * stun_get_message_len_str) reads and writes the channel number and data
+   * length through what used to be direct wide-pointer access. Exercise the
+   * whole round trip on a misaligned buffer.
+   */
+  uint8_t raw[2 + 1024] = {0};
+  uint8_t *buf = misalign(raw);
+  size_t len = 0;
+  const uint16_t channel = 0x4001;
+  const int payload_len = 200;
+
+  TEST_ASSERT_TRUE(stun_init_channel_message_str(channel, buf, &len, payload_len, false));
+  TEST_ASSERT_EQUAL_size_t((size_t)(4 + payload_len), len);
+
+  TEST_ASSERT_TRUE(is_channel_msg_str(buf, len));
+  TEST_ASSERT_FALSE(stun_is_command_message_str(buf, len));
+
+  uint16_t parsed_channel = 0;
+  size_t blen = len;
+  TEST_ASSERT_TRUE(stun_is_channel_message_str(buf, &blen, &parsed_channel, false));
+  TEST_ASSERT_EQUAL_UINT16(channel, parsed_channel);
+
+  size_t app_len = 0;
+  TEST_ASSERT_EQUAL_INT((int)len, stun_get_message_len_str(buf, len, 0, &app_len));
+  TEST_ASSERT_EQUAL_size_t(len, app_len);
+}
+
+static void test_addr_attrs_survive_misaligned_buffer(void) {
+  /* stun_addr_encode/stun_addr_decode wrote and read the port and IPv4
+   * address fields through casts to wider integer pointers into the attribute
+   * body. Round-trip XOR-mapped (port and address are XORed with the magic
+   * cookie / transaction id) and plain address attributes, IPv4 and IPv6, on
+   * a message that sits one byte off an aligned base.
+   */
+  uint8_t raw[2 + 1024] = {0};
+  uint8_t *buf = misalign(raw);
+  size_t len = 0;
+  stun_tid tid = {0};
+  stun_init_success_response_str(STUN_METHOD_BINDING, buf, &len, &tid);
+
+  ioa_addr peer4 = {0};
+  ioa_addr peer6 = {0};
+  ioa_addr origin4 = {0};
+  TEST_ASSERT_EQUAL_INT(0, make_ioa_addr((const uint8_t *)"203.0.113.5", 43210, &peer4));
+  TEST_ASSERT_EQUAL_INT(0, make_ioa_addr((const uint8_t *)"2001:db8::1", 43211, &peer6));
+  TEST_ASSERT_EQUAL_INT(0, make_ioa_addr((const uint8_t *)"192.0.2.10", 3478, &origin4));
+
+  TEST_ASSERT_TRUE(stun_attr_add_addr_str(buf, &len, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, &peer4));
+  TEST_ASSERT_TRUE(stun_attr_add_addr_str(buf, &len, STUN_ATTRIBUTE_XOR_PEER_ADDRESS, &peer6));
+  TEST_ASSERT_TRUE(stun_attr_add_addr_str(buf, &len, STUN_ATTRIBUTE_RESPONSE_ORIGIN, &origin4));
+
+  ioa_addr got4 = {0};
+  ioa_addr got6 = {0};
+  ioa_addr got_origin = {0};
+  TEST_ASSERT_TRUE(stun_attr_get_first_addr_str(buf, len, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, &got4, NULL));
+  TEST_ASSERT_TRUE(stun_attr_get_first_addr_str(buf, len, STUN_ATTRIBUTE_XOR_PEER_ADDRESS, &got6, NULL));
+  TEST_ASSERT_TRUE(stun_attr_get_first_addr_str(buf, len, STUN_ATTRIBUTE_RESPONSE_ORIGIN, &got_origin, NULL));
+
+  TEST_ASSERT_TRUE(addr_eq(&peer4, &got4));
+  TEST_ASSERT_TRUE(addr_eq(&peer6, &got6));
+  TEST_ASSERT_TRUE(addr_eq(&origin4, &got_origin));
 }
 
 static void test_http_message_len_handles_non_null_terminated_buffer(void) {
@@ -414,6 +540,9 @@ int main(void) {
   RUN_TEST(test_rfc5780_other_address_and_response_origin_roundtrip);
   RUN_TEST(test_attr_accessors_survive_misaligned_pointer);
   RUN_TEST(test_value_accessors_survive_misaligned_pointer);
+  RUN_TEST(test_message_build_and_parse_survive_misaligned_buffer);
+  RUN_TEST(test_channel_message_survives_misaligned_buffer);
+  RUN_TEST(test_addr_attrs_survive_misaligned_buffer);
   RUN_TEST(test_http_message_len_handles_non_null_terminated_buffer);
   return UNITY_END();
 }


### PR DESCRIPTION
Follow-up to #1994, which fixed misaligned reads in three attribute accessors. The same cast-the-byte-pointer-to-a-wider-integer-pointer construct remained at ~36 more sites; on a wire buffer that is not 2/4-byte aligned each of them is undefined behavior (UBSan aborts; SIGBUS on strict-alignment targets).

## Fix (commit 1)

Convert every remaining site to `memcpy` through a local:

- **ns_turn_msg.c** — header parse/build (`stun_get/set_command_message_len_str`, `stun_get_method_str`, `stun_get_msg_type_str`, `stun_is_command_message_str` + old-STUN variant, `stun_init_command_str` + old-STUN variant), channel-data framing (`stun_init_channel_message_str`, `stun_is_channel_message_str`, `is_channel_msg_str`, the channel branch of `stun_get_message_len_str`), attribute add (`stun_attr_add_str`, `stun_attr_add_response_port_str`), FINGERPRINT add/verify, transaction-id generation, GCM oauth token encode/decode.
- **ns_turn_msg_addr.c** — port/IPv4-address access in `stun_addr_encode`/`stun_addr_decode`.
- **ns_turn_server.c** — LIFETIME (allocate/refresh) and CONNECTION-ID value reads.
- **uclient.c** — CONNECTION-ID reads, plus a NULL/length guard they were missing.

## Refactor (commit 2)

The 3-line memcpy pattern repeated at every site, so it is folded into six inline helpers in `ns_turn_defs.h` next to the `nswap*` macros: `turn_read_u16/u32/u64(field)` and `turn_write_u16/u32/u64(field, value)`. All byte-swapped field accesses in the codec and server now use them, including the accessors fixed in #1994 and earlier. Fields that are *not* byte-swapped (CONNECTION-ID as-is encoding, already-network-order copies in the addr codec) keep a plain `memcpy`. Typical site: `lifetime = turn_read_u32(value);`.

Commit 3 records both conventions (prefer `turn_` over legacy `ns_` for new identifiers; use the helpers for wire fields) in CLAUDE.md.

## Tests

`test_stun_msg` gains misaligned-buffer round trips for the message builders/parsers (incl. FINGERPRINT and the old-STUN cookie path), channel-data framing, and XOR/plain address attributes (IPv4 + IPv6).

While writing them, it turned out the existing misaligned tests were nondeterministic: `uint8_t` arrays have no alignment guarantee, so the fixed `raw + 1` offset only lands on an odd address when the array base happens to be even — some builds never actually exercised misalignment. A new `misalign()` helper picks the offset at runtime; the existing tests were converted to it as well.

## Validation

- Counterfactual under `-fsanitize=alignment`: with the fix reverted the extended suite reports **57 misaligned accesses at 34 distinct lines**; with it applied, **zero**. Test results on aligned inputs are identical before/after.
- macOS + Linux (Docker): clean builds, full ctest (15/15, 14/14), `run_tests.sh` / `run_tests_conf.sh` / mobile / multiplex-peer / rfc5780 all green, RFC 5769 test vectors pass (covers FINGERPRINT and oauth GCM against known wire bytes), fuzzing smoke targets, and the packaged Docker image Bats suite (19 tests, 0 failures).
- `clang-format` clean; no new compiler warnings on Linux.
