### PR TITLE
DTLS: drop non-handshake records from unknown sources

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -745,6 +745,15 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
       chs = dtls_server_input_handler(server, s, sm->m.sm.nd.nbh);
       ioa_network_buffer_delete(server->e, sm->m.sm.nd.nbh);
       sm->m.sm.nd.nbh = NULL;
+    } else if (!turn_params.no_dtls && (packet_type == UDP_PACKET_CLASS_DTLS_OTHER)) {
+      /* A non-handshake DTLS record (ApplicationData / Alert /
+       * ChangeCipherSpec) from a source with no established DTLS session - the
+       * per-source lookup at the top of this function already missed, so there
+       * are no session keys to decrypt it and it cannot advance any handshake.
+       * Drop it instead of falling through to create_ioa_socket_from_fd below. */
+      ioa_network_buffer_delete(server->e, sm->m.sm.nd.nbh);
+      sm->m.sm.nd.nbh = NULL;
+      return 0;
     }
 #endif
 


### PR DESCRIPTION
A UDP datagram whose first bytes form a DTLS record header with a non-handshake content type (0x17 ApplicationData / 0x15 Alert / 0x14 ChangeCipherSpec) is classified UDP_PACKET_CLASS_DTLS_OTHER. From a source with no established DTLS session it reached handle_udp_packet's new-source branch, skipped the DTLS handshake path (which only runs for UDP_PACKET_CLASS_DTLS_HANDSHAKE) and the stateless-nonce fast path (which only runs for UDP_PACKET_CLASS_STUN_OR_CHANNEL), and fell through to create_ioa_socket_from_fd + open_client_connection_session - allocating a full ~19 KB ts_ur_super_session + ioa_socket + timer + map entry.

Such a record cannot be decrypted (the per-source lookup at the top of handle_udp_packet already missed, so there are no session keys) and cannot advance any handshake. Drop the datagram in the new-source branch instead. Established DTLS sessions are unaffected.