### PR TITLE
Build docker images with optimizations on

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,10 @@ cmake --build build -j$(nproc)
 
 Key CMake options:
 - `-DFUZZER=ON` — build OSS-Fuzz targets (requires Clang or AppleClang)
-- `-DCMAKE_BUILD_TYPE=Debug|Release`
+- `-DCMAKE_BUILD_TYPE=Debug|Release` — defaults to `Release` (`-O3 -DNDEBUG`) when
+  unset, so benchmark and load-test builds are optimized without opting in.
+  `-DFUZZER=ON` builds are exempt: they take their `-O`/`-fsanitize` flags from
+  the OSS-Fuzz `CFLAGS` environment.
 - `-DWITH_MYSQL=ON/OFF`, `-DWITH_PGSQL=ON/OFF`, `-DWITH_MONGO=ON/OFF`, `-DWITH_REDIS=ON/OFF`
 
 ## Required validation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,16 @@ endif()
 message("BUILD_VERSION:${BUILD_VERSION};${_BUILD_VERSION}")
 set(VERSION ${BUILD_VERSION})
 
-if(NOT DEFINED CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release")
-endif(NOT DEFINED CMAKE_BUILD_TYPE)
+option(FUZZER "Build oss-fuzz fuzzing" OFF)
+
+# `project()` already defines CMAKE_BUILD_TYPE as an empty string, so test the
+# value rather than DEFINED -- otherwise an unspecified build type silently
+# compiles at -O0. Fuzzer builds take their -O/-fsanitize flags from the
+# OSS-Fuzz CFLAGS environment and must not be overridden.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES AND NOT FUZZER)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+        "Build type: Debug, Release, RelWithDebInfo or MinSizeRel" FORCE)
+endif()
 string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type)
 if("debug" STREQUAL build_type)
     add_definitions(-D_DEBUG)
@@ -174,7 +181,6 @@ install(DIRECTORY
     )
 include(cmake/CMakeCPack.cmake)
 
-option(FUZZER "Build oss-fuzz fuzzing" OFF)
 if(FUZZER)
     if (NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
         message(FATAL_ERROR "clang is require for libFuzzer")

--- a/docker/coturn/alpine/Dockerfile
+++ b/docker/coturn/alpine/Dockerfile
@@ -60,7 +60,7 @@ RUN if [ "${coturn_git_ref}" != 'HEAD' ]; then true \
  && true; fi
 
 # Build Coturn from sources.
-RUN ./configure --prefix=/usr \
+RUN CFLAGS="-O3" ./configure --prefix=/usr \
                 --turndbdir=/var/lib/coturn \
                 --disable-rpath \
                 --sysconfdir=/etc/coturn \

--- a/docker/coturn/debian/Dockerfile
+++ b/docker/coturn/debian/Dockerfile
@@ -59,7 +59,7 @@ RUN if [ "${coturn_git_ref}" != 'HEAD' ]; then true \
  && true; fi
 
 # Build Coturn from sources.
-RUN ./configure --prefix=/usr \
+RUN CFLAGS="-O3" ./configure --prefix=/usr \
                 --turndbdir=/var/lib/coturn \
                 --disable-rpath \
                 --sysconfdir=/etc/coturn \


### PR DESCRIPTION
Enable `-O3` for docker images
Enable optimizations where makes sense in cmake builds