### PR TITLE
DTLS listener: correct the handshake buffer bound and remove the non-functional client-cert path

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -231,6 +231,27 @@ static size_t print_packet_txt2pcap(uint64_t now, uint8_t *payload, size_t paylo
 
 #if DTLS_SUPPORTED
 
+/*
+ * Upper bound on the handshake buffer OpenSSL grows for a DTLS peer.
+ *
+ * OpenSSL sizes the per-connection handshake buffer from the length declared in
+ * the message header, capped by
+ * max(DTLS1_HM_HEADER_LENGTH + SSL3_RT_MAX_ENCRYPTED_LENGTH, max_cert_list)
+ * (dtls1_max_handshake_message_len() in ssl/statem/statem_dtls.c). A peer that
+ * declares a large length and then sends a single fragment byte still forces
+ * the whole allocation, so max_cert_list is what an unvalidated source can make
+ * the server allocate per pending handshake.
+ *
+ * A source that has not answered the DTLS cookie challenge (RFC 6347, section
+ * 4.2.1) is not validated at all, so keep this at the OpenSSL floor - lower
+ * values have no further effect. REQUEST_CLIENT_CERT is not defined, so the
+ * server never asks for a client certificate and no client handshake message
+ * other than the ClientHello comes close to the floor. A build that enables
+ * REQUEST_CLIENT_CERT and needs to accept a chain larger than the floor has to
+ * raise this, and gives up the bound on unvalidated sources by doing so.
+ */
+#define TURN_DTLS_MAX_CERT_LIST (SSL3_RT_MAX_ENCRYPTED_LENGTH)
+
 static unsigned char dtls_cookie_secret[COOKIE_SECRET_LENGTH];
 static pthread_once_t dtls_cookie_secret_once = PTHREAD_ONCE_INIT;
 
@@ -384,7 +405,7 @@ static ioa_socket_handle dtls_server_input_handler(dtls_listener_relay_server_ty
                                       | SSL_OP_NO_RENEGOTIATION
 #endif
   );
-  SSL_set_max_cert_list(connecting_ssl, 655350);
+  SSL_set_max_cert_list(connecting_ssl, TURN_DTLS_MAX_CERT_LIST);
 
   ioa_socket_handle rc =
       dtls_accept_client_connection(server, s, connecting_ssl, &(server->sm.m.sm.nd.src_addr), &(server->addr), nbh);
@@ -1011,7 +1032,7 @@ static int create_new_connected_udp_socket(dtls_listener_relay_server_type *serv
 #endif
     );
 
-    SSL_set_max_cert_list(connecting_ssl, 655350);
+    SSL_set_max_cert_list(connecting_ssl, TURN_DTLS_MAX_CERT_LIST);
     const int rc = ssl_read(ret->fd, connecting_ssl, server->sm.m.sm.nd.nbh, server->verbose);
 
     if (rc < 0) {

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -52,8 +52,6 @@
 #include <pthread.h>
 #include <stdint.h>
 
-/* #define REQUEST_CLIENT_CERT */
-
 ///////////////////////////////////////////////////
 #if defined(WINDOWS)
 // TODO: test it!
@@ -244,11 +242,11 @@ static size_t print_packet_txt2pcap(uint64_t now, uint8_t *payload, size_t paylo
  *
  * A source that has not answered the DTLS cookie challenge (RFC 6347, section
  * 4.2.1) is not validated at all, so keep this at the OpenSSL floor - lower
- * values have no further effect. REQUEST_CLIENT_CERT is not defined, so the
- * server never asks for a client certificate and no client handshake message
- * other than the ClientHello comes close to the floor. A build that enables
- * REQUEST_CLIENT_CERT and needs to accept a chain larger than the floor has to
- * raise this, and gives up the bound on unvalidated sources by doing so.
+ * values have no further effect. The server does not ask for a client
+ * certificate, so no client handshake message other than the ClientHello comes
+ * close to the floor. Adding client-certificate support means raising this, and
+ * giving up the bound on unvalidated sources unless it is raised only after the
+ * cookie has been answered.
  */
 #define TURN_DTLS_MAX_CERT_LIST (SSL3_RT_MAX_ENCRYPTED_LENGTH)
 
@@ -1402,21 +1400,6 @@ static int reopen_server_socket(dtls_listener_relay_server_type *server, evutil_
   return 0;
 }
 
-#if defined(REQUEST_CLIENT_CERT)
-
-static int dtls_verify_callback(int ok, X509_STORE_CTX *ctx) {
-  /* This function should ask the user
-   * if he trusts the received certificate.
-   * Here we always trust.
-   */
-  if (ok && ctx) {
-    return 1;
-  }
-  return -1;
-}
-
-#endif
-
 static int init_server(dtls_listener_relay_server_type *server, const char *ifname, const char *local_address,
                        uint16_t port, int sock_buf_size, int verbose, ioa_engine_handle e, turn_turnserver *ts,
                        int report_creation, ioa_engine_new_connection_event_handler send_socket) {
@@ -1472,11 +1455,6 @@ void setup_dtls_callbacks(SSL_CTX *ctx) {
   if (!ctx) {
     return;
   }
-
-#if defined(REQUEST_CLIENT_CERT)
-  /* If client has to authenticate, then  */
-  SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE, dtls_verify_callback);
-#endif
 
   SSL_CTX_set_cookie_generate_cb(ctx, generate_cookie);
   SSL_CTX_set_cookie_verify_cb(ctx, verify_cookie);


### PR DESCRIPTION
Two independent corrections in the DTLS listener, both to code carried over unchanged from the 2014 initial import.

## 1. `max_cert_list` was set to an arbitrary 655350

Every incoming DTLS connection called `SSL_set_max_cert_list(connecting_ssl, 655350)` at both `SSL_new()` sites. The constant has no derivation in the tree and no comment explaining it.

It is not an inert setting. OpenSSL derives its DTLS handshake-message limit from it:

```c
/* ssl/statem/statem_dtls.c */
static size_t dtls1_max_handshake_message_len(const SSL_CONNECTION *s)
{
    size_t max_len = DTLS1_HM_HEADER_LENGTH + SSL3_RT_MAX_ENCRYPTED_LENGTH;
    if (max_len < s->max_cert_list)
        return s->max_cert_list;
    return max_len;
}
```

and `dtls1_preprocess_fragment()` grows the per-connection `init_buf` to the length declared in the message header, before the body arrives. A peer that declares a large length and sends one fragment byte still causes the full allocation. So this setting decides how much buffer one pending handshake can reserve: 655362 bytes, against OpenSSL's own default of 102400.

None of that headroom was reachable. The server does not request a client certificate, so it never receives a client `Certificate` message, and no other client handshake message comes close even to the floor of the formula above.

Replaced with a named, documented constant pinned to that floor (`SSL3_RT_MAX_ENCRYPTED_LENGTH`). Lower values would have no effect, since OpenSSL takes the max of the two terms. Nothing a legitimate peer can send is affected.

## 2. `REQUEST_CLIENT_CERT` could not work as written

The listener carried a compile-time client-certificate path whose verify callback was inverted:

```c
static int dtls_verify_callback(int ok, X509_STORE_CTX *ctx) {
  if (ok && ctx) {
    return 1;
  }
  return -1;
}
```

The `return -1` is taken exactly when OpenSSL's own chain validation has already failed. OpenSSL treats any non-zero return from a verify callback as "continue", so a certificate that failed validation was accepted identically to one that passed. The mode was also `SSL_VERIFY_PEER` without `SSL_VERIFY_FAIL_IF_NO_PEER_CERT`, so a client sending no certificate at all passed too.

Enabling the macro therefore gave the appearance of client authentication and none of the effect. Since it was commented out in source, enabling it already required editing this file — so rather than leave that waiting for whoever uncomments it next, the macro, the callback and the `SSL_CTX_set_verify()` call are removed. Client-certificate support can be added properly if it is ever wanted.

## Testing

- `clang-format-15` clean, `make lint` shows no drift
- 16/16 unit tests (`ctest`)
- `examples/run_tests.sh` and `examples/run_tests_conf.sh`, both including the live DTLS handshake path these commits touch — 4/4 OK each
- Fuzzing smoke: `fuzzing/run-local.sh ASan 0 -runs=1` and `ASan 1 -runs=1`

Not yet run: the Linux container pass, which additionally covers the four threaded variants gated off on macOS at `examples/run_tests.sh:176`, plus the mobile / multiplex-peer / rfc5780 / stateless-nonce scripts and the packaged image tests.
