### PR TITLE
Split --stun-backward-compatibility: move RFC 3489 handling to its own deprecated flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ make
 
 STUN specs:
 
-  * [RFC 3489](https://datatracker.ietf.org/doc/html/rfc3489) - "classic" STUN
+  * [RFC 3489](https://datatracker.ietf.org/doc/html/rfc3489) - "classic" STUN (DEPRECATED, opt-in via
+    `--rfc3489-compatibility`; scheduled for removal in the next major release)
   * [RFC 5389](https://datatracker.ietf.org/doc/html/rfc5389) - base "new" STUN specs
   * [RFC 5769](https://datatracker.ietf.org/doc/html/rfc5769) - test vectors for STUN protocol testing
   * [RFC 5780](https://datatracker.ietf.org/doc/html/rfc5780) - NAT behavior discovery support

--- a/STATUS.md
+++ b/STATUS.md
@@ -53,7 +53,9 @@ for Linux. Other platforms support the alternative behavior of RFC 5766.
 
 21) Redis database support added.
 
-22) RFC3489 backward compatibility.
+22) RFC3489 backward compatibility (DEPRECATED, opt-in via
+--rfc3489-compatibility; scheduled for removal in the next major
+release).
 
 23) Multithreaded TCP relay processing (UDP relay has been 
 multithreaded from the beginning).

--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -812,13 +812,28 @@ cli-password=CHANGE_ME
 #
 # rfc5780
 
-# Enable handling old STUN Binding requests and enable MAPPED-ADDRESS
-# attribute in binding response (instead of the XOR-MAPPED-ADDRESS).
+# Add the deprecated MAPPED-ADDRESS attribute to STUN Binding responses, in
+# addition to the XOR-MAPPED-ADDRESS attribute that is always sent. This is only
+# needed for clients that cannot parse XOR-MAPPED-ADDRESS.
 #
 # Strongly encouraged to keep this option off to decrease gain factor in STUN
 # binding responses.
 #
 # stun-backward-compatibility
+
+# DEPRECATED. Enable handling of obsolete RFC 3489 ("classic" STUN) Binding
+# requests, which carry no magic cookie. RFC 5389 deprecated these mechanisms in
+# 2008 and RFC 8489 dropped them entirely; virtually no client still needs this.
+#
+# This option is scheduled for removal in the next major release, and there is no
+# replacement. If you depend on it, please report your use case upstream.
+#
+# Note: before this option existed, the RFC 3489 request path was controlled by
+# stun-backward-compatibility. If you were enabling that option in order to serve
+# classic-STUN clients, you now want rfc3489-compatibility instead (or both, to
+# keep the exact previous behavior).
+#
+# rfc3489-compatibility
 
 # Include descriptive reason strings in STUN/TURN error responses.
 # By default, only the standard reason phrase for the error code is sent

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -934,13 +934,28 @@
 #
 # rfc5780
 
-# Enable handling old STUN Binding requests and disable MAPPED-ADDRESS
-# attribute in binding response (use only the XOR-MAPPED-ADDRESS).
+# Add the deprecated MAPPED-ADDRESS attribute to STUN Binding responses, in
+# addition to the XOR-MAPPED-ADDRESS attribute that is always sent. This is only
+# needed for clients that cannot parse XOR-MAPPED-ADDRESS.
 #
 # Strongly encouraged to keep this option off to decrease gain factor in STUN
 # binding responses.
 #
 # stun-backward-compatibility
