### PR TITLE
Remove syslog from the Docker Compose turnserver.conf

### DIFF
--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -547,10 +547,6 @@ pkey=/etc/ssl/private/privkey.pem
 #
 #log-file=/var/tmp/turn.log
 
-# Option to redirect all log output into system log (syslog).
-#
-syslog
-
 # Set syslog facility for syslog messages
 # Default values is ''.
 #


### PR DESCRIPTION
## What

Deletes the `syslog` directive and its comment from `docker/coturn/turnserver.conf`.

Four lines removed. No source changes.

## Why

`docker/coturn/turnserver.conf` is bind-mounted at `/etc/turnserver.conf` by all five Compose stacks (`docker-compose-{all,mysql,postgresql,redis,mongodb}.yml`), and `/etc/` is in `config_file_search_dirs` (`src/apps/common/apputils.c:1042`), ahead of `/etc/coturn/` — so it is read. The `coturn` service declares no `command:` or `entrypoint:` override, so the image CMD from `docker/coturn/debian/Dockerfile` applies:

```
CMD ["--log-file=stdout", "--external-ip=$(detect-external-ip)"]
```

The config and the CMD contradict each other, and the config wins. In `set_rtpfile()` (`src/apps/common/ns_turn_utils.c:425`), `to_syslog` is checked **before** the `log-file` handling:

```c
if (to_syslog) {
  return;
} else if (!_rtpfile) {
  ...  /* the --log-file=stdout branch, which sets no_stdout_log = 1 */
```

So `--log-file=stdout` never takes effect and `no_stdout_log` is never set. Log lines then leave through the unconditional `fwrite(s, so_far, 1, stdout)` at `ns_turn_utils.c:642` instead of the `fprintf()` + `fflush()` path at `:658`.

That path **never flushes**. Two consequences:

1. **A stopped container loses its whole log.** stdout to a pipe is fully buffered, and nothing flushes it, so unless enough volume accumulated to force a flush, everything sits in the buffer when the process dies.
2. A `syslog()` call is made per line to a socket the container does not provide.

## Measurement

Against the built image, config mounted exactly as Compose mounts it, DB directives stripped so output is deterministic:

| Config | SIGTERM (`docker stop`) | SIGKILL |
|---|---:|---:|
| `syslog` (current) | **0 lines** | **0 lines** |
| removed (this PR) | 44 lines | 42 lines |

This is the ordinary `docker stop` / `docker compose down` path, not just an abrupt-kill edge case.

## Scope note

This does **not** affect the published `coturn/coturn` image. Both Dockerfiles run `rm -f /out/etc/coturn/turnserver.conf.default` (`debian/Dockerfile:81`, `alpine/Dockerfile:82`) and this file is never `COPY`d in, so the image ships with no config and its CMD already works as intended. The bug is confined to the Compose stacks and to anyone who starts from this file when following the "specify your own configuration file" instructions in `docker/coturn/README.md`.

`#syslog-facility` is left in place — it is already commented out and documents a real option.

## Testing

- Docker image built (`make docker.image dockerfile=debian platform=linux/arm64`) and the Bats suite run: **19 tests, 0 failures, 2 skipped**
- Before/after runs against the built image with the config bind-mounted, under both SIGTERM and SIGKILL — table above
- Confirmed the edited config still parses cleanly and is picked up from `/etc/turnserver.conf` (`Default realm: example.org` comes from it)

## Context

Part of a series of small changes ahead of work on structured log output for ELK ingestion. The `fwrite`-vs-`fprintf` split above is also where the unlocked stdout write lives; that one is a source fix and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)