### PR TITLE
Log format: ISO-8601 timestamp by default, no thread id, space delimiter

### DIFF
--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -566,8 +566,9 @@ pkey=/etc/ssl/private/privkey.pem
 # Enable full ISO-8601 timestamp in all logs.
 #new-log-timestamp
 
-# Set timestamp format (in strftime(1) format). Depends on new-log-timestamp to be enabled.
-#new-log-timestamp-format "%FT%T%z"
+# Set timestamp format (in strftime(1) format). Depends on new-log-timestamp to be
+# enabled. Besides the strftime(1) conversions, %f expands to milliseconds.
+#new-log-timestamp-format "%FT%T.%f%z"
 
 # Disabled by default binding logging in verbose log mode to avoid DoS attacks.
 # Enable binding logging and UDP endpoint logs in verbose log mode.

--- a/docker/coturn/turnserver.conf
+++ b/docker/coturn/turnserver.conf
@@ -563,8 +563,9 @@ pkey=/etc/ssl/private/privkey.pem
 #
 #log-min-level=info
 
-# Enable full ISO-8601 timestamp in all logs.
-#new-log-timestamp
+# Use a full ISO-8601 timestamp in all logs. Enabled by default; set to
+# false for the legacy counter of seconds since start.
+#new-log-timestamp=true
 
 # Set timestamp format (in strftime(1) format). Depends on new-log-timestamp to be
 # enabled. Besides the strftime(1) conversions, %f expands to milliseconds.

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -671,8 +671,9 @@
 #
 #log-min-level=info
 
-# Enable full ISO-8601 timestamp in all logs.
-#new-log-timestamp
+# Use a full ISO-8601 timestamp in all logs. Enabled by default; set to
+# false for the legacy counter of seconds since start.
+#new-log-timestamp=true
 
 # Set timestamp format (in strftime(1) format). Depends on new-log-timestamp to be
 # enabled. Besides the strftime(1) conversions, %f expands to milliseconds.

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -674,8 +674,9 @@
 # Enable full ISO-8601 timestamp in all logs.
 #new-log-timestamp
 
-# Set timestamp format (in strftime(1) format). Depends on new-log-timestamp to be enabled.
-#new-log-timestamp-format "%FT%T%z"
+# Set timestamp format (in strftime(1) format). Depends on new-log-timestamp to be
+# enabled. Besides the strftime(1) conversions, %f expands to milliseconds.
+#new-log-timestamp-format "%FT%T.%f%z"
 
 # Disabled by default binding logging in verbose log mode to avoid DoS attacks.
 # Enable binding logging and UDP endpoint logs in verbose log mode.

--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -53,13 +53,6 @@
 
 #include <signal.h>
 
-#if !defined(WINDOWS) && !defined(__CYGWIN__) && !defined(__CYGWIN32__) && !defined(__CYGWIN64__)
-#include <sys/syscall.h>
-#ifdef SYS_gettid
-#define gettid() ((pid_t)syscall(SYS_gettid))
-#endif
-#endif
-
 #include <ctype.h> // for tolower
 #include <errno.h>
 #include <string.h> // for memcmp, strstr, strcmp, strdup, strlen, strerror
@@ -271,7 +264,7 @@ void set_log_min_level(const char *value) {
                 value);
 }
 
-int use_new_log_timestamp_format = 0;
+int use_new_log_timestamp_format = 1;
 
 void addr_debug_print(int verbose, const ioa_addr *addr, const char *s) {
   if (verbose) {
@@ -483,7 +476,7 @@ static size_t turn_log_render_timestamp(char *out, size_t outsz) {
         }
       }
     } else {
-      const int written = snprintf(cache.text, sizeof(cache.text), "%lu: ", (unsigned long)key);
+      const int written = snprintf(cache.text, sizeof(cache.text), "%lu", (unsigned long)key);
       if (written > 0 && (size_t)written < sizeof(cache.text)) {
         len = (size_t)written;
       }
@@ -782,26 +775,28 @@ void turn_log_func_default(const char *const file, const int line, const TURN_LO
   size_t so_far = 0;
   so_far += turn_log_render_timestamp(s, sizeof(s));
 
-#ifdef SYS_gettid
-  so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "(%lu): ", (unsigned long)gettid());
-#endif
+  /* Fields are separated by a single space: ':' occurs throughout message
+   * bodies, so it cannot delimit anything a log parser can rely on. */
+  if (so_far < MAX_RTPPRINTF_BUFFER_SIZE) {
+    s[so_far++] = ' ';
+  }
 
   if (_log_file_line_set) {
-    so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "%s(%d):", file, line);
+    so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "%s(%d) ", file, line);
   }
 
   switch (level) {
   case TURN_LOG_LEVEL_DEBUG:
-    so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "DEBUG: ");
+    so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "DEBUG ");
     break;
   case TURN_LOG_LEVEL_INFO:
