### PR TITLE
Drop --simple-log where it is a no-op alongside --log-file=stdout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,7 +386,7 @@ nohup /root/coturn/build/bin/turnserver \
   --listening-ip=10.116.0.2 --relay-ip=10.116.0.2 \
   --min-port=49152 --max-port=65535 \
   --no-cli --no-tls --no-dtls \
-  --log-file=stdout --simple-log \
+  --log-file=stdout \
   $EXTRA \
   > /root/runs/${LABEL}.turnserver.log 2>&1 &
 echo $! > /root/runs/${LABEL}.pid

--- a/examples/run_tests.sh
+++ b/examples/run_tests.sh
@@ -52,7 +52,7 @@ echo 'Running turnserver'
 # Both platforms capture the log: macOS used to launch with >/dev/null and
 # a fixed sleep, which raced uclient against a still-initializing server on
 # hosts with many local addresses (relay init runs per address).
-$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --log-file=stdout --simple-log --dtls $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
+$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --log-file=stdout --dtls $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"
 
 echo 'Running peer client'

--- a/examples/run_tests_conf.sh
+++ b/examples/run_tests_conf.sh
@@ -39,9 +39,8 @@ if [ $IS_DARWIN -eq 0 ]; then
     # Without this, turnserver writes to its platform-default location
     # (syslog or /var/log/turn_*.log) and our log file stays empty, which
     # breaks wait_for_turnserver's "Total relay threads:" probe and leaves
-    # the FAIL diagnostics useless. simple-log keeps the format compact.
+    # the FAIL diagnostics useless.
     echo "log-file=stdout" >> $BINDIR/turnserver.conf
-    echo "simple-log" >> $BINDIR/turnserver.conf
     # Server-side fast paths: enable on Linux so the conf-driven test
     # cycle also exercises the recvmmsg drain path. The udp-gso path
     # lives behind multiplex-peer (that mode is what enables sendmmsg

