### PR TITLE
fix: external ip must valid if the provider responses EDNS

### DIFF
--- a/docker/coturn/rootfs/usr/local/bin/detect-external-ip.sh
+++ b/docker/coturn/rootfs/usr/local/bin/detect-external-ip.sh
@@ -85,6 +85,9 @@ if [ "$CFG_IPV4" = "true" ]; then
   is_valid_ip() {
     # Check if the input looks like an IPv4 address.
     # Doesn't check if the actual values are valid; assumes they are.
+    if [ $(echo "$1" | wc -l) -ne 1 ]; then
+      return 1
+    fi
     echo "$1" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'
   }
 else
@@ -96,6 +99,9 @@ else
     # Check if the input looks like an IPv6 address.
     # It's almost impossible to check the IPv6 representation because it
     # varies wildly, so just check that there are at least 2 colons.
+    if [ $(echo "$1" | wc -l) -ne 1 ]; then
+      return 1
+    fi
     [ "$(echo "$1" | awk -F':' '{print NF-1}')" -ge 2 ]
   }
 fi


### PR DESCRIPTION
Google may response IP and EDNS records, e.g.

    $ dig @ns1.google.com o-o.myaddr.l.google.com TXT -4 +short | tr -d \"
    edns0-client-subnet 103.252.16.0/24
    172.253.5.26

It pass the is_valid_ip() checking, but not a valid ip address, fix it by examine the first line only.