-    so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "INFO: ");
+    so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "INFO ");
     break;
   case TURN_LOG_LEVEL_WARNING:
-    so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "WARNING: ");
+    so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "WARNING ");
     break;
   case TURN_LOG_LEVEL_ERROR:
-    so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "ERROR: ");
+    so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "ERROR ");
     break;
   }
   so_far += vsnprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), format, args);

--- a/src/apps/common/ns_turn_utils.c
+++ b/src/apps/common/ns_turn_utils.c
@@ -237,10 +237,15 @@ static int no_stdout_log = 0;
 void set_no_stdout_log(int val) { no_stdout_log = val; }
 
 #define MAX_LOG_TIMESTAMP_FORMAT_LEN 48
-static char turn_log_timestamp_format[MAX_LOG_TIMESTAMP_FORMAT_LEN] = "%FT%T%z";
+/* %f is not a strftime conversion; it is expanded here to milliseconds. */
+static char turn_log_timestamp_format[MAX_LOG_TIMESTAMP_FORMAT_LEN] = "%FT%T.%f%z";
+
+/* Bumped so that per-thread timestamp caches re-render after a format change. */
+static turn_atomic_u32 log_timestamp_format_generation = 0;
 
 void set_turn_log_timestamp_format(char *new_format) {
   strncpy(turn_log_timestamp_format, new_format, MAX_LOG_TIMESTAMP_FORMAT_LEN - 1);
+  turn_atomic_fetch_add_u32(&log_timestamp_format_generation, 1);
 }
 
 static const struct {
@@ -339,6 +344,164 @@ static void get_date(char *s, size_t sz) {
   } else if (sz) {
     s[0] = 0;
   }
+}
+
+/* Wall clock as whole seconds plus milliseconds from one reading, so the
+ * seconds text and the fraction appended to it cannot straddle a boundary. */
+static void turn_wall_clock(time_t *secs, unsigned *msec) {
+#if defined(_MSC_VER)
+  /* 100ns ticks since 1601-01-01; 11644473600s from there to the Unix epoch. */
+  FILETIME ft;
+  ULARGE_INTEGER ticks;
+  GetSystemTimeAsFileTime(&ft);
+  ticks.LowPart = ft.dwLowDateTime;
+  ticks.HighPart = ft.dwHighDateTime;
+  const uint64_t since_epoch = ticks.QuadPart - 116444736000000000ULL;
+  *secs = (time_t)(since_epoch / 10000000ULL);
+  *msec = (unsigned)((since_epoch / 10000ULL) % 1000ULL);
+#elif defined(CLOCK_REALTIME)
+  struct timespec tp = {0, 0};
+  clock_gettime(CLOCK_REALTIME, &tp);
+  *secs = tp.tv_sec;
+  *msec = (unsigned)(tp.tv_nsec / 1000000);
+#else
+  *secs = time(NULL);
+  *msec = 0;
+#endif
+}
+
+/* First unescaped %f in the format, skipping %% pairs. */
+static const char *turn_find_msec_spec(const char *format) {
+  for (const char *p = format; *p; ++p) {
+    if (*p != '%') {
+      continue;
+    }
+    if (p[1] == '%') {
+      ++p;
+      continue;
+    }
+    if (p[1] == 'f') {
+      return p;
+    }
+  }
+  return NULL;
+}
+
+#define TURN_LOG_MSEC_DIGITS 3
+
+static void turn_write_msec(char *p, unsigned msec) {
+  p[0] = (char)('0' + (msec / 100) % 10);
+  p[1] = (char)('0' + (msec / 10) % 10);
+  p[2] = (char)('0' + msec % 10);
+}
+
+#define TURN_LOG_NO_MSEC ((size_t)-1)
+
+/* Renders turn_log_timestamp_format, expanding the first %f to milliseconds.
+ * Returns 0 if the result does not fit. *msec_off receives the offset of the
+ * millisecond digits, or TURN_LOG_NO_MSEC when the format has none. */
+static size_t turn_render_timestamp_format(char *buf, size_t bufsz, const struct tm *tm_now, unsigned msec,
+                                           size_t *msec_off) {
+  *msec_off = TURN_LOG_NO_MSEC;
+
+  const char *spec = turn_find_msec_spec(turn_log_timestamp_format);
+  if (!spec) {
+    return strftime(buf, bufsz, turn_log_timestamp_format, tm_now);
+  }
+
+  size_t len = 0;
+  const size_t head_len = (size_t)(spec - turn_log_timestamp_format);
+  if (head_len) {
+    char head[MAX_LOG_TIMESTAMP_FORMAT_LEN] = {0};
+    memcpy(head, turn_log_timestamp_format, head_len);
+    len = strftime(buf, bufsz, head, tm_now);
+    if (len == 0) {
+      return 0;
+    }
+  }
+
+  if (len + TURN_LOG_MSEC_DIGITS >= bufsz) {
+    return 0;
+  }
+  turn_write_msec(buf + len, msec);
+  *msec_off = len;
+  len += TURN_LOG_MSEC_DIGITS;
+
+  const char *tail = spec + 2;
+  if (*tail) {
+    const size_t tail_len = strftime(buf + len, bufsz - len, tail, tm_now);
+    if (tail_len == 0) {
+      return 0;
+    }
+    len += tail_len;
+  }
+  return len;
+}
+
+/*
+ * The timestamp prefix is re-rendered on every log line, but everything down to
+ * the second only changes once a second. Rendering costs a localtime_r() --
+ * which takes a lock inside libc, so it serializes relay threads -- plus a
+ * strftime(). Cache the rendered text per thread and patch in just the
+ * millisecond digits per line: the steady state is a comparison, a memcpy and
+ * three stores, with no state shared between threads to contend on.
+ */
+#define TURN_LOG_TIMESTAMP_CACHE_SIZE 128
+
+static size_t turn_log_render_timestamp(char *out, size_t outsz) {
+  static TURN_THREAD_LOCAL struct {
+    bool valid;
+    bool iso_format;
+    uint32_t generation;
+    turn_time_t key;
+    size_t len;
+    size_t msec_off;
+    char text[TURN_LOG_TIMESTAMP_CACHE_SIZE];
+  } cache;
+
+  const bool iso_format = (use_new_log_timestamp_format != 0);
+  const uint32_t generation = turn_atomic_load_u32(&log_timestamp_format_generation);
+
+  time_t now = 0;
+  unsigned msec = 0;
+  if (iso_format) {
+    turn_wall_clock(&now, &msec);
+  }
+  const turn_time_t key = iso_format ? (turn_time_t)now : log_time();
+
+  if (!cache.valid || cache.key != key || cache.iso_format != iso_format || cache.generation != generation) {
+    size_t len = 0;
+    size_t msec_off = TURN_LOG_NO_MSEC;
+    if (iso_format) {
+      struct tm tm_now = {0};
+      if (turn_localtime(&now, &tm_now)) {
+        len = turn_render_timestamp_format(cache.text, sizeof(cache.text), &tm_now, msec, &msec_off);
+        if (len == 0) {
+          /* Rendering does not fit the cache; fall back to the caller's buffer. */
+          size_t direct_off = TURN_LOG_NO_MSEC;
+          return turn_render_timestamp_format(out, outsz, &tm_now, msec, &direct_off);
+        }
+      }
+    } else {
+      const int written = snprintf(cache.text, sizeof(cache.text), "%lu: ", (unsigned long)key);
+      if (written > 0 && (size_t)written < sizeof(cache.text)) {
+        len = (size_t)written;
+      }
+    }
+    cache.len = len;
+    cache.msec_off = msec_off;
+    cache.key = key;
+    cache.iso_format = iso_format;
+    cache.generation = generation;
+    cache.valid = true;
+  }
+
+  const size_t len = min(cache.len, outsz);
+  memcpy(out, cache.text, len);
+  if (cache.msec_off != TURN_LOG_NO_MSEC && cache.msec_off + TURN_LOG_MSEC_DIGITS <= len) {
+    turn_write_msec(out + cache.msec_off, msec);
+  }
+  return len;
 }
 
 void set_logfile(const char *fn) {
@@ -617,15 +780,7 @@ void turn_log_func_default(const char *const file, const int line, const TURN_LO
 #define MAX_RTPPRINTF_BUFFER_SIZE (1024)
   char s[MAX_RTPPRINTF_BUFFER_SIZE + 1];
   size_t so_far = 0;
-  if (use_new_log_timestamp_format) {
-    const time_t now = time(NULL);
-    struct tm tm_now = {0};
-    if (turn_localtime(&now, &tm_now)) {
-      so_far += strftime(s, sizeof(s), turn_log_timestamp_format, &tm_now);
-    }
-  } else {
-    so_far += snprintf(s, sizeof(s), "%lu: ", (unsigned long)log_time());
-  }
+  so_far += turn_log_render_timestamp(s, sizeof(s));
 
 #ifdef SYS_gettid
   so_far += snprintf(s + so_far, MAX_RTPPRINTF_BUFFER_SIZE - (so_far + 1), "(%lu): ", (unsigned long)gettid());

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1282,6 +1282,8 @@ static char Usage[] =
     " --new-log-timestamp				Enable full ISO-8601 timestamp in all logs.\n"
     " --new-log-timestamp-format    	<format>	Set timestamp format (in strftime(1) format). Depends on "
     "--new-log-timestamp to be enabled.\n"
+    "						Besides the strftime(1) conversions, %f expands to "
+    "milliseconds.\n"
     " --log-binding					Log STUN binding request. It is now disabled by default to "
     "avoid DoS attacks.\n"
     " --stale-nonce[=<value>]			Use extra security with nonce value having limited lifetime (default "

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -1279,7 +1279,9 @@ static char Usage[] =
     "						name will be constructed as-is, without PID and date appendage.\n"
     "						This option can be used, for example, together with the logrotate "
     "tool.\n"
-    " --new-log-timestamp				Enable full ISO-8601 timestamp in all logs.\n"
+    " --new-log-timestamp[=<value>]		Use a full ISO-8601 timestamp in all logs. Enabled by default;\n"
+    "						pass --new-log-timestamp=false for the legacy counter of\n"
+    "						seconds since start.\n"
     " --new-log-timestamp-format    	<format>	Set timestamp format (in strftime(1) format). Depends on "
     "--new-log-timestamp to be enabled.\n"
     "						Besides the strftime(1) conversions, %f expands to "
@@ -2945,7 +2947,7 @@ static void read_config_file(int argc, char **argv, int pass) {
           } else if ((pass == 0) && (c == LOG_MIN_LEVEL_OPT)) {
             set_log_min_level(value);
           } else if ((pass == 0) && (c == NEW_LOG_TIMESTAMP_OPT)) {
-            use_new_log_timestamp_format = 1;
+            use_new_log_timestamp_format = get_bool_value(value);
           } else if ((pass == 0) && (c == NEW_LOG_TIMESTAMP_FORMAT_OPT)) {
             set_turn_log_timestamp_format(value);
           } else if ((pass == 0) && (c == SYSLOG_FACILITY_OPT)) {
@@ -3533,7 +3535,7 @@ int main(int argc, char **argv) {
         set_log_min_level(optarg);
         break;
       case NEW_LOG_TIMESTAMP_OPT:
-        use_new_log_timestamp_format = 1;
+        use_new_log_timestamp_format = get_bool_value(optarg);
         break;
       case NEW_LOG_TIMESTAMP_FORMAT_OPT:
         set_turn_log_timestamp_format(optarg);


### PR DESCRIPTION
## What

Makes the default log line parseable by a log shipper with no configuration. Rebased on `master` (`441d3e9c`, which now includes #2030).

Before:
```
0: (18446744073709551615): INFO: Listener address to use: 127.0.0.1
```
After:
```
2026-08-02T17:32:31.297-0700 INFO Listener address to use: 127.0.0.1
```

Two commits:

| Commit | Change |
|---|---|
| `Cache the rendered log timestamp per thread, add millisecond precision` | perf + sub-second resolution |
| `Log format: ISO-8601 by default, drop thread id, space delimiter` | the format change itself |

## Why

**ISO-8601 by default.** The previous default was a counter of seconds since process start — no wall-clock time at all, so nothing downstream can order or window on it. `--new-log-timestamp` now also honours its boolean argument; it previously ignored the value and could only be turned *on*, so with the default flipped there would have been no way back. `--new-log-timestamp=false` restores the counter.

**Thread id removed.** It was emitted as a bare unlabelled `(N)`, indistinguishable from any parenthesised number in a message body. Worse, it was gated on `#ifdef SYS_gettid` — a test for whether the *constant* exists, not whether the syscall does what was intended. macOS defines `SYS_gettid` as a different syscall, so the call failed with `ESRCH` and every line on every macOS build carried `(18446744073709551615)`, i.e. `(unsigned long)(pid_t)-1`:

```
SYS_gettid defined = 286
syscall(SYS_gettid) = -1  errno=3 (No such process)
as (unsigned long)(pid_t)r = 18446744073709551615
```

Dropping it also removes the deprecated `syscall(2)` use on macOS.

**Space delimiter.** `:` cannot delimit anything a parser can rely on — message bodies are full of it (`realm <north.gov> user <>: ...`). These two changes are coupled: the ISO timestamp emitted *no* trailing separator (the `(tid): ` supplied it), so removing the thread id alone would have produced `...-0700INFO`. The renderer now emits only the timestamp and the caller adds one space.

**Millisecond precision** (first commit). Log shippers need sub-second resolution to order records within a second, which a busy relay produces in bulk. `strftime()` has no sub-second conversion, so `%f` is expanded to milliseconds (`%%f` is left alone) and the default format is `%FT%T.%f%z`.

**Timestamp caching** (first commit). Everything down to the second only changes once a second, but was re-rendered per line — and `localtime_r()` takes a lock inside libc, so relay threads serialised on it and per-line cost *grew* with thread count. Now cached in thread-local storage keyed on the second, with only the millisecond digits patched in per line. A generation counter bumped by `set_turn_log_timestamp_format()` invalidates live caches on a format change; a format rendering longer than the cache falls back to the caller's buffer.

Timestamp rendering, 12 threads on a 12-core machine:

| threads | before (no ms) | after (with ms) |
|---|---:|---:|
| 1 | 163 ns/line | 24 ns/line |
| 4 | 53 ns/line | 6 ns/line |
| 12 | **304 ns/line** | **3 ns/line** |

## Acceptance check

Output run against the stock logstash pattern `%{TIMESTAMP_ISO8601:ts} %{LOGLEVEL:level} %{GREEDYDATA:msg}` — **43/44 startup lines parse with no further configuration**, fields extracting correctly.

The one failure is pre-existing: the banner at `mainrelay.c:3211` embeds `\n\n` *inside* the message, so its text lands on a line with no prefix. The right fix is newline normalisation in the logger, not patching call sites; deferred to the `--log-format` work.

## Compatibility

This is a visible break for anyone parsing coturn logs. `--new-log-timestamp=false` restores the old timestamp but not the thread id or the colons — there is no single flag that restores the previous line verbatim. Worth pairing with the remaining logging changes in one release and one changelog entry.

## Testing

All re-run after the rebase onto `441d3e9c`.

**Linux (Docker)**
- `ctest` 17/17
- `run_tests.sh`, `run_tests_conf.sh`, `run_tests_mobile.sh`, `run_tests_multiplex_peer.sh`, `run_tests_rfc5780.sh`, `run_tests_stateless_nonce.sh`, `run_tests_dtls_default.sh` — all `rc=0`, zero `FAIL` lines
- Both timestamp modes confirmed on glibc: `2026-08-03T00:46:59.742+0000 INFO ...` and, with `--new-log-timestamp=false`, `0 INFO ...`

**macOS**
- `ctest` 18/18; `run_tests.sh`, `run_tests_conf.sh`, `run_tests_mobile.sh`, `run_tests_stateless_nonce.sh` — all `rc=0`, zero `FAIL` lines
- `clang-format` clean

**Fuzzing smoke**
- `fuzzing/run-local.sh ASan 0 -runs=1` and `ASan 1 -runs=1` — both clean, no new findings

**Format matrix**, by hand on both platforms — default, `--new-log-timestamp=false`, explicit on, and the same three through the **config-file** path (a separate parser, also changed).

**Timestamp-cache correctness** — milliseconds vary per line (51 distinct timestamps across 7 seconds under traffic); format edge cases: no `%f`, `%f` alone, `%f` at start, `%f` at end, `100%%f-%T.%f` (escaped `%%f` stays literal while the real one expands), and a >128-byte format hitting the fallback.

The MSVC branch of `turn_wall_clock()` (`GetSystemTimeAsFileTime`) is inspection-only — there is no MSVC toolchain here, so CI is the first real check on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
