### PR TITLE
Size USERNAME, REALM and NONCE limits in bytes per RFC 8489

### DIFF
--- a/src/apps/relay/turn_admin_server.c
+++ b/src/apps/relay/turn_admin_server.c
@@ -1598,16 +1598,18 @@ static char *get_bold_admin_title(void) {
   if (current_socket && current_socket->special_session) {
     struct admin_session *as = (struct admin_session *)current_socket->special_session;
     if (as && as->as_ok) {
+      /* Bound each append by what is left of sbat, not by the length of the value
+       * being appended: the value can be longer than the space remaining. */
       if (as->as_login[0]) {
-        char *dst = sbat + strlen(sbat);
-        snprintf(dst, ADMIN_USER_MAX_LENGTH * 2 + 2, " admin user: <b><i>%s</i></b><br>\r\n", as->as_login);
+        const size_t used = strlen(sbat);
+        snprintf(sbat + used, sizeof(sbat) - used, " admin user: <b><i>%s</i></b><br>\r\n", as->as_login);
       }
       if (as->as_realm[0]) {
-        char *dst = sbat + strlen(sbat);
-        snprintf(dst, STUN_MAX_REALM_SIZE * 2, " admin session realm: <b><i>%s</i></b><br>\r\n", as->as_realm);
+        const size_t used = strlen(sbat);
+        snprintf(sbat + used, sizeof(sbat) - used, " admin session realm: <b><i>%s</i></b><br>\r\n", as->as_realm);
       } else if (as->as_eff_realm[0]) {
-        char *dst = sbat + strlen(sbat);
-        snprintf(dst, STUN_MAX_REALM_SIZE * 2, " admin session realm: <b><i>%s</i></b><br>\r\n", as->as_eff_realm);
+        const size_t used = strlen(sbat);
+        snprintf(sbat + used, sizeof(sbat) - used, " admin session realm: <b><i>%s</i></b><br>\r\n", as->as_eff_realm);
       }
     }
   }

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -697,7 +697,11 @@ bool stun_is_challenge_response_str(const uint8_t *buf, size_t len, int *err_cod
       const uint8_t *value = stun_attr_get_value(sar);
       if (value) {
         size_t vlen = (size_t)stun_attr_get_len(sar);
-        vlen = min(vlen, (size_t)STUN_MAX_REALM_SIZE);
+        /* Truncating would corrupt the realm mid-codepoint and fail the integrity
+         * check later with an unrelated error; reject the challenge instead. */
+        if (vlen > (size_t)STUN_MAX_REALM_SIZE) {
+          return false;
+        }
         memcpy(realm, value, vlen);
         realm[vlen] = 0;
         {
@@ -723,7 +727,9 @@ bool stun_is_challenge_response_str(const uint8_t *buf, size_t len, int *err_cod
           value = stun_attr_get_value(sar);
           if (value) {
             vlen = (size_t)stun_attr_get_len(sar);
-            vlen = min(vlen, (size_t)STUN_MAX_NONCE_SIZE);
+            if (vlen > (size_t)STUN_MAX_NONCE_SIZE) {
+              return false;
+            }
             memcpy(nonce, value, vlen);
             nonce[vlen] = 0;
             if (oauth) {

--- a/src/client/ns_turn_msg_defs.h
+++ b/src/client/ns_turn_msg_defs.h
@@ -46,9 +46,13 @@
 #define STUN_HEADER_LENGTH (20)
 #define STUN_CHANNEL_HEADER_LENGTH (4)
 
-#define STUN_MAX_USERNAME_SIZE (512)
-#define STUN_MAX_REALM_SIZE (127)
-#define STUN_MAX_NONCE_SIZE (127)
+/* Longest valid value in bytes, not in characters. RFC 8489 Section 14.3 caps
+ * USERNAME at fewer than 509 bytes; Sections 14.9 and 14.10 cap REALM and NONCE
+ * at fewer than 128 characters, which is up to 763 bytes once UTF-8 encoded.
+ * Buffers sized from these add one byte for the terminator. */
+#define STUN_MAX_USERNAME_SIZE (508)
+#define STUN_MAX_REALM_SIZE (763)
+#define STUN_MAX_NONCE_SIZE (763)
 #define STUN_MAX_SERVER_NAME_SIZE (1025)
 #define STUN_MAX_PWD_SIZE (256)
 #define AUTH_SECRET_SIZE STUN_MAX_PWD_SIZE

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -3673,7 +3673,12 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
       return -1;
     }
 
-    alen = min((size_t)stun_attr_get_len(sar), sizeof(realm) - 1);
+    alen = (size_t)stun_attr_get_len(sar);
+    if (alen >= sizeof(realm)) {
+      *err_code = 400;
+      *reason = (const uint8_t *)"Realm is too long";
+      return -1;
+    }
     memcpy(realm, stun_attr_get_value(sar), alen);
     realm[alen] = 0;
 
@@ -3715,7 +3720,12 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
     return -1;
   }
 
-  alen = min((size_t)stun_attr_get_len(sar), sizeof(usname) - 1);
+  alen = (size_t)stun_attr_get_len(sar);
+  if (alen >= sizeof(usname)) {
+    *err_code = 400;
+    *reason = (const uint8_t *)"User name is too long";
+    return -1;
+  }
   memcpy(usname, stun_attr_get_value(sar), alen);
   usname[alen] = 0;
 
@@ -3755,7 +3765,12 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
       return -1;
     }
 
-    alen = min((size_t)stun_attr_get_len(sar), sizeof(nonce) - 1);
+    alen = (size_t)stun_attr_get_len(sar);
+    if (alen >= sizeof(nonce)) {
+      *err_code = 400;
+      *reason = (const uint8_t *)"Nonce is too long";
+      return -1;
+    }
     memcpy(nonce, stun_attr_get_value(sar), alen);
     nonce[alen] = 0;
 

--- a/tests/test_stun_msg.c
+++ b/tests/test_stun_msg.c
@@ -245,6 +245,56 @@ static void test_challenge_response_null_terminates_max_length_server_name(void)
   TEST_ASSERT_EQUAL_size_t(STUN_MAX_SERVER_NAME_SIZE, strlen((const char *)server_name));
 }
 
+/* The limits are byte counts, and RFC 8489 states them per attribute: USERNAME
+ * fewer than 509 bytes (Section 14.3); REALM and NONCE fewer than 128
+ * characters (Sections 14.9 and 14.10), which is up to 763 bytes of UTF-8.
+ * Spelled as literals so a change to the macros has to be deliberate. */
+static void test_length_limits_are_the_rfc8489_byte_counts(void) {
+  TEST_ASSERT_EQUAL_INT(508, STUN_MAX_USERNAME_SIZE);
+  TEST_ASSERT_EQUAL_INT(763, STUN_MAX_REALM_SIZE);
+  TEST_ASSERT_EQUAL_INT(763, STUN_MAX_NONCE_SIZE);
+}
+
+/* Builds a 401 challenge carrying realm_len realm bytes and nonce_len nonce
+ * bytes, and reports whether the client accepted it. */
+static bool parse_challenge_with(size_t realm_len, size_t nonce_len) {
+  uint8_t buf[MAX_STUN_MESSAGE_SIZE] = {0};
+  size_t len = 0;
+  stun_tid tid = {0};
+
+  stun_init_error_response_str(STUN_METHOD_ALLOCATE, buf, &len, 401, (const uint8_t *)"Unauthorized", &tid, true);
+
+  uint8_t value[STUN_MAX_REALM_SIZE + 2];
+  memset(value, 'a', sizeof(value));
+  TEST_ASSERT_TRUE(stun_attr_add_str(buf, &len, STUN_ATTRIBUTE_REALM, value, (int)realm_len));
+  TEST_ASSERT_TRUE(stun_attr_add_str(buf, &len, STUN_ATTRIBUTE_NONCE, value, (int)nonce_len));
+
+  int err_code = 0;
+  uint8_t err_msg[128] = {0};
+  uint8_t out_realm[STUN_MAX_REALM_SIZE + 1] = {0};
+  uint8_t out_nonce[STUN_MAX_NONCE_SIZE + 1] = {0};
+
+  return stun_is_challenge_response_str(buf, len, &err_code, err_msg, sizeof(err_msg), out_realm, out_nonce, NULL,
+                                        NULL);
+}
+
+/* A realm or nonce at the RFC 8489 maximum must parse: a 127-character UTF-8
+ * realm can occupy all 763 bytes. */
+static void test_challenge_accepts_max_length_realm_and_nonce(void) {
+  TEST_ASSERT_TRUE(parse_challenge_with(STUN_MAX_REALM_SIZE, STUN_MAX_NONCE_SIZE));
+}
+
+/* Past the maximum the challenge is rejected rather than silently truncated:
+ * truncation cuts a multi-byte codepoint in half and then fails the integrity
+ * check with an unrelated error. */
+static void test_challenge_rejects_oversized_realm(void) {
+  TEST_ASSERT_FALSE(parse_challenge_with(STUN_MAX_REALM_SIZE + 1, 16));
+}
+
+static void test_challenge_rejects_oversized_nonce(void) {
+  TEST_ASSERT_FALSE(parse_challenge_with(16, STUN_MAX_NONCE_SIZE + 1));
+}
+
 /* Build a minimal valid STUN message header with a chosen body length field,
  * so we can drive stun_get_message_len_str() across the uint16_t-overflow
  * boundary. */
@@ -844,6 +894,10 @@ int main(void) {
   RUN_TEST(test_channel_message_roundtrip);
   RUN_TEST(test_channel_message_zeroes_padding_bytes);
   RUN_TEST(test_challenge_response_null_terminates_max_length_server_name);
+  RUN_TEST(test_length_limits_are_the_rfc8489_byte_counts);
+  RUN_TEST(test_challenge_accepts_max_length_realm_and_nonce);
+  RUN_TEST(test_challenge_rejects_oversized_realm);
+  RUN_TEST(test_challenge_rejects_oversized_nonce);
   RUN_TEST(test_message_len_does_not_overflow_uint16);
   RUN_TEST(test_message_len_accepts_full_well_formed_message);
   RUN_TEST(test_rfc5780_change_request_roundtrip);


### PR DESCRIPTION
The three limits were byte counts standing in for character counts, and the auth path silently truncated to them.

RFC 8489 Section 14.3 caps USERNAME at fewer than 509 bytes; Sections 14.9 and 14.10 cap REALM and NONCE at fewer than 128 characters, which is up to 763 bytes once UTF-8 encoded. coturn used 512/127/127, so USERNAME was simultaneously too loose (509-512 accepted, should be rejected) and REALM and NONCE far too tight: a conformant 127-character UTF-8 realm was cut off at 127 bytes, mid-codepoint, and the realm comparison then failed with 437/441 rather than anything diagnostic.

check_stun_auth() now rejects an over-long value with 400 instead of truncating, matching handle_turn_allocate(), which already answered 400 "User name is too long" - the two paths disagreed. The client-side challenge parser rejects an over-long realm or nonce for the same reason: a truncated value fails the later integrity check with an unrelated error.

ts_ur_super_session grows 18520 -> 19152 bytes and turn_session_info 1848 -> 2480, both +632, from the wider realm buffers. These are installed public headers, so the struct-size change is visible to libturnclient consumers.

The turn_realm_option and turn_admin_user realm columns stay varchar(127): the RFC limit governs what must be parsed off the wire, not how long an operator's own realm may be, and those columns sit in composite primary keys where widening risks the InnoDB index-length limit.

get_bold_admin_title() bounded each append by the length of the value being appended rather than by the space left in its 1025-byte buffer; at a 763-byte realm that bound exceeds the buffer, so it now uses the remaining space.