### PR TITLE
don't release port 65535 when turnports_allocate fails

### DIFF
--- a/src/apps/relay/turn_ports.c
+++ b/src/apps/relay/turn_ports.c
@@ -226,6 +226,10 @@ int turnports_allocate_even(turnports *tp, int allocate_rtcp, uint64_t *reservat
       uint16_t i = 0;
       for (i = 0; i < size; i++) {
         const int port = turnports_allocate(tp);
+        if (port < 0) {
+          /* No port available: -1 must not be re-released as (uint16_t)65535. */
+          break;
+        }
         if (port & 0x00000001) {
           turnports_release(tp, port);
         } else if (!allocate_rtcp) {

--- a/tests/test_turn_ports.c
+++ b/tests/test_turn_ports.c
@@ -202,6 +202,32 @@ static void test_evenport_r0_alloc_release_does_not_leak(void) {
   free(t);
 }
 
+/* turnports_allocate() reports failure as -1. turnports_allocate_even() must
+ * not feed that -1 to turnports_release(): the uint16_t parameter turns it into
+ * 65535, and when the range includes 65535 (the default max) and that port is
+ * held by another allocation, the release frees it out from under its owner. */
+static void test_evenport_failure_keeps_foreign_port(void) {
+  turnports *t = turnports_create(NULL, 65534, 65535);
+  TEST_ASSERT_NOT_NULL(t);
+
+  /* Port 65535 is held by a different allocation. */
+  t->status[65535] = TPS_TAKEN_SINGLE;
+  TEST_ASSERT_TRUE(turnports_is_allocated(t, 65535));
+
+  /* Make the next dequeue land on an out-of-range queue entry so
+   * turnports_allocate() returns -1 (turn_ports.c:185) while the pool still
+   * reports a non-empty size and the EVEN-PORT loop runs. */
+  t->ports[t->low & 0xFFFF] = 0;
+  TEST_ASSERT_GREATER_THAN_UINT16(1, turnports_size(t));
+
+  /* No even port can be allocated, so this fails - without touching 65535. */
+  TEST_ASSERT_EQUAL_INT(-1, turnports_allocate_even(t, 1, NULL));
+  TEST_ASSERT_TRUE_MESSAGE(turnports_is_allocated(t, 65535),
+                           "EVEN-PORT failure released a port held by another allocation");
+
+  free(t);
+}
+
 /* R=1 (reservation requested) must still hold the odd sibling so a later
  * RESERVATION-TOKEN allocation can claim it. */
 static void test_evenport_r1_reserves_sibling(void) {
@@ -230,6 +256,7 @@ int main(void) {
   RUN_TEST(test_allocate_survives_counter_wraparound);
   RUN_TEST(test_evenport_r0_does_not_reserve_sibling);
   RUN_TEST(test_evenport_r0_alloc_release_does_not_leak);
+  RUN_TEST(test_evenport_failure_keeps_foreign_port);
   RUN_TEST(test_evenport_r1_reserves_sibling);
   return UNITY_END();
 }


### PR DESCRIPTION
Repro: `turnports_allocate()` returns `-1` from inside `turnports_allocate_even()`'s loop when no port is free (an RFC 8656 EVEN-PORT `ALLOCATE` against a drained or fragmented relay pool).

Cause: the `-1` is `& 1`-tested, classed as an odd port, and passed to `turnports_release(turnports *, uint16_t port)`, whose parameter narrows `-1` to `65535`. With the default `max-port` (`HIGH_DEFAULT_PORTS_BOUNDARY`) that port is in range, so a live allocation still holding `65535` has its status overwritten and the port re-queued into the free list while the owning session's relay socket stays bound. A later allocation can then hand the same relay port to a second session.

Fix: `break` out of the loop when `turnports_allocate()` returns `< 0`.

The added `test_turn_ports` case marks `65535` as held, forces the allocator down its `-1` path, and asserts `turnports_allocate_even()` fails without touching the held port. It fails before the change and passes after.