### PR TITLE
uclient: stamp per-send metadata into the packet, not a shared buffer

### DIFF
--- a/src/apps/uclient/uclient.c
+++ b/src/apps/uclient/uclient.c
@@ -152,7 +152,11 @@ static int client_shutdown(app_ur_session *elem);
 static uint64_t current_time = 0;
 static uint64_t current_mstime = 0;
 
-static char buffer_to_send[65536] = "\0";
+/* Constant payload filler, written once during setup and only read afterwards.
+ * It must stay immutable: every sender thread copies from it concurrently, so
+ * anything stamped here would be shared between sessions. Per-send fields go
+ * into the outgoing packet via stamp_message_info(). */
+static char payload_template[65536] = "\0";
 
 static int total_clients = 0;
 
@@ -1909,6 +1913,24 @@ static int client_shutdown(app_ur_session *elem) {
   return 0;
 }
 
+/* Write this send's sequence number and timestamp into the outgoing packet.
+ * The peer echoes them back and client_read() derives loss, latency and jitter
+ * from them, so they must describe this session's send and no other: stamping
+ * them into the shared payload_template instead let a second sender thread
+ * overwrite them between the stamp and the copy, and the packet then carried
+ * another session's values. memcpy because the destination sits at an
+ * arbitrary offset in the message and mstime is 64-bit.
+ * clmessage_length >= sizeof(message_info) is enforced in mainuclient.c for
+ * every mode that stamps. */
+static void stamp_message_info(void *payload, const app_ur_session *elem) {
+  /* Zero-initialized: message_info has padding between msgnum and mstime, and
+   * the whole struct is copied onto the wire. */
+  message_info mi = {0};
+  mi.msgnum = elem->wmsgnum;
+  mi.mstime = current_mstime;
+  memcpy(payload, &mi, sizeof(mi));
+}
+
 static int client_write(app_ur_session *elem) {
 
   if (!elem) {
@@ -1935,15 +1957,12 @@ static int client_write(app_ur_session *elem) {
       memcpy(elem->out_buffer.buf + 4, &(elem->wmsgnum), sizeof(elem->wmsgnum));
     }
     elem->out_buffer.len = payload_len;
-  } else {
-    message_info *mi = (message_info *)buffer_to_send;
-    mi->msgnum = elem->wmsgnum;
-    mi->mstime = current_mstime;
   }
 
   if (!is_invalid_flood_mode() && is_TCP_relay()) {
 
-    memcpy(elem->out_buffer.buf, buffer_to_send, clmessage_length);
+    memcpy(elem->out_buffer.buf, payload_template, clmessage_length);
+    stamp_message_info(elem->out_buffer.buf, elem);
     elem->out_buffer.len = clmessage_length;
 
     if (elem->pinfo.is_peer) {
@@ -1968,10 +1987,15 @@ static int client_write(app_ur_session *elem) {
   } else if (!is_invalid_flood_mode() && !do_not_use_channel) {
     /* Let's always do padding: */
     stun_init_channel_message(elem->chnum, &(elem->out_buffer), clmessage_length, mandatory_channel_padding || use_tcp);
-    memcpy(elem->out_buffer.buf + 4, buffer_to_send, clmessage_length);
+    memcpy(elem->out_buffer.buf + 4, payload_template, clmessage_length);
+    stamp_message_info(elem->out_buffer.buf + 4, elem);
   } else if (!is_invalid_flood_mode()) {
     stun_init_indication(STUN_METHOD_SEND, &(elem->out_buffer));
-    stun_attr_add(&(elem->out_buffer), STUN_ATTRIBUTE_DATA, buffer_to_send, clmessage_length);
+    /* The DATA value lands 4 bytes (the attribute header) past the current end
+     * of the message, so capture that before appending. */
+    const size_t data_offset = elem->out_buffer.len + 4;
+    stun_attr_add(&(elem->out_buffer), STUN_ATTRIBUTE_DATA, payload_template, clmessage_length);
+    stamp_message_info(elem->out_buffer.buf + data_offset, elem);
     stun_attr_add_addr(&(elem->out_buffer), STUN_ATTRIBUTE_XOR_PEER_ADDRESS, &(elem->pinfo.peer_addr));
     if (dont_fragment) {
       stun_attr_add(&(elem->out_buffer), STUN_ATTRIBUTE_DONT_FRAGMENT, NULL, 0);
@@ -2675,7 +2699,7 @@ void start_mclient(const char *remote_address, uint16_t port, const unsigned cha
   uint32_t stime = current_time;
   reset_load_generator_rate_stats();
 
-  memset(buffer_to_send, 7, clmessage_length);
+  memset(payload_template, 7, clmessage_length);
 
   client_event_base = turn_event_base_new();
 


### PR DESCRIPTION
## Problem

`client_write()` stamped each send's `message_info` — the session's sequence number and the send timestamp — into the head of the **global** `buffer_to_send`, then copied that buffer into the outgoing packet:

```c
message_info *mi = (message_info *)buffer_to_send;
mi->msgnum = elem->wmsgnum;
mi->mstime = current_mstime;
...
memcpy(elem->out_buffer.buf + 4, buffer_to_send, clmessage_length);
```

With more than one sender thread those two steps interleave: a second sender can overwrite `msgnum`/`mstime` between the first sender's stamp and its copy, so a packet goes out carrying another session's values.

The peer echoes the fields back and `client_read()` derives all three quality metrics from them — the loss count (`mi.msgnum != elem->recvmsgnum + 1`), the latency sample, and the jitter. A swapped stamp is therefore scored against the wrong session. Two sender threads are the auto-scaled default from `-m 4` upward (`UCLIENT_AUTO_SENDERS_TARGET`).

ThreadSanitizer flags it as a write/write race between sender threads on `buffer_to_send`, at the `msgnum` and `mstime` offsets.

## Scope, honestly

The race is real and structural, but I could not demonstrate a measurable corruption rate: 0 lost packets over 18,000 messages with `--sender-threads 4`. The stamp-to-copy window is a few instructions, so collisions are rare on loopback. Treat this as removing undefined behaviour and a latent wrong-metric source, not as a claim that existing measurements are wrong.

## Fix

The per-send fields now go into the **destination** after the payload is copied, so nothing per-session is written to shared storage. `buffer_to_send` becomes `payload_template`: filled once during setup and read-only for the rest of the run, which is what makes sharing it safe — the rename is what keeps the invariant from being reintroduced.

The Send-indication path stamps at the DATA value, whose offset is the message length captured *before* the attribute is appended, plus its 4-byte header.

`stamp_message_info()` copies through a zero-initialized local rather than casting the destination to `message_info *`: the destination sits at an arbitrary offset in the message, `mstime` is 64-bit, and the struct's internal padding would otherwise reach the wire uninitialized. `mainuclient.c` already forces `clmessage_length >= sizeof(message_info)` for every mode that stamps.

## Verification

ThreadSanitizer over the load-gen smoke, same invocation and duration for both:

| build | races | `buffer_to_send` races |
|---|---:|---:|
| master | 24 | 2 |
| this branch | 22 | 0 |

Exactly the two targeted races removed, none introduced.

Functional parity checked against master at `-m 60 -n 300 --sender-threads 4 --listener-threads 2` (0% loss, comparable jitter, comparable runtime) and at `-Y packet -m 8 --sender-threads 4` (~15-16M sends).

Also passing: `ctest` 18/18, and `run_tests.sh`, `run_tests_conf.sh`, `run_tests_mobile.sh`, `run_tests_multiplex_peer.sh` with zero `FAIL`. `make lint` clean.

## Still open

The other 13 races are pre-existing and untouched here: `current_time`/`current_mstime` written by several threads, the `start_full_timer` publication, per-thread stat accumulators read by the progress print, and one session struct written by both its listener and its sender. All are in `turnutils_uclient` — a TSan-instrumented `turnserver` and `turnutils_peer` reported zero races throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)