### PR TITLE
Worktree stateless nonce mi fastpath

### DIFF
--- a/docs/401-ratelimit.md
+++ b/docs/401-ratelimit.md
@@ -50,6 +50,17 @@ When enabled, for every request that *would* produce a `401`:
 Counting is **consume-on-401**: only requests that actually result in a `401`
 spend a token. Successful or otherwise-errored requests don't touch the table.
 
+Under `--stateless-nonce` the listener also answers a request carrying a forged
+MESSAGE-INTEGRITY without building a session (see
+[stateless-nonce.md](stateless-nonce.md)). Those replies — `438` for a nonce
+this server never issued, `437`/`441`/`400` for malformed credentials
+attributes — go to an equally unverified source, so they draw on the same
+per-source budget and are suppressed the same way. They are logged as
+`unauthorized-response rate-limit exceeded` rather than the `401` line, and they
+do not touch the Prometheus 401 counters, which stay 401-only. A real client
+needs one `438` to re-authenticate when its nonce expires; at the default 10
+replies/s that is never suppressed.
+
 ## How it works
 
 ### Components
@@ -264,6 +275,11 @@ runs two end-to-end cases against a real `turnserver` with bad credentials:
   exactly one `401 rate-limit exceeded` line must appear.
 - **Negative** (`--unauthorized-ratelimit-rps=100000`): the same traffic stays
   far below the threshold, so the line must *not* appear.
+- The same two thresholds against a `--stateless-nonce-secret` server, driven by
+  a 50-packet forged-MESSAGE-INTEGRITY flood
+  ([examples/scripts/stateless_nonce_forged_mi.py](../examples/scripts/stateless_nonce_forged_mi.py)
+  in `flood` mode): the `438`s must be capped and logged at rps=1, and all 50
+  must be answered with no log line at rps=100000.
 
 It is split out of `run_tests.sh` so the rate-limit server fixture can't mask
 or be masked by the protocol suite's flags. It is **skipped on macOS** (loopback

--- a/docs/stateless-nonce.md
+++ b/docs/stateless-nonce.md
@@ -67,6 +67,13 @@ the timestamp, recompute the MAC, check the age against the nonce lifetime -
    session's, and `438 Wrong nonce` for a nonce this server cannot have
    issued. So a spoofed-source flood that appends a garbage MESSAGE-INTEGRITY
    no longer allocates a socket and a session per packet.
+   These replies are answered to an unverified source, so under
+   `--unauthorized-ratelimit` they spend from the same per-source budget as the
+   401 (logged as `unauthorized-response rate-limit exceeded`). They are poor
+   reflection amplifiers to begin with — a `438` costs the attacker a ≥76-byte
+   request for a 72-byte reply, under 1:1, against 3.6:1 for the 401 that a
+   bare 20-byte header elicits — but a flood is capped all the same, while the
+   one `438` a real client needs when its nonce expires is not.
 2. **Fresh-session nonce acceptance** (`check_stun_auth` in
    `ns_turn_server.c`): when the client's authenticated retry arrives, the
    brand-new session accepts a presented nonce whose MAC verifies for this

--- a/docs/stateless-nonce.md
+++ b/docs/stateless-nonce.md
@@ -57,6 +57,16 @@ the timestamp, recompute the MAC, check the age against the nonce lifetime -
    check) are dropped with no state either. The `--unauthorized-ratelimit`
    response suppression and the Prometheus 401 counters apply to this path
    exactly as they do to the session path.
+   A request that *does* carry MESSAGE-INTEGRITY is admitted to the session
+   path only once its `NONCE` is shown to be one this server issued to that
+   source address — the return-routability proof, and a strict prerequisite
+   for any successful authentication. Everything the session path would reject
+   before the credential lookup is answered here instead, in
+   `check_stun_auth`'s own order and with its own bytes: `400` for a missing
+   or malformed REALM/USERNAME/NONCE, `437`/`441` for a realm that is not the
+   session's, and `438 Wrong nonce` for a nonce this server cannot have
+   issued. So a spoofed-source flood that appends a garbage MESSAGE-INTEGRITY
+   no longer allocates a socket and a session per packet.
 2. **Fresh-session nonce acceptance** (`check_stun_auth` in
    `ns_turn_server.c`): when the client's authenticated retry arrives, the
    brand-new session accepts a presented nonce whose MAC verifies for this
@@ -69,13 +79,13 @@ the timestamp, recompute the MAC, check the age against the nonce lifetime -
 3. **Challenge-session teardown**: a UDP session whose response was only an
    auth challenge (401/438) and that has no allocation is torn down
    immediately after the response is written, instead of lingering for the
-   60s to-be-allocated timeout. This is what bounds memory against floods
-   that *do* attach a (garbage) MESSAGE-INTEGRITY attribute and therefore
-   have to travel the session path.
+   60s to-be-allocated timeout. This still covers every session-path
+   challenge — a stale nonce on an established client, TLS/DTLS clients, a
+   nonce that verifies but whose credentials do not.
 
