### PR TITLE
Enable stateless nonce by default 

### DIFF
--- a/docs/stateless-nonce.md
+++ b/docs/stateless-nonce.md
@@ -112,12 +112,23 @@ The mode is designed to be invisible to clients:
 - Established sessions keep the exact stock stale-nonce behavior: the session
   caches its nonce, `--stale-nonce` expiry regenerates it and answers `438`,
   and the client re-authenticates as usual.
+- Two methods that skip the challenge entirely still have a reply fixed by the
+  request bytes alone, so they are answered here rather than falling back:
+  **CONNECTION-BIND**, which `handle_turn_connection_bind()` rejects on a
+  datagram socket before reading any attribute (`400`), and a **ticketless
+  REFRESH under `--mobility`**, which reaches `437 Invalid allocation` when the
+  source has no allocation. Both matter because neither reply is a `401`/`438`,
+  so neither qualifies for the challenge-session teardown — before this, each
+  such packet from a fresh source held a session for the full 60s
+  to-be-allocated timeout. The REFRESH shortcut is taken only when no attribute
+  could steer the reply elsewhere: a MOBILITY-TICKET (the actual resume path),
+  a malformed LIFETIME (`400`), an address-family attribute (`443`), or any
+  comprehension-required attribute the handler does not know (`420`) all fall
+  back to the session path, so a newly added attribute fails safe.
 - Cases the fast path cannot replicate byte-for-byte fall back to the session
   path automatically: BINDING (RFC 5780 alternate sockets), ALLOCATE when
