### PR TITLE
docs: state OpenSSL 3.0+ as the supported target; drop stale guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ coturn requires following dependencies to be installed first
 - libmicrohttpd (Prometheus metrics interface)
 
 Optional
-- openssl (to support TLS and DTLS, authorized STUN and TURN)
+- openssl 3.0 or newer (to support TLS and DTLS, authorized STUN and TURN); older OpenSSL versions are not supported
 - MariaDB/MySQL (user database)
 - [Hiredis](https://github.com/redis/hiredis) (user database, monitoring)
 - SQLite (user database)

--- a/README.turnserver
+++ b/README.turnserver
@@ -568,10 +568,9 @@ Options with values:
 			By default, no CA is set and no client certificate check is performed.
 
 --ec-curve-name		Curve name for EC ciphers, if supported by OpenSSL
-			library (TLS and DTLS). The default value is prime256v1,
-			if pre-OpenSSL 1.0.2 is used. With OpenSSL 1.0.2+,
-			an optimal curve will be automatically calculated, if not defined
-			by this option.
+			library (TLS and DTLS). If not defined by this option, an
+			optimal curve is automatically calculated. (coturn requires
+			OpenSSL 3.0 or newer; older versions are not supported.)
 
 --dh-file		Use custom DH TLS key, stored in PEM format in the file.
 			Flags --dh566 and --dh1066 are ignored when the DH key is taken from a file.
@@ -977,8 +976,9 @@ location (/var/db/turndb or /usr/local/var/db/turndb or /var/lib/turn/turndb, de
 
 ALPN
 
-The server supports ALPNs "stun.turn" and "stun.nat-discovery", when
-compiled with OpenSSL 1.0.2 or newer. If the server receives a TLS/DTLS
+The server supports ALPNs "stun.turn" and "stun.nat-discovery". (coturn
+requires OpenSSL 3.0 or newer; older versions are not supported.) If the
+server receives a TLS/DTLS
 ClientHello message that contains one or both of those ALPNs, then the
 server chooses the first stun.* label and sends it back (in the ServerHello)
 in the ALPN extension field. If no stun.* label is found, then the server

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -215,8 +215,8 @@ to adjust LD_LIBRARY_PATH.
 # WHICH EXTRA LIBRARIES AND UTILITIES YOU NEED 
 
 In addition to common *NIX OS services and libraries, to compile this code, 
-OpenSSL (version 1.0.0a or better recommended), libevent2 (version 2.0.5 
-or better) and libmicrohttpd (Prometheus metrics interface) are required, 
+OpenSSL (version 3.0 or newer; older versions are not supported), libevent2 
+(version 2.0.5 or better) and libmicrohttpd (Prometheus metrics interface) are required, 
 SQLite C development library and header is optional,
 the PostgreSQL C client development setup is optional, 
 the MySQL (MariaDB) C client development setup is optional, 
@@ -400,26 +400,17 @@ libevent2 from their web site. It was tested with older *NIXes
 
 NOTE: SQLite must be of version 3.x.
 
-NOTE: For extra security features (like DTLS)
-support, OpenSSL version 1.0.0a or newer is recommended. Older versions do 
-not support DTLS, reliably, in some cases. For example, the Debian 'Squeeze'
-Linux supplies 0.9.8 version of OpenSSL, that does not work correctly with
-DTLS over IPv6. If your system already has an older version of OpenSSL
-installed (usually in directory /usr) then you may want to install your
-newer OpenSSL "over" the old one (because it will most probably will not allow
-removal of the old one). When installing the newer OpenSSL, run the OpenSSL's
-configure command like this:
-
-    $ ./config --prefix=/usr
-
-that will set the installation prefix to /usr (without "--prefix=/usr" 
-by default it would be installed to /usr/local). This is necessary if you 
-want to overwrite your existing older OpenSSL installation.
+NOTE: coturn requires OpenSSL 3.0 or newer for TLS and DTLS. Older OpenSSL
+releases (1.x, 1.1.x, 0.9.x) are not supported and are not tested or validated
+against; do not attempt to build or validate coturn with them. If your system
+ships an OpenSSL older than 3.0, build against a newer OpenSSL installed under a
+non-default prefix as described in the next section rather than replacing the
+system OpenSSL.
 
 IX. BUILDING WITH NON-DEFAULT PREFIX DIRECTORY
 
-Say, you have an older system with old openssl and old libevent 
-library and you do not want to change that, but you still want 
+Say, your system ships an OpenSSL older than the required 3.0 (or an old 
+libevent) and you do not want to change that, but you still want 
 to build the turnserver.
 
 Do the following steps:

--- a/docs/OpenSSL.md
+++ b/docs/OpenSSL.md
@@ -1,19 +1,24 @@
 # OPENSSL
 
-If you are using the OpenSSL that is coming with your system, and you are
-OK with it, then you do not have to read this chapter. If your system has
-an outdated OpenSSL version, or if you need some very fresh OpenSSL features
-that are not present in the current usual stable version, then you may have
-to compile (and run) your TURN server with a different OpenSSL version.
+coturn requires **OpenSSL 3.0 or newer**. This is the supported target.
+Older OpenSSL releases (1.x, 1.1.x, 0.9.x) and other libraries are **not
+supported** and are **not tested or validated against** - do not build or
+validate coturn with them. (Some individual features need a newer 3.x: for
+example RFC 7250 raw public keys require OpenSSL 3.2.1 or newer.)
 
-For example, if you need ALPN feature, or DTLS1.2, and your system comes with
-OpenSSL 1.0.1, you will not be able to use those features unless you install
-OpenSSL 1.0.2 and compile and run the TURN server with the newer version.
+A downstream compatibility patch for building against the deprecated,
+end-of-life OpenSSL 1.1.1 is kept under `patches/openssl-1.1.1/` for operators
+who cannot yet move off 1.1.1, but it is unsupported and outside the tested
+configuration.
 
-The problem is, it is usually not safe to replace the system's OpenSSL with
-a different version. Some systems are "bound" to its "native" OpenSSL 
-installations, and their behavior may become unpredictable with the newer
-versions.
+If your system already ships OpenSSL 3.0 or newer, you do not have to read the
+rest of this chapter. If it ships an older version, install a supported OpenSSL
+(3.0+) under a non-default prefix and build coturn against it, as below.
+
+The reason not to simply replace the system's OpenSSL is that some systems are
+"bound" to their "native" OpenSSL installation, and their behavior may become
+unpredictable if it is swapped out. So preserve the system OpenSSL and build
+(and run) the TURN server against a separate, supported OpenSSL:
 
 So you want to preserve your system's OpenSSL but you want to compile and to
 run the TURN server with newer OpenSSL version. There are different ways to


### PR DESCRIPTION
coturn already targets OpenSSL 3.x (the DH-param migration in #1809 dropped 1.1.1 build support, and RFC 7250 raw public keys need 3.2.1), but several docs still referenced OpenSSL 1.0.0a/1.0.1/1.0.2 and 0.9.8 as if they were supported or recommended baselines.

Make the requirement explicit and consistent: OpenSSL 3.0 or newer is the supported target; older releases (1.x, 1.1.x, 0.9.x) and other libraries are not supported and are not tested or validated against.

- docs/OpenSSL.md: lead with the 3.0+ requirement and the unsupported/not- validated statement; note the RFC 7250 raw-public-keys 3.2.1 sub-requirement and the deprecated patches/openssl-1.1.1 bridge; reframe the custom-prefix build guidance for "system ships < 3.0" instead of the old 1.0.1 example.
- docs/Build.md: replace the "1.0.0a or better recommended" / 0.9.8-DTLS-over- IPv6 paragraph with the 3.0+ requirement.
- README.md: mark the openssl dependency as 3.0 or newer.
- README.turnserver: drop the pre-1.0.2 EC-curve and 1.0.2-ALPN version caveats (both moot at 3.0+).