### PR TITLE
clamp software copy length in handle_old_stun_command

### DIFF
--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -4411,7 +4411,7 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
           if (newsz > sizeof(software)) {
             newsz = sizeof(software);
           }
-          memcpy(software, get_version(server), oldsz);
+          memcpy(software, get_version(server), min(oldsz, sizeof(software)));
           size_t len = ioa_network_buffer_get_size(nbh);
           stun_attr_add_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_SERVER, software, newsz);
           ioa_network_buffer_set_size(nbh, len);
@@ -4470,7 +4470,7 @@ static int handle_old_stun_command(turn_turnserver *server, ts_ur_super_session 
       if (newsz > sizeof(software)) {
         newsz = sizeof(software);
       }
-      memcpy(software, get_version(server), oldsz);
+      memcpy(software, get_version(server), min(oldsz, sizeof(software)));
       size_t len = ioa_network_buffer_get_size(nbh);
       stun_attr_add_str(ioa_network_buffer_data(nbh), &len, OLD_STUN_ATTRIBUTE_SERVER, software, newsz);
       ioa_network_buffer_set_size(nbh, len);


### PR DESCRIPTION
Repro: build so `TURN_SOFTWARE` is longer than 120 bytes (e.g. a long `-DTURN_SERVER_BUILD_INFO`), run with `--rfc3489-compatibility` and `--software-attribute`, then send a legacy RFC 3489 Binding request. ASan reports a `stack-buffer-overflow` WRITE at the `memcpy` in `handle_old_stun_command`.
Cause: the SERVER/SOFTWARE string is copied into `uint8_t software[120]` via `memcpy(software, get_version(server), oldsz)`. The neighbouring `if (newsz > sizeof(software))` clamp bounds `newsz` (the attribute length) but never `oldsz`, so the copy length stays uncapped. Both old-STUN response sites carry it.
Fix: bound the copy to `min(oldsz, sizeof(software))`. `oldsz` can be shorter than the rounded-up `newsz`, so copying `newsz` would over-read the source; the buffer is zero-initialised so the trailing pad bytes stay zero.