### PR TITLE
free the secrets list on the get_user_key error paths

### DIFF
--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -542,7 +542,10 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 
     init_secrets_list(&sl);
 
+    /* get_auth_secrets() populates the list before it can fail, so every exit
+       from here on has to release it. */
     if (get_auth_secrets(&sl, realm) < 0) {
+      clean_secrets_list(&sl);
       return ret;
     }
 
@@ -559,6 +562,7 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
       stun_attr_ref sar = stun_attr_get_first_by_type_str(
           ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh), STUN_ATTRIBUTE_MESSAGE_INTEGRITY);
       if (!sar) {
+        clean_secrets_list(&sl);
         return -1;
       }
 
@@ -571,6 +575,7 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
       case SHA384SIZEBYTES:
       case SHA512SIZEBYTES:
       default:
+        clean_secrets_list(&sl);
         return -1;
       };
 


### PR DESCRIPTION
Repro: start with `--use-auth-secret --static-auth-secret=<S>` and a DB backend that is unreachable (`--redis-userdb "ip=127.0.0.1 port=1"` reproduces it directly), then send ALLOCATEs. Under LeakSanitizer, 31 requests give `744 byte(s) leaked in 62 allocation(s)`, rooted at `add_to_secrets_list` / `get_auth_secrets` / `get_user_key`. Clean after the patch.

Cause: `get_auth_secrets()` appends every configured `--static-auth-secret` to the list first and calls the driver afterwards, and the driver return value overwrites the success status, so a driver failure hands back `-1` with the list already populated. Only the final return in `get_user_key` reaches `clean_secrets_list`, so the three earlier returns drop the array and a `turn_strdup` of each secret. The pgsql/mysql/redis/mongo connection helpers re-attempt on every call and keep returning `-1` while the DB is down, so this repeats per request, and it sits on the pre-auth path (`check_stun_auth` -> `start_user_check` -> `get_user_key`) where any client can drive it.

Fix: release the list before each early return. `get_auth_secrets()` already calls `clean_secrets_list` on entry, so the list is only ever owned by this frame.