### PR TITLE
turnutils_peer: reflect DSCP/TOS on echoed datagrams

### DIFF
--- a/examples/run_tests_dscp.sh
+++ b/examples/run_tests_dscp.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+# System-level test for DSCP/TOS preservation across the relay (issue #385).
+#
+# A TURN relay must not strip the IP DSCP/TOS marking off the packets it
+# forwards: coturn reads the marking from each inbound datagram (IP_RECVTOS /
+# IPV6_RECVTCLASS) and re-applies it on the outbound leg. This test proves both
+# directions end to end by observing the marking on the wire.
+#
+# Topology (all on 127.0.0.1):
+#   turnutils_uclient  --(tos 0x22)-->  turnserver  --(relay)-->  turnutils_peer
+# turnutils_uclient marks its own client socket TOS 0x22 / TTL 47
+# (startuclient.c). turnutils_peer echoes each datagram back with the same
+# marking it arrived with (its default behavior), which lets us check the
+# peer->client leg too.
+#
+# tcpdump reads the IP TOS byte off the loopback interface, so the four legs
+# are:
+#   1) client -> listener (:3478)   tos 0x22   (client's own marking)
+#   2) relay  -> peer     (:3480)   tos 0x22   <- coturn reflects (forward)
+#   3) peer   -> relay              tos 0x22   (peer -O reflects the mark back)
+#   4) listener -> client (:3478 >) tos 0x22   <- coturn reflects (return)
+# Legs 2 and 4 are the assertions.
+#
+# Reliable loopback TOS capture and IP_RECVTOS both need Linux; on any other
+# platform, or without tcpdump / capture privileges, this SKIPs (exit 0)
+# rather than failing.
+
+if [ -d examples ]; then
+    cd examples
+fi
+
+PRIMARY_IP=127.0.0.1
+STUN_PORT=3478
+PEER_PORT=3480
+MIN_PORT=50000
+MAX_PORT=50050
+LOOPBACK_IF=lo
+CLIENT_TOS="0x22" # value startuclient.c sets on the uclient socket
+
+TURNSERVER_LOG="/tmp/run_tests_dscp.$$.turnserver.log"
+PEER_LOG="/tmp/run_tests_dscp.$$.peer.log"
+UCLIENT_LOG="/tmp/run_tests_dscp.$$.uclient.log"
+TCPDUMP_LOG="/tmp/run_tests_dscp.$$.tcpdump.log"
+
+turnserver_pid=""
+peer_pid=""
+tcpdump_pid=""
+
+cleanup() {
+    [ -n "$tcpdump_pid" ] && kill "$tcpdump_pid" 2>/dev/null
+    [ -n "$turnserver_pid" ] && kill "$turnserver_pid" 2>/dev/null
+    [ -n "$peer_pid" ] && kill "$peer_pid" 2>/dev/null
+    wait 2>/dev/null
+    rm -f "$TURNSERVER_LOG" "$PEER_LOG" "$UCLIENT_LOG" "$TCPDUMP_LOG"
+}
+trap cleanup EXIT
+
+# Reliable loopback TOS capture (and IP_RECVTOS on the peer) is a Linux thing.
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "SKIP: DSCP test needs Linux for loopback TOS capture and IP_RECVTOS. Skipping."
+    exit 0
+fi
+
+if ! command -v tcpdump >/dev/null 2>&1; then
+    echo "SKIP: tcpdump not found; cannot observe the on-the-wire DSCP marking. Skipping."
+    exit 0
+fi
+
+# Detect cmake vs autotools build layout (mirrors run_tests_rfc5780.sh).
+BINDIR="../bin"
+if [ ! -f $BINDIR/turnserver ]; then
+    BINDIR="../build/bin"
+fi
+
+# Confirm we can actually capture on loopback (needs root / CAP_NET_RAW). A
+# permission failure exits tcpdump immediately with an error on stderr; a
+# working capture stays alive waiting for the -c packet, so liveness after a
+# short sleep means we have the privilege.
+tcpdump -i "$LOOPBACK_IF" -c 1 -w /dev/null 'ip' >/dev/null 2>"$TCPDUMP_LOG" &
+probe_pid=$!
+sleep 0.5
+if kill -0 "$probe_pid" 2>/dev/null; then
+    kill "$probe_pid" 2>/dev/null
+    wait "$probe_pid" 2>/dev/null
+elif grep -qiE "permission|not permitted|no such device|can't|couldn't" "$TCPDUMP_LOG"; then
+    echo "SKIP: tcpdump cannot capture on $LOOPBACK_IF (needs root / CAP_NET_RAW). Skipping."
+    exit 0
+fi
+rm -f "$TCPDUMP_LOG"
+
+# --- start the echo peer (reflects DSCP/TOS by default) ---
+echo "Running turnutils_peer (reflects DSCP/TOS) on $PRIMARY_IP:$PEER_PORT"
+"$BINDIR/turnutils_peer" -L "$PRIMARY_IP" -p "$PEER_PORT" > "$PEER_LOG" 2>&1 &
+peer_pid=$!
+sleep 0.5
+if ! kill -0 "$peer_pid" 2>/dev/null; then
+    echo "FAIL: turnutils_peer did not start"
+    cat "$PEER_LOG"
+    exit 1
+fi
+
+# --- start turnserver: no-auth loopback relay, narrow relay-port range ---
+echo "Running turnserver (no-auth) on $PRIMARY_IP:$STUN_PORT, relay ports $MIN_PORT-$MAX_PORT"
+"$BINDIR/turnserver" \
+    --listening-ip=$PRIMARY_IP --relay-ip=$PRIMARY_IP --allow-loopback-peers \
+    --no-tls --no-dtls --no-auth --cli=false \
+    --listening-port=$STUN_PORT --min-port=$MIN_PORT --max-port=$MAX_PORT \
+    --log-file=stdout > "$TURNSERVER_LOG" 2>&1 &
+turnserver_pid=$!
+
+wait_for_turnserver() {
+    local i
+    for i in $(seq 1 40); do
+        if grep -q "Total auth threads:" "$TURNSERVER_LOG" 2>/dev/null; then
+            return 0
+        fi
+        if ! kill -0 "$turnserver_pid" 2>/dev/null; then
+            echo "FATAL: turnserver (pid $turnserver_pid) exited before init completed"
+            cat "$TURNSERVER_LOG" 2>/dev/null || echo "(log file missing)"
+            return 1
+        fi
+        sleep 0.5
+    done
+    echo "FATAL: turnserver never reached 'Total auth threads:' within 20s"
+    tail -30 "$TURNSERVER_LOG" 2>/dev/null
+    return 1
+}
+wait_for_turnserver || exit 1
+sleep 1
+
+# --- capture on loopback, self-terminating (300 pkts or 20s) ---
+timeout 25 tcpdump -i "$LOOPBACK_IF" -n -v -c 300 \
+    "udp and (port $STUN_PORT or port $PEER_PORT or portrange $MIN_PORT-$MAX_PORT)" \
+    > "$TCPDUMP_LOG" 2>/dev/null &
+tcpdump_pid=$!
+sleep 1
+
+# --- drive traffic: uclient marks TOS 0x22 on its own socket ---
+echo "Running turnutils_uclient (marks TOS $CLIENT_TOS) relaying to the peer"
+timeout 20 "$BINDIR/turnutils_uclient" -n 25 -m 1 -l 100 -e "$PRIMARY_IP" -X -g -z 40 \
+    "$PRIMARY_IP" > "$UCLIENT_LOG" 2>&1
+uclient_rc=$?
+
+sleep 2
+kill "$tcpdump_pid" 2>/dev/null
+wait "$tcpdump_pid" 2>/dev/null
+
+if [ "$uclient_rc" -ne 0 ]; then
+    echo "FAIL: turnutils_uclient exited $uclient_rc"
+    tail -20 "$UCLIENT_LOG"
+    exit 1
+fi
+
+# tcpdump prints a two-line record: "... IP (tos 0xNN,... )" then a
+# "    src.port > dst.port: ..." line. Pair each address line with the tos on
+# the preceding header line.
+tos_to() { # $1 = grep pattern matching the address line's destination
+    grep -B1 "$1" "$TCPDUMP_LOG" | grep -oE "tos 0x[0-9a-f]+" | sort | uniq -c
+}
+tos_from_listener() { # 3478 -> client, header tos on the preceding line
+    grep -B1 "$PRIMARY_IP.$STUN_PORT > " "$TCPDUMP_LOG" | grep -oE "tos 0x[0-9a-f]+" | sort | uniq -c
+}
+
+echo
+echo "--- observed TOS per leg ---"
+echo "leg 2  relay  -> peer     (> .$PEER_PORT):"; tos_to "> $PRIMARY_IP.$PEER_PORT:"
+echo "leg 4  listener-> client  (.$STUN_PORT >):"; tos_from_listener
+
+relay_to_peer_has_mark=$(grep -B1 "> $PRIMARY_IP.$PEER_PORT:" "$TCPDUMP_LOG" | grep -c "tos $CLIENT_TOS")
+listener_to_client_has_mark=$(grep -B1 "$PRIMARY_IP.$STUN_PORT > " "$TCPDUMP_LOG" | grep -c "tos $CLIENT_TOS")
+
+echo
+rc=0
+if [ "$relay_to_peer_has_mark" -gt 0 ]; then
+    echo "OK: forward leg preserved DSCP — relay->peer carried tos $CLIENT_TOS ($relay_to_peer_has_mark pkts)"
+else
+    echo "FAIL: forward leg lost DSCP — no tos $CLIENT_TOS on the relay->peer leg"
+    rc=1
+fi
+if [ "$listener_to_client_has_mark" -gt 0 ]; then
+    echo "OK: return leg preserved DSCP — listener->client carried tos $CLIENT_TOS ($listener_to_client_has_mark pkts)"
+else
+    echo "FAIL: return leg lost DSCP — no tos $CLIENT_TOS on the listener->client leg"
+    rc=1
+fi
+
+if [ "$rc" -ne 0 ]; then
+    echo "--- tcpdump (first 40 lines) ---"
+    head -40 "$TCPDUMP_LOG"
+fi
+exit $rc

