### PR TITLE
Fix localtime() data race in the logger

### DIFF
--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -318,14 +318,27 @@ static void log_lock(void) {
 
 static void log_unlock(void) { turn_mutex_unlock(&log_mutex); }
 
+/* localtime() returns a pointer to a static struct tm shared by all threads;
+ * every relay thread logs, so use the reentrant form. */
+static struct tm *turn_localtime(const time_t *timep, struct tm *result) {
+#if defined(WINDOWS)
+  return (localtime_s(result, timep) == 0) ? result : NULL;
+#else
+  return localtime_r(timep, result);
+#endif
+}
+
 static void get_date(char *s, size_t sz) {
   time_t curtm;
-  struct tm *tm_info;
+  struct tm tm_info = {0};
 
   curtm = time(NULL);
-  tm_info = localtime(&curtm);
 
-  strftime(s, sz, "%F", tm_info);
+  if (turn_localtime(&curtm, &tm_info)) {
+    strftime(s, sz, "%F", &tm_info);
+  } else if (sz) {
+    s[0] = 0;
+  }
 }
 
 void set_logfile(const char *fn) {
@@ -606,7 +619,10 @@ void turn_log_func_default(const char *const file, const int line, const TURN_LO
   size_t so_far = 0;
   if (use_new_log_timestamp_format) {
     const time_t now = time(NULL);
-    so_far += strftime(s, sizeof(s), turn_log_timestamp_format, localtime(&now));
+    struct tm tm_now = {0};
+    if (turn_localtime(&now, &tm_now)) {
+      so_far += strftime(s, sizeof(s), turn_log_timestamp_format, &tm_now);
+    }
   } else {
     so_far += snprintf(s, sizeof(s), "%lu: ", (unsigned long)log_time());
   }

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -255,9 +255,9 @@ static size_t print_packet_txt2pcap(uint64_t now, uint8_t *payload, size_t paylo
  * across all relay threads. A DTLS ClientHello from a new source makes the
  * listener allocate a per-peer SSL + ioa_socket + ts_ur_super_session before
  * the source has answered the RFC 6347 cookie challenge, so a source-spoofing
- * flood of unanswered ClientHellos would otherwise accumulate unbounded state. 
- * Once the cap is reached, new handshakes are dropped until in-progress ones 
- * finish (freeing their slot) or are reaped by the allocate timeout. 
+ * flood of unanswered ClientHellos would otherwise accumulate unbounded state.
+ * Once the cap is reached, new handshakes are dropped until in-progress ones
+ * finish (freeing their slot) or are reaped by the allocate timeout.
  * Legitimate clients finish the handshake in a few
  * round trips and release their slot immediately, so this only bites under a
  * flood.


### PR DESCRIPTION
## What

Replaces both `localtime()` calls in `src/apps/common/ns_turn_utils.c` with a new `turn_localtime()` helper backed by `localtime_r()` (`localtime_s()` on Windows).

One-function change. No lock added, no behavior change.

## Why

`localtime()` returns a pointer to a `static struct tm` shared by every caller in the process. `turn_log_func_default()` runs from every relay thread on every log call, and `get_date()` runs from the SIGHUP rollover path — so two threads logging concurrently can have one observe a `struct tm` the other is mid-write on, producing a corrupted timestamp.

`turn_localtime()` writes into a caller-owned `struct tm` on the stack instead. Follows the existing `#if defined(WINDOWS)` / POSIX split already used in this tree (e.g. `socket_errno()` in `ns_turn_defs.h:160`) rather than introducing a new pattern.

This does not add contention: glibc takes its internal `tzset` lock in `__tz_convert` for both `localtime()` and `localtime_r()`, so the locking profile is unchanged. What changes is only that the output no longer lands in shared mutable state.

## Dropped from an earlier revision of this PR

An earlier push also took `log_lock()` around the stdout `fwrite()`, on the theory that concurrent writers could tear log lines. **That was wrong and has been removed.**

POSIX requires stdio functions to behave as if they use `flockfile()`/`funlockfile()` internally, so a single `fwrite()` of a complete line is already atomic against other stdio calls on the same stream. Measured with a 16-thread harness writing 200-byte lines:

| | torn lines | wall time |
|---|---:|---:|
| no mutex (glibc) | **0 / 320000** | 0.568s |
| extra mutex (glibc) | 0 / 320000 | 0.630s |

Same result on macOS libc at 8 and 12 threads. The lock bought nothing measurable and cost ~11% on the logging path — and it would have introduced a global mutex acquisition into the `--syslog` path, which previously took no lock at all. Thanks for pushing back on this.

## Known pre-existing contention, not addressed here

Worth recording, since it is the real scaling limit on a many-core box and is untouched by this PR:

- The file-logging path takes the global `log_mutex` **and** `fflush()`es on every single line — one `write()` syscall per log line, fully serialized across all relay threads.
- The `strftime`/`localtime_r` pair runs per line even though the result only changes once per second.

Both are candidates for the `--log-format` work (cache the formatted timestamp per second; reconsider flush-per-line), where the record layout is being reworked anyway.

## Testing

- **macOS**: `ctest` 18/18; `run_tests.sh`, `run_tests_conf.sh` clean
- **Linux (Docker)**: `ctest` 17/17; `run_tests`, `_conf`, `_mobile`, `_multiplex_peer`, `_stateless_nonce` — all `rc=0`, zero `FAIL` lines
- `--new-log-timestamp` manually verified to still emit correct ISO-8601 through the new path
- `clang-format` clean

The race is not exercised deterministically by the suite, so this is a correctness fix validated by inspection plus regression-testing the unaffected behavior.

## Context

Part of a series ahead of `--log-format=<json|text>` for structured log output (ELK ingestion). The `snprintf` size-argument underflow noted earlier in review is deferred to that change, which is what makes it reachable (it needs `--log-file-line`, currently dead code with no CLI option wired to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)