--- a/examples/run_tests_dtls_default.sh
+++ b/examples/run_tests_dtls_default.sh
@@ -82,7 +82,7 @@ start_turnserver() {
         --listening-port="$SERVER_PORT" \
         --cert ../examples/ca/turn_server_cert.pem \
         --pkey ../examples/ca/turn_server_pkey.pem \
-        --log-file=stdout --simple-log \
+        --log-file=stdout \
         "$@" > "$DTLS_LOG" 2>&1 &
     turnserver_pid="$!"
     wait_for_turnserver

--- a/examples/run_tests_expiry.sh
+++ b/examples/run_tests_expiry.sh
@@ -60,7 +60,7 @@ $BINDIR/turnserver --verbose --use-auth-secret --static-auth-secret=secret \
     --realm=north.gov --allow-loopback-peers \
     --listening-ip=127.0.0.1 --relay-ip=127.0.0.1 --no-tls \
     --permission-lifetime=$PERM_LIFETIME --channel-lifetime=$CHAN_LIFETIME \
-    --log-file=stdout --simple-log \
+    --log-file=stdout \
     --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem \
     > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"

--- a/examples/run_tests_mobile.sh
+++ b/examples/run_tests_mobile.sh
@@ -56,7 +56,7 @@ fi
 echo 'Running turnserver (--mobility)'
 # Always capture the server log (both platforms): the handoff assertion below
 # greps it for the RFC 8016 dual-5-tuple transition marker.
-$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --mobility --log-file=stdout --simple-log $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
+$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --mobility --log-file=stdout $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"
 
 echo 'Running peer client'

--- a/examples/run_tests_mobility_resume_flood.sh
+++ b/examples/run_tests_mobility_resume_flood.sh
@@ -52,7 +52,7 @@ echo 'Running turnserver (--mobility --user-quota=1)'
 # credentials (--user) match the raw-STUN client's MD5 key derivation.
 $BINDIR/turnserver --realm="$REALM" --user="$USER:$PASS" --user-quota=1 --mobility \
     --listening-port="$PORT" --no-tls --no-cli --relay-threads=1 \
-    --verbose --log-file=stdout --simple-log > "$TURNSERVER_LOG" 2>&1 &
+    --verbose --log-file=stdout > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"
 
 wait_for_turnserver() {

--- a/examples/run_tests_prom.sh
+++ b/examples/run_tests_prom.sh
@@ -22,7 +22,7 @@ turnserver_pid=""
 # and leaving address auto-discovery on makes startup slow and flaky on hosts
 # with tentative/temporary IPv6 addresses (the DTLS/UDP bind retries with
 # sleep(1) until Duplicate Address Detection completes).
-COMMON_ARGS="-L 127.0.0.1 -E 127.0.0.1 --no-tls --log-file=stdout --simple-log"
+COMMON_ARGS="-L 127.0.0.1 -E 127.0.0.1 --no-tls --log-file=stdout"
 
 # stop_turnserver: stop the running turnserver and wait for it to exit so its
 # listening ports are released before the next instance binds them. SIGKILL is

--- a/examples/run_tests_ratelimit_401.sh
+++ b/examples/run_tests_ratelimit_401.sh
@@ -86,7 +86,7 @@ run_ratelimit_server() {
         --allow-loopback-peers --no-cli --no-tls \
         --listening-ip=127.0.0.1 --relay-ip=127.0.0.1 \
         --listening-port=3479 \
-        --log-file=stdout --simple-log \
+        --log-file=stdout \
         "$@" > "$RATELIMIT_LOG" 2>&1 &
     turnserver_pid="$!"
     wait_for_turnserver

--- a/examples/run_tests_rfc5780.sh
+++ b/examples/run_tests_rfc5780.sh
@@ -85,7 +85,7 @@ $BINDIR/turnserver \
     --no-cli --no-tls \
     --listening-ip=$PRIMARY_IP --listening-ip=$ALT_IP \
     --min-port=49152 --max-port=49300 \
-    --log-file=stdout --simple-log > "$TURNSERVER_LOG" 2>&1 &
+    --log-file=stdout > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"
 
 # Poll our uniquely-named log for a known late-startup line instead of racing

--- a/examples/run_tests_stateless_binding.sh
+++ b/examples/run_tests_stateless_binding.sh
@@ -69,7 +69,7 @@ run_server() {
         --allow-loopback-peers --no-cli --no-tls \
         --listening-ip=127.0.0.1 --relay-ip=127.0.0.1 \
         --listening-port=$PORT \
-        --log-file=stdout --simple-log \
+        --log-file=stdout \
         "$@" > "$TURNSERVER_LOG" 2>&1 &
     turnserver_pid="$!"
     wait_for_turnserver

--- a/examples/run_tests_stateless_nonce.sh
+++ b/examples/run_tests_stateless_nonce.sh
@@ -49,7 +49,7 @@ if [ "$(uname -s)" = "Linux" ]; then
 fi
 
 echo 'Running turnserver (--stateless-nonce-secret)'
-$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --stateless-nonce-secret=fleet-nonce-secret --log-file=stdout --simple-log --dtls $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
+$BINDIR/turnserver --use-auth-secret --sock-buf-size=1048576 --static-auth-secret=secret --realm=north.gov --allow-loopback-peers --stateless-nonce-secret=fleet-nonce-secret --log-file=stdout --dtls $TURNSERVER_EXTRA_ARGS --cert ../examples/ca/turn_server_cert.pem --pkey ../examples/ca/turn_server_pkey.pem > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"
 
 echo 'Running peer client'


### PR DESCRIPTION
## What

Removes `--simple-log` from the 11 places it is passed together with `--log-file=stdout`, where it has no effect. Also drops the now-false trailing sentence of the `run_tests_conf.sh` comment.

No behaviour change.

## Why

`--simple-log` only affects two things:

- log-file *naming*, in `set_log_file_name_func` (`src/apps/common/ns_turn_utils.c:357`)
- rollover, in `rollover_logfile` (`src/apps/common/ns_turn_utils.c:546`)

With `--log-file=stdout`, `set_rtpfile` takes the stdout branch at `ns_turn_utils.c:437` and **never populates `log_fn`**. So `set_log_file_name` is never called, and `rollover_logfile` returns immediately at `ns_turn_utils.c:530` on `!log_fn[0]`. The flag is inert.

The comment in `run_tests_conf.sh` claimed "simple-log keeps the format compact", which was wrong twice over: it has no effect there, and it never affected the log *format* in the first place — only file naming and rollover.

## One site deliberately keeps it

`examples/run_tests_multiplex_peer.sh` logs to a real file, not stdout:

```
turnserver_log="$(mktemp "${TMPDIR:-/tmp}/turnserver-multiplex-peer.XXXXXX.log")"
```

and greps that exact path (lines 80, 153, 188). Without `--simple-log`, `set_log_file_name_func` splits at the last `.` and writes `...XXXXXX_<date>.log` instead, so every grep would silently fail. That is the one place the flag is load-bearing.

The commented-out `#simple-log` lines in `examples/etc/turnserver.conf` and `docker/coturn/turnserver.conf` also stay — they document the flag for the file-logging case, which is its actual purpose.

## Verification

Rather than relying on reading the code, the no-op claim was checked directly. Same server invocation, with and without `--simple-log`, both with `--log-file=stdout`:

- 45 log lines each, **byte-identical** after masking the uptime/tid prefix and cwd
- zero files created in either case

## Testing

All `rc=0` with zero `FAIL` lines.

**macOS**: `run_tests`, `_conf`, `_stateless_nonce`, `_mobile`, `_stateless_binding`, `_expiry`, `_ratelimit_401`, `_mobility_resume_flood`, `_prom`, `_dtls_default`, `_rfc5780`, `_multiplex_peer`

**Linux (Docker)**: 17/17 unit tests, plus `run_tests`, `_conf`, `_mobile`, `_multiplex_peer`, `_rfc5780`, `_stateless_nonce`, `_dtls_default`

The Linux pass is the one that matters for `run_tests_conf.sh` — that script only writes `log-file=stdout` on non-Darwin, so the conf edit is only exercised there.

No C/H files touched, so no `clang-format` run was required.

## Context

First of several small changes ahead of work on log formatting for structured-log ingestion (ELK). Splitting the inert-flag cleanup out first so it does not ride along with behavioural changes.
