### PR TITLE
reject 0x1f control character in SASLprep

### DIFF
--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -3144,7 +3144,8 @@ static int adminmain(int argc, char **argv) {
     case 'p':
       STRCPY(pwd, optarg);
       if (!SASLprep((uint8_t *)pwd)) {
-        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong password: %s\n", pwd);
+        /* Do not log the value: it is the password. */
+        TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong password: contains a character prohibited by RFC 4013\n");
         exit(-1);
       }
       if (print_enc_password) {

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1929,7 +1929,9 @@ bool SASLprep(uint8_t *s) {
       case 0x7F:
         return false;
       default:
-        if (c < 0x1F) {
+        /* RFC 4013 Section 2.3 / RFC 3454 Table C.2.1: the prohibited ASCII
+         * control range is U+0000-U+001F, so 0x1F must be rejected too. */
+        if (c <= 0x1F) {
           return false;
         }
         if (c >= 0x80 && c <= 0x9F) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ endfunction()
 
 coturn_add_test(test_ioaddr)
 coturn_add_test(test_stun_msg)
+coturn_add_test(test_saslprep)
 coturn_add_test(test_stateless_nonce)
 coturn_add_test(test_base64)
 coturn_add_test(test_http_server ../src/apps/relay/http_buffer.c)

--- a/tests/test_saslprep.c
+++ b/tests/test_saslprep.c
@@ -1,0 +1,45 @@
+#include "ns_turn_msg.h"
+
+#include <unity.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static bool run_saslprep(const char *in) {
+  uint8_t buf[64] = {0};
+  memcpy(buf, in, strlen(in));
+  return SASLprep(buf);
+}
+
+static void test_plain_ascii_is_accepted(void) { TEST_ASSERT_TRUE(run_saslprep("user")); }
+
+/* RFC 4013 Section 2.3 / RFC 3454 Table C.2.1: the ASCII control range is
+   U+0000-U+001F. Every byte in it (0x1F included) must be rejected. */
+static void test_ascii_control_range_is_rejected(void) {
+  for (int c = 0x01; c <= 0x1F; ++c) {
+    uint8_t buf[4] = {(uint8_t)'a', (uint8_t)c, (uint8_t)'b', 0};
+    char msg[64];
+    snprintf(msg, sizeof(msg), "control byte 0x%02x must be rejected", c);
+    TEST_ASSERT_FALSE_MESSAGE(SASLprep(buf), msg);
+  }
+}
+
+static void test_del_and_c1_controls_are_rejected(void) {
+  uint8_t del[3] = {(uint8_t)'a', 0x7F, 0};
+  TEST_ASSERT_FALSE(SASLprep(del));
+  uint8_t c1[3] = {(uint8_t)'a', 0x9F, 0};
+  TEST_ASSERT_FALSE(SASLprep(c1));
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_plain_ascii_is_accepted);
+  RUN_TEST(test_ascii_control_range_is_rejected);
+  RUN_TEST(test_del_and_c1_controls_are_rejected);
+  return UNITY_END();
+}


### PR DESCRIPTION
Repro: put a raw `0x1F` byte into a credential (`--user`, a `turnusers.txt` line, or an admin-added user) and run it through `SASLprep`; the value is accepted unchanged.
Cause: the RFC 4013 Section 2.3 / RFC 3454 table C.2.1 control-range check in `SASLprep` uses `c < 0x1F`, so `0x1F` (Unit Separator) slips through while `0x00`..`0x1E` are correctly rejected.
Fix: compare with `c <= 0x1F` so the whole `U+0000`..`U+001F` control range is rejected, matching the C.2.1 prohibited set (`0x7F` and the C1 range are already handled).

`tests/test_saslprep.c` walks the whole control range; it fails on `0x1f` with the old bound and passes after.

Also hardened alongside the fix: the `turnadmin -p` rejection branch this change makes reachable for `0x1F` passwords logged the raw password at ERROR level; it now logs a fixed message instead, matching the no-password-logging idiom in `add_static_user_account`.

---

**Upgrade note:** SASLprep now rejects byte `0x1F` (unit separator), completing the RFC 4013 / RFC 3454 Table C.2.1 control-character range (`0x00`–`0x1F`). Previously `0x1F` was the only byte in that range that was accepted. Impact on existing deployments that carry `0x1F` in a credential:

- A `user=` line in turnserver.conf (or `-u` on the command line) whose **username** contains `0x1F` is now rejected at load: the server still starts, logs one `Wrong user name` ERROR, and continues **without that account** — its clients will get 401.
- `turnadmin` now refuses `-u`, `-r`, or `-p` values containing `0x1F` for **all** commands, including `-d` (delete). A database account created with `0x1F` before this change still authenticates on the wire but can no longer be managed with turnadmin; remove or rename it via direct database access.
- Audit for affected credentials before upgrading, e.g. `grep -P '^user=.*\x1f' /etc/turnserver.conf` and the equivalent query against your user database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3hK3GoPexQVTyKfGov1LD
