### PR TITLE
Fix outgoing UDP TTL pinned to 1 on client-facing sockets

### DIFF
--- a/src/apps/relay/ns_ioalib_engine_impl.c
+++ b/src/apps/relay/ns_ioalib_engine_impl.c
@@ -2008,6 +2008,13 @@ ioa_socket_handle create_ioa_socket_from_fd(ioa_engine_handle e, ioa_socket_raw 
 
   if (parent_s) {
     add_socket_to_parent(parent_s, ret);
+    /* This socket shares the parent's fd, so IP_TTL/TOS is the same kernel-level
+     * socket option: inherit the parent's known state instead of leaving these
+     * zero-initialized, which floors every outgoing TTL to 1 (see set_socket_ttl). */
+    ret->default_ttl = parent_s->default_ttl;
+    ret->current_ttl = parent_s->current_ttl;
+    ret->default_tos = parent_s->default_tos;
+    ret->current_tos = parent_s->current_tos;
   } else {
     set_socket_options(ret);
   }


### PR DESCRIPTION
create_ioa_socket_from_fd() only populates default_ttl/current_ttl (via set_socket_options()) when the new socket has no parent. Every per-session UDP client socket is created with the listener as its parent (it aliases the listener's fd), so that branch was skipped and both fields stayed at their calloc'd zero.

set_socket_ttl() treats a TTL_IGNORE (-1) request as "use default_ttl", which resolved to 0, and a floor clamp added in e4023de then rounded that up to 1 before calling setsockopt(IP_TTL). Because the client socket shares the listener's real fd, this pinned the outgoing TTL to 1 for every UDP TURN/STUN response the server ever sends on that listener.

Fix by inheriting the parent's already-correct ttl/tos state, since it describes the shared underlying fd rather than being per-struct.

Reproduced on a loopback capture: server responses carried ttl 1 before this change and ttl 64 after, with unit tests and examples/run_tests.sh passing.

Fixes #2043