### PR TITLE
fix: shrink oversized stack frames in the test utilities

### DIFF
--- a/src/apps/natdiscovery/natdiscovery.c
+++ b/src/apps/natdiscovery/natdiscovery.c
@@ -504,14 +504,16 @@ static int stunclient_receive(stun_buffer *buf, int sockfd, ioa_addr *local_addr
 static int run_stunclient(ioa_addr *local_addr, ioa_addr *remote_addr, ioa_addr *reflexive_addr, ioa_addr *other_addr,
                           uint16_t *local_port, bool *rfc5780, bool change_ip, bool change_port, int padding) {
   int ret = 0;
-  stun_buffer buf;
+  stun_buffer *buf = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
 
   init_socket(&udp_fd, local_addr, *local_port, remote_addr);
 
-  ret = stunclient_send(&buf, udp_fd, local_addr, local_port, remote_addr, change_ip, change_port, padding, -1);
-  ret = stunclient_receive(&buf, udp_fd, local_addr, reflexive_addr, other_addr, rfc5780);
+  ret = stunclient_send(buf, udp_fd, local_addr, local_port, remote_addr, change_ip, change_port, padding, -1);
+  ret = stunclient_receive(buf, udp_fd, local_addr, reflexive_addr, other_addr, rfc5780);
 
   socket_closesocket(udp_fd);
+
+  free(buf);
 
   return ret;
 }
@@ -520,28 +522,31 @@ static int run_stunclient_hairpinning(ioa_addr *local_addr, ioa_addr *remote_add
                                       ioa_addr *other_addr, uint16_t *local_port, bool *rfc5780, bool change_ip,
                                       bool change_port, int padding) {
   int ret = 0;
-  stun_buffer buf;
-  stun_buffer buf2;
+  stun_buffer *buf = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
+  stun_buffer *buf2 = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
 
   init_socket(&udp_fd, local_addr, *local_port, remote_addr);
 
-  ret = stunclient_send(&buf, udp_fd, local_addr, local_port, remote_addr, change_ip, change_port, padding, -1);
-  ret = stunclient_receive(&buf, udp_fd, local_addr, reflexive_addr, other_addr, rfc5780);
+  ret = stunclient_send(buf, udp_fd, local_addr, local_port, remote_addr, change_ip, change_port, padding, -1);
+  ret = stunclient_receive(buf, udp_fd, local_addr, reflexive_addr, other_addr, rfc5780);
 
   addr_cpy(remote_addr, reflexive_addr);
   addr_set_port(local_addr, 0);
 
   init_socket(&udp_fd2, local_addr, 0, remote_addr);
 
-  ret = stunclient_send(&buf2, udp_fd2, local_addr, local_port, remote_addr, change_ip, change_port, padding, -1);
-  ret = stunclient_receive(&buf, udp_fd, local_addr, reflexive_addr, other_addr, rfc5780);
+  ret = stunclient_send(buf2, udp_fd2, local_addr, local_port, remote_addr, change_ip, change_port, padding, -1);
+  ret = stunclient_receive(buf, udp_fd, local_addr, reflexive_addr, other_addr, rfc5780);
 
   if (ret) {
-    ret = stunclient_receive(&buf2, udp_fd2, local_addr, reflexive_addr, other_addr, rfc5780);
+    ret = stunclient_receive(buf2, udp_fd2, local_addr, reflexive_addr, other_addr, rfc5780);
   }
 
   socket_closesocket(udp_fd);
   socket_closesocket(udp_fd2);
+
+  free(buf);
+  free(buf2);
 
   return ret;
 }
@@ -550,14 +555,14 @@ static int run_stunclient_lifetime(int timer, ioa_addr *local_addr, ioa_addr *re
                                    ioa_addr *other_addr, uint16_t *local_port, bool *rfc5780, bool change_ip,
                                    bool change_port, int padding) {
   int ret = 0;
-  stun_buffer buf;
-  stun_buffer buf2;
+  stun_buffer *buf = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
+  stun_buffer *buf2 = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
   uint16_t response_port;
 
   init_socket(&udp_fd, local_addr, *local_port, remote_addr);
 
-  ret = stunclient_send(&buf, udp_fd, local_addr, local_port, remote_addr, change_ip, change_port, padding, -1);
-  ret = stunclient_receive(&buf, udp_fd, local_addr, reflexive_addr, other_addr, rfc5780);
+  ret = stunclient_send(buf, udp_fd, local_addr, local_port, remote_addr, change_ip, change_port, padding, -1);
+  ret = stunclient_receive(buf, udp_fd, local_addr, reflexive_addr, other_addr, rfc5780);
 
   addr_set_port(local_addr, 0);
   sleep(timer);
@@ -565,12 +570,15 @@ static int run_stunclient_lifetime(int timer, ioa_addr *local_addr, ioa_addr *re
   init_socket(&udp_fd2, local_addr, 0, remote_addr);
   response_port = addr_get_port(reflexive_addr);
 
-  ret = stunclient_send(&buf2, udp_fd2, local_addr, local_port, remote_addr, change_ip, change_port, padding,
+  ret = stunclient_send(buf2, udp_fd2, local_addr, local_port, remote_addr, change_ip, change_port, padding,
                         response_port);
-  ret = stunclient_receive(&buf, udp_fd, local_addr, reflexive_addr, other_addr, rfc5780);
+  ret = stunclient_receive(buf, udp_fd, local_addr, reflexive_addr, other_addr, rfc5780);
 
   socket_closesocket(udp_fd);
   socket_closesocket(udp_fd2);
+
+  free(buf);
+  free(buf2);
 
   return ret;
 }

--- a/src/apps/peer/udpserver.c
+++ b/src/apps/peer/udpserver.c
@@ -209,7 +209,9 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
 
   ioa_addr *addr = (ioa_addr *)arg;
 
-  stun_buffer buffer;
+  /* One event_base dispatches every peer socket serially, so a module-static
+   * echo buffer is race-free and keeps ~64 KB out of the callback frame. */
+  static stun_buffer buffer;
   ioa_addr remote_addr;
   uint32_t slen = get_ioa_addr_len(addr);
   ssize_t len = 0;

--- a/src/apps/stunclient/stunclient.c
+++ b/src/apps/stunclient/stunclient.c
@@ -320,7 +320,8 @@ static int run_stunclient(const char *rip, uint16_t rport, uint16_t *port, bool 
                           bool change_ip, bool change_port, int padding, unsigned int timeout_ms, bool print_details) {
 
   ioa_addr remote_addr;
-  stun_buffer buf;
+  int ret = 0;
+  stun_buffer *buf = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
 
   memset(&remote_addr, 0, sizeof(remote_addr));
   if (make_ioa_addr((const uint8_t *)rip, rport, &remote_addr) < 0) {
@@ -355,16 +356,16 @@ static int run_stunclient(const char *rip, uint16_t rport, uint16_t *port, bool 
     }
   }
 
-  stun_prepare_binding_request(&buf);
+  stun_prepare_binding_request(buf);
 
   if (response_port >= 0 && response_port <= USHRT_MAX) {
-    stun_attr_add_response_port_str((uint8_t *)(buf.buf), (size_t *)&(buf.len), (uint16_t)response_port);
+    stun_attr_add_response_port_str((uint8_t *)(buf->buf), (size_t *)&(buf->len), (uint16_t)response_port);
   }
   if (change_ip || change_port) {
-    stun_attr_add_change_request_str((uint8_t *)buf.buf, (size_t *)&(buf.len), change_ip, change_port);
+    stun_attr_add_change_request_str((uint8_t *)buf->buf, (size_t *)&(buf->len), change_ip, change_port);
   }
 
-  if (padding && !stun_attr_add_padding_str((uint8_t *)buf.buf, (size_t *)&(buf.len), 1500)) {
+  if (padding && !stun_attr_add_padding_str((uint8_t *)buf->buf, (size_t *)&(buf->len), 1500)) {
     printf("%s: ERROR: Cannot add padding\n", __FUNCTION__);
   }
 
@@ -373,7 +374,7 @@ static int run_stunclient(const char *rip, uint16_t rport, uint16_t *port, bool 
     uint32_t slen = get_ioa_addr_len(&remote_addr);
 
     do {
-      len = sendto(udp_fd, buf.buf, buf.len, 0, (struct sockaddr *)&remote_addr, (socklen_t)slen);
+      len = sendto(udp_fd, buf->buf, buf->len, 0, (struct sockaddr *)&remote_addr, (socklen_t)slen);
     } while (len < 0 && (socket_eintr() || socket_enobufs() || socket_eagain()));
 
     if (len < 0) {
@@ -397,10 +398,10 @@ static int run_stunclient(const char *rip, uint16_t rport, uint16_t *port, bool 
   {
     ssize_t len = 0;
     int recvd = 0;
-    const int to_recv = sizeof(buf.buf);
+    const int to_recv = sizeof(buf->buf);
 
     do {
-      len = recv(udp_fd, buf.buf, to_recv - recvd, 0);
+      len = recv(udp_fd, buf->buf, to_recv - recvd, 0);
       if (len > 0) {
         recvd += len;
         break;
@@ -410,26 +411,24 @@ static int run_stunclient(const char *rip, uint16_t rport, uint16_t *port, bool 
     if (recvd > 0) {
       len = recvd;
     } else {
-      if (socket_eagain() || socket_ewouldblock()) {
-        return 1;
-      }
-      return -1;
+      ret = (socket_eagain() || socket_ewouldblock()) ? 1 : -1;
+      goto done;
     }
-    buf.len = len;
+    buf->len = len;
 
-    if (stun_is_command_message(&buf)) {
+    if (stun_is_command_message(buf)) {
 
-      if (stun_is_response(&buf)) {
+      if (stun_is_response(buf)) {
 
-        if (stun_is_success_response(&buf)) {
+        if (stun_is_success_response(buf)) {
 
-          if (stun_is_binding_response(&buf)) {
+          if (stun_is_binding_response(buf)) {
 
             ioa_addr reflexive_addr;
             addr_set_any(&reflexive_addr);
-            if (stun_attr_get_first_addr(&buf, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, &reflexive_addr, NULL)) {
+            if (stun_attr_get_first_addr(buf, STUN_ATTRIBUTE_XOR_MAPPED_ADDRESS, &reflexive_addr, NULL)) {
 
-              stun_attr_ref sar = stun_attr_get_first_by_type_str(buf.buf, buf.len, STUN_ATTRIBUTE_OTHER_ADDRESS);
+              stun_attr_ref sar = stun_attr_get_first_by_type_str(buf->buf, buf->len, STUN_ATTRIBUTE_OTHER_ADDRESS);
               if (sar) {
                 *rfc5780 = 1;
                 if (print_details) {
@@ -437,11 +436,11 @@ static int run_stunclient(const char *rip, uint16_t rport, uint16_t *port, bool 
                   printf("RFC 5780 response %d\n", ++counter);
                 }
                 ioa_addr other_addr;
-                stun_attr_get_addr_str((uint8_t *)buf.buf, (size_t)buf.len, sar, &other_addr, NULL);
-                sar = stun_attr_get_first_by_type_str(buf.buf, buf.len, STUN_ATTRIBUTE_RESPONSE_ORIGIN);
+                stun_attr_get_addr_str((uint8_t *)buf->buf, (size_t)buf->len, sar, &other_addr, NULL);
+                sar = stun_attr_get_first_by_type_str(buf->buf, buf->len, STUN_ATTRIBUTE_RESPONSE_ORIGIN);
                 if (sar) {
                   ioa_addr response_origin;
-                  stun_attr_get_addr_str((uint8_t *)buf.buf, (size_t)buf.len, sar, &response_origin, NULL);
+                  stun_attr_get_addr_str((uint8_t *)buf->buf, (size_t)buf->len, sar, &response_origin, NULL);
                   if (print_details) {
                     addr_debug_print(1, &response_origin, "Response origin: ");
                   }
@@ -464,7 +463,7 @@ static int run_stunclient(const char *rip, uint16_t rport, uint16_t *port, bool 
           int err_code = 0;
           uint8_t err_msg[1025] = "\0";
           size_t err_msg_size = sizeof(err_msg);
-          if (stun_is_error_response(&buf, &err_code, err_msg, err_msg_size)) {
+          if (stun_is_error_response(buf, &err_code, err_msg, err_msg_size)) {
             printf("The response is an error %d (%s)\n", err_code, (char *)err_msg);
           } else {
             printf("The response is an unrecognized error\n");
@@ -478,7 +477,11 @@ static int run_stunclient(const char *rip, uint16_t rport, uint16_t *port, bool 
     }
   }
 
-  return 0;
+done:
+
+  free(buf);
+
+  return ret;
 }
 #endif // ifdef __cplusplus
 

--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -2070,7 +2070,9 @@ static void client_discard_input_handler(evutil_socket_t fd, short what, void *a
     return;
   }
 
-  uint8_t buffer[STUN_BUFFER_SIZE];
+  /* Received bytes are discarded, so the drain loop just needs somewhere to put
+   * them — a full STUN_BUFFER_SIZE frame on a listener thread buys nothing. */
+  uint8_t buffer[4096];
 
   if (elem->pinfo.ssl) {
     int rc = 0;
@@ -2228,6 +2230,11 @@ static void start_allocation_flood(const char *remote_address, uint16_t port, co
   synthetic_peer_counter = 0;
   reset_load_generator_rate_stats();
 
+  /* Each app_ur_session carries two ~64 KB stun_buffers. Allocate the pair once
+   * and reset it per iteration rather than paying for it in the frame. */
+  app_ur_session *ss_probe = (app_ur_session *)turn_calloc(1, sizeof(app_ur_session));
+  app_ur_session *ss_alloc = (app_ur_session *)turn_calloc(1, sizeof(app_ur_session));
+
   while (unlimited || (tot_allocations < total_target)) {
     for (int i = 0; i < mclient; ++i) {
       app_ur_conn_info clnet_info_probe;
@@ -2248,16 +2255,14 @@ static void start_allocation_flood(const char *remote_address, uint16_t port, co
 
       turn_refresh_allocation(clnet_verbose, &clnet_info, 0);
 
-      app_ur_session ss_probe;
-      app_ur_session ss_alloc;
-      memset(&ss_probe, 0, sizeof(ss_probe));
-      memset(&ss_alloc, 0, sizeof(ss_alloc));
-      ss_probe.pinfo = clnet_info_probe;
-      ss_alloc.pinfo = clnet_info;
-      if (ss_probe.pinfo.fd >= 0 || ss_probe.pinfo.ssl) {
-        uc_delete_session_elem_data(&ss_probe);
+      memset(ss_probe, 0, sizeof(*ss_probe));
+      memset(ss_alloc, 0, sizeof(*ss_alloc));
+      ss_probe->pinfo = clnet_info_probe;
+      ss_alloc->pinfo = clnet_info;
+      if (ss_probe->pinfo.fd >= 0 || ss_probe->pinfo.ssl) {
+        uc_delete_session_elem_data(ss_probe);
       }
-      uc_delete_session_elem_data(&ss_alloc);
+      uc_delete_session_elem_data(ss_alloc);
 
       ++tot_allocations;
 
@@ -2274,6 +2279,9 @@ static void start_allocation_flood(const char *remote_address, uint16_t port, co
       }
     }
   }
+
+  free(ss_probe);
+  free(ss_alloc);
 
   __turn_getMSTime();
   print_load_generator_rate(__FUNCTION__);
@@ -2422,17 +2430,19 @@ static int start_c2c(const char *remote_address, uint16_t port, const unsigned c
 
 static int refresh_channel(app_ur_session *elem, uint16_t method, uint32_t lt) {
 
-  stun_buffer message;
   app_ur_conn_info *clnet_info = &(elem->pinfo);
 
   if (clnet_info->is_peer) {
     return 0;
   }
 
+  int ret = 0;
+  stun_buffer *message = (stun_buffer *)turn_calloc(1, sizeof(stun_buffer));
+
   if (!method || (method == STUN_METHOD_REFRESH)) {
-    stun_init_request(STUN_METHOD_REFRESH, &message);
+    stun_init_request(STUN_METHOD_REFRESH, message);
     lt = htonl(lt);
-    stun_attr_add(&message, STUN_ATTRIBUTE_LIFETIME, (const char *)&lt, 4);
+    stun_attr_add(message, STUN_ATTRIBUTE_LIFETIME, (const char *)&lt, 4);
 
     if (dual_allocation && !mobility) {
       int t = ((uint8_t)turn_random_number()) % 3;
@@ -2443,55 +2453,62 @@ static int refresh_channel(app_ur_session *elem, uint16_t method, uint32_t lt) {
         field[1] = 0;
         field[2] = 0;
         field[3] = 0;
-        stun_attr_add(&message, STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY, (const char *)field, 4);
+        stun_attr_add(message, STUN_ATTRIBUTE_REQUESTED_ADDRESS_FAMILY, (const char *)field, 4);
       }
     }
 
-    add_origin(&message);
-    if (add_integrity(clnet_info, &message) < 0) {
-      return -1;
+    add_origin(message);
+    if (add_integrity(clnet_info, message) < 0) {
+      ret = -1;
+      goto done;
     }
     if (use_fingerprints) {
-      stun_attr_add_fingerprint_str(message.buf, (size_t *)&(message.len));
+      stun_attr_add_fingerprint_str(message->buf, (size_t *)&(message->len));
     }
-    send_buffer(clnet_info, &message, 0, 0);
+    send_buffer(clnet_info, message, 0, 0);
   }
 
   if (lt && !addr_any(&(elem->pinfo.peer_addr))) {
 
     if (!no_permissions) {
       if (!method || (method == STUN_METHOD_CREATE_PERMISSION)) {
-        stun_init_request(STUN_METHOD_CREATE_PERMISSION, &message);
-        stun_attr_add_addr(&message, STUN_ATTRIBUTE_XOR_PEER_ADDRESS, &(elem->pinfo.peer_addr));
-        add_origin(&message);
-        if (add_integrity(clnet_info, &message) < 0) {
-          return -1;
+        stun_init_request(STUN_METHOD_CREATE_PERMISSION, message);
+        stun_attr_add_addr(message, STUN_ATTRIBUTE_XOR_PEER_ADDRESS, &(elem->pinfo.peer_addr));
+        add_origin(message);
+        if (add_integrity(clnet_info, message) < 0) {
+          ret = -1;
+          goto done;
         }
         if (use_fingerprints) {
-          stun_attr_add_fingerprint_str(message.buf, (size_t *)&(message.len));
+          stun_attr_add_fingerprint_str(message->buf, (size_t *)&(message->len));
         }
-        send_buffer(&(elem->pinfo), &message, 0, 0);
+        send_buffer(&(elem->pinfo), message, 0, 0);
       }
     }
 
     if (!method || (method == STUN_METHOD_CHANNEL_BIND)) {
       if (STUN_VALID_CHANNEL(elem->chnum)) {
-        stun_set_channel_bind_request(&message, &(elem->pinfo.peer_addr), elem->chnum);
-        add_origin(&message);
-        if (add_integrity(clnet_info, &message) < 0) {
-          return -1;
+        stun_set_channel_bind_request(message, &(elem->pinfo.peer_addr), elem->chnum);
+        add_origin(message);
+        if (add_integrity(clnet_info, message) < 0) {
+          ret = -1;
+          goto done;
         }
         if (use_fingerprints) {
-          stun_attr_add_fingerprint_str(message.buf, (size_t *)&(message.len));
+          stun_attr_add_fingerprint_str(message->buf, (size_t *)&(message->len));
         }
-        send_buffer(&(elem->pinfo), &message, 1, 0);
+        send_buffer(&(elem->pinfo), message, 1, 0);
       }
     }
   }
 
   elem->refresh_time = current_mstime + 30 * 1000;
 
-  return 0;
+done:
+
+  free(message);
+
+  return ret;
 }
 
 static inline int client_timer_handler(app_ur_session *elem, int *done) {


### PR DESCRIPTION
Code scanning (MSVC C6262) reports eight "Function uses N bytes of stack" alerts across turnutils_uclient, turnutils_stunclient, turnutils_natdiscovery and turnutils_peer. Each one is a stun_buffer (~64 KB, STUN_BUFFER_SIZE = MAX_STUN_MESSAGE_SIZE = 65507) or an app_ur_session (which embeds two of them) declared as a local. The largest is 270 KB in the allocation flood.

Sizes are compile-time constants and none of this recurses, so no frame can be overrun by input. It is headroom pressure rather than a vulnerability: uclient's listener and sender threads get far less stack than the main thread, and non-main pthread stacks default to 512 KB on macOS.

- uclient.c: start_allocation_flood declared both app_ur_session values in the loop body. Allocate the pair once and reset per iteration, so the flood does no extra per-iteration allocation.
- uclient.c: refresh_channel heaps its stun_buffer, freed through a single exit path.
- uclient.c: the discard handler's drain buffer drops to 4 KB. The bytes are thrown away, so the loop only needs somewhere to put them; a smaller buffer just means more iterations.
- stunclient.c, natdiscovery.c: heap the stun_buffer locals. Paths that call err() skip the free, since the process is exiting.
- udpserver.c: the non-Linux echo handler takes a module-static buffer, matching the rationale the Linux recvmmsg path in the same file already documents (one event_base, all sockets dispatched serially).

No behaviour change: every return value, retry and error path is preserved.

Measured with -fstack-usage, the eight frames go from 65-270 KB to 96 B - 4.2 KB.