### PR TITLE
Do not ask the kernel for an outgoing IP TTL of zero

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -1108,6 +1108,12 @@ static int set_socket_ttl(ioa_socket_handle s, int ttl) {
     ttl = s->default_ttl;
   }
 
+  /* Linux rejects IP_TTL outside 1..255; a relayed packet that arrived with
+   * TTL 1 would otherwise ask for 0. */
+  if (ttl < 1) {
+    ttl = 1;
+  }
+
   if (s->current_ttl != ttl) {
     const int ret = set_raw_socket_ttl(s->fd, s->family, ttl);
     s->current_ttl = ttl;


### PR DESCRIPTION
## Problem

Relaying a packet that arrived with an IP TTL of `1` makes the server log:

```
ERROR: set TTL on socket: Invalid argument
```

The relay copies the inbound TTL onto the outgoing socket, decremented by one. The guards in `ns_turn_server.c` (Send indication, ChannelData, and the peer -> client path) only reject `recv_ttl == 0`, so `recv_ttl == 1` passes through and asks for an outgoing TTL of `0`.

`CORRECT_RAW_TTL` only remaps values `< 0` or `> 255`, and `set_socket_ttl()` only remaps negatives, so `0` reaches `setsockopt()` unchanged. Linux rejects `IP_TTL` outside `1..255` with `EINVAL`:

```
IP_TTL=0 -> ret=-1 errno=22 (Invalid argument)
IP_TTL=1 -> ret=0 errno=0 (ok)
```

macOS and the BSDs accept `0`, which is why this only shows up on Linux deployments. Besides the log noise, the `setsockopt()` failure leaves the socket at its previous TTL, while `s->current_ttl` is updated as though the call had succeeded — so the mismatch persists silently for the life of the socket.

## Fix

Floor the requested TTL at `1` in `set_socket_ttl()`, after the existing `> default_ttl` clamp so a zero `default_ttl` cannot reintroduce the bad value.

The forwarding guard itself is left alone: strictly, a packet whose TTL expires at this hop should be dropped rather than forwarded with TTL 1, but that is a behavior change to the relay path and is out of scope here.

## Testing

- macOS build, `ctest` 18/18, and all six `examples/run_tests*.sh` scripts pass (multiplex-peer and RFC 5780 SKIP on macOS as expected).
- Linux in Docker on a clean checkout: build, `ctest` 17/17, and all six example scripts pass, including the multiplex-peer and RFC 5780 paths that skip on macOS.
- Fuzzing smoke tests (ASan targets 0 and 1) pass.
- Packaged Docker image (`debian`, arm64) builds; Bats image tests 19 tests, 0 failures, 2 skipped.
- `clang-format-15` clean.
