### PR TITLE
DTLS: cap concurrent half-open handshakes (pre-cookie state-exhaustion)

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -250,6 +250,37 @@ static size_t print_packet_txt2pcap(uint64_t now, uint8_t *payload, size_t paylo
  */
 #define TURN_DTLS_MAX_CERT_LIST (SSL3_RT_MAX_ENCRYPTED_LENGTH)
 
+/*
+ * Cap on concurrent half-open (handshake-incomplete) DTLS sockets, summed
+ * across all relay threads. A DTLS ClientHello from a new source makes the
+ * listener allocate a per-peer SSL + ioa_socket + ts_ur_super_session before
+ * the source has answered the RFC 6347 cookie challenge, so a source-spoofing
+ * flood of unanswered ClientHellos would otherwise accumulate unbounded state
+ * (GHSA-5x2p-4vqj-f6m4, CWE-770/400). Once the cap is reached, new handshakes
+ * are dropped until in-progress ones finish (freeing their slot) or are reaped
+ * by the allocate timeout. Legitimate clients finish the handshake in a few
+ * round trips and release their slot immediately, so this only bites under a
+ * flood.
+ *
+ * The cap scales with server size: it is this many slots per relay thread, so a
+ * bigger deployment (more relay threads) tolerates proportionally more
+ * concurrent handshakes and a small box is not over-committed. The live count
+ * is a single global counter rather than a hard per-thread partition, so a busy
+ * relay thread can use headroom left idle by others while the process-wide
+ * ceiling (this * relay-thread count) still bounds total memory. A fixed
+ * per-thread bound for now; a --dtls-max-half-open option could expose it.
+ */
+#define TURN_DTLS_HALF_OPEN_PER_THREAD 16
+
+/* Process-wide cap = per-thread budget * number of relay threads (>= 1). */
+static uint32_t dtls_half_open_cap(void) {
+  uint32_t threads = (uint32_t)turn_params.general_relay_servers_number;
+  if (threads < 1) {
+    threads = 1;
+  }
+  return TURN_DTLS_HALF_OPEN_PER_THREAD * threads;
+}
+
 static unsigned char dtls_cookie_secret[COOKIE_SECRET_LENGTH];
 static pthread_once_t dtls_cookie_secret_once = PTHREAD_ONCE_INIT;
 
@@ -384,6 +415,14 @@ static ioa_socket_handle dtls_server_input_handler(dtls_listener_relay_server_ty
   BIO *wbio = NULL;
   struct timeval timeout;
 
+  /* Refuse a new DTLS handshake once too many are already in flight, before
+   * allocating any per-peer state, so a ClientHello flood cannot exhaust memory
+   * (GHSA-5x2p-4vqj-f6m4). The reserved slot is released below if the accept
+   * fails, or later when the handshake finishes / the socket is closed. */
+  if (!turn_dtls_half_open_try_inc(dtls_half_open_cap())) {
+    return NULL;
+  }
+
   /* Create BIO */
   wbio = BIO_new_dgram(s->fd, BIO_NOCLOSE);
   (void)BIO_dgram_set_peer(wbio, (struct sockaddr *)&(server->sm.m.sm.nd.src_addr));
@@ -414,6 +453,13 @@ static ioa_socket_handle dtls_server_input_handler(dtls_listener_relay_server_ty
       SSL_shutdown(connecting_ssl);
     }
     SSL_free(connecting_ssl);
+    /* No socket was created, so nothing will ever release the slot we reserved
+     * above - release it here. */
+    turn_dtls_half_open_dec();
+  } else {
+    /* The socket now owns the reserved slot; it is released when the handshake
+     * completes (data path below) or the socket is closed. */
+    rc->dtls_half_open = true;
   }
 
   return rc;
@@ -673,6 +719,14 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
       }
     }
 
