### PR TITLE
Silently ignore attributes after message-integrity

### DIFF
--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -584,7 +584,7 @@ static bool udp_stateless_binding_fast_path(dtls_listener_relay_server_type *ser
  * is truncated exactly as check_stun_auth() truncates it, so both paths judge
  * the same string. Returns false when the attribute is absent. */
 static bool udp_get_string_attr(const uint8_t *data, size_t len, uint16_t attr_type, char *out, size_t out_size) {
-  stun_attr_ref sar = stun_attr_get_first_by_type_str(data, len, attr_type);
+  stun_attr_ref sar = stun_attr_get_first_covered_by_type_str(data, len, attr_type);
   if (!sar) {
     return false;
   }

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -411,8 +411,8 @@ int get_user_key(int in_oauth, int *out_oauth, int *max_session_time, uint8_t *u
 
   if (in_oauth && out_oauth && usname && usname[0]) {
 
-    stun_attr_ref sar = stun_attr_get_first_by_type_str(ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh),
-                                                        STUN_ATTRIBUTE_OAUTH_ACCESS_TOKEN);
+    stun_attr_ref sar = stun_attr_get_first_covered_by_type_str(
+        ioa_network_buffer_data(nbh), ioa_network_buffer_get_size(nbh), STUN_ATTRIBUTE_OAUTH_ACCESS_TOKEN);
     if (sar) {
 
       const int len = stun_attr_get_len(sar);

--- a/src/client/ns_turn_msg.c
+++ b/src/client/ns_turn_msg.c
@@ -1613,6 +1613,18 @@ stun_attr_ref stun_attr_get_first_by_type_str(const uint8_t *buf, size_t len, ui
   return NULL;
 }
 
+stun_attr_ref stun_attr_get_first_covered_by_type_str(const uint8_t *buf, size_t len, uint16_t attr_type) {
+  stun_attr_ref attr = stun_attr_get_first_str(buf, len);
+  while (attr) {
+    if (stun_attr_get_type(attr) == attr_type) {
+      return attr;
+    }
+    attr = stun_attr_get_next_covered_str(buf, len, attr);
+  }
+
+  return NULL;
+}
+
 static stun_attr_ref stun_attr_check_valid(stun_attr_ref attr, size_t remaining) {
   if (remaining >= 4) {
     /* Read the size of the attribute */

--- a/src/client/ns_turn_msg.h
+++ b/src/client/ns_turn_msg.h
@@ -177,6 +177,13 @@ stun_attr_ref stun_attr_get_next_str(const uint8_t *buf, size_t len, stun_attr_r
  * yet; when it is, this boundary moves to the end of that attribute.
  */
 stun_attr_ref stun_attr_get_next_covered_str(const uint8_t *buf, size_t len, stun_attr_ref prev);
+/**
+ * Like stun_attr_get_first_by_type_str(), but honours the same MESSAGE-INTEGRITY
+ * boundary as stun_attr_get_next_covered_str(): an attribute that appears only
+ * after MESSAGE-INTEGRITY is not found. Use this for any attribute the server
+ * acts on, so an unprotected copy appended past the HMAC cannot supply it.
+ */
+stun_attr_ref stun_attr_get_first_covered_by_type_str(const uint8_t *buf, size_t len, uint16_t attr_type);
 bool stun_attr_add_str(uint8_t *buf, size_t *len, uint16_t attr, const uint8_t *avalue, int alen);
 bool stun_attr_add_addr_str(uint8_t *buf, size_t *len, uint16_t attr_type, const ioa_addr *ca);
 bool stun_attr_get_addr_str(const uint8_t *buf, size_t len, stun_attr_ref attr, ioa_addr *ca,

--- a/src/server/ns_turn_server.c
+++ b/src/server/ns_turn_server.c
@@ -3670,8 +3670,8 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
 
     /* REALM ATTR: */
 
-    sar = stun_attr_get_first_by_type_str(ioa_network_buffer_data(in_buffer->nbh),
-                                          ioa_network_buffer_get_size(in_buffer->nbh), STUN_ATTRIBUTE_REALM);
+    sar = stun_attr_get_first_covered_by_type_str(ioa_network_buffer_data(in_buffer->nbh),
+                                                  ioa_network_buffer_get_size(in_buffer->nbh), STUN_ATTRIBUTE_REALM);
 
     if (!sar) {
       *err_code = 400;
@@ -3719,8 +3719,8 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
 
   /* USERNAME ATTR: */
 
-  sar = stun_attr_get_first_by_type_str(ioa_network_buffer_data(in_buffer->nbh),
-                                        ioa_network_buffer_get_size(in_buffer->nbh), STUN_ATTRIBUTE_USERNAME);
+  sar = stun_attr_get_first_covered_by_type_str(ioa_network_buffer_data(in_buffer->nbh),
+                                                ioa_network_buffer_get_size(in_buffer->nbh), STUN_ATTRIBUTE_USERNAME);
 
   if (!sar) {
     *err_code = 400;
@@ -3766,8 +3766,8 @@ static int check_stun_auth(turn_turnserver *server, ts_ur_super_session *ss, stu
   {
     /* NONCE ATTR: */
 
-    sar = stun_attr_get_first_by_type_str(ioa_network_buffer_data(in_buffer->nbh),
-                                          ioa_network_buffer_get_size(in_buffer->nbh), STUN_ATTRIBUTE_NONCE);
+    sar = stun_attr_get_first_covered_by_type_str(ioa_network_buffer_data(in_buffer->nbh),
+                                                  ioa_network_buffer_get_size(in_buffer->nbh), STUN_ATTRIBUTE_NONCE);
 
     if (!sar) {
       *err_code = 400;

--- a/tests/test_stun_msg.c
+++ b/tests/test_stun_msg.c
@@ -775,6 +775,49 @@ static void test_covered_walk_hides_message_integrity_sha256_from_420(void) {
   TEST_ASSERT_EQUAL_INT(0, count_attrs_of_type(buf, len, TEST_ATTR_MESSAGE_INTEGRITY_SHA256, true));
 }
 
+static bool attr_value_equals(stun_attr_ref sar, const char *expected) {
+  const int alen = stun_attr_get_len(sar);
+  return (alen == (int)strlen(expected)) && (memcmp(stun_attr_get_value(sar), expected, (size_t)alen) == 0);
+}
+
+static void test_covered_by_type_ignores_attr_after_message_integrity(void) {
+  uint8_t buf[1024] = {0};
+  size_t len = 0;
+  uint8_t hmac[SHA1SIZEBYTES] = {0};
+
+  /* A USERNAME that exists only past the HMAC boundary: nothing signed it, so
+     check_stun_auth() must not derive a key from it. */
+  stun_init_request_str(STUN_METHOD_ALLOCATE, buf, &len);
+  TEST_ASSERT_TRUE(stun_attr_add_str(buf, &len, STUN_ATTRIBUTE_MESSAGE_INTEGRITY, hmac, SHA1SIZEBYTES));
+  TEST_ASSERT_TRUE(
+      stun_attr_add_str(buf, &len, STUN_ATTRIBUTE_USERNAME, TEST_UNAME, (int)strlen((const char *)TEST_UNAME)));
+
+  TEST_ASSERT_NOT_NULL(stun_attr_get_first_by_type_str(buf, len, STUN_ATTRIBUTE_USERNAME));
+  TEST_ASSERT_NULL(stun_attr_get_first_covered_by_type_str(buf, len, STUN_ATTRIBUTE_USERNAME));
+}
+
+static void test_covered_by_type_keeps_protected_attr_over_trailing_copy(void) {
+  uint8_t buf[1024] = {0};
+  size_t len = 0;
+
+  build_authenticated_allocate(buf, &len);
+  TEST_ASSERT_TRUE(stun_attr_add_str(buf, &len, STUN_ATTRIBUTE_USERNAME, (const uint8_t *)"attacker", 8));
+
+  stun_attr_ref sar = stun_attr_get_first_covered_by_type_str(buf, len, STUN_ATTRIBUTE_USERNAME);
+  TEST_ASSERT_NOT_NULL(sar);
+  TEST_ASSERT_TRUE(attr_value_equals(sar, (const char *)TEST_UNAME));
+}
+
+static void test_covered_by_type_finds_message_integrity_itself(void) {
+  uint8_t buf[1024] = {0};
+  size_t len = 0;
+
+  build_authenticated_allocate(buf, &len);
+
+  /* The boundary is inclusive, so the auth path can still locate the HMAC. */
+  TEST_ASSERT_NOT_NULL(stun_attr_get_first_covered_by_type_str(buf, len, STUN_ATTRIBUTE_MESSAGE_INTEGRITY));
+}
+
 /* RFC 8656 par. 12: ChannelBind may only establish channels 0x4000-0x4FFF;
    0x5000-0xFFFF is reserved for RFC 7983 demultiplexing. The receive-side
    macro deliberately keeps the RFC 5766 range so legacy ChannelData frames
@@ -915,6 +958,9 @@ int main(void) {
   RUN_TEST(test_covered_walk_yields_message_integrity_itself);
   RUN_TEST(test_covered_walk_is_full_walk_without_message_integrity);
   RUN_TEST(test_covered_walk_hides_message_integrity_sha256_from_420);
+  RUN_TEST(test_covered_by_type_ignores_attr_after_message_integrity);
+  RUN_TEST(test_covered_by_type_keeps_protected_attr_over_trailing_copy);
+  RUN_TEST(test_covered_by_type_finds_message_integrity_itself);
   RUN_TEST(test_channel_bind_macro_is_strict_rfc8656_range);
   RUN_TEST(test_channel_bind_request_stays_in_rfc8656_range);
   RUN_TEST(test_channel_bind_request_keeps_explicit_valid_channel);


### PR DESCRIPTION
as stipulated by
  https://datatracker.ietf.org/doc/html/rfc8489#section-9
which says
  Note that agents MUST ignore all attributes that follow MESSAGE-
  INTEGRITY, with the exception of the MESSAGE-INTEGRITY-SHA256 and
  FINGERPRINT attributes.

Claims this leads to auth bypass are overrated.