-The result: for MESSAGE-INTEGRITY-less floods the attacker's memory cost is
-zero; for garbage-MI floods it is one transient session per packet, freed as
-soon as the challenge is sent.
+The result: an unauthenticated flood allocates nothing at all, whether or not
+it carries a MESSAGE-INTEGRITY attribute. Only a source that echoes back a
+nonce this server issued to it gets a session.
 
 ## Wire compatibility
 
@@ -100,11 +110,15 @@ The mode is designed to be invisible to clients:
   alternate/aux server redirection (300) is configured, REFRESH under
   `--mobility` (MOBILITY-TICKET may authenticate without a first-pass
   challenge), CONNECTION-BIND (exempt from the challenge), and any request
-  carrying MESSAGE-INTEGRITY.
+  whose nonce verifies (the credential lookup itself may be asynchronous, and
+  resuming it needs a session).
 
 `examples/run_tests_stateless_nonce.sh` asserts all of this end-to-end: the
 standard client workload must succeed unchanged over UDP/TCP (and TLS/DTLS on
-Linux), and the server log must show the fast path actually engaged.
+Linux), the server log must show the fast path actually engaged, and
+`examples/scripts/stateless_nonce_forged_mi.py` drives the forged-integrity
+shapes and pins each reply code (438/437/441/400, and 401 for a request whose
+nonce does verify).
 
 ## Shared fleet key (`--stateless-nonce-secret`)
 

--- a/examples/run_tests_ratelimit_401.sh
+++ b/examples/run_tests_ratelimit_401.sh
@@ -127,3 +127,41 @@ if grep -q '401 rate-limit exceeded from' "$RATELIMIT_LOG"; then
 else
     echo OK
 fi
+
+# The stateless-nonce listener answers a forged MESSAGE-INTEGRITY with a 438
+# without building a session. That reply still goes to an unverified source, so
+# it draws on the same per-source budget as the 401.
+FLOOD=50
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 not available (forged-MESSAGE-INTEGRITY reflection cap)"
+    exit 0
+fi
+
+echo "Running unauthenticated-reply rate-limit (forged MESSAGE-INTEGRITY, positive)"
+run_ratelimit_server --stateless-nonce-secret=fleet-nonce-secret \
+    --unauthorized-ratelimit --unauthorized-ratelimit-rps=1 || exit 1
+replied="$(python3 scripts/stateless_nonce_forged_mi.py 127.0.0.1 3479 user flood "$FLOOD" \
+           | sed -n 's/.*replied=\([0-9]*\).*/\1/p')"
+if [ -n "$replied" ] && [ "$replied" -lt "$FLOOD" ] \
+   && grep -q 'unauthorized-response rate-limit exceeded from' "$RATELIMIT_LOG"; then
+    echo "OK ($replied/$FLOOD 438s answered, rest suppressed)"
+else
+    echo "FAIL: forged-MI 438s not capped (replied=$replied of $FLOOD)"
+    echo "--- turnserver log (last 40 lines) ---"
+    tail -40 "$RATELIMIT_LOG"
+    exit 1
+fi
+
+echo "Running unauthenticated-reply rate-limit (forged MESSAGE-INTEGRITY, negative: high threshold)"
+run_ratelimit_server --stateless-nonce-secret=fleet-nonce-secret \
+    --unauthorized-ratelimit --unauthorized-ratelimit-rps=100000 || exit 1
+replied="$(python3 scripts/stateless_nonce_forged_mi.py 127.0.0.1 3479 user flood "$FLOOD" \
+           | sed -n 's/.*replied=\([0-9]*\).*/\1/p')"
+if [ "$replied" = "$FLOOD" ] && ! grep -q 'unauthorized-response rate-limit exceeded from' "$RATELIMIT_LOG"; then
+    echo OK
+else
+    echo "FAIL: 438s suppressed below threshold (replied=$replied of $FLOOD)"
+    echo "--- turnserver log (last 40 lines) ---"
+    tail -40 "$RATELIMIT_LOG"
+    exit 1
+fi

--- a/examples/run_tests_stateless_nonce.sh
+++ b/examples/run_tests_stateless_nonce.sh
@@ -22,11 +22,12 @@
 TURNSERVER_LOG="/tmp/run_tests_stateless_nonce.$$.turnserver.log"
 PEER_LOG="/tmp/run_tests_stateless_nonce.$$.peer.log"
 UCLIENT_LOG="/tmp/run_tests_stateless_nonce.$$.uclient.log"
+PROBE_LOG="/tmp/run_tests_stateless_nonce.$$.probe.log"
 
 cleanup() {
     kill "$turnserver_pid" "$peer_pid" 2>/dev/null
     wait "$turnserver_pid" "$peer_pid" 2>/dev/null
-    rm -f "$TURNSERVER_LOG" "$PEER_LOG" "$UCLIENT_LOG"
+    rm -f "$TURNSERVER_LOG" "$PEER_LOG" "$UCLIENT_LOG" "$PROBE_LOG"
 }
 trap cleanup EXIT
 
