### PR TITLE
Count every STUN Binding response in the Prometheus metrics

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -4672,13 +4672,13 @@ void stun_report_binding(void *a, STUN_PROMETHEUS_METRIC_TYPE type) {
 #if !defined(TURN_NO_PROMETHEUS)
   UNUSED_ARG(a);
   switch (type) {
-  case 0:
+  case STUN_PROMETHEUS_METRIC_TYPE_REQUEST:
     prom_inc_stun_binding_request();
     break;
-  case 1:
+  case STUN_PROMETHEUS_METRIC_TYPE_RESPONSE:
     prom_inc_stun_binding_response();
     break;
-  case 2:
+  case STUN_PROMETHEUS_METRIC_TYPE_ERROR:
     prom_inc_stun_binding_error();
     break;
   default:

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -2985,6 +2985,10 @@ static int handle_turn_binding(turn_turnserver *server, ts_ur_super_session *ss,
   const SOCKET_TYPE st = get_ioa_socket_type(ss->client_socket);
   int use_reflected_from = 0;
 
+  /* Every incoming Binding request is counted here, exactly once; the matching
+   * response/error is counted where the reply is actually sent out. */
+  stun_report_binding(ss, STUN_PROMETHEUS_METRIC_TYPE_REQUEST);
+
   if (!(ss->client_socket)) {
     return -1;
   }
@@ -3076,12 +3080,7 @@ static int handle_turn_binding(turn_turnserver *server, ts_ur_super_session *ss,
 
   if (*ua_num > 0) {
     *err_code = 420;
-    stun_report_binding(ss, STUN_PROMETHEUS_METRIC_TYPE_ERROR);
-  } else if (*err_code) {
-    stun_report_binding(ss, STUN_PROMETHEUS_METRIC_TYPE_ERROR);
-
-  } else if (ss->client_socket && get_remote_addr_from_ioa_socket(ss->client_socket)) {
-    stun_report_binding(ss, STUN_PROMETHEUS_METRIC_TYPE_REQUEST);
+  } else if (!(*err_code) && ss->client_socket && get_remote_addr_from_ioa_socket(ss->client_socket)) {
 
     size_t len = ioa_network_buffer_get_size(nbh);
     if (stun_set_binding_response_str(ioa_network_buffer_data(nbh), &len, tid,
@@ -4204,6 +4203,10 @@ static int handle_turn_command(turn_turnserver *server, ts_ur_super_session *ss,
       ioa_network_buffer_set_size(nbh, len);
     }
 
+    if (method == STUN_METHOD_BINDING) {
+      stun_report_binding(ss, err_code ? STUN_PROMETHEUS_METRIC_TYPE_ERROR : STUN_PROMETHEUS_METRIC_TYPE_RESPONSE);
+    }
+
     if (err_code) {
       if (server->verbose) {
         log_method(ss, "message", err_code, reason);
@@ -4277,6 +4280,7 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
         }
 
         send_turn_message_to(server, nbh, &response_origin, &response_destination);
+        stun_report_binding(ss, STUN_PROMETHEUS_METRIC_TYPE_RESPONSE);
 
         no_response = 1;
       }
@@ -4332,6 +4336,10 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
       size_t len = ioa_network_buffer_get_size(nbh);
       stun_attr_add_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_SERVER, software, newsz);
       ioa_network_buffer_set_size(nbh, len);
+    }
+
+    if (method == STUN_METHOD_BINDING) {
+      stun_report_binding(ss, err_code ? STUN_PROMETHEUS_METRIC_TYPE_ERROR : STUN_PROMETHEUS_METRIC_TYPE_RESPONSE);
     }
 
     if (err_code) {


### PR DESCRIPTION
## Problem

`stun_binding_response` — documented as *"Outgoing STUN Binding responses"* — had exactly one call site in the tree, at `handle_turn_command`'s `STUN_METHOD_BINDING` case, inside:

```c
if (*resp_constructed && !err_code && (origin_changed || dest_changed)) {
```

That is the RFC 5780 CHANGE-REQUEST / RESPONSE-PORT branch. So the counter only moved for NAT-behaviour-discovery traffic — on a server without `--rfc5780` it stayed at zero regardless of how many Binding requests were answered.

Everything else was uncounted:

- **The ordinary success response.** `handle_turn_binding` builds it and sets `*resp_constructed = 1`; when origin/dest are unchanged the shared tail of `handle_turn_command` sends it, with no increment. This is the vast majority of Binding responses.
- **RFC 3489 / old-STUN entirely.** `handle_old_stun_command` calls the same `handle_turn_binding` (so it *did* contribute requests) but never reported a response — not on its change-request send, not on its normal send. It actively widened the gap.
- **Errors raised outside attribute parsing**, such as the generic `err_code = 400` fallback, hit neither `stun_binding_error` nor `stun_binding_response`.

Net effect: `stun_binding_request` ≫ `stun_binding_response` even when every single request succeeded, and the three counters could not be reconciled against each other.

## Fix

Report the outcome where the reply is actually sent, rather than on one branch:

- Count `REQUEST` once per incoming Binding request, at the top of `handle_turn_binding`. It previously sat on the success branch, making it "requests that parsed cleanly" rather than what the metric name says.
- Drop the `REQUEST`/`ERROR` increments from inside `handle_turn_binding` — reporting an error there double-counted once the shared tail handled the same error, and missed errors raised elsewhere.
- Report `RESPONSE` or `ERROR` from the send tails of both `handle_turn_command` and `handle_old_stun_command`, gated on `STUN_METHOD_BINDING`.
- Add the missing `RESPONSE` report to the old-STUN change-request send.
- `stun_report_binding()` now switches on the enum names instead of bare `case 0/1/2`, which is what made the mismatch easy to miss when reading.

## Notes for reviewers

- **Gating on `method == STUN_METHOD_BINDING` is sufficient in both tails**: they are only reachable for requests, since every other message class (indications, responses, malformed) sets `no_response = 1` before reaching them.
- **`REQUEST` semantics change slightly** — it now also counts requests that end in an error, which is what the metric name and help string describe. This makes `request ≈ response + error` hold.
- **Deliberate drops still count as request-only**: the UDP 401 rate limiter and `to_be_closed` sockets suppress the reply, so a request with no response is the correct reading there.

## Validation

Live check against a `--prometheus` server driven by `turnutils_stunclient`:

| | `stun_binding_request` | `stun_binding_response` |
|---|---|---|
| before | 5 | *(line never emitted)* |
| after | 5 | 5 |

Also passing on the isolated change: `ctest` 15/15, `examples/run_tests.sh` (TCP/TLS/UDP/DTLS), `examples/run_tests_prom.sh`, `turnutils_rfc5769check`, and `clang-format-15` clean.

Not covered: `examples/run_tests_rfc5780.sh` **SKIPped** on the dev machine (needs a `127.0.0.2` loopback alias), so the RFC 5780 branch — the one call site that was already correct and is unchanged here — was not exercised end-to-end. The Linux/Docker validation pass was not run either. Draft pending CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