+
+# DEPRECATED. Enable handling of obsolete RFC 3489 ("classic" STUN) Binding
+# requests, which carry no magic cookie. RFC 5389 deprecated these mechanisms in
+# 2008 and RFC 8489 dropped them entirely; virtually no client still needs this.
+#
+# This option is scheduled for removal in the next major release, and there is no
+# replacement. If you depend on it, please report your use case upstream.
+#
+# Note: before this option existed, the RFC 3489 request path was controlled by
+# stun-backward-compatibility. If you were enabling that option in order to serve
+# classic-STUN clients, you now want rfc3489-compatibility instead (or both, to
+# keep the exact previous behavior).
+#
+# rfc3489-compatibility
 
 
 # Accept ChannelBind channel numbers from the obsolete RFC 5766 range

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -1253,7 +1253,24 @@ DEPRECATED and now the default behaviour. See \-\-rfc5780.
 .TP
 .B
 \fB\-\-stun\-backward\-compatibility\fP
-Enable handling old STUN Binding requests using MAPPED\-ADDRESS attribute in binding response (instead of XOR\-MAPPED\-ADDRESS).
+Add the deprecated MAPPED\-ADDRESS attribute to STUN Binding responses, in addition to the
+XOR\-MAPPED\-ADDRESS attribute that is always sent. Only needed for clients that cannot parse
+XOR\-MAPPED\-ADDRESS. Strongly encouraged to keep this option off to decrease gain factor in
+STUN binding responses.
+.RE
+
+.RS
+.TP
+.B
+\fB\-\-rfc3489\-compatibility\fP
+DEPRECATED. Enable handling of obsolete RFC 3489 ("classic" STUN) Binding requests, which carry
+no magic cookie. RFC 5389 deprecated these mechanisms and RFC 8489 dropped them entirely. This
+option is scheduled for removal in the next major release, with no replacement.
+.IP
+Before this option existed, the RFC 3489 request path was controlled by
+\fB\-\-stun\-backward\-compatibility\fP. Operators who set that option in order to serve
+classic\-STUN clients should now set \fB\-\-rfc3489\-compatibility\fP instead, or both options to
+retain the exact previous behavior.
 .RE
 
 .RS

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -857,7 +857,7 @@ static udp_packet_classification_t classify_udp_packet(const uint8_t *data, size
     return UDP_PACKET_CLASS_DTLS_OTHER;
   }
 #endif