@@ -142,6 +143,25 @@ else
     echo "FAIL: no listener fast-path marker in server log"
     diagnose_failure "fast-path marker"
     exit 1
+fi
+
+# A request carrying MESSAGE-INTEGRITY only reaches the session path once its
+# nonce proves to be one the server issued to that source address; the listener
+# answers the rejections ahead of that itself, and must answer them exactly as
+# check_stun_auth would.
+if command -v python3 >/dev/null 2>&1; then
+    echo "Running forged-MESSAGE-INTEGRITY probe"
+    if python3 scripts/stateless_nonce_forged_mi.py 127.0.0.1 3478 user > "$PROBE_LOG" 2>&1; then
+        cat "$PROBE_LOG"
+        echo "OK (forged MESSAGE-INTEGRITY answered without a session)"
+    else
+        cat "$PROBE_LOG"
+        echo "FAIL: forged-MESSAGE-INTEGRITY probe"
+        diagnose_failure "forged-mi probe"
+        exit 1
+    fi
+else
+    echo "SKIP: python3 not available (forged-MESSAGE-INTEGRITY probe)"
 fi
 
 if [ $IS_DARWIN -eq 1 ]; then

--- a/examples/scripts/stateless_nonce_forged_mi.py
+++ b/examples/scripts/stateless_nonce_forged_mi.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# Forged-MESSAGE-INTEGRITY probe for the stateless-nonce listener fast path
+# (see examples/run_tests_stateless_nonce.sh).
+#
+# A request that carries MESSAGE-INTEGRITY is only worth a session once its
+# NONCE proves to be one the server issued to that very source address. The
+# listener therefore answers the pre-credential rejections itself, and the
+# replies must be byte-compatible with what check_stun_auth() would have sent
+# from a session: 438 for a nonce the server never issued, 437/441 for a
+# mismatched realm, 400 for missing/malformed credentials attributes - and a
+# valid nonce must still be admitted to the session path (401, because the
+# forged integrity fails there).
+#
+# Raw STUN over the standard library only, so the test can send the exact
+# malformed shapes turnutils_uclient will never produce.
+
+import os
+import socket
+import struct
+import sys
+
+MAGIC = 0x2112A442
+M_ALLOCATE = 0x0003
+M_REFRESH = 0x0004
+
+A_USERNAME = 0x0006
+A_MI = 0x0008
+A_ERROR = 0x0009
+A_REALM = 0x0014
+A_NONCE = 0x0015
+A_REQ_TRANSPORT = 0x0019
+
+FORGED_MI = b"\0" * 20  # right length, wrong HMAC
+FORGED_NONCE = b"deadbeefdeadbeefdeadbeef"  # right format, never issued here
+
+
+def attr(t, v):
+    return struct.pack("!HH", t, len(v)) + v + b"\0" * ((-len(v)) & 3)
+
+
+def make(typ, attrs):
+    body = b"".join(attr(t, v) for t, v in attrs)
+    return struct.pack("!HHI12s", typ, len(body), MAGIC, os.urandom(12)) + body
+
+
+def parse(msg):
+    typ, ln, _magic, _tid = struct.unpack("!HHI12s", msg[:20])
+    out = []
+    p = 20
+    while p + 4 <= min(len(msg), 20 + ln):
+        t, n = struct.unpack("!HH", msg[p : p + 4])
+        out.append((t, msg[p + 4 : p + 4 + n]))
+        p += 4 + n + ((-n) & 3)
+    return typ, out
+
+
+def get(attrs, t):
+    for k, v in attrs:
+        if k == t:
+            return v
+    return None
+
+
+def errcode(attrs):
+    v = get(attrs, A_ERROR)
+    if not v or len(v) < 4:
+        return None
+    return (v[2] & 7) * 100 + v[3]
+
+
+def xact(sock, msg, host, port):
+    sock.sendto(msg, (host, port))
+    return parse(sock.recvfrom(4096)[0])
+
+
+def check(label, sock, host, port, msg, want):
+    try:
+        _typ, aa = xact(sock, msg, host, port)
+    except socket.timeout:
+        print(f"FAIL: {label}: no response (want {want})")
+        return False
+    got = errcode(aa)
+    if got != want:
+        print(f"FAIL: {label}: got error {got}, want {want}")
+        return False
+    print(f"OK: {label}: {got}")
+    return True
+
+
+def main():
+    host = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 3478
+    user = (sys.argv[3] if len(sys.argv) > 3 else "user").encode()
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(3)
+
+    # A first request without MESSAGE-INTEGRITY: the plain fast-path challenge,
+    # and the source of a genuinely issued nonce for the last check.
+    try:
+        _typ, aa = xact(s, make(M_ALLOCATE, [(A_REQ_TRANSPORT, b"\x11\0\0\0")]), host, port)
+    except socket.timeout:
+        print("FAIL: no 401 challenge for the unauthenticated request")
+        return 2
+    realm = get(aa, A_REALM)
+    issued_nonce = get(aa, A_NONCE)
+    if errcode(aa) != 401 or not realm or not issued_nonce:
+        print(f"FAIL: unauthenticated request: err={errcode(aa)} realm={realm} nonce={issued_nonce}")
+        return 2
+    print(f"OK: unauthenticated challenge: 401 realm={realm.decode()}")
+
+    creds = [(A_USERNAME, user), (A_REALM, realm)]
+    ok = True
+
+    # A nonce this server never issued to this address: 438, no session.
+    ok &= check(
+        "forged MI, unissued nonce",
+        s,
+        host,
+        port,
+        make(M_ALLOCATE, creds + [(A_NONCE, FORGED_NONCE), (A_REQ_TRANSPORT, b"\x11\0\0\0"), (A_MI, FORGED_MI)]),
+        438,
+    )
+
+    # Realm mismatch is rejected before the nonce is even looked at.
+    ok &= check(
+        "forged MI, wrong realm (ALLOCATE)",
+        s,
+        host,
+        port,
+        make(
+            M_ALLOCATE,
+            [(A_USERNAME, user), (A_REALM, b"wrong.realm"), (A_NONCE, issued_nonce), (A_MI, FORGED_MI)],
+        ),
+        437,
+    )
+    ok &= check(
+        "forged MI, wrong realm (REFRESH)",
+        s,
+        host,
+        port,
+        make(
+            M_REFRESH,
+            [(A_USERNAME, user), (A_REALM, b"wrong.realm"), (A_NONCE, issued_nonce), (A_MI, FORGED_MI)],
+        ),
+        441,
+    )
+
+    ok &= check(
+        "forged MI, no NONCE",
+        s,
+        host,
+        port,
+        make(M_ALLOCATE, creds + [(A_REQ_TRANSPORT, b"\x11\0\0\0"), (A_MI, FORGED_MI)]),
+        400,
+    )
+    ok &= check(
+        "forged MI, no USERNAME",
+        s,
+        host,
+        port,
+        make(M_ALLOCATE, [(A_REALM, realm), (A_NONCE, issued_nonce), (A_MI, FORGED_MI)]),
+        400,
+    )
+
+    # The nonce the server issued to this socket must still be admitted to the
+    # session path, where the forged integrity is what fails (401).
+    ok &= check(
+        "forged MI, issued nonce (admitted to session path)",
+        s,
+        host,
+        port,
+        make(M_ALLOCATE, creds + [(A_NONCE, issued_nonce), (A_REQ_TRANSPORT, b"\x11\0\0\0"), (A_MI, FORGED_MI)]),
+        401,
+    )
+
+    if not ok:
+        return 2
+    print("RESULT forged-mi-probe=pass")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/scripts/stateless_nonce_forged_mi.py
+++ b/examples/scripts/stateless_nonce_forged_mi.py
@@ -87,10 +87,34 @@ def check(label, sock, host, port, msg, want):
     return True
 
 