--- a/src/apps/peer/udpserver.c
+++ b/src/apps/peer/udpserver.c
@@ -45,6 +45,7 @@
 #include <limits.h> // for USHRT_MAX
 
 #if defined(__linux__)
+#include <netinet/in.h> // for IPPROTO_IP/IPPROTO_IPV6, IP_RECVTOS, IPV6_RECVTCLASS
 #include <netinet/udp.h>
 #include <sys/socket.h>
 #ifndef UDP_SEGMENT
@@ -57,6 +58,12 @@
 
 /////////////// io handlers ///////////////////
 
+/* DSCP/TOS reflection: turnutils_peer echoes every datagram back with the same
+ * marking it arrived with, so an end-to-end QoS test can confirm a TURN relay
+ * preserves DSCP on the peer->client leg too (issue #385). This reads the
+ * marking off the ancillary data of each inbound packet, so — like the relay's
+ * own TOS handling — it lives on the Linux recvmmsg path; other platforms echo
+ * without it (the relay likewise drops TOS there, per RFC 5766). */
 #if defined(__linux__)
 
 /* Per-callback batch state. The peer is single-threaded (one libevent
@@ -81,6 +88,65 @@ static struct mmsghdr g_msgs[PEER_BATCH];
 static struct iovec g_iovs[PEER_BATCH];
 static ioa_addr g_srcs[PEER_BATCH];
 static uint8_t g_bufs[PEER_BATCH][PEER_DGRAM_MAX];
+/* Per-entry recv ancillary buffers (TOS) and the parsed marking per datagram. */
+static char g_cmsgs[PEER_BATCH][CMSG_SPACE(sizeof(int)) * 2];
+static int g_toss[PEER_BATCH];
+
+/* Last (fd, tos) pushed to a socket: a steady single flow keeps the marking
+ * constant, so this short-circuits the repeated setsockopt, exactly like the
+ * relay's own set_socket_tos. Single-threaded peer, so no locking. */
+static evutil_socket_t g_tos_fd = -1;
+static int g_tos_cur = INT_MIN;
+
+/* Ask the kernel to attach the received DSCP/TOS as ancillary data. */
+static void enable_recv_tos(evutil_socket_t fd, int family) {
+  const int on = 1;
+  if (family == AF_INET6) {
+#if defined(IPV6_RECVTCLASS)
+    if (setsockopt(fd, IPPROTO_IPV6, IPV6_RECVTCLASS, (const void *)&on, sizeof(on)) < 0) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "set IPV6_RECVTCLASS on peer socket: %s\n", strerror(errno));
+    }
+#endif
+  } else {
+#if defined(IP_RECVTOS)
+    if (setsockopt(fd, IPPROTO_IP, IP_RECVTOS, (const void *)&on, sizeof(on)) < 0) {
+      TURN_LOG_FUNC(TURN_LOG_LEVEL_WARNING, "set IP_RECVTOS on peer socket: %s\n", strerror(errno));
+    }
+#endif
+  }
+}
+
+/* Pull the DSCP/TOS marking out of a received message's ancillary data, or -1
+ * if none was present. */
+static int peer_recv_tos(struct msghdr *mh) {
+  for (struct cmsghdr *cm = CMSG_FIRSTHDR(mh); cm != NULL; cm = CMSG_NXTHDR(mh, cm)) {
+#if defined(IP_RECVTOS)
+    if (cm->cmsg_level == IPPROTO_IP && (cm->cmsg_type == IP_TOS || cm->cmsg_type == IP_RECVTOS)) {
+      return *((unsigned char *)CMSG_DATA(cm));
+    }
+#endif
+#if defined(IPV6_RECVTCLASS) || defined(IPV6_TCLASS)
+    if (cm->cmsg_level == IPPROTO_IPV6 && cm->cmsg_type == IPV6_TCLASS) {
+      return *((unsigned char *)CMSG_DATA(cm));
+    }
+#endif
+  }
+  return -1;
+}
+
+/* Set the socket's egress marking so the echo carries it. No-op when the value
+ * is already current or was not captured (< 0). */
+static void peer_reflect_tos(evutil_socket_t fd, int family, int tos) {
+  if (tos < 0) {
+    return;
+  }
+  if (fd == g_tos_fd && tos == g_tos_cur) {
+    return;
+  }
+  set_raw_socket_tos(fd, family, tos);
+  g_tos_fd = fd;
+  g_tos_cur = tos;
+}
 
 static int try_gso_echo(evutil_socket_t fd, int n) {
   if (n < 2) {
@@ -158,6 +224,8 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
       g_msgs[i].msg_hdr.msg_iovlen = 1;
       g_msgs[i].msg_hdr.msg_name = &g_srcs[i];
       g_msgs[i].msg_hdr.msg_namelen = sizeof(g_srcs[i]);
+      g_msgs[i].msg_hdr.msg_control = g_cmsgs[i];
+      g_msgs[i].msg_hdr.msg_controllen = sizeof(g_cmsgs[i]);
       g_msgs[i].msg_len = 0;
     }
 
@@ -168,6 +236,37 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
 
     if (n <= 0) {
       return;
+    }
+
+    /* Read each datagram's marking, then drop the recv control so the mmsghdr
+     * array can be reused for sending. If the whole batch shares one marking
+     * (a single steady flow — the common case, and what GSO already needs),
+     * push it to the socket once and fall through to the batched echo. A mixed
+     * batch takes a per-packet echo so each reply keeps its own marking. */
+    int uniform_tos = 1;
+    for (int i = 0; i < n; ++i) {
+      g_toss[i] = peer_recv_tos(&g_msgs[i].msg_hdr);
+      g_msgs[i].msg_hdr.msg_control = NULL;
+      g_msgs[i].msg_hdr.msg_controllen = 0;
+      if (i > 0 && g_toss[i] != g_toss[0]) {
+        uniform_tos = 0;
+      }
+    }
+    if (uniform_tos) {
+      peer_reflect_tos(fd, g_srcs[0].ss.sa_family, g_toss[0]);
+    } else {
+      for (int i = 0; i < n; ++i) {
+        peer_reflect_tos(fd, g_srcs[i].ss.sa_family, g_toss[i]);
+        ssize_t r;
+        do {
+          r = sendto(fd, g_bufs[i], (size_t)g_msgs[i].msg_len, 0, (const struct sockaddr *)&g_srcs[i],
+                     g_msgs[i].msg_hdr.msg_namelen);
+        } while (r < 0 && errno == EINTR);
+      }
+      if (n < PEER_BATCH) {
+        return;
+      }
+      continue;
     }
 
     int sent = try_gso_echo(fd, n);
@@ -200,6 +299,13 @@ static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) 
 }
 
 #else /* !__linux__ */
