### PR TITLE
Declare ERROR-CODE / ADDRESS-ERROR-CODE reason phrases without padding

### DIFF
--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -879,7 +879,7 @@ const uint8_t *get_default_reason(int error_code) {
 }
 
 static void stun_init_error_response_common_str(uint8_t *buf, size_t *len, uint16_t error_code, const uint8_t *reason,
-                                                stun_tid *id, bool include_reason_string) {
+                                                stun_tid *id, bool include_reason_string, bool pad_reason_phrase) {
 
   if (include_reason_string && (!reason || !strcmp((const char *)reason, "Unknown error"))) {
     reason = get_default_reason(error_code);
@@ -897,8 +897,9 @@ static void stun_init_error_response_common_str(uint8_t *buf, size_t *len, uint1
   avalue[sizeof(avalue) - 1] = 0;
   int alen = 4 + (int)strlen((const char *)(avalue + 4));
 
-  //"Manual" padding for compatibility with classic old stun:
-  {
+  /* RFC 3489 Section 11.2.9 requires a reason phrase length that is a multiple of 4;
+   * RFC 8489 Section 14 requires the declared length to exclude padding. */
+  if (pad_reason_phrase) {
     const int rem = alen % 4;
     if (rem) {
       alen += (4 - rem);
@@ -917,7 +918,7 @@ void old_stun_init_error_response_str(uint16_t method, uint8_t *buf, size_t *len
 
   old_stun_init_command_str(stun_make_error_response(method), buf, len, cookie);
 
-  stun_init_error_response_common_str(buf, len, error_code, reason, id, include_reason_string);
+  stun_init_error_response_common_str(buf, len, error_code, reason, id, include_reason_string, true);
 }
 
 void stun_init_error_response_str(uint16_t method, uint8_t *buf, size_t *len, uint16_t error_code,
@@ -925,7 +926,7 @@ void stun_init_error_response_str(uint16_t method, uint8_t *buf, size_t *len, ui
 
   stun_init_command_str(stun_make_error_response(method), buf, len);
 
-  stun_init_error_response_common_str(buf, len, error_code, reason, id, include_reason_string);
+  stun_init_error_response_common_str(buf, len, error_code, reason, id, include_reason_string, false);
 }
 
 /////////// CHANNEL ////////////////////////////////////////////////
@@ -1807,22 +1808,16 @@ bool stun_attr_add_bandwidth_str(uint8_t *buf, size_t *len, band_limit_t bps0) {
 bool stun_attr_add_address_error_code(uint8_t *buf, size_t *len, int requested_address_family, int error_code) {
   const uint8_t *reason = get_default_reason(error_code);
 
-  uint8_t avalue[513];
+  uint8_t avalue[513] = {0};
   avalue[0] = (uint8_t)requested_address_family;
   avalue[1] = 0;
   avalue[2] = (uint8_t)(error_code / 100);
   avalue[3] = (uint8_t)(error_code % 100);
   strncpy((char *)(avalue + 4), (const char *)reason, sizeof(avalue) - 4);
   avalue[sizeof(avalue) - 1] = 0;
-  int alen = 4 + (int)strlen((const char *)(avalue + 4));
 
-  //"Manual" padding for compatibility with classic old stun:
-  {
-    const int rem = alen % 4;
-    if (rem) {
-      alen += (4 - rem);
-    }
-  }
+  /* RFC 8489 Section 14: the declared length excludes padding. */
+  const int alen = 4 + (int)strlen((const char *)(avalue + 4));
 
   return stun_attr_add_str(buf, len, STUN_ATTRIBUTE_ADDRESS_ERROR_CODE, (uint8_t *)avalue, alen);
 }

--- a/tests/test_stun_msg.c
+++ b/tests/test_stun_msg.c
@@ -90,6 +90,79 @@ static void test_error_response_without_reason_string_still_parses(void) {
   TEST_ASSERT_EQUAL_INT(437, err_code);
 }
 
+/* RFC 8489 Section 14: the declared length is the value length prior to padding. */
+static void test_error_code_length_excludes_padding(void) {
+  const uint8_t *reason = get_default_reason(508);
+  const int reason_len = (int)strlen((const char *)reason);
+  /* Only an unpadded reason phrase can distinguish the two lengths. */
+  TEST_ASSERT_NOT_EQUAL_INT(0, reason_len % 4);
+
+  uint8_t buf[1024] = {0};
+  size_t len = 0;
+  stun_tid tid = {0};
+
+  stun_init_error_response_str(STUN_METHOD_ALLOCATE, buf, &len, 508, reason, &tid, true);
+
+  stun_attr_ref sar = stun_attr_get_first_by_type_str(buf, len, STUN_ATTRIBUTE_ERROR_CODE);
+  TEST_ASSERT_NOT_NULL(sar);
+  TEST_ASSERT_EQUAL_INT(4 + reason_len, stun_attr_get_len(sar));
+  TEST_ASSERT_EQUAL_MEMORY(reason, stun_attr_get_value(sar) + 4, (size_t)reason_len);
+
+  /* The attribute is still padded on the wire; only the declared length differs. */
+  TEST_ASSERT_EQUAL_size_t(0, len % 4);
+  TEST_ASSERT_EQUAL_size_t(STUN_HEADER_LENGTH + 4 + 28, len);
+
+  /* Pad bytes are zeroed, not stale buffer contents. */
+  const uint8_t *pad = stun_attr_get_value(sar) + 4 + reason_len;
+  for (size_t i = 0; i < (size_t)(28 - 4 - reason_len); ++i) {
+    TEST_ASSERT_EQUAL_UINT8(0, pad[i]);
+  }
+}
+
+/* RFC 3489 Section 11.2.9 requires a reason phrase length that is a multiple of 4. */
+static void test_old_stun_error_code_length_stays_padded(void) {
+  const uint8_t *reason = get_default_reason(508);
+  const int reason_len = (int)strlen((const char *)reason);
+
+  uint8_t buf[1024] = {0};
+  size_t len = 0;
+  stun_tid tid = {0};
+
+  old_stun_init_error_response_str(STUN_METHOD_BINDING, buf, &len, 508, reason, &tid, 0, true);
+
+  /* ERROR-CODE is the only attribute, so it starts right after the header. */
+  const uint8_t *attr = buf + STUN_HEADER_LENGTH;
+  TEST_ASSERT_EQUAL_UINT16(STUN_ATTRIBUTE_ERROR_CODE, turn_read_u16(attr));
+  TEST_ASSERT_EQUAL_UINT16(4 + reason_len + (4 - (reason_len % 4)), turn_read_u16(attr + 2));
+}
+
+/* RFC 8656 Section 18.12 ADDRESS-ERROR-CODE, declared per RFC 8489 Section 14. */
+static void test_address_error_code_length_excludes_padding(void) {
+  const uint8_t *reason = get_default_reason(508);
+  const int reason_len = (int)strlen((const char *)reason);
+  TEST_ASSERT_NOT_EQUAL_INT(0, reason_len % 4);
+
+  uint8_t buf[1024] = {0};
+  size_t len = 0;
+  stun_tid tid = {0};
+
+  stun_init_success_response_str(STUN_METHOD_ALLOCATE, buf, &len, &tid);
+  TEST_ASSERT_TRUE(
+      stun_attr_add_address_error_code(buf, &len, STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6, 508));
+
+  stun_attr_ref sar = stun_attr_get_first_by_type_str(buf, len, STUN_ATTRIBUTE_ADDRESS_ERROR_CODE);
+  TEST_ASSERT_NOT_NULL(sar);
+  TEST_ASSERT_EQUAL_INT(4 + reason_len, stun_attr_get_len(sar));
+
+  const uint8_t *value = stun_attr_get_value(sar);
+  TEST_ASSERT_EQUAL_UINT8(STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY_VALUE_IPV6, value[0]);
+  TEST_ASSERT_EQUAL_UINT8(5, value[2]);
+  TEST_ASSERT_EQUAL_UINT8(8, value[3]);
+  TEST_ASSERT_EQUAL_MEMORY(reason, value + 4, (size_t)reason_len);
+
+  TEST_ASSERT_EQUAL_size_t(0, len % 4);
+}
+
 static void test_truncated_buffer_is_not_command_message(void) {
   uint8_t buf[10] = {0};
   TEST_ASSERT_FALSE(stun_is_command_message_str(buf, sizeof(buf)));
@@ -763,6 +836,9 @@ int main(void) {
   RUN_TEST(test_success_response_carries_transaction_id);
   RUN_TEST(test_error_response_carries_error_code);
   RUN_TEST(test_error_response_without_reason_string_still_parses);
+  RUN_TEST(test_error_code_length_excludes_padding);
+  RUN_TEST(test_old_stun_error_code_length_stays_padded);
+  RUN_TEST(test_address_error_code_length_excludes_padding);
   RUN_TEST(test_truncated_buffer_is_not_command_message);
   RUN_TEST(test_zeroed_buffer_is_not_command_message);
   RUN_TEST(test_channel_message_roundtrip);


### PR DESCRIPTION
RFC 8489 par. 14 (and RFC 5389 par. 15 before it) requires an attribute's Length field to be the length of the value **prior to** padding. Both error-code builders rounded the declared length up to a 4-byte boundary before calling `stun_attr_add_str()`, which pads and zeroes the pad bytes on its own. The rounding therefore only inflated the declared length, so the reason phrase carried up to 3 trailing NUL bytes *within its own declared length*.

It fires in practice: `"Insufficient Capacity"` is 21 bytes and was declared as 28.

## Classic STUN is the deliberate exception

RFC 3489 par. 11.2.9 requires the reason phrase length itself to be a multiple of 4, which is what the `//"Manual" padding for compatibility with classic old stun` comment was about — the comment was correct, for that dialect only.

`stun_init_error_response_common_str()` therefore takes a `pad_reason_phrase` flag:

- `old_stun_init_error_response_str()`, reachable only under `--rfc3489-compatibility`, keeps the rounding.
- `stun_init_error_response_str()` drops it.

`ADDRESS-ERROR-CODE` (RFC 8656 par. 18.12) is RFC 8656-only with no classic-STUN heritage, so its rounding goes unconditionally.

The total on-the-wire attribute size is unchanged in every case; only the declared length shrinks to the true reason length, and the pad bytes are still zeroed by `stun_attr_add_str()`.

## Tests

Three tests in `tests/test_stun_msg.c`:

- `test_error_code_length_excludes_padding` and `test_address_error_code_length_excludes_padding` — both fail without this change (`Expected 25 Was 28`).
- `test_old_stun_error_code_length_stays_padded` — pins the RFC 3489 path so the exception is not later removed as dead weight. It passes both with and without the change, confirming that path is untouched.

## Validation

Full battery from `CLAUDE.md`, on macOS and Linux:

- unit tests: 16/16 macOS, 15/15 Linux
- RFC 5769 vectors: all pass
- system tests: `run_tests`, `_conf`, `_mobile`, `_multiplex_peer`, `_stateless_nonce` on both; `_rfc5780` runs on Linux (skips on macOS, no 127.0.0.2 alias)
- fuzzing smoke: ASan targets 0 and 1 clean
- packaged Docker image: 19 Bats tests, 0 failures
- `clang-format-15` clean