+def flood(host, port, user, realm, count):
+    """Send `count` forged-MESSAGE-INTEGRITY requests as fast as possible and
+    report how many were answered. Used to observe --unauthorized-ratelimit
+    suppressing the 438s; the caller owns the pass/fail decision."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(0.5)
+    msg = make(
+        M_ALLOCATE,
+        [(A_USERNAME, user), (A_REALM, realm), (A_NONCE, FORGED_NONCE), (A_REQ_TRANSPORT, b"\x11\0\0\0"), (A_MI, FORGED_MI)],
+    )
+    for _ in range(count):
+        s.sendto(msg, (host, port))
+    replied = 0
+    while True:
+        try:
+            s.recvfrom(4096)
+        except socket.timeout:
+            break
+        replied += 1
+    print(f"RESULT flood sent={count} replied={replied}")
+    return 0
+
+
 def main():
     host = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
     port = int(sys.argv[2]) if len(sys.argv) > 2 else 3478
     user = (sys.argv[3] if len(sys.argv) > 3 else "user").encode()
+    flood_count = int(sys.argv[5]) if len(sys.argv) > 5 and sys.argv[4] == "flood" else 0
 
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(3)
@@ -108,6 +132,9 @@ def main():
         print(f"FAIL: unauthenticated request: err={errcode(aa)} realm={realm} nonce={issued_nonce}")
         return 2
     print(f"OK: unauthenticated challenge: 401 realm={realm.decode()}")
+
+    if flood_count:
+        return flood(host, port, user, realm, flood_count)
 
     creds = [(A_USERNAME, user), (A_REALM, realm)]
     ok = True

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -600,9 +600,68 @@ static bool udp_stateless_binding_fast_path(dtls_listener_relay_server_type *ser
   return true;
 }
 
-/* Stateless-nonce fast path (issue #1999): answer a MESSAGE-INTEGRITY-less
- * request from an unknown UDP source with the derived-nonce 401 challenge
- * directly from the listener, without creating a child socket or session.
+/* Copy a NUL-terminated attribute value out of a request. An over-long value
+ * is truncated exactly as check_stun_auth() truncates it, so both paths judge
+ * the same string. Returns false when the attribute is absent. */
+static bool udp_get_string_attr(const uint8_t *data, size_t len, uint16_t attr_type, char *out, size_t out_size) {
+  stun_attr_ref sar = stun_attr_get_first_by_type_str(data, len, attr_type);
+  if (!sar) {
+    return false;
+  }
+  const size_t alen = min((size_t)stun_attr_get_len(sar), out_size - 1);
+  memcpy(out, stun_attr_get_value(sar), alen);
+  out[alen] = 0;
+  return true;
+}
+
+/* Emit the reply handle_turn_command would build for a brand-new session: the
+ * error response, the challenge attributes when `nonce` is given (as
+ * create_challenge_response does), then SOFTWARE and FINGERPRINT. */
+static void udp_send_stateless_error(dtls_listener_relay_server_type *server, ioa_net_data *nd, uint16_t method,
+                                     stun_tid *tid, int err_code, const uint8_t *reason, const char *nonce,
+                                     const char *realm, bool enforce_fingerprints) {
+  turn_turnserver *ts = server->ts;
+
+  ioa_network_buffer_handle nbh = ioa_network_buffer_allocate(server->e);
+  size_t rlen = ioa_network_buffer_get_size(nbh);
+  stun_init_error_response_str(method, ioa_network_buffer_data(nbh), &rlen, err_code, reason, tid,
+                               ts->include_reason_string);
+  if (nonce) {
+    stun_attr_add_str(ioa_network_buffer_data(nbh), &rlen, STUN_ATTRIBUTE_NONCE, (const uint8_t *)nonce,
+                      (int)strlen(nonce));
+    stun_attr_add_str(ioa_network_buffer_data(nbh), &rlen, STUN_ATTRIBUTE_REALM, (const uint8_t *)realm,
+                      (int)strlen(realm));
+    if (ts->oauth) {
+      const char *server_name = ts->oauth_server_name;
+      if (!(server_name && server_name[0])) {
+        server_name = realm;
+      }
+      stun_attr_add_str(ioa_network_buffer_data(nbh), &rlen, STUN_ATTRIBUTE_THIRD_PARTY_AUTHORIZATION,
+                        (const uint8_t *)server_name, strlen(server_name));
+    }
+  }
+  if (ts->software_attribute) {
+    const char *software = get_version(ts);
+    stun_attr_add_str(ioa_network_buffer_data(nbh), &rlen, STUN_ATTRIBUTE_SOFTWARE, (const uint8_t *)software,
+                      strlen(software));
+  }
+  if (ts->fingerprint || enforce_fingerprints) {
+    if (!stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &rlen)) {
+      ioa_network_buffer_delete(server->e, nbh);
+      return;
+    }
+  }
+  ioa_network_buffer_set_size(nbh, rlen);
+
+  udp_send_message(server, nbh, &(nd->src_addr));
+  ioa_network_buffer_delete(server->e, nbh);
+}
+
+/* Stateless-nonce fast path (issue #1999): answer a request from an unknown
+ * UDP source with the derived-nonce 401 challenge directly from the listener,
+ * without creating a child socket or session. A request that does carry
+ * MESSAGE-INTEGRITY is admitted to the session path only once its NONCE is
+ * shown to be one this server issued to that very source address.
  * Packets the relay would silently ignore for a fresh source (indications,
  * unbound channel data, malformed-but-classifiable STUN) are swallowed with
  * no state either. Returns true when the packet was fully handled here;
@@ -653,10 +712,12 @@ static bool udp_stateless_nonce_fast_path(dtls_listener_relay_server_type *serve
     return true;
   }
 
-  /* Requests that carry MESSAGE-INTEGRITY must go through the session path
-   * for credential verification. */
-  if (stun_attr_get_first_by_type_str(data, len, STUN_ATTRIBUTE_MESSAGE_INTEGRITY)) {
-    return false;
+  /* MESSAGE-INTEGRITY is acted upon further down, after the method-specific
+   * branches. check_stun_auth() answers any other length with the same 401
+   * challenge as a missing attribute, so treat it as missing here. */
+  stun_attr_ref mi_attr = stun_attr_get_first_by_type_str(data, len, STUN_ATTRIBUTE_MESSAGE_INTEGRITY);
+  if (mi_attr && (stun_attr_get_len(mi_attr) != SHA1SIZEBYTES)) {
+    mi_attr = NULL;
   }
 
   const uint16_t method = stun_get_method_str(data, len);
@@ -691,10 +752,11 @@ static bool udp_stateless_nonce_fast_path(dtls_listener_relay_server_type *serve
     return false;
   }
 
-  /* Every remaining request method gets a 401 challenge from
-   * check_stun_auth() before any method-specific processing. Build the same
-   * challenge here: error response, NONCE, REALM, [THIRD-PARTY-AUTHORIZATION],
-   * [SOFTWARE], [FINGERPRINT] - the same attributes in the same order. */
+  /* Every remaining request method reaches check_stun_auth() before any
+   * method-specific processing. Its replies - the 401 challenge below, and the
+   * pre-credential rejections in the MESSAGE-INTEGRITY block - are rebuilt here
+   * attribute for attribute: error response, NONCE, REALM,
+   * [THIRD-PARTY-AUTHORIZATION], [SOFTWARE], [FINGERPRINT]. */
 
   realm_options_t realm_options;
   get_default_realm_options(&realm_options);
@@ -723,10 +785,73 @@ static bool udp_stateless_nonce_fast_path(dtls_listener_relay_server_type *serve
     }
   }
 
+  stun_tid tid;
+  stun_tid_from_message_str(data, len, &tid);
+
+  if (mi_attr) {
+    /* A nonce this server issued to this source address is what proves the
+     * source return-routable, and it is a strict prerequisite for any
+     * successful authentication - so a flood carrying a forged
+     * MESSAGE-INTEGRITY gets no session here either. Every rejection ahead of
+     * the credential lookup is decided by the request bytes alone; the checks
+     * below follow check_stun_auth()'s order exactly. */
+    char realm[STUN_MAX_REALM_SIZE + 1] = {0};
+    char usname[STUN_MAX_USERNAME_SIZE + 1] = {0};
+    char client_nonce[STUN_MAX_NONCE_SIZE + 1] = {0};
+
+    if (!udp_get_string_attr(data, len, STUN_ATTRIBUTE_REALM, realm, sizeof(realm)) ||
+        !is_secure_string((const uint8_t *)realm, 0)) {
+      udp_send_stateless_error(server, nd, method, &tid, 400, NULL, NULL, NULL, enforce_fingerprints);
+      return true;
+    }
+
+    if (strcmp(realm, realm_options.name)) {
+      if (method == STUN_METHOD_ALLOCATE) {
+        udp_send_stateless_error(
+            server, nd, method, &tid, 437,
+            (const uint8_t *)"Allocation mismatch: wrong credentials: the realm value is incorrect", NULL, NULL,
+            enforce_fingerprints);
+      } else {
+        udp_send_stateless_error(server, nd, method, &tid, 441,
+                                 (const uint8_t *)"Wrong credentials: the realm value is incorrect", NULL, NULL,
+                                 enforce_fingerprints);
+      }
+      return true;
+    }
+
+    if (!udp_get_string_attr(data, len, STUN_ATTRIBUTE_USERNAME, usname, sizeof(usname)) ||
+        !is_secure_string((const uint8_t *)usname, 1)) {
+      udp_send_stateless_error(server, nd, method, &tid, 400, NULL, NULL, NULL, enforce_fingerprints);
+      return true;
+    }
+
+    if (!udp_get_string_attr(data, len, STUN_ATTRIBUTE_NONCE, client_nonce, sizeof(client_nonce))) {
+      udp_send_stateless_error(server, nd, method, &tid, 400, NULL, NULL, NULL, enforce_fingerprints);
+      return true;
+    }
+
+    if (turn_check_stateless_nonce(ts->stateless_nonce_key, ts->stateless_nonce_key_size, &(nd->src_addr),
+                                   (uint32_t)turn_time(), turn_server_stateless_nonce_lifetime(ts), client_nonce,
+                                   NULL)) {
+      /* The source is proven return-routable and the credentials now have to be
+       * looked up, possibly asynchronously - that needs a session. */
+      return false;
+    }
+  }
+
   char nonce[TURN_STATELESS_NONCE_SIZE] = {0};
   if (!turn_generate_stateless_nonce(ts->stateless_nonce_key, ts->stateless_nonce_key_size, &(nd->src_addr),
                                      (uint32_t)turn_time(), nonce, sizeof(nonce))) {
     return false;
+  }
+
+  if (mi_attr) {
+    /* "Wrong nonce": the same challenge attributes as the 401 path, but no rate
+     * limit and no unauthenticated-401 accounting - check_stun_auth() applies
+     * neither to a 438. */
+    udp_send_stateless_error(server, nd, method, &tid, 438, (const uint8_t *)"Wrong nonce", nonce, realm_options.name,
+                             enforce_fingerprints);
+    return true;
   }
 
   if (ts->unauthenticated_401_request_cb) {
@@ -756,37 +881,6 @@ static bool udp_stateless_nonce_fast_path(dtls_listener_relay_server_type *serve
                   "401 rate-limit bucket collision from %s, sharing active bucket budget for this window\n", raddr);
   }
 
-  stun_tid tid;
-  stun_tid_from_message_str(data, len, &tid);
-
-  ioa_network_buffer_handle nbh = ioa_network_buffer_allocate(server->e);
-  size_t rlen = ioa_network_buffer_get_size(nbh);
-  stun_init_error_response_str(method, ioa_network_buffer_data(nbh), &rlen, 401, NULL, &tid, ts->include_reason_string);
-  stun_attr_add_str(ioa_network_buffer_data(nbh), &rlen, STUN_ATTRIBUTE_NONCE, (const uint8_t *)nonce,
-                    (int)strlen(nonce));
-  stun_attr_add_str(ioa_network_buffer_data(nbh), &rlen, STUN_ATTRIBUTE_REALM, (const uint8_t *)realm_options.name,
-                    (int)strlen(realm_options.name));
-  if (ts->oauth) {
-    const char *server_name = ts->oauth_server_name;
-    if (!(server_name && server_name[0])) {
-      server_name = realm_options.name;
-    }
-    stun_attr_add_str(ioa_network_buffer_data(nbh), &rlen, STUN_ATTRIBUTE_THIRD_PARTY_AUTHORIZATION,
-                      (const uint8_t *)server_name, strlen(server_name));
-  }
-  if (ts->software_attribute) {
-    const char *software = get_version(ts);
-    stun_attr_add_str(ioa_network_buffer_data(nbh), &rlen, STUN_ATTRIBUTE_SOFTWARE, (const uint8_t *)software,
-                      strlen(software));
-  }
-  if (ts->fingerprint || enforce_fingerprints) {
-    if (!stun_attr_add_fingerprint_str(ioa_network_buffer_data(nbh), &rlen)) {
-      ioa_network_buffer_delete(server->e, nbh);
-      return true;
-    }
-  }
-  ioa_network_buffer_set_size(nbh, rlen);
-
   if (ts->unauthenticated_401_response_cb) {
     ts->unauthenticated_401_response_cb();
   }
@@ -800,8 +894,7 @@ static bool udp_stateless_nonce_fast_path(dtls_listener_relay_server_type *serve
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "stateless-nonce: listener fast-path challenge active\n");
   }
 
-  udp_send_message(server, nbh, &(nd->src_addr));
-  ioa_network_buffer_delete(server->e, nbh);
+  udp_send_stateless_error(server, nd, method, &tid, 401, NULL, nonce, realm_options.name, enforce_fingerprints);
 
   return true;
 }

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -614,6 +614,41 @@ static bool udp_get_string_attr(const uint8_t *data, size_t len, uint16_t attr_t
   return true;
 }
 
+/* Charge one unauthenticated reply to this source's --unauthorized-ratelimit
+ * budget - the same bucket the 401 challenge uses, since every reply to an
+ * unverified source is a reflection surface whatever its error code. Returns
+ * true when the caller must stay silent. */
+static bool udp_unauthenticated_reply_ratelimited(dtls_listener_relay_server_type *server, const ioa_addr *src,
+                                                  int err_code) {
+  turn_turnserver *ts = server->ts;
+
+  if (!ts->ratelimit_unauthorized_requests || !*(ts->ratelimit_unauthorized_requests)) {
+    return false;
+  }
+
+  bool first_drop = false;
+  bool first_collision = false;
+  const bool over = ratelimit_consume_address(src, (uint32_t) * (ts->ratelimit_unauthorized_requests_per_sec),
+                                              &first_drop, &first_collision);
+
+  if (first_collision) {
+    char raddr[INET6_ADDRSTRLEN + 1] = {0};
+    addr_to_string_no_port(src, raddr);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
+                  "401 rate-limit bucket collision from %s, sharing active bucket budget for this window\n", raddr);
+  }
+  if (over && first_drop) {
+    char raddr[INET6_ADDRSTRLEN + 1] = {0};
+    addr_to_string_no_port(src, raddr);
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO,
+                  "unauthorized-response rate-limit exceeded from %s (error %d), suppressing responses for this "
+                  "window\n",
+                  raddr, err_code);
+  }
+
+  return over;
+}
+
 /* Emit the reply handle_turn_command would build for a brand-new session: the
  * error response, the challenge attributes when `nonce` is given (as
  * create_challenge_response does), then SOFTWARE and FINGERPRINT. */
@@ -799,59 +834,61 @@ static bool udp_stateless_nonce_fast_path(dtls_listener_relay_server_type *serve
     char usname[STUN_MAX_USERNAME_SIZE + 1] = {0};
     char client_nonce[STUN_MAX_NONCE_SIZE + 1] = {0};
 
+    int err_code = 400;
+    const uint8_t *reason = NULL;
+    bool challenge = false;
+
     if (!udp_get_string_attr(data, len, STUN_ATTRIBUTE_REALM, realm, sizeof(realm)) ||
         !is_secure_string((const uint8_t *)realm, 0)) {
-      udp_send_stateless_error(server, nd, method, &tid, 400, NULL, NULL, NULL, enforce_fingerprints);
-      return true;
-    }
-
-    if (strcmp(realm, realm_options.name)) {
+      ;
+    } else if (strcmp(realm, realm_options.name)) {
       if (method == STUN_METHOD_ALLOCATE) {
-        udp_send_stateless_error(
-            server, nd, method, &tid, 437,
-            (const uint8_t *)"Allocation mismatch: wrong credentials: the realm value is incorrect", NULL, NULL,
-            enforce_fingerprints);
+        err_code = 437;
+        reason = (const uint8_t *)"Allocation mismatch: wrong credentials: the realm value is incorrect";
       } else {
-        udp_send_stateless_error(server, nd, method, &tid, 441,
-                                 (const uint8_t *)"Wrong credentials: the realm value is incorrect", NULL, NULL,
-                                 enforce_fingerprints);
+        err_code = 441;
+        reason = (const uint8_t *)"Wrong credentials: the realm value is incorrect";
       }
-      return true;
-    }
-
-    if (!udp_get_string_attr(data, len, STUN_ATTRIBUTE_USERNAME, usname, sizeof(usname)) ||
-        !is_secure_string((const uint8_t *)usname, 1)) {
-      udp_send_stateless_error(server, nd, method, &tid, 400, NULL, NULL, NULL, enforce_fingerprints);
-      return true;
-    }
-
-    if (!udp_get_string_attr(data, len, STUN_ATTRIBUTE_NONCE, client_nonce, sizeof(client_nonce))) {
-      udp_send_stateless_error(server, nd, method, &tid, 400, NULL, NULL, NULL, enforce_fingerprints);
-      return true;
-    }
-
-    if (turn_check_stateless_nonce(ts->stateless_nonce_key, ts->stateless_nonce_key_size, &(nd->src_addr),
-                                   (uint32_t)turn_time(), turn_server_stateless_nonce_lifetime(ts), client_nonce,
-                                   NULL)) {
+    } else if (!udp_get_string_attr(data, len, STUN_ATTRIBUTE_USERNAME, usname, sizeof(usname)) ||
+               !is_secure_string((const uint8_t *)usname, 1)) {
+      ;
+    } else if (!udp_get_string_attr(data, len, STUN_ATTRIBUTE_NONCE, client_nonce, sizeof(client_nonce))) {
+      ;
+    } else if (turn_check_stateless_nonce(ts->stateless_nonce_key, ts->stateless_nonce_key_size, &(nd->src_addr),
+                                          (uint32_t)turn_time(), turn_server_stateless_nonce_lifetime(ts), client_nonce,
+                                          NULL)) {
       /* The source is proven return-routable and the credentials now have to be
        * looked up, possibly asynchronously - that needs a session. */
       return false;
+    } else {
+      err_code = 438;
+      reason = (const uint8_t *)"Wrong nonce";
+      challenge = true;
     }
+
+    /* These replies go to an unverified source, so they share the 401's
+     * per-source budget: a real client needs one 438 to re-authenticate after
+     * its nonce expires, a spoofed flood gets one per window. */
+    if (udp_unauthenticated_reply_ratelimited(server, &(nd->src_addr), err_code)) {
+      return true;
+    }
+
+    char fresh_nonce[TURN_STATELESS_NONCE_SIZE] = {0};
+    if (challenge &&
+        !turn_generate_stateless_nonce(ts->stateless_nonce_key, ts->stateless_nonce_key_size, &(nd->src_addr),
+                                       (uint32_t)turn_time(), fresh_nonce, sizeof(fresh_nonce))) {
+      return false;
+    }
+
+    udp_send_stateless_error(server, nd, method, &tid, err_code, reason, challenge ? fresh_nonce : NULL,
+                             realm_options.name, enforce_fingerprints);
+    return true;
   }
 
   char nonce[TURN_STATELESS_NONCE_SIZE] = {0};
   if (!turn_generate_stateless_nonce(ts->stateless_nonce_key, ts->stateless_nonce_key_size, &(nd->src_addr),
                                      (uint32_t)turn_time(), nonce, sizeof(nonce))) {
     return false;
-  }
-
-  if (mi_attr) {
-    /* "Wrong nonce": the same challenge attributes as the 401 path, but no rate
-     * limit and no unauthenticated-401 accounting - check_stun_auth() applies
-     * neither to a 438. */
-    udp_send_stateless_error(server, nd, method, &tid, 438, (const uint8_t *)"Wrong nonce", nonce, realm_options.name,
-                             enforce_fingerprints);
-    return true;
   }
 
   if (ts->unauthenticated_401_request_cb) {


### PR DESCRIPTION
What — the fast path fell through on the mere presence of MESSAGE-INTEGRITY, so 20 garbage bytes put a spoofed flood back on the session-creating path. Framed honestly as ~19 KB of alloc+zeroing per ~100-byte packet rather than an OOM, since close_after_auth_challenge already bounded steady-state memory. Headline number: 200 forged-MI packets → 200 sessions before, 0 after, all still answered.
How, part 1 — nonce validated in the listener; 400 / 437 / 441 / 438 answered there in check_stun_auth's order; wrong-length MI treated as missing; a verifying nonce still falls through because the credential lookup can be async. Plus the --stun-only side improvement.
How, part 2 — rejections charged to the existing --unauthorized-ratelimit bucket, with the reasoning for not dropping them: RFC 8489 §9.2.5 needs the 438 for stale-nonce recovery, and after part 1 that legitimate retry lands on this very path. Includes the amplification measurements (438 under 1:1 vs 401 at 3.6–5.4:1) to explain why this caps a vector rather than closing an amplification hole.
Wire compatibility — nine shapes dumped attribute-by-attribute against a pre-change build, identical.
Tests — the new probe script and its assertions, the two rate-limit cases, and the full green matrix including fuzz smoke and the Docker image Bats run.