### PR TITLE
Gate merges on the more tests suites

### DIFF
--- a/.github/workflows/actions/ubuntu-build-deps/action.yml
+++ b/.github/workflows/actions/ubuntu-build-deps/action.yml
@@ -38,6 +38,7 @@ runs:
             iwyu \
             ninja-build \
             pkgconf \
+            python3 \
             wget
         if [ "$(lsb_release -s -r)x" == "16.04x" ]; then apt install -y clang-tools; fi
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,3 +74,22 @@ jobs:
       - run: ./run_tests_prom.sh
         working-directory: examples/
         if: ${{ contains(matrix.os, 'ubuntu') }}
+
+      # Regression cover for shipped security fixes. These drive raw STUN over
+      # python3, so a missing interpreter must not silently skip them here.
+      - run: ./run_tests_mobility_quota.sh
+        working-directory: examples/
+      - run: ./run_tests_mobility_resume_flood.sh
+        working-directory: examples/
+      - run: ./run_tests_stateless_binding.sh
+        working-directory: examples/
+      - run: ./run_tests_stateless_nonce.sh
+        working-directory: examples/
+
+      - run: ./run_tests_expiry.sh
+        working-directory: examples/
+      # Needs a second bindable loopback address, which is native on Linux.
+      - run: ./run_tests_rfc5780.sh
+        working-directory: examples/
+      - run: ./run_tests_multiplex_peer.sh
+        working-directory: examples/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,6 +51,21 @@ jobs:
       - run: ./run_tests_dtls_default.sh
         working-directory: examples/
 
+      # run_tests_rfc5780.sh and run_tests_multiplex_peer.sh are deliberately
+      # absent: the first needs a 127.0.0.2 alias macOS does not configure by
+      # default and would only SKIP, the second exercises Linux-only paths.
+      # Both run in the Linux workflow.
+      - run: ./run_tests_mobility_quota.sh
+        working-directory: examples/
+      - run: ./run_tests_mobility_resume_flood.sh
+        working-directory: examples/
+      - run: ./run_tests_stateless_binding.sh
+        working-directory: examples/
+      - run: ./run_tests_stateless_nonce.sh
+        working-directory: examples/
+      - run: ./run_tests_expiry.sh
+        working-directory: examples/
+
   build-cmake:
     name: build + test cmake
     strategy:
@@ -86,4 +101,19 @@ jobs:
       - run: ./run_tests_conf.sh
         working-directory: examples/
       - run: ./run_tests_dtls_default.sh
+        working-directory: examples/
+
+      # run_tests_rfc5780.sh and run_tests_multiplex_peer.sh are deliberately
+      # absent: the first needs a 127.0.0.2 alias macOS does not configure by
+      # default and would only SKIP, the second exercises Linux-only paths.
+      # Both run in the Linux workflow.
+      - run: ./run_tests_mobility_quota.sh
+        working-directory: examples/
+      - run: ./run_tests_mobility_resume_flood.sh
+        working-directory: examples/
+      - run: ./run_tests_stateless_binding.sh
+        working-directory: examples/
+      - run: ./run_tests_stateless_nonce.sh
+        working-directory: examples/
+      - run: ./run_tests_expiry.sh
         working-directory: examples/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -63,8 +63,6 @@ jobs:
         working-directory: examples/
       - run: ./run_tests_stateless_nonce.sh
         working-directory: examples/
-      - run: ./run_tests_expiry.sh
-        working-directory: examples/
 
   build-cmake:
     name: build + test cmake
@@ -114,6 +112,4 @@ jobs:
       - run: ./run_tests_stateless_binding.sh
         working-directory: examples/
       - run: ./run_tests_stateless_nonce.sh
-        working-directory: examples/
-      - run: ./run_tests_expiry.sh
         working-directory: examples/

--- a/examples/run_tests_conf.sh
+++ b/examples/run_tests_conf.sh
@@ -34,13 +34,13 @@ fi
 echo "dtls" >> $BINDIR/turnserver.conf
 echo "cert=../examples/ca/turn_server_cert.pem" >> $BINDIR/turnserver.conf
 echo "pkey=../examples/ca/turn_server_pkey.pem" >> $BINDIR/turnserver.conf
