### PR TITLE
Add --drain-min-allocations: shutdown threshold for drain mode

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -643,6 +643,10 @@ Options with values:
 --max-allocate-timeout	Max time, in seconds, allowed for full allocation establishment.
 			Default is 60 seconds.
 
+--drain-min-allocations	In drain mode (entered on SIGUSR1), shut down once the number of
+			active allocations drops to this value or below.
+			Default is 0 (wait until all allocations are gone).
+
 --denied-peer-ip=<IPaddr[-IPaddr]>
 
 --allowed-peer-ip=<IPaddr[-IPaddr]> Options to ban or allow specific ip addresses or ranges

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -754,6 +754,12 @@
 #
 #max-allocate-timeout=60
 
+# In drain mode (entered on SIGUSR1), the server shuts down once the number of
+# active allocations drops to this value or below.
+# Default is 0: wait until all allocations are gone.
+#
+#drain-min-allocations=0
+
 # Option to allow or ban specific ip addresses or ranges of ip addresses.
 # If an ip address is specified as both allowed and denied, then the ip address is
 # considered to be allowed. This is useful when you wish to ban a range of ip

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -1090,6 +1090,12 @@ The connection string has the same parameters as redis\-userdb connection string
 \fB\-\-max\-allocate\-timeout\fP
 Max time, in seconds, allowed for full allocation establishment.
 Default is 60 seconds.
+.TP
+.B
+\fB\-\-drain\-min\-allocations\fP
+In drain mode (entered on SIGUSR1), shut down once the number of
+active allocations drops to this value or below.
+Default is 0 (wait until all allocations are gone).
 .RE
 
 .RS

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -198,6 +198,7 @@ turn_params_t turn_params = {
 
     /////////////// stop server ////////////////
     false, /*drain_turn_server*/
+    0,     /*drain_min_allocations*/
     false, /*stop_turn_server*/
 
     /////////////// MISC PARAMS ////////////////
@@ -1317,6 +1318,10 @@ static char Usage[] =
     "						The default value is ':'.\n"
     " --max-allocate-timeout=<seconds>		Max time, in seconds, allowed for full allocation establishment. "
     "Default is 60.\n"
+    " --drain-min-allocations=<number>		In drain mode (SIGUSR1), shut down once the number of active "
+    "allocations\n"
+    "						drops to this value or below. Default is 0 (wait until all "
+    "allocations are gone).\n"
     " --allowed-peer-ip=<ip[-ip]> 			Specifies an ip or range of ips that are explicitly allowed to "
     "connect to the \n"
     "						turn server. Multiple allowed-peer-ip can be set.\n"
@@ -1611,6 +1616,7 @@ enum EXTRA_OPTS {
   UDP_GSO_OPT,
 #endif
   VERSION_OPT,
+  DRAIN_MIN_ALLOCATIONS_OPT,
   RATELIMIT_OPT,
   RATELIMIT_RPS_OPT,
   CPUS_OPT,
@@ -1728,6 +1734,7 @@ static const struct myoption long_options[] = {
     {"udp-alternate-server", required_argument, NULL, UDP_ALTERNATE_SERVER_OPT},
     {"rest-api-separator", required_argument, NULL, 'C'},
     {"max-allocate-timeout", required_argument, NULL, MAX_ALLOCATE_TIMEOUT_OPT},
+    {"drain-min-allocations", required_argument, NULL, DRAIN_MIN_ALLOCATIONS_OPT},
     {"no-multicast-peers", optional_argument, NULL, NO_MULTICAST_PEERS_OPT},
     {"allow-loopback-peers", optional_argument, NULL, ALLOW_LOOPBACK_PEERS_OPT},
     {"allowed-peer-ip", required_argument, NULL, ALLOWED_PEER_IPS},
@@ -2279,6 +2286,14 @@ static void set_option(int c, char *value) {
     TURN_MAX_ALLOCATE_TIMEOUT = atoi(value);
     TURN_MAX_ALLOCATE_TIMEOUT_STUN_ONLY = atoi(value);
     break;
+  case DRAIN_MIN_ALLOCATIONS_OPT: {
+    int dma = get_int_value(value, 0);
+    if (dma < 0) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "WARNING: negative drain-min-allocations value %d ignored, using 0\n", dma);
+      dma = 0;
+    }
+    turn_params.drain_min_allocations = (size_t)dma;
+  } break;
   case 'S':
     turn_params.stun_only = get_bool_value(value);
     break;

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -296,6 +296,9 @@ typedef struct _turn_params_ {
 
   /////////////// stop/drain server ////////////////
   bool drain_turn_server;
+  /* Drain completes once the active allocation count drops to this value
+   * (default 0: wait for every allocation to go away). */
+  size_t drain_min_allocations;
   /////////////// stop server ////////////////
   /* Written from the signal handler and the admin thread, read by every
    * worker loop — volatile so those reads are not optimized away. */

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1315,9 +1315,11 @@ void run_listener_server(struct listener_server *ls) {
       }
     }
 
-    if (turn_params.drain_turn_server && global_allocation_count == 0) {
+    if (turn_params.drain_turn_server && global_allocation_count <= turn_params.drain_min_allocations) {
       turn_params.stop_turn_server = true;
-      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "Drain complete, shutting down now...\n");
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
+                    "Drain complete (%zu allocations remaining, threshold %zu), shutting down now...\n",
+                    global_allocation_count, turn_params.drain_min_allocations);
     }
 
     run_events(ls->event_base, ls->ioa_eng);


### PR DESCRIPTION
## Summary

In drain mode (entered on SIGUSR1) the server waits for the active allocation count to reach exactly 0 before shutting down. This PR adds `--drain-min-allocations=<number>` (also usable as a `turnserver.conf` key) so drain completes once the active allocation count drops **to the configured value or below**. The default of 0 preserves the existing behavior exactly.

This is useful when a small number of long-lived allocations shouldn't hold up a rolling restart or decommission indefinitely.

## Changes

- `turn_params_t` gains a `drain_min_allocations` field (default 0), wired through the option enum, long-options table, usage text, and config parsing. Negative values are logged and clamped to 0.
- The drain check in `run_listener_server` becomes `global_allocation_count <= turn_params.drain_min_allocations`, and the "Drain complete" log line now reports the remaining count and threshold.
- Documentation added to the example `turnserver.conf`, `README.turnserver`, and the `turnserver.1` man page (man page edited in place to match the committed txt2man output rather than regenerating, to avoid unrelated formatting churn).

## Validation

- Functional smoke test: with `--drain-min-allocations=10` and 6 live allocations, SIGUSR1 shut the server down, logging `Drain complete (6 allocations remaining, threshold 10)`. Control run with the default kept draining while allocations were active. Config-file spelling verified.
- macOS: build, all 15 unit tests, `run_tests.sh`, `run_tests_conf.sh`, `run_tests_mobile.sh`, `run_tests_multiplex_peer.sh`, `run_tests_rfc5780.sh` — all pass, no FAIL lines; clang-format clean.
- Fuzzing smoke tests (ASan, both targets): pass.
- Linux (Docker): clean build, ctest, all five system-test suites pass.
- Packaged Debian Docker image (arm64): builds; Bats tests 19/19 pass (2 environment skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)