-  alternate/aux server redirection (300) is configured, REFRESH under
-  `--mobility` (MOBILITY-TICKET may authenticate without a first-pass
-  challenge), CONNECTION-BIND (exempt from the challenge), and any request
-  whose nonce verifies (the credential lookup itself may be asynchronous, and
+  alternate/aux server redirection (300) is configured, and any request whose
+  nonce verifies (the credential lookup itself may be asynchronous, and
   resuming it needs a session).
 
 `examples/run_tests_stateless_nonce.sh` asserts all of this end-to-end: the
@@ -173,17 +184,21 @@ Operational notes:
 
 ## Limitations
 
-- **Off by default.** Enable with `--stateless-nonce` (config file:
-  `stateless-nonce`), or implicitly via `--stateless-nonce-secret`.
-- **Nonce length changes when the flag is on.** Challenges carry a 24-char
-  nonce instead of the stock 16-char one. RFC 8489 requires clients to treat
-  the nonce as an opaque string of up to 128 characters, so compliant clients
-  are unaffected; a hypothetical client with a hard-coded 16-char nonce
-  buffer would only misbehave with the flag enabled.
-- **BINDING floods are out of scope.** BINDING is answerable without
-  authentication, so an unknown-source BINDING still creates a session (as
-  today). `--secure-stun` BINDING challenges do benefit from the
-  challenge-session teardown, but not from the listener fast path.
+- **On by default.** Disable with `--stateless-nonce=false` (config file:
+  `stateless-nonce=false`). `--stateless-nonce-secret` implies it.
+- **Nonce length.** Challenges carry a 24-char nonce instead of the legacy
+  16-char one. RFC 8489 requires clients to treat the nonce as an opaque
+  string of up to 128 characters, so compliant clients are unaffected; a
+  hypothetical client with a hard-coded 16-char nonce buffer would need
+  `--stateless-nonce=false`.
+- **Restarts and fleets.** The default key is ephemeral, so a restart costs
+  each client one `438` re-auth round-trip, as does a retry that lands on a
+  different instance behind a load balancer. Set `--stateless-nonce-secret`
+  across the fleet to avoid both.
+- **BINDING does not use this path.** BINDING is answerable without
+  authentication and is short-circuited by its own listener fast path, which
+  is independent of this option. `--secure-stun` BINDING challenges benefit
+  from the challenge-session teardown, but not from the nonce fast path.
 - **TCP/TLS are unchanged.** Those transports cannot be source-spoofed and
   already pin a connection per client; sessions there keep stock behavior
   (the derived nonce is used, which is harmless).

--- a/examples/etc/turnserver.conf
+++ b/examples/etc/turnserver.conf
@@ -267,9 +267,10 @@
 # Note: nonces are bound to this process's key; in a multi-server deployment
 # behind a UDP load balancer, a client whose retry lands on a different
 # server re-authenticates via the standard 438 round-trip.
-# This option is disabled by default.
+# This option is enabled by default; the challenge nonce is then 24 characters
+# instead of the legacy 16. Set it to false to restore the stored random nonce.
 #
-#stateless-nonce
+#stateless-nonce=false
 
 # Derive the stateless-nonce signing key from this secret instead of a
 # random per-process key (implies stateless-nonce). Servers sharing the

--- a/examples/run_tests_stateless_nonce.sh
+++ b/examples/run_tests_stateless_nonce.sh
@@ -126,12 +126,14 @@ run_uclient "stateless-nonce turn client TCP" -t
 # The UDP run above must have gone through the listener fast path: the first
 # ALLOCATE has no MESSAGE-INTEGRITY, so the 401 challenge is emitted without
 # creating a session, and the server logs this one-time marker.
-echo "Checking secret-derived key markers"
-if grep -q "Stateless nonce mode is enabled (implied by --stateless-nonce-secret)" "$TURNSERVER_LOG" \
-   && grep -q "Stateless nonce key derived from the configured secret" "$TURNSERVER_LOG"; then
-    echo "OK (key derived from secret, mode implied)"
+# Only the key-derivation marker is asserted: stateless mode is the default, so
+# --stateless-nonce-secret no longer has anything to imply and logs the
+# "implied by" line only when an explicit --stateless-nonce=false preceded it.
+echo "Checking secret-derived key marker"
+if grep -q "Stateless nonce key derived from the configured secret" "$TURNSERVER_LOG"; then
+    echo "OK (key derived from secret)"
 else
-    echo "FAIL: missing stateless-nonce-secret startup markers in server log"
+    echo "FAIL: missing stateless-nonce-secret startup marker in server log"
     diagnose_failure "secret markers"
     exit 1
 fi
@@ -162,6 +164,35 @@ if command -v python3 >/dev/null 2>&1; then
     fi
 else
     echo "SKIP: python3 not available (forged-MESSAGE-INTEGRITY probe)"
+fi
+
+# Stateless mode is the default, so the legacy stored-nonce path has no other
+# coverage: pin that --stateless-nonce=false still starts, still challenges,
+# and still hands out the 16-character random nonce.
+if command -v python3 >/dev/null 2>&1; then
+    echo "Running legacy stored-nonce check (--stateless-nonce=false)"
+    LEGACY_LOG="/tmp/run_tests_stateless_nonce.$$.legacy.log"
+    $BINDIR/turnserver --use-auth-secret --static-auth-secret=secret --realm=north.gov --allow-loopback-peers \
+        --stateless-nonce=false --listening-port=3488 --no-cli --log-file=stdout > "$LEGACY_LOG" 2>&1 &
+    legacy_pid="$!"
+    for _ in $(seq 1 40); do
+        grep -q "Total auth threads:" "$LEGACY_LOG" 2>/dev/null && break
+        sleep 0.5
+    done
+    legacy_rc=0
+    python3 scripts/stateless_nonce_forged_mi.py 127.0.0.1 3488 user noncelen 16 || legacy_rc=$?
+    legacy_ok=0
+    if [ $legacy_rc -eq 0 ] && ! grep -q "stateless-nonce: listener fast-path challenge active" "$LEGACY_LOG"; then
+        echo "OK (legacy 16-char nonce, no fast path)"
+    else
+        echo "FAIL: legacy stored-nonce path"
+        tail -20 "$LEGACY_LOG"
+        legacy_ok=1
+    fi
+    kill "$legacy_pid" 2>/dev/null
+    wait "$legacy_pid" 2>/dev/null
+    rm -f "$LEGACY_LOG"
+    [ $legacy_ok -eq 0 ] || exit 1
 fi
 
 if [ $IS_DARWIN -eq 1 ]; then

--- a/examples/scripts/stateless_nonce_forged_mi.py
+++ b/examples/scripts/stateless_nonce_forged_mi.py
@@ -22,6 +22,7 @@ import sys
 MAGIC = 0x2112A442
 M_ALLOCATE = 0x0003
 M_REFRESH = 0x0004
+M_CONNECTION_BIND = 0x000B
 
 A_USERNAME = 0x0006
 A_MI = 0x0008
@@ -29,6 +30,7 @@ A_ERROR = 0x0009
 A_REALM = 0x0014
 A_NONCE = 0x0015
 A_REQ_TRANSPORT = 0x0019
+A_CONNECTION_ID = 0x002A
 
 FORGED_MI = b"\0" * 20  # right length, wrong HMAC
 FORGED_NONCE = b"deadbeefdeadbeefdeadbeef"  # right format, never issued here
@@ -115,6 +117,9 @@ def main():
     port = int(sys.argv[2]) if len(sys.argv) > 2 else 3478
     user = (sys.argv[3] if len(sys.argv) > 3 else "user").encode()
     flood_count = int(sys.argv[5]) if len(sys.argv) > 5 and sys.argv[4] == "flood" else 0
+    # noncelen <n>: assert the challenge nonce is n characters. Used to pin the
+    # legacy stored-nonce path (16) once stateless mode became the default (24).
+    want_nonce_len = int(sys.argv[5]) if len(sys.argv) > 5 and sys.argv[4] == "noncelen" else 0
 
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(3)
@@ -132,6 +137,13 @@ def main():
         print(f"FAIL: unauthenticated request: err={errcode(aa)} realm={realm} nonce={issued_nonce}")
         return 2
     print(f"OK: unauthenticated challenge: 401 realm={realm.decode()}")
+
+    if want_nonce_len:
+        if len(issued_nonce) != want_nonce_len:
+            print(f"FAIL: nonce length {len(issued_nonce)}, want {want_nonce_len}")
+            return 2
+        print(f"RESULT nonce_len={len(issued_nonce)}")
+        return 0
 
     if flood_count:
         return flood(host, port, user, realm, flood_count)
@@ -171,6 +183,18 @@ def main():
             [(A_USERNAME, user), (A_REALM, b"wrong.realm"), (A_NONCE, issued_nonce), (A_MI, FORGED_MI)],
         ),
         441,
