### PR TITLE
skip null memcpy on zero-length stun auth attribute

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -589,7 +589,9 @@ static bool udp_get_string_attr(const uint8_t *data, size_t len, uint16_t attr_t
     return false;
   }
   const size_t alen = min((size_t)stun_attr_get_len(sar), out_size - 1);
-  memcpy(out, stun_attr_get_value(sar), alen);
+  if (alen) {
+    memcpy(out, stun_attr_get_value(sar), alen);
+  }
   out[alen] = 0;
   return true;
 }

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -3679,7 +3679,9 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
       *reason = (const uint8_t *)"Realm is too long";
       return -1;
     }
-    memcpy(realm, stun_attr_get_value(sar), alen);
+    if (alen) {
+      memcpy(realm, stun_attr_get_value(sar), alen);
+    }
     realm[alen] = 0;
 
     if (!is_secure_string(realm, 0)) {
@@ -3726,7 +3728,9 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
     *reason = (const uint8_t *)"User name is too long";
     return -1;
   }
-  memcpy(usname, stun_attr_get_value(sar), alen);
+  if (alen) {
+    memcpy(usname, stun_attr_get_value(sar), alen);
+  }
   usname[alen] = 0;
 
   if (!is_secure_string(usname, 1)) {
@@ -3771,7 +3775,9 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
       *reason = (const uint8_t *)"Nonce is too long";
       return -1;
     }
-    memcpy(nonce, stun_attr_get_value(sar), alen);
+    if (alen) {
+      memcpy(nonce, stun_attr_get_value(sar), alen);
+    }
     nonce[alen] = 0;
 
     /* Stale Nonce check: */


### PR DESCRIPTION
Repro: build with `-fsanitize=undefined` and send an unauthenticated STUN request carrying a well-formed 4-byte `REALM`, `USERNAME` or `NONCE` TLV with length `0`.

Cause: `stun_attr_get_value()` returns `NULL` for a zero-length attribute, so `check_stun_auth()` reaches `memcpy(dst, stun_attr_get_value(sar), alen)` with a `NULL` source and `alen == 0`. `memcpy` is declared `nonnull`, so this is undefined behaviour; glibc UBSan reports `null pointer passed as argument 2, which is declared to never be null`. The same shape sits on the pre-auth stateless-nonce fast path in `udp_get_string_attr()`. The sibling `ORIGIN` readers in both files already guard with `if (sarlen > 0)`.

Fix: wrap each copy in `if (alen)` so an empty attribute skips the `memcpy` and only writes the terminator. Behaviour is unchanged (the destination is still an empty string).

Verified with a reproducer that drives the real `stun_attr_*` getters over a zero-length `USERNAME`: `gcc -fsanitize=undefined` trips on the unpatched sink and runs clean after. `ctest` 18/18 and `run_tests.sh` / `run_tests_conf.sh` pass.