### PR TITLE
hiredis: clean up failed async connection setup

### DIFF
--- a/src/apps/relay/hiredis_libevent2.c
+++ b/src/apps/relay/hiredis_libevent2.c
@@ -260,6 +260,7 @@ redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int
     return NULL;
   } else if (ac->err) {
     fprintf(stderr, "Error: %s:%s\n", ac->errstr, ac->c.errstr);
+    redisAsyncFree(ac);
     return NULL;
   }
 
@@ -306,6 +307,11 @@ redis_context_handle redisLibeventAttach(struct event_base *base, char *ip0, int
   e->wev = event_new(e->base, e->context->c.fd, EV_WRITE, redisLibeventWriteEvent, e);
 
   if (e->rev == NULL || e->wev == NULL) {
+    redisAsyncFree(ac);
+    e->context = NULL;
+    free(e->ip);
+    free(e->user);
+    free(e->pwd);
     free(e);
     return NULL;
   }
@@ -370,6 +376,11 @@ static void redis_reconnect(struct redisLibeventEvents *e) {
     return;
   }
 
+  if (ac->err) {
+    redisAsyncFree(ac);
+    return;
+  }
+
   e->context = ac;
 
   /* Re-upgrade to TLS before any command is queued on the new context. */
@@ -394,6 +405,8 @@ static void redis_reconnect(struct redisLibeventEvents *e) {
   e->wev = event_new(e->base, e->context->c.fd, EV_WRITE, redisLibeventWriteEvent, e);
 
   if (e->rev == NULL || e->wev == NULL) {
+    redisAsyncFree(ac);
+    e->context = NULL;
     return;
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -226,8 +226,28 @@ if(HIREDIS_FOUND AND LIBEVENT_FOUND)
     target_link_libraries(test_redis_format PRIVATE turnclient unity ${LIBEVENT_LIBRARIES})
     add_test(NAME test_redis_format COMMAND test_redis_format)
     list(APPEND COTURN_TEST_TARGETS test_redis_format)
+
+    # Uses real hiredis/libevent cleanup and wraps event_new() only to inject
+    # deterministic read/write event allocation failures.
+    add_executable(test_redis_libevent_cleanup test_redis_libevent_cleanup.c)
+    target_include_directories(test_redis_libevent_cleanup PRIVATE
+        ../src/apps/relay
+        ../src/server
+        ../src/apps/common
+        ../src
+        ../src/client
+        ${HIREDIS_INCLUDE_DIRS}
+        ${OPENSSL_INCLUDE_DIR}
+        ${LIBEVENT_INCLUDE_DIRS})
+    target_link_directories(test_redis_libevent_cleanup PRIVATE
+        ${HIREDIS_LIBRARY_DIRS}
+        ${LIBEVENT_LIBRARY_DIRS})
+    target_link_libraries(test_redis_libevent_cleanup PRIVATE
+        turnclient unity ${HIREDIS_LIBRARIES} ${LIBEVENT_LIBRARIES})
+    add_test(NAME test_redis_libevent_cleanup COMMAND test_redis_libevent_cleanup)
+    list(APPEND COTURN_TEST_TARGETS test_redis_libevent_cleanup)
 else()
-    message(STATUS "hiredis/libevent headers not found; skipping test_redis_format")
+    message(STATUS "hiredis/libevent not found; skipping Redis tests")
 endif()
 
 # Vendored Prometheus client (src/prometheus). Fully self-contained: only the

--- a/tests/test_redis_libevent_cleanup.c
+++ b/tests/test_redis_libevent_cleanup.c
@@ -1,0 +1,170 @@
+/*
+ * Regression tests for Redis/libevent cleanup on connection and event setup
+ * failures. The real hiredis and libevent implementations are used; only
+ * event_new() is wrapped so each allocation failure can be injected
+ * deterministically. redisAsyncFree() is wrapped to count calls before
+ * delegating to the real hiredis implementation.
+ */
+
+#include <unity.h>
+
+#include <event2/event.h>
+#include <hiredis/async.h>
+#include <hiredis/hiredis.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+static int fail_event_new_call;
+static int event_new_calls;
+static int redis_async_free_calls;
+
+static struct event *call_real_event_new(struct event_base *base, evutil_socket_t fd, short events,
+                                         event_callback_fn callback, void *arg) {
+  return event_new(base, fd, events, callback, arg);
+}
+
+static struct event *fault_event_new(struct event_base *base, evutil_socket_t fd, short events,
+                                     event_callback_fn callback, void *arg) {
+  ++event_new_calls;
+  if (event_new_calls == fail_event_new_call) {
+    return NULL;
+  }
+  return call_real_event_new(base, fd, events, callback, arg);
+}
+
+static void call_real_redis_async_free(redisAsyncContext *ac) { redisAsyncFree(ac); }
+
+static void tracking_redis_async_free(redisAsyncContext *ac) {
+  ++redis_async_free_calls;
+  call_real_redis_async_free(ac);
+}
+
+#define event_new fault_event_new
+#define redisAsyncFree tracking_redis_async_free
+#include "hiredis_libevent2.c"
+#undef redisAsyncFree
+#undef event_new
+
+static struct event_base *base;
+
+static void reset_faults(void) {
+  fail_event_new_call = 0;
+  event_new_calls = 0;
+  redis_async_free_calls = 0;
+}
+
+static struct redisLibeventEvents *make_reconnect_handle(const char *ip, int port) {
+  struct redisLibeventEvents *e = turn_calloc(1, sizeof(*e));
+  e->allocated = 1;
+  e->invalid = 1;
+  e->base = base;
+  e->ip = turn_strdup(ip);
+  e->port = port;
+  return e;
+}
+
+static void free_handle(struct redisLibeventEvents *e) {
+  if (!e) {
+    return;
+  }
+  if (e->context) {
+    call_real_redis_async_free(e->context);
+    e->context = NULL;
+  } else {
+    if (e->rev) {
+      event_free(e->rev);
+    }
+    if (e->wev) {
+      event_free(e->wev);
+    }
+  }
+  free(e->ip);
+  free(e->user);
+  free(e->pwd);
+  free(e);
+}
+
+void setUp(void) {
+  reset_faults();
+  base = event_base_new();
+  TEST_ASSERT_NOT_NULL(base);
+}
+
+void tearDown(void) {
+  event_base_free(base);
+  base = NULL;
+}
+
+static void test_attach_frees_hiredis_error_context(void) {
+  redis_context_handle handle = redisLibeventAttach(base, "256.256.256.256", 6379, NULL, NULL, 0, NULL);
+
+  TEST_ASSERT_NULL(handle);
+  TEST_ASSERT_EQUAL_INT(1, redis_async_free_calls);
+}
+
+static void assert_attach_event_failure_is_cleaned(int failed_call) {
+  fail_event_new_call = failed_call;
+
+  redis_context_handle handle = redisLibeventAttach(base, "127.0.0.1", 1, "user", "password", 0, NULL);
+
+  TEST_ASSERT_NULL(handle);
+  TEST_ASSERT_EQUAL_INT(1, redis_async_free_calls);
+  TEST_ASSERT_EQUAL_INT(2, event_new_calls);
+}
+
+static void test_attach_cleans_up_when_read_event_creation_fails(void) { assert_attach_event_failure_is_cleaned(1); }
+
+static void test_attach_cleans_up_when_write_event_creation_fails(void) { assert_attach_event_failure_is_cleaned(2); }
+
+static void test_reconnect_frees_hiredis_error_context(void) {
+  struct redisLibeventEvents *e = make_reconnect_handle("256.256.256.256", 6379);
+
+  redis_reconnect(e);
+
+  TEST_ASSERT_NULL(e->context);
+  TEST_ASSERT_NULL(e->rev);
+  TEST_ASSERT_NULL(e->wev);
+  TEST_ASSERT_EQUAL_INT(1, redis_async_free_calls);
+  free_handle(e);
+}
+
+static void assert_reconnect_event_failure_is_recoverable(int failed_call) {
+  struct redisLibeventEvents *e = make_reconnect_handle("127.0.0.1", 1);
+  fail_event_new_call = failed_call;
+
+  redis_reconnect(e);
+
+  TEST_ASSERT_NULL(e->context);
+  TEST_ASSERT_NULL(e->rev);
+  TEST_ASSERT_NULL(e->wev);
+  TEST_ASSERT_EQUAL_INT(1, redis_async_free_calls);
+  TEST_ASSERT_EQUAL_INT(2, event_new_calls);
+
+  reset_faults();
+  redis_reconnect(e);
+  TEST_ASSERT_NOT_NULL(e->context);
+  TEST_ASSERT_NOT_NULL(e->rev);
+  TEST_ASSERT_NOT_NULL(e->wev);
+  TEST_ASSERT_EQUAL_INT(0, e->invalid);
+  free_handle(e);
+}
+
+static void test_reconnect_recovers_after_read_event_creation_fails(void) {
+  assert_reconnect_event_failure_is_recoverable(1);
+}
+
+static void test_reconnect_recovers_after_write_event_creation_fails(void) {
+  assert_reconnect_event_failure_is_recoverable(2);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_attach_frees_hiredis_error_context);
+  RUN_TEST(test_attach_cleans_up_when_read_event_creation_fails);
+  RUN_TEST(test_attach_cleans_up_when_write_event_creation_fails);
+  RUN_TEST(test_reconnect_frees_hiredis_error_context);
+  RUN_TEST(test_reconnect_recovers_after_read_event_creation_fails);
+  RUN_TEST(test_reconnect_recovers_after_write_event_creation_fails);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- free non-NULL Hiredis async contexts returned with an error
- clean up partially initialized libevent state in attach and reconnect paths
- keep failed reconnect state retryable
- add real Hiredis/libevent fault-injection regression tests

## Problem

`redisAsyncConnect()` can return a non-NULL context with `ac->err` set. The
caller still owns that context, but the initial attach path did not free it,
while the reconnect path could treat it as a valid connection.

If either `event_new()` call failed, the initial attach path freed only its
wrapper, while reconnect retained a partial context/event state.

Cleanup must go through `redisAsyncFree()` because the registered libevent
cleanup callback owns the events. Freeing those events separately would result
in a double-free.

## Fix

- call `redisAsyncFree()` for Hiredis error contexts
- clean up the async context when either event allocation fails
- release attach-only wrapper strings after context cleanup
- reset the reconnect context to `NULL` so a later retry can succeed

## Testing

The new test uses the real Hiredis and libevent implementations. It wraps only
`event_new()` to inject deterministic read/write event allocation failures.

It covers:

- Hiredis error contexts during initial attach and reconnect
- read and write event allocation failures
- successful retry after reconnect setup fails

Results:

- same unpatched commit plus the regression test: 6/6 cases fail
- patched ASan/UBSan/LSan regression test: 6/6 cases pass
- patched ASan/UBSan/LSan CTest: 16/16 pass when excluding the pre-existing
  `test_turn_ports` teardown leak
- Release build and CTest: 17/17 pass
- `turnutils_rfc5769check`: all checks pass
- `git diff --check` and clang-format check pass

## Tool-assisted discovery

This was found while evaluating Vul-RAG and PailGen on coturn.

PailGen's initial event-failure cleanup draft conflicted with Hiredis' cleanup
callback and was rejected after ASan detected a double-free. The final cleanup
and regression tests were manually ownership-reviewed and validated using the
real libraries.

This is presented as a robustness and resource-cleanup fix. I am not claiming
a demonstrated remote security impact.
