### PR TITLE
Start the DTLS listeners only when --dtls is given

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -67,6 +67,8 @@ jobs:
         working-directory: examples/
       - run: ./run_tests_conf.sh
         working-directory: examples/
+      - run: ./run_tests_dtls_default.sh
+        working-directory: examples/
       - run: ./run_tests_mobile.sh
         working-directory: examples/
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,5 +46,7 @@ jobs:
         working-directory: examples/
       - run: ./run_tests_conf.sh
         working-directory: examples/
+      - run: ./run_tests_dtls_default.sh
+        working-directory: examples/
       - run: ./run_tests_mobile.sh
         working-directory: examples/

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,6 +67,8 @@ jobs:
         working-directory: examples/
       - run: ./run_tests_conf.sh
         working-directory: examples/
+      - run: ./run_tests_dtls_default.sh
+        working-directory: examples/
       - run: ./run_tests_mobile.sh
         working-directory: examples/
       - run: ./run_tests_prom.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,6 +48,8 @@ jobs:
         working-directory: examples/
       - run: ./run_tests_conf.sh
         working-directory: examples/
+      - run: ./run_tests_dtls_default.sh
+        working-directory: examples/
 
   build-cmake:
     name: build + test cmake
@@ -82,4 +84,6 @@ jobs:
       - run: ./run_tests.sh
         working-directory: examples/
       - run: ./run_tests_conf.sh
+        working-directory: examples/
+      - run: ./run_tests_dtls_default.sh
         working-directory: examples/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,10 @@ cd examples
                                 # UDP/TCP (+TLS/DTLS on Linux), asserting
                                 # wire-transparency plus the listener
                                 # fast-path marker in the server log.
+./run_tests_dtls_default.sh     # pins that the DTLS listeners stay down
+                                # unless --dtls is given, that --dtls brings
+                                # them up, and that the deprecated --no-dtls /
+                                # --no-dtls=false still work and warn.
 ./run_tests_prom.sh             # only when Prometheus support is built
 cd ..
 
@@ -130,7 +134,8 @@ docker run --rm \
        rm -rf build && ln -s build-linux build && \
        cd examples && ./run_tests.sh && ./run_tests_conf.sh && \
        ./run_tests_mobile.sh && ./run_tests_multiplex_peer.sh && \