+    )
+
+    # CONNECTION-BIND is exempt from the auth challenge and is rejected on a
+    # datagram socket before any attribute is read, so the listener answers it
+    # without a session.
+    ok &= check(
+        "CONNECTION-BIND over UDP",
+        s,
+        host,
+        port,
+        make(M_CONNECTION_BIND, [(A_CONNECTION_ID, b"\0\0\0\1")]),
+        400,
     )
 
     ok &= check(

--- a/man/man1/turnserver.1
+++ b/man/man1/turnserver.1
@@ -1293,7 +1293,9 @@ time plus an HMAC over the client address, keyed by a per\-process
 secret) instead of storing a random nonce in per\-client session state. Unauthenticated UDP requests are then
 answered without allocating a session, bounding server memory under
 spoofed\-source floods of structurally valid STUN messages.
-Wire\-compatible with standard TURN clients. Disabled by default.
+Wire\-compatible with standard TURN clients. Enabled by default; disable
+with \-\-stateless\-nonce=false, which restores the stored random nonce and
+the legacy 16\-character challenge in place of the 24\-character one.
 .TP
 .B
 \fB\-\-stateless\-nonce\-secret\fP=<secret>

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -824,7 +824,7 @@ static bool udp_stateless_nonce_fast_path(dtls_listener_relay_server_type *serve
     stun_tid_from_message_str(data, len, &ctid);
     if (!udp_unauthenticated_reply_ratelimited(server, &(nd->src_addr), 400)) {
       udp_send_stateless_error(server, nd, method, &ctid, 400,
-                               (const uint8_t *)"Bad request: CONNECTION_BIND only possible with TCP/TLS", NULL, NULL,
+                               (const uint8_t *)"CONNECTION_BIND only possible with TCP/TLS", NULL, NULL,
                                enforce_fingerprints);
     }
     return true;

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -672,6 +672,49 @@ static void udp_send_stateless_error(dtls_listener_relay_server_type *server, io
   ioa_network_buffer_delete(server->e, nbh);
 }
 
+/* True when a REFRESH carries no attribute that could steer
+ * handle_turn_refresh() away from its ticketless "437 Invalid allocation"
+ * reply. Anything that could produce 420, 443 or 400 instead - and any
+ * MOBILITY-TICKET, which selects the resume path - returns false so the
+ * request falls back to the session path. A new comprehension-required
+ * attribute therefore fails safe: it reads as unknown here and falls back. */
+static bool udp_refresh_is_plain_ticketless(const uint8_t *data, size_t len) {
+  stun_attr_ref sar = stun_attr_get_first_str(data, len);
+  while (sar) {
+    const int attr_type = stun_attr_get_type(sar);
+    switch (attr_type) {
+    /* Ignored by handle_turn_refresh's walk, so they cannot change the reply. */
+    case STUN_ATTRIBUTE_OAUTH_ACCESS_TOKEN:
+    case STUN_ATTRIBUTE_PRIORITY:
+    case STUN_ATTRIBUTE_FINGERPRINT:
+    case STUN_ATTRIBUTE_MESSAGE_INTEGRITY:
+    case STUN_ATTRIBUTE_USERNAME:
+    case STUN_ATTRIBUTE_REALM:
+    case STUN_ATTRIBUTE_NONCE:
+    case STUN_ATTRIBUTE_ORIGIN:
+      break;
+    case STUN_ATTRIBUTE_LIFETIME:
+      /* A malformed LIFETIME is 400 "Wrong Lifetime field format"; a valid one
+       * only sets to_delete, which does not apply without an allocation. */
+      if ((stun_attr_get_len(sar) != 4) || !stun_attr_get_value(sar)) {
+        return false;
+      }
+      break;
+    case STUN_ATTRIBUTE_MOBILITY_TICKET:
+    case STUN_ATTRIBUTE_ADDITIONAL_ADDRESS_FAMILY:
+      return false;
+    default:
+      /* Comprehension-required attributes the walk does not know are 420. */
+      if ((attr_type >= 0x0000) && (attr_type <= 0x7FFF)) {
+        return false;
+      }
+      break;
+    }
+    sar = stun_attr_get_next_covered_str(data, len, sar);
+  }
+  return true;
+}
+
 /* Stateless-nonce fast path (issue #1999): answer a request from an unknown
  * UDP source with the derived-nonce 401 challenge directly from the listener,
  * without creating a child socket or session. A request that does carry
@@ -757,14 +800,34 @@ static bool udp_stateless_nonce_fast_path(dtls_listener_relay_server_type *serve
       return false;
     }
   } else if (method == STUN_METHOD_REFRESH) {
-    /* With --mobility a REFRESH can resume a session using MOBILITY-TICKET
-     * instead of a first-pass challenge. */
+    /* With --mobility a REFRESH skips the auth challenge entirely: it may
+     * resume an allocation using MOBILITY-TICKET. A resume attempt needs the
+     * session path, but a ticketless REFRESH from a source with no allocation
+     * always ends at 437, so answer it here. */
     if (*(ts->mobility)) {
-      return false;
+      if (!udp_refresh_is_plain_ticketless(data, len)) {
+        return false;
+      }
+      stun_tid rtid;
+      stun_tid_from_message_str(data, len, &rtid);
+      if (!udp_unauthenticated_reply_ratelimited(server, &(nd->src_addr), 437)) {
+        udp_send_stateless_error(server, nd, method, &rtid, 437, (const uint8_t *)"Invalid allocation", NULL, NULL,
+                                 enforce_fingerprints);
+      }
+      return true;
     }
   } else if (method == STUN_METHOD_CONNECTION_BIND) {
-    /* CONNECTION-BIND is exempt from the auth challenge. */
-    return false;
+    /* CONNECTION-BIND is exempt from the auth challenge, and
+     * handle_turn_connection_bind() rejects it on a datagram socket before it
+     * looks at any attribute, so the reply is fixed for every UDP source. */
+    stun_tid ctid;
+    stun_tid_from_message_str(data, len, &ctid);
+    if (!udp_unauthenticated_reply_ratelimited(server, &(nd->src_addr), 400)) {
+      udp_send_stateless_error(server, nd, method, &ctid, 400,
+                               (const uint8_t *)"Bad request: CONNECTION_BIND only possible with TCP/TLS", NULL, NULL,
+                               enforce_fingerprints);
+    }
+    return true;
   }
 
   /* Every remaining request method reaches check_stun_auth() before any

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -264,9 +264,9 @@ turn_params_t turn_params = {
     RATELIMIT_DEFAULT_MAX_REQUESTS_PER_SEC, /* unauthorized-ratelimit-rps */
 
     ///////// Stateless nonce /////////
