### PR TITLE
Return allocation mismatch for ChannelBind without allocation

### DIFF
--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -2871,7 +2871,10 @@ static int handle_turn_channel_bind(turn_turnserver *server, ts_ur_super_session
   if (ss->is_tcp_relay) {
     *err_code = 403;
     *reason = (const uint8_t *)"Channel bind cannot be used with TCP relay";
-  } else if (is_allocation_valid(a)) {
+  } else if (!is_allocation_valid(a)) {
+    *err_code = 437;
+    *reason = (const uint8_t *)"Allocation Mismatch";
+  } else {
 
     stun_attr_ref sar =
         stun_attr_get_first_str(ioa_network_buffer_data(in_buffer->nbh), ioa_network_buffer_get_size(in_buffer->nbh));

--- a/tests/test_turn_server_send.c
+++ b/tests/test_turn_server_send.c
@@ -701,6 +701,25 @@ static void test_channel_bind_binds_the_peer_address(void) {
   TEST_ASSERT_TRUE(addr_eq(&peer, &(chn->peer_addr)));
 }
 
+/* RFC 8656 Section 7.3: requests other than Allocate require an existing
+ * allocation for the request's 5-tuple. A ChannelBind received after that
+ * allocation expires reports Allocation Mismatch rather than falling through
+ * to the generic Bad Request response. */
+static void test_channel_bind_without_a_valid_allocation_reports_mismatch(void) {
+  ioa_addr peer;
+  make_addr(&peer, PEER_A, PEER_PORT_A);
+
+  msg_begin(STUN_METHOD_CHANNEL_BIND, false);
+  msg_add_channel_number(TEST_CHANNEL_NUMBER);
+  msg_add_peer(&peer);
+  msg_finish();
+  set_allocation_valid(&(ss.alloc), false);
+
+  int constructed = 0;
+  TEST_ASSERT_EQUAL_INT(437, run_channel_bind(&constructed));
+  TEST_ASSERT_FALSE(constructed);
+}
+
 /* RFC 8489 Section 14: only the first occurrence of a repeated attribute needs
  * to be processed. A channel binds to exactly one peer, so the first
  * XOR-PEER-ADDRESS must win however many follow it - otherwise the bound peer
@@ -795,6 +814,7 @@ int main(void) {
   RUN_TEST(test_create_permission_ignores_the_port);
   RUN_TEST(test_create_permission_without_peer_address_is_rejected);
   RUN_TEST(test_channel_bind_binds_the_peer_address);
+  RUN_TEST(test_channel_bind_without_a_valid_allocation_reports_mismatch);
   RUN_TEST(test_channel_bind_uses_first_of_duplicate_peer_addresses);
   RUN_TEST(test_channel_bind_permits_only_the_first_peer);
   RUN_TEST(test_random_challenge_nonce_is_sixteen_lowercase_hex_chars);

--- a/tests/test_turn_server_send.c
+++ b/tests/test_turn_server_send.c
@@ -701,10 +701,10 @@ static void test_channel_bind_binds_the_peer_address(void) {
   TEST_ASSERT_TRUE(addr_eq(&peer, &(chn->peer_addr)));
 }
 
-/* RFC 8656 Section 7.3: requests other than Allocate require an existing
- * allocation for the request's 5-tuple. A ChannelBind received after that
- * allocation expires reports Allocation Mismatch rather than falling through
- * to the generic Bad Request response. */
+/* RFC 8656 Section 5: for any request other than Allocate, a 5-tuple that
+ * does not identify an existing allocation is rejected with 437 (Allocation
+ * Mismatch). A ChannelBind received after its allocation expires reports
+ * that rather than falling through to the generic Bad Request response. */
 static void test_channel_bind_without_a_valid_allocation_reports_mismatch(void) {
   ioa_addr peer;
   make_addr(&peer, PEER_A, PEER_PORT_A);


### PR DESCRIPTION
When a client sends ChannelBind after its TURN allocation has expired or disappeared, the server should report Allocation Mismatch so the client can recreate the allocation. The current handler leaves the error unset and the generic response path emits Bad Request instead.

## What changes

- Return error 437, Allocation Mismatch, when ChannelBind has no valid allocation for its 5-tuple.
- Add a server-handler regression test for the expired-allocation case.

## Verification

The focused server test executable passes all 22 cases. The new regression test fails against the previous handler because it does not set the required 437 error.
