### PR TITLE
Keep the legacy random nonce at 16 chars

### DIFF
--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -3486,6 +3486,30 @@ static int need_stun_authentication(turn_turnserver *server, ts_ur_super_session
   return 0;
 }
 
+/* Fill `nonce` (at least NONCE_MAX_SIZE bytes) with the legacy random
+ * challenge nonce: TURN_RANDOM_NONCE_LENGTH lowercase hex chars.
+ *
+ * Each snprintf is bounded by what is left of TURN_RANDOM_NONCE_SIZE, not of
+ * the destination buffer: `%08lx` of a 64-bit draw is up to 16 chars and
+ * `%04x` of a 32-bit draw is 8, so it is the bound that clips every write back
+ * to the 16-char format. Bounding by the (larger) stateless-nonce buffer would
+ * let those digits through and emit a 24-char nonce instead. */
+static void generate_random_challenge_nonce(uint8_t *nonce) {
+  if (TURN_RANDOM_SIZE == 8) {
+    for (int i = 0; i < (NONCE_LENGTH_32BITS >> 1); i++) {
+      uint8_t *s = nonce + 8 * i;
+      const uint64_t rand = (uint64_t)turn_random_number();
+      snprintf((char *)s, TURN_RANDOM_NONCE_SIZE - 8 * i, "%08lx", (unsigned long)rand);
+    }
+  } else {
+    for (int i = 0; i < NONCE_LENGTH_32BITS; i++) {
+      uint8_t *s = nonce + 4 * i;
+      const uint32_t rand = (uint32_t)turn_random_number();
+      snprintf((char *)s, TURN_RANDOM_NONCE_SIZE - 4 * i, "%04x", (unsigned int)rand);
+    }
+  }
+}
+
 static int create_challenge_response(ts_ur_super_session *ss, stun_tid *tid, int *resp_constructed, int *err_code,
                                      const uint8_t **reason, ioa_network_buffer_handle nbh, uint16_t method) {
   size_t len = ioa_network_buffer_get_size(nbh);
@@ -3493,8 +3517,9 @@ static int create_challenge_response(ts_ur_super_session *ss, stun_tid *tid, int
   stun_init_error_response_str(method, ioa_network_buffer_data(nbh), &len, *err_code, *reason, tid,
                                srv ? srv->include_reason_string : false);
   *resp_constructed = 1;
-  /* strlen, not NONCE_MAX_SIZE - 1: the random nonce (16 chars) and the
-   * stateless timestamp||MAC nonce (24 chars) differ in length. */
+  /* strlen, not NONCE_MAX_SIZE - 1: the random nonce (TURN_RANDOM_NONCE_LENGTH
+   * chars) and the stateless timestamp||MAC nonce
+   * (TURN_STATELESS_NONCE_LENGTH) differ in length. */
   stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_NONCE, ss->nonce,
                     (int)strlen((char *)ss->nonce));
   char *realm = ss->realm_options.name;
@@ -3591,21 +3616,7 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
       }
 
       if (need_random_nonce) {
-        int i = 0;
-
-        if (TURN_RANDOM_SIZE == 8) {
-          for (i = 0; i < (NONCE_LENGTH_32BITS >> 1); i++) {
-            uint8_t *s = ss->nonce + 8 * i;
-            const uint64_t rand = (uint64_t)turn_random_number();
-            snprintf((char *)s, NONCE_MAX_SIZE - 8 * i, "%08lx", (unsigned long)rand);
-          }
-        } else {
-          for (i = 0; i < NONCE_LENGTH_32BITS; i++) {
-            uint8_t *s = ss->nonce + 4 * i;
-            const uint32_t rand = (uint32_t)turn_random_number();
-            snprintf((char *)s, NONCE_MAX_SIZE - 4 * i, "%04x", (unsigned int)rand);
-          }
-        }
+        generate_random_challenge_nonce(ss->nonce);
       }
       ss->nonce_expiration_time = server->ctime + *(server->stale_nonce);
     }

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -3517,6 +3517,9 @@ static int create_challenge_response(ts_ur_super_session *ss, stun_tid *tid, int
   stun_init_error_response_str(method, ioa_network_buffer_data(nbh), &len, *err_code, *reason, tid,
                                srv ? srv->include_reason_string : false);
   *resp_constructed = 1;
+  /* strlen, not NONCE_MAX_SIZE - 1: the random nonce (TURN_RANDOM_NONCE_LENGTH
+   * chars) and the stateless timestamp||MAC nonce
+   * (TURN_STATELESS_NONCE_LENGTH) differ in length. */
   stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_NONCE, ss->nonce,
                     (int)strlen((char *)ss->nonce));
   char *realm = ss->realm_options.name;

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -3517,9 +3517,6 @@ static int create_challenge_response(ts_ur_super_session *ss, stun_tid *tid, int
   stun_init_error_response_str(method, ioa_network_buffer_data(nbh), &len, *err_code, *reason, tid,
                                srv ? srv->include_reason_string : false);
   *resp_constructed = 1;
-  /* strlen, not NONCE_MAX_SIZE - 1: the random nonce (TURN_RANDOM_NONCE_LENGTH
-   * chars) and the stateless timestamp||MAC nonce
-   * (TURN_STATELESS_NONCE_LENGTH) differ in length. */
   stun_attr_add_str(ioa_network_buffer_data(nbh), &len, STUN_ATTRIBUTE_NONCE, ss->nonce,
                     (int)strlen((char *)ss->nonce));
   char *realm = ss->realm_options.name;

--- a/src/server/ns_turn_session.h
+++ b/src/server/ns_turn_session.h
@@ -67,10 +67,16 @@ struct _realm_options_t {
 
 typedef uint64_t turnsession_id;
 
+/* The legacy random challenge nonce: 16 lowercase hex chars. */
+#define TURN_RANDOM_NONCE_LENGTH (NONCE_LENGTH_32BITS * 4)
+#define TURN_RANDOM_NONCE_SIZE (TURN_RANDOM_NONCE_LENGTH + 1)
+
 /* Big enough for both nonce formats the server can issue: the legacy random
- * nonce (NONCE_LENGTH_32BITS * 4 = 16 chars) and the stateless timestamp||MAC
- * nonce (TURN_STATELESS_NONCE_LENGTH = 24 chars). The two differ in length,
- * so emitters must use strlen(), not NONCE_MAX_SIZE - 1. */
+ * nonce (TURN_RANDOM_NONCE_LENGTH = 16 chars) and the stateless
+ * timestamp||MAC nonce (TURN_STATELESS_NONCE_LENGTH = 24 chars). The two
+ * differ in length, so emitters must use strlen(), not NONCE_MAX_SIZE - 1, and
+ * a generator must bound itself with its own format's size - bounding the
+ * random nonce with NONCE_MAX_SIZE widens it to 24 chars. */
 #define NONCE_MAX_SIZE (TURN_STATELESS_NONCE_SIZE)
 
 typedef uint64_t mobile_id_t;

--- a/tests/test_turn_server_send.c
+++ b/tests/test_turn_server_send.c
@@ -646,6 +646,11 @@ static void test_create_permission_without_peer_address_is_rejected(void) {
   TEST_ASSERT_EQUAL_INT(400, run_create_permission(NULL));
 }
 
+/* Spelled as a literal, not as TURN_RANDOM_NONCE_LENGTH: the generator bounds
+ * itself with that macro, so asserting it would hold for any width the macro
+ * happened to take. 16 is the wire format. */
+#define RANDOM_NONCE_WIRE_LENGTH 16
+
 /* The legacy challenge nonce is 16 lowercase hex chars on every platform. It
  * is written into a buffer sized for the longer stateless nonce, so a
  * generator bound by the buffer rather than by its own format emits 24 chars
@@ -653,16 +658,23 @@ static void test_create_permission_without_peer_address_is_rejected(void) {
  * that never enabled --stateless-nonce. Loop, because only draws above 2^32
  * overflow the format. */
 static void test_random_challenge_nonce_is_sixteen_lowercase_hex_chars(void) {
+  TEST_ASSERT_EQUAL_size_t(RANDOM_NONCE_WIRE_LENGTH, (size_t)TURN_RANDOM_NONCE_LENGTH);
+
   for (int attempt = 0; attempt < 64; ++attempt) {
     uint8_t nonce[NONCE_MAX_SIZE];
     memset(nonce, 0xff, sizeof(nonce));
 
     generate_random_challenge_nonce(nonce);
 
-    TEST_ASSERT_EQUAL_size_t(TURN_RANDOM_NONCE_LENGTH, strlen((char *)nonce));
-    for (size_t i = 0; i < TURN_RANDOM_NONCE_LENGTH; ++i) {
+    TEST_ASSERT_EQUAL_size_t(RANDOM_NONCE_WIRE_LENGTH, strlen((char *)nonce));
+    for (size_t i = 0; i < RANDOM_NONCE_WIRE_LENGTH; ++i) {
       const char c = (char)nonce[i];
       TEST_ASSERT_TRUE(((c >= '0') && (c <= '9')) || ((c >= 'a') && (c <= 'f')));
+    }
+    /* The generator gets a NONCE_MAX_SIZE buffer but may only use its own
+     * format's size, so everything past the terminator is still untouched. */
+    for (size_t i = RANDOM_NONCE_WIRE_LENGTH + 1; i < sizeof(nonce); ++i) {
+      TEST_ASSERT_EQUAL_HEX8(0xff, nonce[i]);
     }
   }
 }

--- a/tests/test_turn_server_send.c
+++ b/tests/test_turn_server_send.c
@@ -646,6 +646,27 @@ static void test_create_permission_without_peer_address_is_rejected(void) {
   TEST_ASSERT_EQUAL_INT(400, run_create_permission(NULL));
 }
 
+/* The legacy challenge nonce is 16 lowercase hex chars on every platform. It
+ * is written into a buffer sized for the longer stateless nonce, so a
+ * generator bound by the buffer rather than by its own format emits 24 chars
+ * (64-bit) or 20 (LLP64/32-bit) instead - a wire-format change for servers
+ * that never enabled --stateless-nonce. Loop, because only draws above 2^32
+ * overflow the format. */
+static void test_random_challenge_nonce_is_sixteen_lowercase_hex_chars(void) {
+  for (int attempt = 0; attempt < 64; ++attempt) {
+    uint8_t nonce[NONCE_MAX_SIZE];
+    memset(nonce, 0xff, sizeof(nonce));
+
+    generate_random_challenge_nonce(nonce);
+
+    TEST_ASSERT_EQUAL_size_t(TURN_RANDOM_NONCE_LENGTH, strlen((char *)nonce));
+    for (size_t i = 0; i < TURN_RANDOM_NONCE_LENGTH; ++i) {
+      const char c = (char)nonce[i];
+      TEST_ASSERT_TRUE(((c >= '0') && (c <= '9')) || ((c >= 'a') && (c <= 'f')));
+    }
+  }
+}
+
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_send_relays_payload_to_the_permitted_peer);
@@ -665,5 +686,6 @@ int main(void) {
   RUN_TEST(test_create_permission_installs_every_peer_address);
   RUN_TEST(test_create_permission_ignores_the_port);
   RUN_TEST(test_create_permission_without_peer_address_is_rejected);
+  RUN_TEST(test_random_challenge_nonce_is_sixteen_lowercase_hex_chars);
   return UNITY_END();
 }


### PR DESCRIPTION
## What

The legacy (non-`--stateless-nonce`) challenge nonce has been 24 hex chars instead of 16 since #2002, on every 64-bit server — including those that never enabled `--stateless-nonce`.

## Why

`generate_random_challenge_nonce` writes each `turn_random_number()` draw with `snprintf` and relies on the size bound to clip it. `"%08lx"` of a 64-bit draw is *up to 16* hex chars, and `"%04x"` of a 32-bit draw is 8 — the bound is what cuts each write back to 8. That bound was `NONCE_MAX_SIZE`, which [grew from 17 to 25](https://github.com/coturn/coturn/blob/master/src/server/ns_turn_session.h) when it was redefined as `TURN_STATELESS_NONCE_SIZE` to hold the 24-char stateless nonce. The extra digits then went through:

| Platform | `sizeof(long)` | Branch | Before #2002 | On master |
|---|---|---|---|---|
| Linux/macOS x86-64, arm64 | 8 | `%08lx` | 16 chars | **24 chars** |
| Windows x64, 32-bit | 4 | `%04x` | 16 chars | **20 chars** |

Reproduced standalone with the exact expressions from the two loops:

```
sizeof(long)=8
old NONCE_MAX_SIZE=17: len=16 'deadbeefdeadbeef'
new NONCE_MAX_SIZE=25: len=24 'deadbeefdeadbeefcafebabf'
```

## Impact

Low, and not a security issue:

- **No overflow** — `ss->nonce` is `NONCE_MAX_SIZE` (25) bytes; the maximum write is 24 + NUL.
- **No auth breakage** — validation is a `strcmp` against `ss->nonce`, so the longer nonce round-trips.
- **Entropy went up, not down** — 96 bits vs. the previous 64 on LP64.
- **Still RFC-legal** — RFC 8489 §14.10 caps the nonce below 128 characters.

What it does break is a documented invariant: `ns_turn_session.h` and `create_challenge_response` both state that the two nonce formats *differ in length*, and `tests/test_stateless_nonce.c` asserts that "legacy random-style 16-char nonces are not stateless nonces". On 64-bit they no longer differ. Nothing branches on that length today (`turn_check_stateless_nonce` rejects on the MAC, not the length), but it is a trap for the next length-based fast path. Separately, an opt-in feature silently changed wire output for deployments that did not opt in.

## Change

- Add `TURN_RANDOM_NONCE_LENGTH` / `TURN_RANDOM_NONCE_SIZE` so each nonce format is sized by its own constant.
- Extract the generation into `generate_random_challenge_nonce()`, bounded by `TURN_RANDOM_NONCE_SIZE`, with a comment recording that the bound — not the format specifier — is what fixes the width.
- Cover both loops with a unit test in the existing server-core harness.

Behavior is restored byte-for-byte to pre-#2002: the truncation semantics are preserved rather than replaced with an explicit bit-selection, which would have picked different bits.

## Validation

- `ctest` — 18/18 pass on macOS/arm64, 17/17 in Linux/Docker.
- Reverting just the bound fails the new test with `Expected 16 Was 24`.
- `run_tests.sh`, `run_tests_conf.sh`, `run_tests_stateless_nonce.sh`, `run_tests_mobile.sh`, `run_tests_multiplex_peer.sh`, `run_tests_dtls_default.sh`, `run_tests_rfc5780.sh` — all clean on Linux; the first four also clean on macOS.
- `fuzzing/run-local.sh ASan 0 -runs=1` and `ASan 1 -runs=1` — clean.
- `clang-format-15` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)