### PR TITLE
Fix NULL deref: --prometheus-address/-path/-port take a required value

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1697,9 +1697,9 @@ static const struct myoption long_options[] = {
 #endif
 #if !defined(TURN_NO_PROMETHEUS)
     {"prometheus", optional_argument, NULL, PROMETHEUS_OPT},
-    {"prometheus-port", optional_argument, NULL, PROMETHEUS_PORT_OPT},
-    {"prometheus-address", optional_argument, NULL, PROMETHEUS_ADDRESS_OPT},
-    {"prometheus-path", optional_argument, NULL, PROMETHEUS_PATH_OPT},
+    {"prometheus-port", required_argument, NULL, PROMETHEUS_PORT_OPT},
+    {"prometheus-address", required_argument, NULL, PROMETHEUS_ADDRESS_OPT},
+    {"prometheus-path", required_argument, NULL, PROMETHEUS_PATH_OPT},
     {"prometheus-username-labels", optional_argument, NULL, PROMETHEUS_ENABLE_USERNAMES_OPT},
     {"prometheus-tls", optional_argument, NULL, PROMETHEUS_TLS_OPT},
     {"prometheus-cert", required_argument, NULL, PROMETHEUS_CERT_OPT},


### PR DESCRIPTION
Closes #1765.

## Problem

`--prometheus-address`, `--prometheus-path` and `--prometheus-port` were declared `optional_argument` in `long_options[]`, but their `set_option()` cases consume the value unconditionally:

```c
case PROMETHEUS_ADDRESS_OPT:
  STRCPY(turn_params.prometheus_address, value);
case PROMETHEUS_PATH_OPT:
  STRCPY(turn_params.prometheus_path, value);
```

With `optional_argument`, `getopt_long` only attaches a value written as `--opt=value`. The space-separated form documented in our own usage text — `--prometheus-address <address>` — leaves the value as an unconsumed positional argument and hands `set_option()` `optarg == NULL`, so `STRCPY` calls `strncpy(dst, NULL, n)` and the server segfaults during startup:

```
$ turnserver --prometheus --prometheus-address 127.0.0.1
Segmentation fault (core dumped)

EXC_BAD_ACCESS, KERN_INVALID_ADDRESS at 0x0
_platform_strnlen <- stpncpy <- __strncpy_chk <- set_option <- main
```

`--prometheus-port` does not crash (`get_port_value()` is NULL-safe) but silently discards the default 9641 and configures port 0.

## Fix

Declare all three `required_argument`, matching every other value-taking option in the table — including the neighbouring `--prometheus-cert` and `--prometheus-key`. This addresses the root cause rather than the symptom:

- `--prometheus-address 127.0.0.1` (the documented form) now works instead of crashing;
- `--prometheus-address=127.0.0.1` keeps working unchanged;
- a bare `--prometheus-address` now prints the usage text and exits via the existing `default:` case instead of dereferencing NULL.

The genuine boolean toggles (`--prometheus`, `--prometheus-tls`, `--prometheus-username-labels`) stay `optional_argument`, as do the options that intentionally fall back to a default when passed bare (`--stale-nonce`, `--channel-lifetime`, ...), which route through the NULL-safe `get_int_value()`.

Config-file parsing is unaffected: `parse_arg_string()` yields `""`, never NULL, for a bare key.

## Scope

#1765 reports "at least 30+ similar problems". There are 41 unguarded `value` dereferences in `set_option()`, but a sweep of all 85 non-`required_argument` long options plus every colon-less short option (`-v -V -o -f -h -z -n -a -S`), each invoked with no value, crashes on exactly these two. The examples cited in the issue (`--server-name`, `-i`) are `required_argument`, so `getopt_long` guarantees a non-NULL `optarg` or returns `'?'` — they do not reproduce. Hence the narrow diff rather than a blanket NULL-check pass.

## Testing

| Check | Result |
|---|---|
| `ctest --test-dir build` | 16/16 pass |
| `examples/run_tests.sh` | exit 0, no FAIL |
| `examples/run_tests_conf.sh` | exit 0, no FAIL |
| `examples/run_tests_prom.sh` | exit 0, no FAIL (8 prometheus scenarios) |
| `clang-format-15` | no drift |

Verified that `--prometheus --prometheus-port 9999 --prometheus-address 127.0.0.1` now logs `prometheus exporter server will listen on 127.0.0.1:9999 (http)` where it previously segfaulted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