+# Force log output to stdout (which we redirect to $TURNSERVER_LOG below).
+# Without this, turnserver writes to its platform-default location
+# (syslog or /var/log/turn_*.log) and our log file stays empty, which
+# breaks wait_for_turnserver's "Total relay threads:" probe and leaves
+# the FAIL diagnostics useless.
+echo "log-file=stdout" >> $BINDIR/turnserver.conf
 if [ $IS_DARWIN -eq 0 ]; then
-    # Force log output to stdout (which we redirect to $TURNSERVER_LOG below).
-    # Without this, turnserver writes to its platform-default location
-    # (syslog or /var/log/turn_*.log) and our log file stays empty, which
-    # breaks wait_for_turnserver's "Total relay threads:" probe and leaves
-    # the FAIL diagnostics useless.
-    echo "log-file=stdout" >> $BINDIR/turnserver.conf
     # Server-side fast paths: enable on Linux so the conf-driven test
     # cycle also exercises the recvmmsg drain path. The udp-gso path
     # lives behind multiplex-peer (that mode is what enables sendmmsg
@@ -54,11 +54,11 @@ if [ $IS_DARWIN -eq 0 ]; then
 fi
 
 echo 'Running turnserver'
-if [ $IS_DARWIN -eq 1 ]; then
-    $BINDIR/turnserver -c $BINDIR/turnserver.conf > /dev/null &
-else
-    $BINDIR/turnserver -c $BINDIR/turnserver.conf > "$TURNSERVER_LOG" 2>&1 &
-fi
+# Both platforms capture the log: macOS used to launch with >/dev/null and a
+# fixed sleep, which raced uclient against a still-initializing server on hosts
+# with many local addresses (relay init runs per address). Same shape as
+# run_tests.sh.
+$BINDIR/turnserver -c $BINDIR/turnserver.conf > "$TURNSERVER_LOG" 2>&1 &
 turnserver_pid="$!"
 echo 'Running peer client'
 if [ $IS_DARWIN -eq 1 ]; then
@@ -97,15 +97,11 @@ wait_for_turnserver() {
     tail -30 "$TURNSERVER_LOG" 2>/dev/null || echo "(log file missing)"
     return 1
 }
-if [ $IS_DARWIN -eq 1 ]; then
-    sleep 5
-else
-    wait_for_turnserver || exit 1
-    # No-barrier builds can log readiness before all worker event loops have
-    # had a scheduling turn. Keep the old startup cushion after the active
-    # per-process readiness check.
-    sleep 2
-fi
+wait_for_turnserver || exit 1
+# No-barrier builds can log readiness before all worker event loops have
+# had a scheduling turn. Keep the old startup cushion after the active
+# per-process readiness check.
+sleep 2
 
 # See run_tests.sh for rationale — same shape, mirrored here so the
 # conf-driven test produces the same actionable failure output.


### PR DESCRIPTION
Seven suites in examples/ ran on no platform, so nothing stopped a regression in what they cover. Three of them are the only automated proof that a shipped security fix still holds: the mobility quota bypass, and the two pre-auth session-cost paths.

The Linux workflow gains all seven. macOS gains the five that do real work there; run_tests_rfc5780.sh needs a 127.0.0.2 alias macOS does not configure by default and would only report SKIP, and run_tests_multiplex_peer.sh exercises Linux-only paths.

The ubuntu build-deps action gains python3. The ubuntu:22.04 and ubuntu:24.04 container images ship none, and four of these suites drive raw STUN through it: run_tests_mobility_quota.sh calls it unguarded and would have failed, while three others guard the call and would have skipped in silence - the worst outcome for a job whose purpose is to catch a revert.

run_tests_conf.sh no longer sleeps a fixed 5 seconds on macOS. It discarded the server log there, so it could not use the readiness probe it already had for other platforms and raced uclient against a still- initializing server. It now captures the log on both platforms and polls, as run_tests.sh has done since the same race was fixed there.

Verified per platform (autotools build, as CI builds): ubuntu:24.04 and amazonlinux:2023 containers and macOS, all suites rc=0 with no unexpected skips. Reverting the mobility quota fix makes run_tests_mobility_quota.sh exit 1 with flood_accepted=8, so the gate demonstrably catches a revert.