-  if (turn_params.stun_backward_compatibility && old_stun_is_command_message_str(data, blen, &old_stun_cookie)) {
+  if (turn_params.rfc3489_compatibility && old_stun_is_command_message_str(data, blen, &old_stun_cookie)) {
     return UDP_PACKET_CLASS_OLD_STUN;
   }
 

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -247,6 +247,7 @@ turn_params_t turn_params = {
     false, /* log_binding */
     false, /* stun_backward_compatibility */
     false, /* rfc5766_channel_numbers */
+    false, /* rfc3489_compatibility */
     false, /* respond_http_unsupported */
     true,  /* drop_invalid_packets */
     false, /* drop_invalid_packets_log */
@@ -1401,8 +1402,17 @@ static char Usage[] =
     "amplification attack.)\n"
     "						Strongly encouraged to keep it off to decrease gain factor in STUN "
     "binding responses.\n"
-    " --stun-backward-compatibility		        Enable handling old STUN Binding requests and enable "
-    "MAPPED-ADDRESS attribute\n"
+    " --stun-backward-compatibility		        Add the deprecated MAPPED-ADDRESS attribute to STUN Binding\n"
+    "						responses, alongside XOR-MAPPED-ADDRESS, for clients that cannot "
+    "parse\n"
+    "						the latter. Strongly encouraged to keep it off to decrease gain factor "
+    "in\n"
+    "						STUN binding responses.\n"
+    " --rfc3489-compatibility			DEPRECATED. Enable handling of obsolete RFC 3489 (\"classic\" "
+    "STUN)\n"
+    "						Binding requests, which carry no magic cookie. Scheduled for removal "
+    "in\n"
+    "						the next major release; there is no replacement.\n"
     " --rfc5766-channel-numbers			Accept ChannelBind channel numbers from the obsolete RFC 5766 "
     "range 0x5000-0x7FFF,\n"
     "						which RFC 8656 reserves for multiplexing collision avoidance "
@@ -1633,6 +1643,7 @@ enum EXTRA_OPTS {
   ENABLE_RFC5780,
   STUN_BACKWARD_COMPATIBILITY_OPT,
   RFC5766_CHANNEL_NUMBERS_OPT,
+  RFC3489_COMPATIBILITY_OPT,
   RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT,
   RESPOND_HTTP_UNSUPPORTED_OPT,
   DROP_INVALID_PACKETS_OPT,
@@ -1803,6 +1814,7 @@ static const struct myoption long_options[] = {
     {"rfc5780", optional_argument, NULL, ENABLE_RFC5780},
     {"stun-backward-compatibility", optional_argument, NULL, STUN_BACKWARD_COMPATIBILITY_OPT},
     {"rfc5766-channel-numbers", optional_argument, NULL, RFC5766_CHANNEL_NUMBERS_OPT},
+    {"rfc3489-compatibility", optional_argument, NULL, RFC3489_COMPATIBILITY_OPT},
     {"response-origin-only-with-rfc5780", optional_argument, NULL, RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT},
     {"respond-http-unsupported", optional_argument, NULL, RESPOND_HTTP_UNSUPPORTED_OPT},
     {"drop-invalid-packets", optional_argument, NULL, DROP_INVALID_PACKETS_OPT},
@@ -2654,6 +2666,9 @@ static void set_option(int c, char *value) {
     break;
   case RFC5766_CHANNEL_NUMBERS_OPT:
     turn_params.rfc5766_channel_numbers = get_bool_value(value);
+    break;
+  case RFC3489_COMPATIBILITY_OPT:
+    turn_params.rfc3489_compatibility = get_bool_value(value);
     break;
   case RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT:
     break;
@@ -3601,6 +3616,17 @@ int main(int argc, char **argv) {
    * who want to opt out can pass --udp-recvmmsg=false. */
   turn_params.udp_sendmmsg = turn_params.multiplex_peer;
 #endif
+
+  if (turn_params.rfc3489_compatibility) {
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
+                  "DEPRECATED: --rfc3489-compatibility enables handling of obsolete RFC 3489 (\"classic\" STUN) "
+                  "Binding requests. RFC 5389 deprecated those mechanisms in 2008 and RFC 8489 dropped them "
+                  "entirely. This option is scheduled for removal in the next major release, with no "
+                  "replacement. If you still need it, please report your use case upstream.\n");
+    if (turn_params.no_stun) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "--rfc3489-compatibility has no effect because --no-stun is also set.\n");
+    }
+  }
 
   if (turn_params.bps_capacity && !(turn_params.max_bps)) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -355,6 +355,7 @@ typedef struct _turn_params_ {
   bool log_binding;
   bool stun_backward_compatibility;
   bool rfc5766_channel_numbers;
+  bool rfc3489_compatibility;
   bool respond_http_unsupported;
   bool drop_invalid_packets;
   bool drop_invalid_packets_log;

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1381,8 +1381,9 @@ static void setup_relay_server(struct relay_server *rs, ioa_engine_handle e, int
       turn_params.server_relay, send_turn_session_info, send_https_socket, turn_params.sock_buf_size, allocate_bps,
       turn_params.oauth, turn_params.oauth_server_name, turn_params.acme_redirect,
       turn_params.allocation_default_address_family, &turn_params.log_binding, &turn_params.stun_backward_compatibility,
-      &turn_params.rfc5766_channel_numbers, &turn_params.respond_http_unsupported, turn_params.include_reason_string,
-      &turn_params.ratelimit_unauthorized_requests, &turn_params.ratelimit_unauthorized_requests_per_sec);
+      &turn_params.rfc5766_channel_numbers, &turn_params.rfc3489_compatibility, &turn_params.respond_http_unsupported,
+      turn_params.include_reason_string, &turn_params.ratelimit_unauthorized_requests,
+      &turn_params.ratelimit_unauthorized_requests_per_sec);
   set_unauthenticated_401_metric_cbs(&(rs->server), prom_inc_unauthenticated_401_request,
                                      prom_inc_unauthenticated_401_response,
                                      prom_inc_unauthenticated_401_dropped_response);

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1348,8 +1348,12 @@ bool stun_set_binding_response_str(uint8_t *buf, size_t *len, stun_tid *tid, con
         return false;
       }
     }
+    /* MAPPED-ADDRESS is the only address attribute RFC 3489 defines, so the old-STUN
+     * path always needs it. On the modern path it is purely a backward-compatibility
+     * courtesy for clients that cannot parse XOR-MAPPED-ADDRESS, and it widens the
+     * response, so it stays opt-in there. */
     if (reflexive_addr) {
-      if (stun_backward_compatibility &&
+      if ((old_stun || stun_backward_compatibility) &&
           !stun_attr_add_addr_str(buf, len, STUN_ATTRIBUTE_MAPPED_ADDRESS, reflexive_addr)) {
         return false;
       }

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -5049,7 +5049,7 @@ static int read_client_connection(turn_turnserver *server, ts_ur_super_session *
 
   } else if (old_stun_is_command_message_str(ioa_network_buffer_data(in_buffer->nbh),
                                              ioa_network_buffer_get_size(in_buffer->nbh), &old_stun_cookie) &&
-             !(*(server->no_stun)) && *(server->stun_backward_compatibility)) {
+             !(*(server->no_stun)) && *(server->rfc3489_compatibility)) {
 
     ioa_network_buffer_handle nbh = ioa_network_buffer_allocate(server->e);
     int resp_constructed = 0;
@@ -5384,22 +5384,25 @@ static void client_input_handler(ioa_socket_handle s, int event_type, ioa_net_da
 
 ///////////////////////////////////////////////////////////
 
-void init_turn_server(
-    turn_turnserver *server, turnserver_id id, int verbose, ioa_engine_handle e, turn_credential_type ct,
-    int fingerprint, dont_fragment_option_t dont_fragment, get_user_key_cb userkeycb,
-    check_new_allocation_quota_cb chquotacb, release_allocation_quota_cb raqcb, ioa_addr *external_ip,
-    bool *check_origin, bool *no_tcp_relay, bool *no_udp_relay, vintp stale_nonce, vintp max_allocate_lifetime,
-    vintp channel_lifetime, vintp permission_lifetime, bool *stun_only, bool *no_stun, bool software_attribute,
-    bool *web_admin_listen_on_workers, turn_server_addrs_list_t *alternate_servers_list,
-    turn_server_addrs_list_t *tls_alternate_servers_list, turn_server_addrs_list_t *tcp_alternate_servers_list,
-    turn_server_addrs_list_t *udp_alternate_servers_list, turn_server_addrs_list_t *aux_servers_list,
-    int self_udp_balance, bool *no_multicast_peers, bool *allow_loopback_peers, ip_range_list_t *ip_whitelist,
-    ip_range_list_t *ip_blacklist, send_socket_to_relay_cb send_socket_to_relay, bool *secure_stun, bool *mobility,
-    int server_relay, send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
-    int sock_buf_size, allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
-    const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family, bool *log_binding,
-    bool *stun_backward_compatibility, bool *rfc5766_channel_numbers, bool *respond_http_unsupported,
-    bool include_reason_string, bool *ratelimit_unauthorized_requests, vintp ratelimit_unauthorized_requests_per_sec) {
+void init_turn_server(turn_turnserver *server, turnserver_id id, int verbose, ioa_engine_handle e,
+                      turn_credential_type ct, int fingerprint, dont_fragment_option_t dont_fragment,
+                      get_user_key_cb userkeycb, check_new_allocation_quota_cb chquotacb,
+                      release_allocation_quota_cb raqcb, ioa_addr *external_ip, bool *check_origin, bool *no_tcp_relay,
+                      bool *no_udp_relay, vintp stale_nonce, vintp max_allocate_lifetime, vintp channel_lifetime,
+                      vintp permission_lifetime, bool *stun_only, bool *no_stun, bool software_attribute,
+                      bool *web_admin_listen_on_workers, turn_server_addrs_list_t *alternate_servers_list,
+                      turn_server_addrs_list_t *tls_alternate_servers_list,
+                      turn_server_addrs_list_t *tcp_alternate_servers_list,
+                      turn_server_addrs_list_t *udp_alternate_servers_list, turn_server_addrs_list_t *aux_servers_list,
+                      int self_udp_balance, bool *no_multicast_peers, bool *allow_loopback_peers,
+                      ip_range_list_t *ip_whitelist, ip_range_list_t *ip_blacklist,
+                      send_socket_to_relay_cb send_socket_to_relay, bool *secure_stun, bool *mobility, int server_relay,
+                      send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
+                      int sock_buf_size, allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
+                      const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family,
+                      bool *log_binding, bool *stun_backward_compatibility, bool *rfc5766_channel_numbers,
+                      bool *rfc3489_compatibility, bool *respond_http_unsupported, bool include_reason_string,
+                      bool *ratelimit_unauthorized_requests, vintp ratelimit_unauthorized_requests_per_sec) {
 
   if (!server) {
     return;
@@ -5479,6 +5482,8 @@ void init_turn_server(
   server->stun_backward_compatibility = stun_backward_compatibility;
 
   server->rfc5766_channel_numbers = rfc5766_channel_numbers;
+
+  server->rfc3489_compatibility = rfc3489_compatibility;
 
   server->respond_http_unsupported = respond_http_unsupported;
 

--- a/src/server/ns_turn_server.h
+++ b/src/server/ns_turn_server.h
@@ -199,12 +199,16 @@ struct _turn_turnserver {
   /* Log Binding Requrest */
   bool *log_binding;
 
-  /* Enable handling old STUN Binding Requests and enable MAPPED-ADDRESS attribute in response */
+  /* Add the deprecated MAPPED-ADDRESS attribute to Binding responses, alongside XOR-MAPPED-ADDRESS */
   bool *stun_backward_compatibility;
 
   /* Accept ChannelBind channel numbers from the obsolete RFC 5766 range
      0x5000-0x7FFF, which RFC 8656 reserves for multiplexing (RFC 7983) */
   bool *rfc5766_channel_numbers;
+
+  /* DEPRECATED: handle obsolete RFC 3489 ("classic" STUN) Binding Requests, which carry no magic
+   * cookie. Scheduled for removal in the next major release. */
+  bool *rfc3489_compatibility;
 
   /* Return an HTTP 400 response to HTTP connections made to ports not
      otherwise handling HTTP. */
@@ -259,8 +263,9 @@ void init_turn_server(
     int server_relay, send_turn_session_info_cb send_turn_session_info, send_https_socket_cb send_https_socket,
     int sock_buf_size, allocate_bps_cb allocate_bps_func, int oauth, const char *oauth_server_name,
     const char *acme_redirect, ALLOCATION_DEFAULT_ADDRESS_FAMILY allocation_default_address_family, bool *log_binding,
-    bool *stun_backward_compatibility, bool *rfc5766_channel_numbers, bool *respond_http_unsupported,
-    bool include_reason_string, bool *ratelimit_unauthorized_requests, vintp ratelimit_unauthorized_requests_per_sec);
+    bool *stun_backward_compatibility, bool *rfc5766_channel_numbers, bool *rfc3489_compatibility,
+    bool *respond_http_unsupported, bool include_reason_string, bool *ratelimit_unauthorized_requests,
+    vintp ratelimit_unauthorized_requests_per_sec);
 
 ioa_engine_handle turn_server_get_engine(turn_turnserver *s);
 

--- a/tests/test_stun_msg.c
+++ b/tests/test_stun_msg.c
@@ -699,6 +699,63 @@ static void test_legacy_rfc5766_channel_frame_still_recognized(void) {
   TEST_ASSERT_EQUAL_UINT16(legacy_channel, parsed_channel);
 }
 
+static void test_binding_response_address_attrs_by_compat_mode(void) {
+  /* stun_backward_compatibility and the old_stun (RFC 3489) request path are
+     independent knobs, so each combination has to produce the right address
+     attributes on its own:
+
+       - XOR-MAPPED-ADDRESS is RFC 5389 only; RFC 3489 has no such attribute.
+       - MAPPED-ADDRESS is the ONLY address attribute RFC 3489 defines, so the
+         old-STUN path must always emit it, regardless of the modern-response
+         backward-compatibility flag. On the modern path it stays opt-in,
+         because it widens the response and raises the amplification gain. */
+  ioa_addr reflexive = {0};
+  TEST_ASSERT_EQUAL_INT(0, make_ioa_addr((const uint8_t *)"203.0.113.5", 43210, &reflexive));
+
+  const struct {
+    bool old_stun;
+    bool backward_compat;
+    int want_xor;
+    int want_mapped;
+  } cases[] = {
+      {false, false, 1, 0}, /* default: XOR only */
+      {false, true, 1, 1},  /* --stun-backward-compatibility: both */
+      {true, false, 0, 1},  /* --rfc3489-compatibility alone: MAPPED only */
+      {true, true, 0, 1},   /* both flags: still MAPPED only on the old path */
+  };
+
+  for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+    uint8_t buf[1024] = {0};
+    size_t len = 0;
+    stun_tid tid = {0};
+    const uint32_t cookie = 0x12345678;
+
+    TEST_ASSERT_TRUE(stun_set_binding_response_str(buf, &len, &tid, &reflexive, 0, NULL, cookie, cases[i].old_stun,
+                                                   cases[i].backward_compat, true));
+
+    TEST_ASSERT_EQUAL_INT(cases[i].want_xor, count_attrs_of_type(buf, len, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, false));
+    TEST_ASSERT_EQUAL_INT(cases[i].want_mapped, count_attrs_of_type(buf, len, STUN_ATTRIBUTE_MAPPED_ADDRESS, false));
+
+    /* Whichever attribute is present must round-trip to the address we passed in,
+       and the old path must echo the caller's cookie rather than the magic one. */
+    const uint16_t addr_attr =
+        cases[i].want_xor ? STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS : (uint16_t)STUN_ATTRIBUTE_MAPPED_ADDRESS;
+    stun_attr_ref sar = stun_attr_get_first_by_type_str(buf, len, addr_attr);
+    TEST_ASSERT_NOT_NULL(sar);
+    ioa_addr got = {0};
+    TEST_ASSERT_TRUE(stun_attr_get_addr_str(buf, len, sar, &got, NULL));
+    TEST_ASSERT_TRUE(addr_eq(&reflexive, &got));
+
+    if (cases[i].old_stun) {
+      uint32_t parsed_cookie = 0;
+      TEST_ASSERT_TRUE(old_stun_is_command_message_str(buf, len, &parsed_cookie));
+      TEST_ASSERT_EQUAL_UINT32(cookie, parsed_cookie);
+    } else {
+      TEST_ASSERT_TRUE(stun_is_command_message_str(buf, len));
+    }
+  }
+}
+
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_init_request_produces_valid_stun_header);
@@ -732,5 +789,6 @@ int main(void) {
   RUN_TEST(test_channel_bind_request_stays_in_rfc8656_range);
   RUN_TEST(test_channel_bind_request_keeps_explicit_valid_channel);
   RUN_TEST(test_legacy_rfc5766_channel_frame_still_recognized);
+  RUN_TEST(test_binding_response_address_attrs_by_compat_mode);
   return UNITY_END();
 }


### PR DESCRIPTION
## Problem

`--stun-backward-compatibility` controls two unrelated behaviors:

- **(a)** accepting obsolete **RFC 3489** ("classic" STUN) Binding requests, which carry no magic cookie;
- **(b)** adding the deprecated `MAPPED-ADDRESS` attribute to modern **RFC 5389** Binding responses, alongside `XOR-MAPPED-ADDRESS`.

Only (a) is the obsolete part. (b) serves clients that speak RFC 5389 correctly but cannot parse `XOR-MAPPED-ADDRESS`, and (b) is what the amplification warning in `turnserver.conf` is actually about. So retiring RFC 3489 support can't be done by deleting the flag — that would silently drop (b) too.

## Change

Move (a) behind a new `--rfc3489-compatibility`, which logs a deprecation warning at startup naming the removal release. `--stun-backward-compatibility` keeps (b) only.

Setting **both** reproduces the previous single-flag behavior exactly, so operators have a mechanical migration path.

| Flags | Modern request | Old (cookie-less) request |
|---|---|---|
| none (default) | `XOR-MAPPED` | no response |
| `--stun-backward-compatibility` | `XOR-MAPPED` + `MAPPED` | no response |
| `--rfc3489-compatibility` | `XOR-MAPPED` | `MAPPED` + `SOFTWARE`, cookie echoed |
| both | `XOR-MAPPED` + `MAPPED` | `MAPPED` + `SOFTWARE`, cookie echoed |

Nothing changes for anyone who does not set either flag; both default to off.

### A bug the split exposed

Because the two halves are now independent, the old-STUN path can no longer borrow (b) to supply an address. `MAPPED-ADDRESS` is the **only** address attribute RFC 3489 defines, but it was gated purely on `stun_backward_compatibility` — so `--rfc3489-compatibility` alone would have answered classic-STUN clients with an **address-less** response (`[SOFTWARE]` and nothing else).

`stun_set_binding_response_str()` now always emits `MAPPED-ADDRESS` when building an old-STUN response. On the modern path it stays opt-in, since it widens the response and raises the amplification gain.

### Other bits

- The UDP classifier follows the new flag, so an old-STUN datagram is only spared `--drop-invalid-packets` when the option that can actually process it is enabled.
- Corrects the flag's description in both shipped `turnserver.conf` files, which disagreed with each other and with the code: the `examples/` copy claimed the option *disables* `MAPPED-ADDRESS`, and the `docker/` copy said "instead of" rather than "in addition to" `XOR-MAPPED-ADDRESS`.
- `README.md` / `STATUS.md` / man page now mark RFC 3489 support as deprecated.

## Context

RFC 5389 deprecated the RFC 3489 mechanisms in 2008; RFC 8489 dropped the compatibility language entirely. This PR is step 1 of a two-step retirement — it decouples the useful half from the obsolete half and starts the deprecation clock. Step 2 (deleting the RFC 3489 request path and the `old_stun_*` API, ~300 lines) is left for a major-version window, since those functions are installed as public `libturnclient` API.

## Testing

- New unit test pins the address-attribute matrix across both knobs; verified it fails without the `MAPPED-ADDRESS` fix above.
- `ctest`: 16/16 macOS, 15/15 Linux.
- All six `examples/run_tests*.sh` clean on macOS and in a Linux container (including `run_tests_rfc5780.sh`, which shares the CHANGE-REQUEST code path — 0 FAIL / 0 SKIP in the container; it skips on macOS without a `127.0.0.2` alias).
- Both fuzz targets smoke-clean; packaged Docker image tests 19 passed / 0 failed.
- All four flag combinations verified end-to-end via CLI **and** config file with a raw prober, since `turnutils_stunclient` deliberately cannot send a cookie-less request.
- `clang-format-15` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)