### PR TITLE
DTLS: release idle handshake buffers on half-open sockets

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -436,6 +436,10 @@ static ioa_socket_handle dtls_server_input_handler(dtls_listener_relay_server_ty
 
   SSL_set_accept_state(connecting_ssl);
 
+  /* Release idle record buffers so a half-open handshake (parked after the
+   * HelloVerifyRequest) does not pin them */
+  SSL_set_mode(connecting_ssl, SSL_MODE_RELEASE_BUFFERS);
+
   SSL_set_bio(connecting_ssl, NULL, wbio);
   SSL_set_options(connecting_ssl, SSL_OP_COOKIE_EXCHANGE
 #if defined(SSL_OP_NO_RENEGOTIATION)


### PR DESCRIPTION
Set SSL_MODE_RELEASE_BUFFERS on the DTLS listener handshake SSL so OpenSSL frees the per-connection read/write record buffers whenever they drain to empty. A half-open handshake parked after the HelloVerifyRequest - waiting for the cookie-bearing ClientHello that a source-spoofing flooder never sends - then does not pin those buffers.

This complements the concurrent half-open cap (already in master): the cap bounds how many such handshakes can exist at once, this trims what each one holds while idle. The saving is modest - measured ~13% of per-half-open RSS on OpenSSL 3.x. It is a single line with no effect on the handshake itself.