### PR TITLE
docs: cite RFC 7350 for DTLS support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ STUN specs:
   * [RFC 5389](https://datatracker.ietf.org/doc/html/rfc5389) - base "new" STUN specs
   * [RFC 5769](https://datatracker.ietf.org/doc/html/rfc5769) - test vectors for STUN protocol testing
   * [RFC 5780](https://datatracker.ietf.org/doc/html/rfc5780) - NAT behavior discovery support
+  * [RFC 7350](https://datatracker.ietf.org/doc/html/rfc7350) - DTLS as transport for STUN & TURN
   * [RFC 7443](https://datatracker.ietf.org/doc/html/rfc7443) - ALPN support for STUN & TURN
   * [RFC 7635](https://datatracker.ietf.org/doc/html/rfc7635) - oAuth third-party TURN/STUN authorization
   
@@ -70,7 +71,7 @@ TURN specs:
   * [RFC 7443](https://datatracker.ietf.org/doc/html/rfc7443) - ALPN support for STUN & TURN
   * [RFC 7635](https://datatracker.ietf.org/doc/html/rfc7635) - oAuth third-party TURN/STUN authorization
   * [RFC 8016](https://datatracker.ietf.org/doc/html/rfc8016) - Mobility with Traversal Using Relays around NAT (TURN)
-  * DTLS support (http://tools.ietf.org/html/draft-petithuguenin-tram-turn-dtls-00)
+  * [RFC 7350](https://datatracker.ietf.org/doc/html/rfc7350) - DTLS as transport for STUN & TURN
   * TURN REST API (http://tools.ietf.org/html/draft-uberti-behave-turn-rest-00)
   * Origin field in TURN (Multi-tenant TURN Server) (https://tools.ietf.org/html/draft-ietf-tram-stun-origin-06)
   * TURN Bandwidth draft specs (http://tools.ietf.org/html/draft-thomson-tram-turn-bandwidth-01)
@@ -88,8 +89,8 @@ The implementation fully supports the following client-to-TURN-server protocols:
 
   * UDP (per [RFC 5766](https://datatracker.ietf.org/doc/html/rfc5766))
   * TCP (per [RFC 5766](https://datatracker.ietf.org/doc/html/rfc5766) and [RFC 6062](https://datatracker.ietf.org/doc/html/rfc6062))
-  * TLS (per [RFC 5766](https://datatracker.ietf.org/doc/html/rfc) and [RFC 6062](https://datatracker.ietf.org/doc/html/rfc6062)): including TLS1.3; ECDHE is supported.
-  * DTLS1.0 and DTLS1.2 (http://tools.ietf.org/html/draft-petithuguenin-tram-turn-dtls-00)
+  * TLS (per [RFC 5766](https://datatracker.ietf.org/doc/html/rfc5766) and [RFC 6062](https://datatracker.ietf.org/doc/html/rfc6062)): including TLS1.3; ECDHE is supported.
+  * DTLS1.0 and DTLS1.2 (per [RFC 7350](https://datatracker.ietf.org/doc/html/rfc7350))
   * SCTP (experimental implementation).
 
 Relay protocols:


### PR DESCRIPTION
## Summary

The README's DTLS bullets still cited `draft-petithuguenin-tram-turn-dtls-00`, an individual draft that expired in early 2014. Per the [IETF datatracker](https://datatracker.ietf.org/doc/draft-petithuguenin-tram-turn-dtls/), it was replaced by `draft-petithuguenin-tram-stun-dtls`, adopted by the TRAM WG as `draft-ietf-tram-stun-dtls`, and published as [RFC 7350](https://datatracker.ietf.org/doc/html/rfc7350) (August 2014) — "Datagram Transport Layer Security (DTLS) as Transport for Session Traversal Utilities for NAT (STUN)".

coturn's implementation meets RFC 7350's normative requirements (DTLS 1.2 via `DTLS_server_method()`, default port 5349 shared with TLS, the mandated GCM cipher suites in the default `DEFAULT` cipher list, RFC 6347 cookie exchange in the DTLS listener, and UDP-only allocations over DTLS), so the docs should cite the RFC rather than its expired precursor.

## Changes

- Replace both `draft-petithuguenin-tram-turn-dtls-00` links with RFC 7350 (TURN specs list and the client-protocols DTLS bullet).
- Add RFC 7350 to the STUN specs list — the RFC covers STUN over DTLS, not just TURN.
- Fix the TLS bullet's RFC 5766 link, which pointed at a bare `datatracker.ietf.org/doc/html/rfc` URL with no RFC number.

Documentation-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)