### PR TITLE
Narrow ChannelBind to the RFC 8656 channel range 0x4000-0x4FFF

### DIFF
--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -943,6 +943,18 @@
 # stun-backward-compatibility
 
 
+# Accept ChannelBind channel numbers from the obsolete RFC 5766 range
+# 0x5000-0x7FFF. RFC 8656 narrows the allowed range to 0x4000-0x4FFF and
+# reserves the rest for DTLS-SRTP multiplexing collision avoidance (RFC 7983),
+# so by default such ChannelBind requests are rejected with error 400.
+#
+# Enable only for compatibility with legacy RFC 5766 clients that pick
+# channel numbers above 0x4FFF. ChannelData sent on those channels may be
+# silently dropped by conformant demultiplexing endpoints.
+#
+# rfc5766-channel-numbers
+
+
 # Return an HTTP/S response when an HTTP/S connection is made to a TCP port
 # otherwise only supporting STUN/TURN. This may be useful for debugging and
 # diagnosing connection problems. A "400 Not supported" response is currently

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -246,6 +246,7 @@ turn_params_t turn_params = {
 
     false, /* log_binding */
     false, /* stun_backward_compatibility */
+    false, /* rfc5766_channel_numbers */
     false, /* respond_http_unsupported */
     true,  /* drop_invalid_packets */
     false, /* drop_invalid_packets_log */
@@ -1402,6 +1403,13 @@ static char Usage[] =
     "binding responses.\n"
     " --stun-backward-compatibility		        Enable handling old STUN Binding requests and enable "
     "MAPPED-ADDRESS attribute\n"
+    " --rfc5766-channel-numbers			Accept ChannelBind channel numbers from the obsolete RFC 5766 "
+    "range 0x5000-0x7FFF,\n"
+    "						which RFC 8656 reserves for multiplexing collision avoidance "
+    "(RFC 7983). Only for\n"
+    "						compatibility with legacy clients; ChannelData on those "
+    "channels may be dropped by\n"
+    "						conformant demultiplexing endpoints.\n"
     " --respond-http-unsupported			Return an HTTP reponse with a 400 status code to HTTP "
     "connections made to ports not\n"
     "						supporting HTTP. The default behaviour is to immediately "
@@ -1624,6 +1632,7 @@ enum EXTRA_OPTS {
   NO_RFC5780,
   ENABLE_RFC5780,
   STUN_BACKWARD_COMPATIBILITY_OPT,
+  RFC5766_CHANNEL_NUMBERS_OPT,
   RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT,
   RESPOND_HTTP_UNSUPPORTED_OPT,
   DROP_INVALID_PACKETS_OPT,
@@ -1793,6 +1802,7 @@ static const struct myoption long_options[] = {
     {"no-rfc5780", optional_argument, NULL, NO_RFC5780},
     {"rfc5780", optional_argument, NULL, ENABLE_RFC5780},
     {"stun-backward-compatibility", optional_argument, NULL, STUN_BACKWARD_COMPATIBILITY_OPT},
+    {"rfc5766-channel-numbers", optional_argument, NULL, RFC5766_CHANNEL_NUMBERS_OPT},
     {"response-origin-only-with-rfc5780", optional_argument, NULL, RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT},
     {"respond-http-unsupported", optional_argument, NULL, RESPOND_HTTP_UNSUPPORTED_OPT},
     {"drop-invalid-packets", optional_argument, NULL, DROP_INVALID_PACKETS_OPT},
@@ -2641,6 +2651,9 @@ static void set_option(int c, char *value) {
     break;
   case STUN_BACKWARD_COMPATIBILITY_OPT:
     turn_params.stun_backward_compatibility = get_bool_value(value);
+    break;
+  case RFC5766_CHANNEL_NUMBERS_OPT:
+    turn_params.rfc5766_channel_numbers = get_bool_value(value);
     break;
   case RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT:
     break;

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -354,6 +354,7 @@ typedef struct _turn_params_ {
 
   bool log_binding;
   bool stun_backward_compatibility;
+  bool rfc5766_channel_numbers;
   bool respond_http_unsupported;
   bool drop_invalid_packets;
   bool drop_invalid_packets_log;

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1381,7 +1381,7 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
       turn_params.server_relay, send_turn_session_info, send_https_socket, turn_params.sock_buf_size, allocate_bps,
       turn_params.oauth, turn_params.oauth_server_name, turn_params.acme_redirect,
       turn_params.allocation_default_address_family, &turn_params.log_binding, &turn_params.stun_backward_compatibility,
-      &turn_params.respond_http_unsupported, turn_params.include_reason_string,
+      &turn_params.rfc5766_channel_numbers, &turn_params.respond_http_unsupported, turn_params.include_reason_string,
       &turn_params.ratelimit_unauthorized_requests, &turn_params.ratelimit_unauthorized_requests_per_sec);
   set_unauthenticated_401_metric_cbs(&(rs->server), prom_inc_unauthenticated_401_request,
                                      prom_inc_unauthenticated_401_response,

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1293,8 +1293,8 @@ bool stun_set_allocate_response_str(uint8_t *buf, size_t *len, stun_tid *tid, co
 uint16_t stun_set_channel_bind_request_str(uint8_t *buf, size_t *len, const ioa_addr *peer_addr,
                                            uint16_t channel_number) {
 
-  if (!STUN_VALID_CHANNEL(channel_number)) {
-    channel_number = 0x4000 + ((uint16_t)(((uint32_t)turn_random_number()) % (0x7FFF - 0x4000 + 1)));
+  if (!STUN_VALID_CHANNEL_BIND(channel_number)) {
+    channel_number = 0x4000 + ((uint16_t)(((uint32_t)turn_random_number()) % (0x4FFF - 0x4000 + 1)));
   }
 
   stun_init_request_str(STUN_METHOD_CHANNEL_BIND, buf, len);

--- a/src/client/ns_turn_msg_defs.h
+++ b/src/client/ns_turn_msg_defs.h
@@ -141,6 +141,21 @@
 #define STUN_ATTRIBUTE_ADDRESS_ERROR_CODE (0x8001)
 /* <<== RFC 8656 */
 
+/* Channel-number ranges.
+ *
+ * RFC 8656 par. 12 narrows the allowed ChannelBind range to 0x4000-0x4FFF;
+ * 0x5000-0xFFFF is reserved so that the first byte of a ChannelData message
+ * stays inside the [64..79] slot that RFC 7983 assigns to TURN in the
+ * DTLS-SRTP demultiplexing scheme. STUN_VALID_CHANNEL_BIND is that strict
+ * range: use it wherever a channel number is being established (ChannelBind,
+ * on both the client and the server side).
+ *
+ * STUN_VALID_CHANNEL keeps the RFC 5766 range (0x4000-0x7FFF) and is the
+ * lenient receive/framing-side check: ChannelData from legacy RFC 5766 peers
+ * must still be recognized as ChannelData so that stream framing stays in
+ * sync (the server option --rfc5766-channel-numbers re-enables binding in
+ * the legacy range). */
+#define STUN_VALID_CHANNEL_BIND(chn) ((chn) >= 0x4000 && (chn) <= 0x4FFF)
 #define STUN_VALID_CHANNEL(chn) ((chn) >= 0x4000 && (chn) <= 0x7FFF)
 
 ///////// extra values //////////////////

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -2876,7 +2876,7 @@ static int handle_turn_channel_bind(turn_turnserver *server, ts_ur_super_session
       *err_code = 400;
       *reason = (const uint8_t *)"Bad channel bind request";
 
-    } else if (!STUN_VALID_CHANNEL(chnum)) {
+    } else if (!STUN_VALID_CHANNEL_BIND(chnum) && !(*server->rfc5766_channel_numbers && STUN_VALID_CHANNEL(chnum))) {
 
       *err_code = 400;
       *reason = (const uint8_t *)"Bad channel number";
@@ -5391,8 +5391,8 @@ void init_turn_server(
     int server_relay, send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
     int sock_buf_size, allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
     const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family, bool *log_binding,
-    bool *stun_backward_compatibility, bool *respond_http_unsupported, bool include_reason_string,
-    bool *ratelimit_unauthorized_requests, vintp ratelimit_unauthorized_requests_per_sec) {
+    bool *stun_backward_compatibility, bool *rfc5766_channel_numbers, bool *respond_http_unsupported,
+    bool include_reason_string, bool *ratelimit_unauthorized_requests, vintp ratelimit_unauthorized_requests_per_sec) {
 
   if (!server) {
     return;
@@ -5470,6 +5470,8 @@ void init_turn_server(
   server->log_binding = log_binding;
 
   server->stun_backward_compatibility = stun_backward_compatibility;
+
+  server->rfc5766_channel_numbers = rfc5766_channel_numbers;
 
   server->respond_http_unsupported = respond_http_unsupported;
 

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -202,6 +202,10 @@ struct _turn_turnserver {
   /* Enable handling old STUN Binding Requests and enable MAPPED-ADDRESS attribute in response */
   bool *stun_backward_compatibility;
 
+  /* Accept ChannelBind channel numbers from the obsolete RFC 5766 range
+     0x5000-0x7FFF, which RFC 8656 reserves for multiplexing (RFC 7983) */
+  bool *rfc5766_channel_numbers;
+
   /* Return an HTTP 400 response to HTTP connections made to ports not
      otherwise handling HTTP. */
   bool *respond_http_unsupported;
@@ -255,8 +259,8 @@ void init_turn_server(
     int server_relay, send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
     int sock_buf_size, allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
     const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family, bool *log_binding,
-    bool *stun_backward_compatibility, bool *respond_http_unsupported, bool include_reason_string,
-    bool *ratelimit_unauthorized_requests, vintp ratelimit_unauthorized_requests_per_sec);
+    bool *stun_backward_compatibility, bool *rfc5766_channel_numbers, bool *respond_http_unsupported,
+    bool include_reason_string, bool *ratelimit_unauthorized_requests, vintp ratelimit_unauthorized_requests_per_sec);
 
 ioa_engine_handle turn_server_get_engine(turn_turnserver *s);
 

--- a/tests/test_stun_msg.c
+++ b/tests/test_stun_msg.c
@@ -652,6 +652,53 @@ static void test_covered_walk_hides_message_integrity_sha256_from_420(void) {
   TEST_ASSERT_EQUAL_INT(0, count_attrs_of_type(buf, len, TEST_ATTR_MESSAGE_INTEGRITY_SHA256, true));
 }
 
+/* RFC 8656 par. 12: ChannelBind may only establish channels 0x4000-0x4FFF;
+   0x5000-0xFFFF is reserved for RFC 7983 demultiplexing. The receive-side
+   macro deliberately keeps the RFC 5766 range so legacy ChannelData frames
+   are still recognized and stream framing stays in sync. */
+static void test_channel_bind_macro_is_strict_rfc8656_range(void) {
+  TEST_ASSERT_FALSE(STUN_VALID_CHANNEL_BIND(0x3FFF));
+  TEST_ASSERT_TRUE(STUN_VALID_CHANNEL_BIND(0x4000));
+  TEST_ASSERT_TRUE(STUN_VALID_CHANNEL_BIND(0x4FFF));
+  TEST_ASSERT_FALSE(STUN_VALID_CHANNEL_BIND(0x5000));
+  TEST_ASSERT_FALSE(STUN_VALID_CHANNEL_BIND(0x7FFF));
+
+  TEST_ASSERT_FALSE(STUN_VALID_CHANNEL(0x3FFF));
+  TEST_ASSERT_TRUE(STUN_VALID_CHANNEL(0x4000));
+  TEST_ASSERT_TRUE(STUN_VALID_CHANNEL(0x5000));
+  TEST_ASSERT_TRUE(STUN_VALID_CHANNEL(0x7FFF));
+  TEST_ASSERT_FALSE(STUN_VALID_CHANNEL(0x8000));
+}
+
+static void test_channel_bind_request_stays_in_rfc8656_range(void) {
+  const uint16_t requested[] = {0x0000, 0x3FFF, 0x5000, 0x7FFF, 0xFFFF};
+  for (size_t i = 0; i < sizeof(requested) / sizeof(requested[0]); ++i) {
+    uint8_t buf[1024] = {0};
+    size_t len = 0;
+    const uint16_t chosen = stun_set_channel_bind_request_str(buf, &len, NULL, requested[i]);
+    TEST_ASSERT_TRUE(STUN_VALID_CHANNEL_BIND(chosen));
+  }
+}
+
+static void test_channel_bind_request_keeps_explicit_valid_channel(void) {
+  uint8_t buf[1024] = {0};
+  size_t len = 0;
+  TEST_ASSERT_EQUAL_UINT16(0x4ABC, stun_set_channel_bind_request_str(buf, &len, NULL, 0x4ABC));
+}
+
+static void test_legacy_rfc5766_channel_frame_still_recognized(void) {
+  uint8_t buf[1024] = {0};
+  size_t len = 0;
+  const uint16_t legacy_channel = 0x7ABC;
+  const int payload_len = 16;
+  TEST_ASSERT_TRUE(stun_init_channel_message_str(legacy_channel, buf, &len, payload_len, false));
+
+  uint16_t parsed_channel = 0;
+  size_t blen = len;
+  TEST_ASSERT_TRUE(stun_is_channel_message_str(buf, &blen, &parsed_channel, false));
+  TEST_ASSERT_EQUAL_UINT16(legacy_channel, parsed_channel);
+}
+
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_init_request_produces_valid_stun_header);
@@ -681,5 +728,9 @@ int main(void) {
   RUN_TEST(test_covered_walk_yields_message_integrity_itself);
   RUN_TEST(test_covered_walk_is_full_walk_without_message_integrity);
   RUN_TEST(test_covered_walk_hides_message_integrity_sha256_from_420);
+  RUN_TEST(test_channel_bind_macro_is_strict_rfc8656_range);
+  RUN_TEST(test_channel_bind_request_stays_in_rfc8656_range);
+  RUN_TEST(test_channel_bind_request_keeps_explicit_valid_channel);
+  RUN_TEST(test_legacy_rfc5766_channel_frame_still_recognized);
   return UNITY_END();
 }


### PR DESCRIPTION
RFC 8656 par. 12 reduces the allowed channel numbers from RFC 5766's 0x4000-0x7FFF so that ChannelData first bytes stay inside the [64..79] slot RFC 7983 assigns to TURN in the DTLS-SRTP demultiplexing scheme; 0x5000-0xFFFF is reserved for collision avoidance. Channels bound in the legacy range produce frames that conformant demultiplexing endpoints must drop.

Split the validation macro instead of tightening it in place:

- STUN_VALID_CHANNEL_BIND is the strict RFC 8656 range, used where a channel is established: the server's ChannelBind check now returns 400 for 0x5000+, and stun_set_channel_bind_request_str() picks its random channel from the strict range, so turnutils_uclient is conformant automatically (and still interops with old servers, the strict range being a subset of the legacy one).
- STUN_VALID_CHANNEL keeps the lenient RFC 5766 range for all receive/framing-side checks, so ChannelData from legacy peers is still recognized and stream framing stays in sync.
- New server option --rfc5766-channel-numbers (default off) restores acceptance of legacy-range ChannelBind for deployments with old clients that pick channels above 0x4FFF.