-    false, /* stateless-nonce */
-    {0},   /* stateless_nonce_key (generated at startup when enabled) */
-    false  /* stateless_nonce_key_set */
+    true, /* stateless-nonce */
+    {0},  /* stateless_nonce_key (generated at startup when enabled) */
+    false /* stateless_nonce_key_set */
 };
 
 //////////////// OpenSSL Init //////////////////////
@@ -1480,7 +1480,8 @@ static char Usage[] =
     "                                                 session. Unauthenticated UDP requests are then\n"
     "                                                 answered without allocating per-client session\n"
     "                                                 state, bounding memory under spoofed-source floods\n"
-    "                                                 of structurally valid STUN messages. Off by default.\n"
+    "                                                 of structurally valid STUN messages. On by default;\n"
+    "                                                 disable with --stateless-nonce=false.\n"
     " --stateless-nonce-secret=<secret>              Derive the stateless-nonce signing key from this\n"
     "                                                 secret instead of a random per-process key, so\n"
     "                                                 servers sharing the secret (and NTP-synced clocks)\n"

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -2650,12 +2650,12 @@ static int handle_turn_connection_bind(turn_turnserver *server, ts_ur_super_sess
   } else if (is_allocation_valid(a)) {
 
     *err_code = 400;
-    *reason = (const uint8_t *)"Bad request: CONNECTION_BIND cannot be issued after allocation";
+    *reason = (const uint8_t *)"CONNECTION_BIND cannot be issued after allocation";
 
   } else if (!is_stream_socket(get_ioa_socket_type(ss->client_socket))) {
 
     *err_code = 400;
-    *reason = (const uint8_t *)"Bad request: CONNECTION_BIND only possible with TCP/TLS";
+    *reason = (const uint8_t *)"CONNECTION_BIND only possible with TCP/TLS";
 
   } else {
     tcp_connection_id id = 0;


### PR DESCRIPTION
## What

Makes `--stateless-nonce` the default, and closes two paths that created a
per-packet session for unauthenticated UDP traffic even when it was enabled.


## Behaviour changes for operators

1. **The default challenge nonce goes from 16 to 24 characters.** RFC 8489
   requires clients to treat NONCE as an opaque string of up to 128 characters,
   so compliant clients are unaffected. `--stateless-nonce=false` restores the
   stored random nonce and the 16-character challenge.
2. **The default signing key is ephemeral**, so a restart costs each client one
   `438` re-auth round-trip, as does a retry that lands on a different instance
   behind a load balancer. `--stateless-nonce-secret` shares the key across a
   fleet and avoids both. (This is not a regression — today a retry landing on
   another instance finds no session either — but it becomes the default story.)


## Validation

Run in a container (Linux, isolated network namespace):

- build clean; 17/17 unit tests
- 11 example suites with zero FAIL lines: `run_tests`, `_conf`,
  `_stateless_nonce`, `_mobile`, `_dtls_default`, `_multiplex_peer`,
  `_stateless_binding`, `_ratelimit_401`, `_mobility_quota`, `_expiry`,
  `_mobility_resume_flood`
- both fuzzing smoke targets (`ASan 0`, `ASan 1`)
- `clang-format-15` clean; mandoc lint unchanged at 104 pre-existing warnings