+
+/* No ancillary-data recv path here, so TOS is not reflected off-Linux — the
+ * same tradeoff the relay makes (RFC 5766 "alternative behavior"). */
+static void enable_recv_tos(evutil_socket_t fd, int family) {
+  UNUSED_ARG(fd);
+  UNUSED_ARG(family);
+}
 
 static void udp_server_input_handler(evutil_socket_t fd, short what, void *arg) {
 
@@ -271,6 +377,9 @@ static int udp_create_server_socket(server_type *const server, const char *const
   }
 
   socket_set_nonblocking(udp_fd);
+
+  /* Echo back with the sender's DSCP/TOS: read it via IP_RECVTOS/IPV6_RECVTCLASS. */
+  enable_recv_tos(udp_fd, server_addr->ss.sa_family);
 
   struct event *udp_ev =
       event_new(server->event_base, udp_fd, EV_READ | EV_PERSIST, udp_server_input_handler, server_addr);


### PR DESCRIPTION
## What

`turnutils_peer` now echoes each datagram back with the **same DSCP/TOS marking it arrived with**, instead of a bare TOS of 0.

## Why

Reported in #385: DSCP markers appear lost across a TURN relay. coturn actually reflects TOS correctly in **both** directions — but the reflection on the peer→client leg mirrors whatever the *peer* sends, and `turnutils_peer` sent an unmarked (CS0) echo. So the test tooling itself made the relay's return-leg DSCP handling impossible to observe, and matched the exact "CS7 → CS0" symptom in the report. With the peer reflecting, the full round-trip DSCP path is testable.

## How

- On Linux, the marking is read off each datagram's ancillary data (`IP_RECVTOS` / `IPV6_RECVTCLASS`) on the `recvmmsg` path. A batch that shares one marking — a single steady flow, and what UDP-GSO already requires — sets the socket TOS once and keeps the `sendmmsg`/GSO fast path; a mixed batch falls back to a per-packet echo so each reply keeps its own marking.
- Off-Linux the peer echoes without TOS reflection — the same tradeoff the relay itself makes (RFC 5766 "alternative behavior"), so no new cross-platform ancillary-data code is introduced.

## Test

New `examples/run_tests_dscp.sh` system test: it marks the client socket (TOS `0x22`, as `turnutils_uclient` already does), drives traffic through a loopback relay, and asserts via `tcpdump` that the DSCP survives on **both** the relay→peer and listener→client legs. It SKIPs (exit 0) off-Linux or without `tcpdump` / capture privileges, matching the style of `run_tests_rfc5780.sh`.

## Validation

Validated in a Linux container:
- `ctest`: 17/17 pass
- `run_tests_dscp.sh`: both legs carry `tos 0x22` (forward + return) — OK
- `run_tests.sh` incl. the `-Y packet` GSO load-gen smoke: OK (batched/GSO fast path preserved)
- `clang-format-15`: clean

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)