+    /* The DTLS handshake just finished on this session's socket: release its
+     * half-open slot so it no longer counts against the cap (it is now a
+     * return-routable, fully-established peer). */
+    if (s && s->dtls_half_open && s->ssl && SSL_is_init_finished(s->ssl)) {
+      s->dtls_half_open = false;
+      turn_dtls_half_open_dec();
+    }
+
     if (s && ioa_socket_check_bandwidth(s, sm->m.sm.nd.nbh, 1)) {
       s->e = ioa_eng;
       if (s && s->read_cb && sm->m.sm.nd.nbh) {
@@ -745,6 +799,13 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
       chs = dtls_server_input_handler(server, s, sm->m.sm.nd.nbh);
       ioa_network_buffer_delete(server->e, sm->m.sm.nd.nbh);
       sm->m.sm.nd.nbh = NULL;
+      if (!chs) {
+        /* The handshake produced no DTLS socket: the half-open cap was reached
+         * or the handshake errored. Drop it - a DTLS handshake datagram must
+         * never fall through to create_ioa_socket_from_fd below and become a
+         * plain-UDP socket + session (GHSA-5x2p-4vqj-f6m4). */
+        return 0;
+      }
     } else if (!turn_params.no_dtls && (packet_type == UDP_PACKET_CLASS_DTLS_OTHER)) {
       /* A non-handshake DTLS record (ApplicationData / Alert /
        * ChangeCipherSpec) from a source with no established DTLS session - the

--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -689,6 +689,37 @@ static void maybe_flush_prom_counters(ioa_engine_handle e) {
   prom_flush_401_counters();
 }
 
+/* Concurrent DTLS handshakes that have not finished yet, summed across all
+ * relay threads. Bounds pre-cookie per-source state (GHSA-5x2p-4vqj-f6m4): a
+ * ClientHello flood cannot grow this past the cap the listener enforces. */
+static turn_atomic_u32 turn_dtls_half_open = 0;
+
+bool turn_dtls_half_open_try_inc(uint32_t cap) {
+  for (;;) {
+    const uint32_t cur = turn_atomic_load_u32(&turn_dtls_half_open);
+    if (cur >= cap) {
+      return false;
+    }
+    if (turn_atomic_cas_u32(&turn_dtls_half_open, cur, cur + 1)) {
+      return true;
+    }
+  }
+}
+
+void turn_dtls_half_open_dec(void) {
+  for (;;) {
+    const uint32_t cur = turn_atomic_load_u32(&turn_dtls_half_open);
+    if (cur == 0) {
+      return; /* defensive: never wrap below zero */
+    }
+    if (turn_atomic_cas_u32(&turn_dtls_half_open, cur, cur - 1)) {
+      return;
+    }
+  }
+}
+
+uint32_t turn_dtls_half_open_count(void) { return turn_atomic_load_u32(&turn_dtls_half_open); }
+
 static void timer_handler(ioa_engine_handle e, void *arg) {
 
   UNUSED_ARG(arg);
@@ -2148,6 +2179,14 @@ void close_ioa_socket(ioa_socket_handle s) {
     }
 
     s->done = 1;
+
+    /* Release the DTLS half-open slot if this socket's handshake never finished
+     * (GHSA-5x2p-4vqj-f6m4). Idempotent via the flag; a completed handshake
+     * already cleared it in the listener's data path. */
+    if (s->dtls_half_open) {
+      s->dtls_half_open = false;
+      turn_dtls_half_open_dec();
+    }
 
     while (!buffer_list_empty(&(s->bufs))) {
       pop_elem_from_buffer_list(&(s->bufs));

--- a/src/apps/relay/ns_ioalib_impl.h
+++ b/src/apps/relay/ns_ioalib_impl.h
@@ -245,6 +245,13 @@ struct _ioa_socket {
    * set-sites. Defaults to false via the calloc() zero-init every ioa_socket
    * gets; only the shared sockets flip it true. */
   bool udp_recvmmsg_eligible;
+  /* DTLS half-open accounting: true from the moment this DTLS child socket is
+   * created (handshake not yet finished) until the handshake completes or the
+   * socket is closed. While true the socket holds one slot in the global
+   * turn_dtls_half_open counter; the flag makes the decrement idempotent and
+   * lets close_ioa_socket() release a slot for a handshake that never
+   * completed. Zero-initialized by the calloc() every ioa_socket gets. */
+  bool dtls_half_open;
   int done;
   ts_ur_super_session *session;
   int current_df_relay_flag;
@@ -300,6 +307,18 @@ void mp_deregister_permission_peers(ioa_engine_handle e, const ioa_addr *peer_ad
 void mp_deregister_session_peers(ioa_engine_handle e, void *turn_session, int address_family);
 ioa_socket_handle mp_get_socket(ioa_engine_handle e, int af);
 uint16_t mp_get_port(ioa_engine_handle e, int af);
+
+/* DTLS half-open handshake cap (state-exhaustion mitigation, GHSA-5x2p-4vqj-f6m4).
+ * A DTLS ClientHello from a new source creates a per-peer SSL + socket + session
+ * before the source has proven return-routable via the DTLS cookie, so a flood
+ * of unanswered ClientHellos accumulates state. These bound the number of
+ * concurrent half-open (handshake-incomplete) DTLS sockets across all relay
+ * threads. turn_dtls_half_open_try_inc() reserves a slot if the live count is
+ * below cap (false = cap reached, caller must drop); turn_dtls_half_open_dec()
+ * releases one; the count is exposed for logging/tests. */
+bool turn_dtls_half_open_try_inc(uint32_t cap);
+void turn_dtls_half_open_dec(void);
+uint32_t turn_dtls_half_open_count(void);
 
 /* engine handling */
 


### PR DESCRIPTION
A DTLS ClientHello from a new source makes the listener allocate a per-peer SSL + ioa_socket + ts_ur_super_session in dtls_server_input_handler before the source has answered the RFC 6347 cookie challenge. A cookie-less ClientHello only elicits a HelloVerifyRequest, which a source-spoofing attacker or botnet never answers, so one datagram per forged source accumulated durable state with no bound until the allocate timeout

Bound the number of concurrent half-open (handshake-incomplete) DTLS sockets across all relay threads with a global atomic counter (turn_dtls_half_open). The cap scales with server size - TURN_DTLS_HALF_OPEN_PER_THREAD (16) times the relay-thread count - so a bigger deployment tolerates proportionally more concurrent handshakes and a small box is not over-committed. A single global counter (rather than a hard per-thread partition) lets a busy relay thread use headroom left idle by others while the process-wide ceiling still bounds total memory.

The listener reserves a slot before allocating any per-peer state and drops the datagram when the cap is reached; the slot is released when the handshake completes (data path) or the socket is closed (close_ioa_socket, covering handshakes that never finish and are reaped by the allocate timeout). A per-socket dtls_half_open flag makes the release idempotent.

This does not touch the DTLS cookie/handshake flow, so legitimate handshakes are unchanged - a completing client releases its slot within a few round trips, so the cap only bites under a flood.

Also stops a DTLS handshake datagram that yields no socket (cap reached or handshake error) from falling through to create_ioa_socket_from_fd and becoming a plain-UDP session.

Builds on the DTLS_OTHER drop in the previous commit.