-       ./run_tests_rfc5780.sh && ./run_tests_stateless_nonce.sh'
+       ./run_tests_rfc5780.sh && ./run_tests_stateless_nonce.sh && \
+       ./run_tests_dtls_default.sh'
 ```
 
 Also validate the packaged Docker image. Run the same stale-output cleanup at

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The implementation fully supports the following client-to-TURN-server protocols:
   * UDP (per [RFC 5766](https://datatracker.ietf.org/doc/html/rfc5766))
   * TCP (per [RFC 5766](https://datatracker.ietf.org/doc/html/rfc5766) and [RFC 6062](https://datatracker.ietf.org/doc/html/rfc6062))
   * TLS (per [RFC 5766](https://datatracker.ietf.org/doc/html/rfc5766) and [RFC 6062](https://datatracker.ietf.org/doc/html/rfc6062)): including TLS1.3; ECDHE is supported.
-  * DTLS1.0 and DTLS1.2 (per [RFC 7350](https://datatracker.ietf.org/doc/html/rfc7350))
+  * DTLS1.0 and DTLS1.2 (per [RFC 7350](https://datatracker.ietf.org/doc/html/rfc7350)): the DTLS listeners are not started unless `--dtls` is given.
   * SCTP (experimental implementation).
 
 Relay protocols:

--- a/README.turnserver
+++ b/README.turnserver
@@ -232,7 +232,10 @@ Flags:
 
 --no-tls		Do not start TLS client listeners.
 
---no-dtls		Do not start DTLS client listeners.
+--dtls			Start DTLS client listeners. DTLS is not started by default.
+
+--no-dtls		Deprecated: DTLS client listeners are not started unless
+			--dtls is given.
 
 --no-udp-relay		Do not allow UDP relay endpoints defined in RFC 5766,
 			use only TCP relay endpoints as defined in RFC 6062.
@@ -543,14 +546,14 @@ Options with values:
 
 --cert			Certificate file, PEM format. Same file
 			search rules applied as for the configuration
-			file. If both --no-tls and --no-dtls options
-			are specified, then this parameter is not needed.
+			file. If --no-tls is specified and --dtls is not,
+			then this parameter is not needed.
 			Default value is turn_server_cert.pem.
 
 --pkey		     	Private key file, PEM format. Same file
 			search rules applied as for the configuration
-			file. If both --no-tls and --no-dtls options
-			are specified, then this parameter is not needed.
+			file. If --no-tls is specified and --dtls is not,
+			then this parameter is not needed.
 			Default value is turn_server_pkey.pem.
 
 --raw-public-keys        Raw public keys support.

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -522,8 +522,12 @@
 #
 #no-tls
 
-# Uncomment if no DTLS client listener is desired.
-# By default DTLS client listener is always started.
+# Uncomment to start the DTLS client listener.
+# By default the DTLS client listener is not started.
+#
+#dtls
+
+# Deprecated: DTLS is not started unless 'dtls' is set above.
 #
 #no-dtls
 

--- a/examples/run_tests.sh
+++ b/examples/run_tests.sh
@@ -52,7 +52,7 @@ echo 'Running turnserver'
 # Both platforms capture the log: macOS used to launch with >/dev/null and
 # a fixed sleep, which raced uclient against a still-initializing server on
 # hosts with many local addresses (relay init runs per address).
-$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --log-file=stdout --simple-log $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
+$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --log-file=stdout --simple-log --dtls $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"
 
 echo 'Running peer client'

--- a/examples/run_tests_conf.sh
+++ b/examples/run_tests_conf.sh
@@ -31,6 +31,7 @@ echo "allow-loopback-peers" >> $BINDIR/turnserver.conf
 if [ $IS_DARWIN -eq 0 ]; then
     echo "sock-buf-size=1048576" >> $BINDIR/turnserver.conf
 fi
+echo "dtls" >> $BINDIR/turnserver.conf
 echo "cert=../examples/ca/turn_server_cert.pem" >> $BINDIR/turnserver.conf
 echo "pkey=../examples/ca/turn_server_pkey.pem" >> $BINDIR/turnserver.conf
 if [ $IS_DARWIN -eq 0 ]; then

--- a/examples/run_tests_dtls_default.sh
+++ b/examples/run_tests_dtls_default.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# DTLS opt-in test.
+#
+# DTLS client listeners are not started unless --dtls is given, even when
+# usable certificates are configured. This suite pins that default and the
+# compatibility handling of the deprecated --no-dtls flag:
+#
+#   default:      no flag, certificates present -> no DTLS listener, a DTLS
+#                 client cannot complete a session, and the log says how to
+#                 turn it on.
+#   --dtls:       DTLS listener up, DTLS client relays end to end.
+#   --no-dtls:    still off, plus the deprecation warning.
+#   --no-dtls=false: on (the old way of asking for DTLS keeps working), plus
+#                 the deprecation warning pointing at --dtls.
+#
+# Ports are offset from the defaults so a concurrent run_tests.sh cannot be
+# mistaken for this suite's server.
+
+DTLS_LOG="/tmp/run_tests_dtls_default.$$.turnserver.log"
+UCLIENT_LOG="/tmp/run_tests_dtls_default.$$.uclient.log"
+PEER_LOG="/tmp/run_tests_dtls_default.$$.peer.log"
+turnserver_pid=""
+peer_pid=""
+
+# turnutils_peer binds PEER_PORT and PEER_PORT+1 (the RTCP sibling), so leave a
+# gap between the two.
+SERVER_PORT=3489
+PEER_PORT=3490
+
+cleanup() {
+    if [ -n "$turnserver_pid" ]; then
+        kill "$turnserver_pid" 2>/dev/null
+        wait "$turnserver_pid" 2>/dev/null
+    fi
+    if [ -n "$peer_pid" ]; then
+        kill "$peer_pid" 2>/dev/null
+        wait "$peer_pid" 2>/dev/null
+    fi
+    rm -f "$DTLS_LOG" "$UCLIENT_LOG" "$PEER_LOG"
+}
+trap cleanup EXIT
+
+# Detect cmake build and adjust path.
+BINDIR="../bin"
+if [ ! -f "$BINDIR/turnserver" ]; then
+    BINDIR="../build/bin"
+fi
+
+wait_for_turnserver() {
+    local i
+    for i in $(seq 1 40); do
+        if grep -q "Total auth threads:" "$DTLS_LOG" 2>/dev/null; then
+            return 0
+        fi
+        if ! kill -0 "$turnserver_pid" 2>/dev/null; then
+            echo "FATAL: turnserver (pid $turnserver_pid) exited before init completed"
+            echo "--- turnserver log ---"
+            cat "$DTLS_LOG" 2>/dev/null || echo "(log file missing)"
+            return 1
+        fi
+        sleep 0.5
+    done
+    echo "FATAL: turnserver never reached 'Total auth threads:' init line within 20s"
+    echo "--- turnserver log (last 30 lines) ---"
+    tail -30 "$DTLS_LOG" 2>/dev/null || echo "(log file missing)"
+    return 1
+}
+
+# Start a fresh turnserver with certificates configured plus whatever DTLS
+# flag the case under test needs.
+start_turnserver() {
+    if [ -n "$turnserver_pid" ]; then
+        kill "$turnserver_pid" 2>/dev/null
+        wait "$turnserver_pid" 2>/dev/null
+        turnserver_pid=""
+    fi
+    : > "$DTLS_LOG"
+    "$BINDIR/turnserver" --use-auth-secret --static-auth-secret=secret --realm=north.gov \
+        --allow-loopback-peers --no-cli \
+        --listening-ip=127.0.0.1 --relay-ip=127.0.0.1 \
+        --listening-port="$SERVER_PORT" \
+        --cert ../examples/ca/turn_server_cert.pem \
+        --pkey ../examples/ca/turn_server_pkey.pem \
+        --log-file=stdout --simple-log \
+        "$@" > "$DTLS_LOG" 2>&1 &
+    turnserver_pid="$!"
+    wait_for_turnserver
+}
+
+# Run a command under a deadline. The negative case below has no server to talk
+# to, so the client would otherwise retry forever. coreutils `timeout` is not on
+# a stock macOS runner, so do the watchdog in bash.
+run_bounded() {
+    local secs="$1"
+    shift
+    "$@" &
+    local cmd_pid="$!"
+    ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null ) &
+    local watchdog_pid="$!"
+    wait "$cmd_pid" 2>/dev/null
+    local rc=$?
+    kill -TERM "$watchdog_pid" 2>/dev/null
+    wait "$watchdog_pid" 2>/dev/null
+    return $rc
+}
+
+# A DTLS relay session (-S over UDP). Returns 0 only when the full 1000-byte
+# round trip completed, which needs a DTLS listener on the other end.
+#
+# The deadline is an argument because the two directions need different ones: a
+# successful session takes about 16s, so the "no listener" case has to wait
+# meaningfully longer than that before concluding nothing happened, while the
+# positive cases only need a ceiling high enough not to cut a slow runner off.
+dtls_client_works() {
+    local deadline="$1"
+    run_bounded "$deadline" "$BINDIR/turnutils_uclient" -S \
+        -e 127.0.0.1 -r "$PEER_PORT" -p "$SERVER_PORT" -X -g \
+        -u user -W secret 127.0.0.1 > "$UCLIENT_LOG" 2>&1
+    grep -q "start_mclient: tot_send_bytes ~ 1000, tot_recv_bytes ~ 1000" "$UCLIENT_LOG"
+}
+
+fail() {
+    echo "FAIL: $1"
+    echo "--- turnserver log (last 40 lines) ---"
+    tail -40 "$DTLS_LOG"
+    echo "--- uclient log (last 20 lines) ---"
+    tail -20 "$UCLIENT_LOG" 2>/dev/null || echo "(no uclient log)"
+    exit 1
+}
+
+echo 'Running peer client'
+"$BINDIR/turnutils_peer" -L 127.0.0.1 -p "$PEER_PORT" > "$PEER_LOG" 2>&1 &
+peer_pid="$!"
+sleep 1
+
+echo "Running DTLS default (no flag)"
+start_turnserver || exit 1
+grep -q "DTLS cipher suite:" "$DTLS_LOG" && fail "DTLS context created without --dtls"
+grep -q "DTLS listeners are not started" "$DTLS_LOG" || fail "missing the hint that --dtls turns DTLS on"
+dtls_client_works 40 && fail "DTLS client completed a session with no --dtls"
+echo OK
+
+echo "Running DTLS enabled (--dtls)"
+start_turnserver --dtls || exit 1
+grep -q "DTLS cipher suite:" "$DTLS_LOG" || fail "no DTLS context with --dtls"
+dtls_client_works 90 || fail "DTLS client could not relay with --dtls"
+echo OK
+
+echo "Running deprecated --no-dtls"
+start_turnserver --no-dtls || exit 1
+grep -q "no-dtls is deprecated" "$DTLS_LOG" || fail "--no-dtls did not warn"
+grep -q "DTLS cipher suite:" "$DTLS_LOG" && fail "--no-dtls started DTLS"
+echo OK
+
+echo "Running deprecated --no-dtls=false"
+start_turnserver --no-dtls=false || exit 1
+grep -q "no-dtls=false is deprecated" "$DTLS_LOG" || fail "--no-dtls=false did not warn"
+grep -q "DTLS cipher suite:" "$DTLS_LOG" || fail "--no-dtls=false did not start DTLS"
+dtls_client_works 90 || fail "DTLS client could not relay with --no-dtls=false"
+echo OK

--- a/examples/run_tests_expiry.sh
+++ b/examples/run_tests_expiry.sh
@@ -58,7 +58,7 @@ echo "Running turnserver (verbose, permission/channel lifetime ${PERM_LIFETIME}s
 # loopback.
 $BINDIR/turnserver --verbose --use-auth-secret --static-auth-secret=secret \
     --realm=north.gov --allow-loopback-peers \
-    --listening-ip=127.0.0.1 --relay-ip=127.0.0.1 --no-dtls --no-tls \
+    --listening-ip=127.0.0.1 --relay-ip=127.0.0.1 --no-tls \
     --permission-lifetime=$PERM_LIFETIME --channel-lifetime=$CHAN_LIFETIME \
     --log-file=stdout --simple-log \
     --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem \

--- a/examples/run_tests_mobility_resume_flood.sh
+++ b/examples/run_tests_mobility_resume_flood.sh
@@ -51,7 +51,7 @@ echo 'Running turnserver (--mobility --user-quota=1)'
 # --user-quota=1 proves the quota does not bound the chain. Long-term
 # credentials (--user) match the raw-STUN client's MD5 key derivation.
 $BINDIR/turnserver --realm="$REALM" --user="$USER:$PASS" --user-quota=1 --mobility \
-    --listening-port="$PORT" --no-tls --no-dtls --no-cli --relay-threads=1 \
+    --listening-port="$PORT" --no-tls --no-cli --relay-threads=1 \
     --verbose --log-file=stdout --simple-log > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"
 

--- a/examples/run_tests_multiplex_peer.sh
+++ b/examples/run_tests_multiplex_peer.sh
@@ -112,6 +112,7 @@ start_turnserver() {
     "${TURNSERVER_EXTRA_ARGS[@]}" \
     "$@" \
     -v \
+    --dtls \
     --cert ca/turn_server_cert.pem \
     --pkey ca/turn_server_pkey.pem \
     --simple-log \

--- a/examples/run_tests_prom.sh
+++ b/examples/run_tests_prom.sh
@@ -22,7 +22,7 @@ turnserver_pid=""
 # and leaving address auto-discovery on makes startup slow and flaky on hosts
 # with tentative/temporary IPv6 addresses (the DTLS/UDP bind retries with
 # sleep(1) until Duplicate Address Detection completes).
-COMMON_ARGS="-L 127.0.0.1 -E 127.0.0.1 --no-tls --no-dtls --log-file=stdout --simple-log"
+COMMON_ARGS="-L 127.0.0.1 -E 127.0.0.1 --no-tls --log-file=stdout --simple-log"
 
 # stop_turnserver: stop the running turnserver and wait for it to exit so its
 # listening ports are released before the next instance binds them. SIGKILL is
@@ -178,7 +178,7 @@ wait_for_prom_decision
 assert_prom_no_response "https://localhost:9641/metrics"
 stop_turnserver
 
-# COMMON_ARGS already supplies -L/-E 127.0.0.1 and --no-tls --no-dtls.
+# COMMON_ARGS already supplies -L/-E 127.0.0.1 and --no-tls.
 echo "Running turnserver with prometheus 401 mitigation counters"
 start_turnserver --prometheus --prometheus-address="127.0.0.1" --prometheus-port="8081" \
   --use-auth-secret --static-auth-secret=secret --realm=north.gov \

--- a/examples/run_tests_ratelimit_401.sh
+++ b/examples/run_tests_ratelimit_401.sh
@@ -83,7 +83,7 @@ run_ratelimit_server() {
     fi
     : > "$RATELIMIT_LOG"
     "$BINDIR/turnserver" --use-auth-secret --static-auth-secret=secret --realm=north.gov \
-        --allow-loopback-peers --no-cli --no-tls --no-dtls \
+        --allow-loopback-peers --no-cli --no-tls \
         --listening-ip=127.0.0.1 --relay-ip=127.0.0.1 \
         --listening-port=3479 \
         --log-file=stdout --simple-log \

--- a/examples/run_tests_rfc5780.sh
+++ b/examples/run_tests_rfc5780.sh
@@ -82,7 +82,7 @@ echo "Running turnserver with RFC 5780 enabled on $PRIMARY_IP + $ALT_IP"
 $BINDIR/turnserver \
     --use-auth-secret --static-auth-secret=secret --realm=north.gov \
     --allow-loopback-peers --rfc5780 \
-    --no-cli --no-tls --no-dtls \
+    --no-cli --no-tls \
     --listening-ip=$PRIMARY_IP --listening-ip=$ALT_IP \
     --min-port=49152 --max-port=49300 \
     --log-file=stdout --simple-log > "$TURNSERVER_LOG" 2>&1 &

--- a/examples/run_tests_stateless_binding.sh
+++ b/examples/run_tests_stateless_binding.sh
@@ -66,7 +66,7 @@ run_server() {
     fi
     : > "$TURNSERVER_LOG"
     "$BINDIR/turnserver" --use-auth-secret --static-auth-secret=secret --realm=north.gov \
-        --allow-loopback-peers --no-cli --no-tls --no-dtls \
+        --allow-loopback-peers --no-cli --no-tls \
         --listening-ip=127.0.0.1 --relay-ip=127.0.0.1 \
         --listening-port=$PORT \
         --log-file=stdout --simple-log \

--- a/examples/run_tests_stateless_nonce.sh
+++ b/examples/run_tests_stateless_nonce.sh
@@ -49,7 +49,7 @@ if [ "$(uname -s)" = "Linux" ]; then
 fi
 
 echo 'Running turnserver (--stateless-nonce-secret)'
-$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --stateless-nonce-secret=fleet-nonce-secret --log-file=stdout --simple-log $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
+$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --stateless-nonce-secret=fleet-nonce-secret --log-file=stdout --simple-log --dtls $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"
 
 echo 'Running peer client'

--- a/examples/scripts/basic/relay.sh
+++ b/examples/scripts/basic/relay.sh
@@ -10,7 +10,7 @@
 # use fingerprints (-f)
 # use 3 relay threads (-m 3)
 # use min UDP relay port 32355 and max UDP relay port 65535
-# --no-tls and --no-dtls mean that we are not trying to
+# --no-tls means that we are not trying to
 # --no-auth means that no authentication to be used, 
 # allow anonymous users. 
 # start TLS and DTLS services.
@@ -24,4 +24,4 @@ fi
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/:/usr/local/mysql/lib/
 export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:/usr/local/lib/:/usr/local/mysql/lib/
 
-PATH="bin:../bin:../../bin:${PATH}" turnserver -v --syslog -L 127.0.0.1 -L ::1 -E 127.0.0.1 -E ::1 --allow-loopback-peers --cli-password secred --max-bps=3000000 -f -m 3 --min-port=32355 --max-port=65535 --no-tls --no-dtls --no-auth --db="var/db/turndb" $@
+PATH="bin:../bin:../../bin:${PATH}" turnserver -v --syslog -L 127.0.0.1 -L ::1 -E 127.0.0.1 -E ::1 --allow-loopback-peers --cli-password secred --max-bps=3000000 -f -m 3 --min-port=32355 --max-port=65535 --no-tls --no-auth --db="var/db/turndb" $@

--- a/examples/scripts/loadbalance/master_relay.sh
+++ b/examples/scripts/loadbalance/master_relay.sh
@@ -22,7 +22,7 @@
 # 7) "--user=gorst:hero" means "allow user 'gorst' with password 'hero' ". 
 # 8) "--log-file=stdout" means that all log output will go to the stdout. 
 # 9) "-v" means normal verbose mode (with some moderate logging).
-# 10) --no-dtls and --no-tls measn that we are not using DTLS & TLS protocols here 
+# 10) --no-tls means that we are not using the TLS protocol here
 # (for the sake of simplicity).
 # 11) --alternate-server options set the "slave" servers.
 # 12) --cli-password=secret means that cli password set to "secret"
@@ -35,5 +35,5 @@ fi
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/:/usr/local/mysql/lib/
 export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:/usr/local/lib/:/usr/local/mysql/lib/
 
-PATH="./bin/:../bin/:../../bin/:${PATH}" turnserver --syslog -a -L 127.0.0.1 -E 127.0.0.1 --allow-loopback-peers --max-bps=3000000 -f -m 3 --min-port=32355 --max-port=65535 --user=ninefingers:0xbc807ee29df3c9ffa736523fb2c4e8ee --user=gorst:hero -r north.gov --log-file=stdout -v --no-dtls --no-tls --alternate-server=127.0.0.1:3333 --alternate-server=127.0.0.1:4444 --cli-password=secret $@
+PATH="./bin/:../bin/:../../bin/:${PATH}" turnserver --syslog -a -L 127.0.0.1 -E 127.0.0.1 --allow-loopback-peers --max-bps=3000000 -f -m 3 --min-port=32355 --max-port=65535 --user=ninefingers:0xbc807ee29df3c9ffa736523fb2c4e8ee --user=gorst:hero -r north.gov --log-file=stdout -v --no-tls --alternate-server=127.0.0.1:3333 --alternate-server=127.0.0.1:4444 --cli-password=secret $@
  

--- a/examples/scripts/loadbalance/slave_relay_1.sh
+++ b/examples/scripts/loadbalance/slave_relay_1.sh
@@ -22,7 +22,7 @@
 # 7) "--user=gorst:hero" means "allow user 'gorst' with password 'hero' ". 
 # 8) "--log-file=stdout" means that all log output will go to the stdout. 
 # 9) "-v" means normal verbose mode (with some moderate logging).
-# 10) --no-dtls and --no-tls measn that we are not using DTLS & TLS protocols here 
+# 10) --no-tls means that we are not using the TLS protocol here
 # (for the sake of simplicity).
 # 11) -p 3333 means that we are using UDP & TCP listening port 3333.
 # 12) --cli-password=secret means that cli password set to "secret"
@@ -35,4 +35,4 @@ fi
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/:/usr/local/mysql/lib/
 export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:/usr/local/lib/:/usr/local/mysql/lib/
 
-PATH="./bin/:../bin/:../../bin/:${PATH}" turnserver --syslog -a -L 127.0.0.1 -E 127.0.0.1 --allow-loopback-peers --max-bps=3000000 -f -m 3 --min-port=10000 --max-port=19999 --user=ninefingers:0xbc807ee29df3c9ffa736523fb2c4e8ee --user=gorst:hero -r north.gov --log-file=stdout -v --no-dtls --no-tls -p 3333 --cli-port=5767 --cli-password=secret $@
+PATH="./bin/:../bin/:../../bin/:${PATH}" turnserver --syslog -a -L 127.0.0.1 -E 127.0.0.1 --allow-loopback-peers --max-bps=3000000 -f -m 3 --min-port=10000 --max-port=19999 --user=ninefingers:0xbc807ee29df3c9ffa736523fb2c4e8ee --user=gorst:hero -r north.gov --log-file=stdout -v --no-tls -p 3333 --cli-port=5767 --cli-password=secret $@

--- a/examples/scripts/loadbalance/slave_relay_2.sh
+++ b/examples/scripts/loadbalance/slave_relay_2.sh
@@ -22,7 +22,7 @@
 # 7) "--user=gorst:hero" means "allow user 'gorst' with password 'hero' ". 
 # 8) "--log-file=stdout" means that all log output will go to the stdout. 
 # 9) "-v" means normal verbose mode (with some moderate logging).
-# 10) --no-dtls and --no-tls measn that we are not using DTLS & TLS protocols here 
+# 10) --no-tls means that we are not using the TLS protocol here
 # (for the sake of simplicity).
 # 11) -p 4444 means that we are using UDP & TCP listening port 4444.
 # 12) --cli-password=secret means that cli password set to "secret"
@@ -35,4 +35,4 @@ fi
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib/:/usr/local/mysql/lib/
 export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:/usr/local/lib/:/usr/local/mysql/lib/
 
-PATH="./bin/:../bin/:../../bin/:${PATH}" turnserver --syslog -a -L 127.0.0.1 -E 127.0.0.1 --allow-loopback-peers --max-bps=3000000 -f -m 3 --min-port=20000 --max-port=29999 --user=ninefingers:0xbc807ee29df3c9ffa736523fb2c4e8ee --user=gorst:hero -r north.gov --log-file=stdout -v --no-dtls --no-tls -p 4444 --cli-port=5768 --cli-password=secret $@
+PATH="./bin/:../bin/:../../bin/:${PATH}" turnserver --syslog -a -L 127.0.0.1 -E 127.0.0.1 --allow-loopback-peers --max-bps=3000000 -f -m 3 --min-port=20000 --max-port=29999 --user=ninefingers:0xbc807ee29df3c9ffa736523fb2c4e8ee --user=gorst:hero -r north.gov --log-file=stdout -v --no-tls -p 4444 --cli-port=5768 --cli-password=secret $@

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -1058,7 +1058,7 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
     chs = NULL;
 
 #if DTLS_SUPPORTED
-    if (!turn_params.no_dtls && (packet_type == UDP_PACKET_CLASS_DTLS_HANDSHAKE)) {
+    if (turn_params.dtls && (packet_type == UDP_PACKET_CLASS_DTLS_HANDSHAKE)) {
       chs = dtls_server_input_handler(server, s, sm->m.sm.nd.nbh);
       ioa_network_buffer_delete(server->e, sm->m.sm.nd.nbh);
       sm->m.sm.nd.nbh = NULL;
@@ -1069,7 +1069,7 @@ static int handle_udp_packet(dtls_listener_relay_server_type *server, struct mes
          * plain-UDP socket + session (GHSA-5x2p-4vqj-f6m4). */
         return 0;
       }
-    } else if (!turn_params.no_dtls && (packet_type == UDP_PACKET_CLASS_DTLS_OTHER)) {
+    } else if (turn_params.dtls && (packet_type == UDP_PACKET_CLASS_DTLS_OTHER)) {
       /* A non-handshake DTLS record (ApplicationData / Alert /
        * ChangeCipherSpec) from a source with no established DTLS session - the
        * per-source lookup at the top of this function already missed, so there
@@ -1190,10 +1190,10 @@ static udp_packet_classification_t classify_udp_packet(const uint8_t *data, size
     return UDP_PACKET_CLASS_STUN_OR_CHANNEL;
   }
 #if DTLS_SUPPORTED
-  if (!turn_params.no_dtls && is_dtls_handshake_message(data, (int)blen)) {
+  if (turn_params.dtls && is_dtls_handshake_message(data, (int)blen)) {
     return UDP_PACKET_CLASS_DTLS_HANDSHAKE;
   }
-  if (!turn_params.no_dtls && is_dtls_message(data, (int)blen)) {
+  if (turn_params.dtls && is_dtls_message(data, (int)blen)) {
     return UDP_PACKET_CLASS_DTLS_OTHER;
   }
 #endif
@@ -1339,8 +1339,8 @@ static int create_new_connected_udp_socket(dtls_listener_relay_server_type *serv
   ret->default_tos = s->default_tos;
 
 #if DTLS_SUPPORTED
-  if (!turn_params.no_dtls && is_dtls_handshake_message(ioa_network_buffer_data(server->sm.m.sm.nd.nbh),
-                                                        (int)ioa_network_buffer_get_size(server->sm.m.sm.nd.nbh))) {
+  if (turn_params.dtls && is_dtls_handshake_message(ioa_network_buffer_data(server->sm.m.sm.nd.nbh),
+                                                    (int)ioa_network_buffer_get_size(server->sm.m.sm.nd.nbh))) {
 
     SSL *connecting_ssl = NULL;
 
@@ -1659,9 +1659,9 @@ static int create_server_socket(dtls_listener_relay_server_type *server, int rep
   }
 
   if (report_creation) {
-    if (!turn_params.no_udp && !turn_params.no_dtls) {
+    if (!turn_params.no_udp && turn_params.dtls) {
       addr_debug_print(server->verbose, &server->addr, "DTLS/UDP listener opened on");
-    } else if (!turn_params.no_dtls) {
+    } else if (turn_params.dtls) {
       addr_debug_print(server->verbose, &server->addr, "DTLS listener opened on");
     } else if (!turn_params.no_udp) {
       addr_debug_print(server->verbose, &server->addr, "UDP listener opened on");
@@ -1727,9 +1727,9 @@ static int reopen_server_socket(dtls_listener_relay_server_type *server, evutil_
     event_add(server->udp_listen_ev, NULL);
   }
 
-  if (!turn_params.no_udp && !turn_params.no_dtls) {
+  if (!turn_params.no_udp && turn_params.dtls) {
     addr_debug_print(server->verbose, &server->addr, "DTLS/UDP listener opened on ");
-  } else if (!turn_params.no_dtls) {
+  } else if (turn_params.dtls) {
     addr_debug_print(server->verbose, &server->addr, "DTLS listener opened on ");
   } else if (!turn_params.no_udp) {
     addr_debug_print(server->verbose, &server->addr, "UDP listener opened on ");

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -116,12 +116,8 @@ turn_params_t turn_params = {
 #else
     false,
 #endif
-/*no_dtls*/
-#if !DTLS_SUPPORTED
-    true,
-#else
+    /* dtls: the DTLS listeners are opt-in, enabled with --dtls. */
     false,
-#endif
 
     NULL,      /*tls_ctx_update_ev*/
     {0, NULL}, /*tls_mutex*/
@@ -1219,11 +1215,12 @@ static char Usage[] =
     "command line only.\n"
     " --cert			<filename>		Certificate file, PEM format. Same file search rules\n"
     "						applied as for the configuration file.\n"
-    "						If both --no-tls and --no_dtls options\n"
-    "						are specified, then this parameter is not needed.\n"
+    "						If --no-tls is specified and --dtls is not,\n"
+    "						then this parameter is not needed.\n"
     " --pkey			<filename>		Private key file, PEM format. Same file search rules\n"
     "						applied as for the configuration file.\n"
-    "						If both --no-tls and --no-dtls options\n"
+    "						If --no-tls is specified and --dtls is not,\n"
+    "						then this parameter is not needed.\n"
     " --pkey-pwd		<password>		If the private key file is encrypted, then this password to be "
     "used.\n"
     " --cipher-list		<cipher-string>		Allowed OpenSSL cipher list for TLS/DTLS connections.\n"
@@ -1254,7 +1251,9 @@ static char Usage[] =
     " --no-udp					Do not start UDP client listeners.\n"
     " --no-tcp					Do not start TCP client listeners.\n"
     " --no-tls					Do not start TLS client listeners.\n"
-    " --no-dtls					Do not start DTLS client listeners.\n"
+    " --dtls					Start DTLS client listeners. DTLS is not started by default.\n"
+    " --no-dtls					Deprecated: DTLS client listeners are not started unless\n"
+    "						--dtls is given.\n"
     " --no-udp-relay					Do not allow UDP relay endpoints, use only TCP relay option.\n"
     " --no-tcp-relay					Do not allow TCP relay endpoints, use only UDP relay options.\n"
     " -l, --log-file		<filename>		Option to set the full path name of the log file.\n"
@@ -1557,6 +1556,7 @@ enum EXTRA_OPTS {
   NO_TCP_OPT,
   TCP_PROXY_PORT_OPT,
   NO_TLS_OPT,
+  DTLS_OPT,
   NO_DTLS_OPT,
   NO_UDP_RELAY_OPT,
   NO_TCP_RELAY_OPT,
@@ -1753,7 +1753,8 @@ static const struct myoption long_options[] = {
     {"no-udp", optional_argument, NULL, NO_UDP_OPT},
     {"no-tcp", optional_argument, NULL, NO_TCP_OPT},
     {"no-tls", optional_argument, NULL, NO_TLS_OPT},
-    {"no-dtls", optional_argument, NULL, NO_DTLS_OPT},
+    {"dtls", optional_argument, NULL, DTLS_OPT},
+    /* deprecated: */ {"no-dtls", optional_argument, NULL, NO_DTLS_OPT},
     {"no-udp-relay", optional_argument, NULL, NO_UDP_RELAY_OPT},
     {"no-tcp-relay", optional_argument, NULL, NO_TCP_RELAY_OPT},
     {"stale-nonce", optional_argument, NULL, STALE_NONCE_OPT},
@@ -2576,12 +2577,28 @@ static void set_option(int c, char *value) {
     turn_params.no_tls = get_bool_value(value);
 #endif
     break;
+  case DTLS_OPT:
+#if DTLS_SUPPORTED
+    turn_params.dtls = get_bool_value(value);
+#else
+    turn_params.dtls = false;
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "CONFIG: --dtls is ignored: this build has no DTLS support\n");
+#endif
+    break;
   case NO_DTLS_OPT:
 #if DTLS_SUPPORTED
-    turn_params.no_dtls = get_bool_value(value);
+    turn_params.dtls = !get_bool_value(value);
 #else
-    turn_params.no_dtls = true;
+    turn_params.dtls = false;
 #endif
+    if (!turn_params.dtls) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
+                    "CONFIG: --no-dtls is deprecated and now redundant: DTLS listeners are not started unless --dtls "
+                    "is given\n");
+    } else {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING,
+                    "CONFIG: --no-dtls=false is deprecated: use --dtls to start the DTLS listeners\n");
+    }
     break;
   case CERT_FILE_OPT:
     STRCPY(turn_params.cert_file, value);
@@ -3547,7 +3564,7 @@ int main(int argc, char **argv) {
 #endif
 
 #if !DTLS_SUPPORTED
-  turn_params.no_dtls = true;
+  turn_params.dtls = false;
 #endif
 
   if (strstr(argv[0], "turnadmin")) {
@@ -3968,7 +3985,7 @@ static void adjust_key_file_name(char *fn, const char *file_title, int critical)
 keyerr:
   if (critical) {
     turn_params.no_tls = true;
-    turn_params.no_dtls = true;
+    turn_params.dtls = false;
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "cannot start TLS and DTLS listeners because %s file is not set properly\n",
                   file_title);
   }
@@ -4400,25 +4417,25 @@ static void openssl_setup(void) {
   }
 #endif
 
-  if (!(turn_params.no_tls && turn_params.no_dtls) && !turn_params.cert_file[0]) {
+  if ((!turn_params.no_tls || turn_params.dtls) && !turn_params.cert_file[0]) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "\nWARNING: certificate file is not specified, I cannot start TLS/DTLS "
                                           "services.\nOnly 'plain' UDP/TCP listeners can be started.\n");
     turn_params.no_tls = true;
-    turn_params.no_dtls = true;
+    turn_params.dtls = false;
   }
 
-  if (!(turn_params.no_tls && turn_params.no_dtls) && !turn_params.pkey_file[0]) {
+  if ((!turn_params.no_tls || turn_params.dtls) && !turn_params.pkey_file[0]) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "\nWARNING: private key file is not specified, I cannot start TLS/DTLS "
                                           "services.\nOnly 'plain' UDP/TCP listeners can be started.\n");
     turn_params.no_tls = true;
-    turn_params.no_dtls = true;
+    turn_params.dtls = false;
   }
 
-  if (!(turn_params.no_tls && turn_params.no_dtls)) {
+  if (!turn_params.no_tls || turn_params.dtls) {
     adjust_key_file_names();
   }
 
-  if (turn_params.tls_port_configured && turn_params.no_tls && turn_params.no_dtls) {
+  if (turn_params.tls_port_configured && turn_params.no_tls && !turn_params.dtls) {
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR,
                   "tls-listening-port %d is configured, but the TLS and DTLS listeners are disabled "
                   "(see the messages above). The server will NOT listen on that port. Set valid 'cert' and "
@@ -4453,7 +4470,7 @@ static void openssl_load_certificates(void) {
 #endif
   }
 
-  if (!turn_params.no_dtls) {
+  if (turn_params.dtls) {
 #if !DTLS_SUPPORTED
     TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "ERROR: DTLS is not supported.\n");
 #else
@@ -4464,6 +4481,10 @@ static void openssl_load_certificates(void) {
     setup_dtls_callbacks(turn_params.dtls_ctx);
     TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "DTLS cipher suite: %s\n", turn_params.cipher_list);
 #endif
+  } else if (!turn_params.no_tls) {
+    /* The certificates are usable, so the operator may well have expected the
+     * DTLS listeners to come up with the TLS ones. */
+    TURN_LOG_FUNC(TURN_LOG_LEVEL_INFO, "DTLS listeners are not started; use --dtls to start them\n");
   }
   TURN_MUTEX_UNLOCK(&turn_params.tls_mutex);
 }

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -207,7 +207,7 @@ typedef struct _turn_params_ {
   bool enable_tlsv1_1;
   bool no_tlsv1_2;
   bool no_tls;
-  bool no_dtls;
+  bool dtls;
 
   struct event *tls_ctx_update_ev;
   TURN_MUTEX_DECLARE(tls_mutex)

--- a/src/apps/relay/netengine.c
+++ b/src/apps/relay/netengine.c
@@ -1068,7 +1068,7 @@ static void setup_socket_per_thread_udp_listener_servers(void) {
 
     const int index = i;
 
-    if (!turn_params.no_udp || !turn_params.no_dtls) {
+    if (!turn_params.no_udp || turn_params.dtls) {
 
       ioa_addr addr;
       char saddr[MAX_IOA_ADDR_STRING];
@@ -1127,7 +1127,7 @@ static void setup_socket_per_thread_udp_listener_servers(void) {
         turn_params.listener.udp_services[index + 1] = NULL;
       }
     }
-    if (!turn_params.no_dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port))) {
+    if (turn_params.dtls && (turn_params.no_udp || (turn_params.listener_port != turn_params.tls_listener_port))) {
 
       turn_params.listener.dtls_services[index] = (dtls_listener_relay_server_type **)allocate_super_memory_engine(
           turn_params.listener.ioa_eng,

--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -755,7 +755,7 @@ static void cli_print_configuration(struct cli_session *cs) {
 
     cli_print_flag(cs, turn_params.no_udp, "no-udp", 0);
     cli_print_flag(cs, turn_params.no_tcp, "no-tcp", 0);
-    cli_print_flag(cs, turn_params.no_dtls, "no-dtls", 0);
+    cli_print_flag(cs, turn_params.dtls, "dtls", 0);
     cli_print_flag(cs, turn_params.no_tls, "no-tls", 0);
 
     cli_print_flag(cs, (turn_params.enable_tlsv1 && !turn_params.no_tls), "TLSv1.0", 0);
@@ -2173,7 +2173,7 @@ static void write_pc_page(ioa_socket_handle s) {
 
         https_print_flag(sb, turn_params.no_udp, "no-udp", 0);
         https_print_flag(sb, turn_params.no_tcp, "no-tcp", 0);
-        https_print_flag(sb, turn_params.no_dtls, "no-dtls", 0);
+        https_print_flag(sb, turn_params.dtls, "dtls", 0);
         https_print_flag(sb, turn_params.no_tls, "no-tls", 0);
 
         https_print_flag(sb, (!turn_params.no_tlsv1_2 && !turn_params.no_tls), "TLSv1.2", 0);


### PR DESCRIPTION
## What

The DTLS client listeners are no longer started by default. They come up only
when `--dtls` is given.

Until now DTLS came up automatically whenever usable certificates were
configured, so every deployment that wanted TLS also exposed a DTLS handshake
path it had never asked for. That path is the most expensive unauthenticated
entry point the server has: it builds an `SSL` object, an `ioa_socket` and a
session *before* the DTLS cookie is verified. Deployments that do not serve
DTLS clients were paying for that surface silently.

## Compatibility

`--no-dtls` keeps its meaning, including `--no-dtls=false` to ask for DTLS, so
an existing configuration resolves to exactly the listeners it asked for. Both
spellings now log a deprecation warning naming `--dtls`:

```
CONFIG: --no-dtls is deprecated and now redundant: DTLS listeners are not started unless --dtls is given
CONFIG: --no-dtls=false is deprecated: use --dtls to start the DTLS listeners
```

**This is a behaviour change for anyone who relied on the old default.** A
deployment that configured certificates and passed no DTLS flag loses its DTLS
listeners on upgrade. The only signal such an operator gets is a startup line,
emitted when the certificates are usable but DTLS is off:

```
DTLS listeners are not started; use --dtls to start them
```

If the project would rather have a transition release — default unchanged, but
logging that it is about to change — that is a small edit to this branch; say
so in review.

## How

`turn_params` carries the state as `dtls` rather than the previous `no_dtls`,
so the listener and netengine tests read as "DTLS is on" instead of double
negatives, and `openssl_setup()`'s two-flag guards lose their De Morgan
wrapper (`!(no_tls && no_dtls)` becomes `!no_tls || dtls`). The telnet CLI and
web admin listings consequently report `dtls` instead of `no-dtls`, matching
the flag an operator actually sets.

Documentation follows in `README.md`, `README.turnserver`, the built-in help
and `examples/etc/turnserver.conf`. The `--pkey` help entry had a sentence
truncated mid-clause; the rewrite fixes it.

## Tests

New `examples/run_tests_dtls_default.sh` pins four cases:

- no flag: no DTLS context, the hint line is logged, and a `turnutils_uclient -S`
  session cannot complete;
- `--dtls`: context created, DTLS client relays end to end;
- `--no-dtls`: warns, stays off;
- `--no-dtls=false`: warns, starts DTLS, client relays.

It is wired into all four workflows, so this default is now covered on both
Linux and macOS. Example scripts that only ever wanted DTLS off drop the
now-redundant flag; the ones that drive DTLS clients pass `--dtls`.

Also run green: `ctest` (18/18 macOS, 17/17 Linux) and, on both platforms where
applicable, `run_tests.sh`, `run_tests_conf.sh`, `run_tests_multiplex_peer.sh`,
`run_tests_stateless_nonce.sh`, `run_tests_stateless_binding.sh`,
`run_tests_ratelimit_401.sh`, `run_tests_mobile.sh`, `run_tests_rfc5780.sh`,
`run_tests_expiry.sh`; fuzzing smoke tests (ASan, both targets); and the
packaged Debian image build plus its Bats suite (19 tests, 0 failures,
2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
