### PR TITLE
Return 508, not 400/440, when a well-formed Allocate cannot be satisfied

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,7 @@ environment variable such as `DIGITALOCEAN_TOKEN`.
   randomly between 0 and -1 ([startuclient.c:440](src/apps/uclient/startuclient.c:440)).
 - `--no-even-port` — force `ep = -1` unconditionally. **Required** for
   alloc-flood runs against `--multiplex-peer`, which strictly rejects
-  EVEN-PORT with error 400 ([ns_ioalib_engine_impl.c:1585](src/apps/relay/ns_ioalib_engine_impl.c:1585)).
+  EVEN-PORT with error 508 ([ns_ioalib_engine_impl.c:1603](src/apps/relay/ns_ioalib_engine_impl.c:1603)).
 - `-K N` / `--listener-threads N`, `--sender-threads N` — loadgen-side
   receive/send pools. Auto: 0 for `-m < 4`, bumped to 1 listener / 2
   sender for `-m >= 4`. Max 4 each. Use `--sender-threads 4` to push
@@ -480,7 +480,7 @@ For any run, look at the three `mpstat Average:` lines:
 
 ```bash
 # on uclient — alloc-flood; --no-even-port keeps multiplex-peer from
-# rejecting every other request with 400.
+# rejecting every other request with 508.
 timeout -s INT 60s /root/coturn/build/bin/turnutils_uclient \
   -Y alloc -m 200 -n 1000 -c --no-even-port \
   -L 10.116.0.3 \

--- a/docs/multiplex-peer.md
+++ b/docs/multiplex-peer.md
@@ -299,7 +299,7 @@ With 4 threads: open 3480–3487.  With 8 threads: open 3480–3495.
 
 | Limitation | Detail |
 |------------|--------|
-| EVEN-PORT silently ignored | Modern WebRTC uses `rtcp-mux` — EVEN-PORT is not needed |
+| EVEN-PORT rejected with 508 (Insufficient Capacity) | Modern WebRTC uses `rtcp-mux` — EVEN-PORT is not needed |
 | Clients on different threads see different relay ports | Correct and expected; the thread assignment is stable per connection |
 | Source-IP must be preserved | If a load balancer SNATs clients, the src-IP uniqueness guarantee breaks — use DSR or PROXY protocol |
 | Ports exposed = 2 × relay_threads | Still tiny compared to the default range; adjust `--relay-threads` if needed |

--- a/examples/run_tests_multiplex_peer.sh
+++ b/examples/run_tests_multiplex_peer.sh
@@ -76,7 +76,7 @@ run_client() {
       return 0
     fi
 
-    if printf '%s\n' "$output" | grep -q "error 400" &&
+    if printf '%s\n' "$output" | grep -q "error 508" &&
       grep -q "EVEN-PORT is not supported with multiplex-peer" "$turnserver_log" &&
       [ "$attempt" -lt "$max_attempts" ]; then
       echo "Retrying $name after randomized EVEN-PORT request"

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -1601,8 +1601,10 @@ int create_relay_ioa_sockets(ioa_engine_handle e, ioa_socket_handle client_s, in
                              void *acbarg, bool multiplex_peer_mode) {
   if (multiplex_peer_mode && transport == STUN_ATTRIBUTE_TRANSPORT_UDP_VALUE) {
     if (even_port >= 0) {
+      /* RFC 8656 par. 7.2: the request is well-formed but this configuration
+       * cannot satisfy it, so 508 (Insufficient Capacity), not 400. */
       if (err_code) {
-        *err_code = 400;
+        *err_code = 508;
       }
       if (reason) {
         *reason = (const uint8_t *)"EVEN-PORT is not supported with multiplex-peer";

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -1420,12 +1420,19 @@ static int handle_turn_allocate(turn_turnserver *server, ts_ur_super_session *ss
 
         if (af4 && af6) {
           if (server->external_ip_set) {
-            *err_code = 440;
+            /* RFC 8656 par. 7.2: both families are supported here, the server
+             * just cannot do a dual allocation with a rewritten external
+             * address -- 508 (Insufficient Capacity), not 440, so clients do
+             * not conclude the server lacks an address family entirely. */
+            *err_code = 508;
             *reason = (const uint8_t *)"Dual allocation cannot be supported in the current server configuration";
           }
           if (even_port > 0) {
-            *err_code = 440;
-            *reason = (const uint8_t *)"Dual allocation cannot be supported with even-port functionality";
+            /* Unreachable backstop: the attribute loop above already rejects
+             * ADDITIONAL-ADDRESS-FAMILY + EVEN-PORT in both orderings. Kept
+             * with the same 400 the loop uses (malformed combination). */
+            *err_code = 400;
+            *reason = (const uint8_t *)"Even Port cannot be used with Dual Allocation";
           }
         }
 


### PR DESCRIPTION
## Summary

RFC 8656 §7.2 assigns **508 (Insufficient Capacity)** to a well-formed request the server cannot satisfy; 400 means the request was malformed and 440 means the address family is unsupported. Two config-dependent Allocate paths used the wrong code:

- **Dual allocation under `--external-ip`** returned **440**, which tells the client the server lacks an address family entirely — a client may permanently disable IPv6 against a server that supports it fine. Now 508.
- **EVEN-PORT under `--multiplex-peer`** returned **400**, which tells a conformant client its request was malformed, so it will not retry without EVEN-PORT. Now 508, matching the sibling missing-shared-socket path in `create_relay_ioa_sockets()`.

The `even_port` arm of the dual-allocation check is an unreachable backstop (the attribute loop already rejects ADDITIONAL-ADDRESS-FAMILY + EVEN-PORT in both attribute orderings); it is now commented as such and aligned with the upstream check's 400 and reason text instead of the old 440.

Also updated: `run_tests_multiplex_peer.sh`'s randomized-EVEN-PORT retry now matches on error 508, and the stale EVEN-PORT notes in CLAUDE.md and docs/multiplex-peer.md are corrected (the latter claimed EVEN-PORT was silently ignored; it is rejected).

## Validation

- macOS and Linux (Docker): clean builds, all unit tests, all example suites (`run_tests`, `_conf`, `_mobile`, `_multiplex_peer`, `_rfc5780`, `_stateless_nonce`) with zero FAIL lines; fuzzing smoke tests.
- Both paths verified end-to-end: `turnutils_uclient -Z` against an `--external-ip` server now receives `error 508`, and an EVEN-PORT Allocate against a `--multiplex-peer` server (Linux) receives `error 508` with the matching server-log reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)