### PR TITLE
Make the multiplex-peer example tests request EVEN-PORT never, not ra…

### DIFF
--- a/examples/run_tests_multiplex_peer.sh
+++ b/examples/run_tests_multiplex_peer.sh
@@ -55,8 +55,6 @@ run_client() {
   local expected_bytes="$3"
   local output
   local rc=0
-  local attempt
-  local max_attempts=8
   shift 3
 
   echo "Running $name"
@@ -64,27 +62,15 @@ run_client() {
   peer_pid="$!"
   sleep 1
 
-  for attempt in $(seq 1 "$max_attempts"); do
-    rc=0
-    output=$("$BINDIR/turnutils_uclient" "$@" 2>&1) || rc=$?
-    if printf '%s\n' "$output" |
-      grep -q "start_mclient: tot_send_bytes ~ $expected_bytes, tot_recv_bytes ~ $expected_bytes"; then
-      kill "$peer_pid" 2>/dev/null || true
-      wait "$peer_pid" 2>/dev/null || true
-      peer_pid=""
-      echo OK
-      return 0
-    fi
-
-    if printf '%s\n' "$output" | grep -q "error 508" &&
-      grep -q "EVEN-PORT is not supported with multiplex-peer" "$turnserver_log" &&
-      [ "$attempt" -lt "$max_attempts" ]; then
-      echo "Retrying $name after randomized EVEN-PORT request"
-      continue
-    fi
-
-    break
-  done
+  output=$("$BINDIR/turnutils_uclient" "$@" 2>&1) || rc=$?
+  if printf '%s\n' "$output" |
+    grep -q "start_mclient: tot_send_bytes ~ $expected_bytes, tot_recv_bytes ~ $expected_bytes"; then
+    kill "$peer_pid" 2>/dev/null || true
+    wait "$peer_pid" 2>/dev/null || true
+    peer_pid=""
+    echo OK
+    return 0
+  fi
 
   kill "$peer_pid" 2>/dev/null || true
   wait "$peer_pid" 2>/dev/null || true
@@ -168,18 +154,21 @@ expect_peer_endpoint_limit() {
 echo "Running turnserver in multiplex-peer mode on base port $MULTIPLEX_PEER_PORT"
 start_turnserver
 
-# Multiplex-peer is incompatible with EVEN-PORT, so these tests disable RTCP reservation with -c.
-run_client "turn client UDP" 3480 500 -c -e 127.0.0.1 -r 3480 -X -g -u user -W secret 127.0.0.1
-run_client "turn client TCP" 3482 500 -c -t -e 127.0.0.1 -r 3482 -X -g -u user -W secret 127.0.0.1
-run_client "turn client TLS" 3484 500 -c -t -S -e 127.0.0.1 -r 3484 -X -g -u user -W secret 127.0.0.1
-run_client "turn client DTLS" 3490 500 -c -S -e 127.0.0.1 -r 3490 -X -g -u user -W secret 127.0.0.1
+# Multiplex-peer rejects EVEN-PORT with 508, and -c alone leaves the client
+# picking EVEN-PORT at random, so --no-even-port is what makes these runs
+# deterministic.
+run_client "turn client UDP" 3480 500 -c --no-even-port -e 127.0.0.1 -r 3480 -X -g -u user -W secret 127.0.0.1
+run_client "turn client TCP" 3482 500 -c --no-even-port -t -e 127.0.0.1 -r 3482 -X -g -u user -W secret 127.0.0.1
+run_client "turn client TLS" 3484 500 -c --no-even-port -t -S -e 127.0.0.1 -r 3484 -X -g -u user -W secret 127.0.0.1
+run_client "turn client DTLS" 3490 500 -c --no-even-port -S -e 127.0.0.1 -r 3490 -X -g -u user -W secret 127.0.0.1
 
 sleep 2
 
 stop_turnserver
 echo "Restarting turnserver with --multiplex-peer-max-peers=4"
 start_turnserver --multiplex-peer-max-peers=4
-run_client "turn client UDP (peer-endpoint cap 4)" 3492 500 -c -e 127.0.0.1 -r 3492 -X -g -u user -W secret 127.0.0.1
+run_client "turn client UDP (peer-endpoint cap 4)" 3492 500 -c --no-even-port -e 127.0.0.1 -r 3492 -X -g -u user \
+  -W secret 127.0.0.1
 
 stop_turnserver
 echo "Restarting turnserver with --multiplex-peer-max-peers=1"


### PR DESCRIPTION
…ndomly

run_client drove turnutils_uclient with -c only. In clnet_allocate, -c leaves the EVEN-PORT slot to be picked at random between 0 and -1, and multiplex-peer strictly rejects EVEN-PORT with error 508, so roughly half of all attempts were thrown away. The script compensated with an eight-attempt retry loop, which still failed outright about once in 256 per run_client call and about once in 50 per script run - observed on
https://github.com/coturn/coturn/actions/runs/31279481991 (amazonlinux:2023), where all eight attempts of the first UDP case drew EVEN-PORT.

Pass --no-even-port, which forces the slot to -1 unconditionally, and drop the retry loop it makes dead. Nothing is lost in coverage: EVEN-PORT under multiplex-peer is defined to be a 508, so the random draw only ever decided whether a run was wasted. A retry that can no longer fire for its stated reason would silently swallow a genuine regression.

expect_peer_endpoint_limit already passed --no-even-port for the same reason.