### PR TITLE
Deprecate option drop-invalid-packets

### DIFF
--- a/README.turnserver
+++ b/README.turnserver
@@ -307,8 +307,6 @@ Flags:
 			main ORIGIN attribute value (if the ORIGIN was
 			initially used by the session).
 
---drop-invalid-packets	Drop invalid packets early. Enabled by default.
-
 --drop-invalid-packets-log	Log invalid packets. The default behaviour is to not log invalid packets.
 
 --udp-recvmmsg		Enable Linux-only batched UDP receive via recvmmsg() on UDP sockets.

--- a/docs/rfc3489-deprecation.md
+++ b/docs/rfc3489-deprecation.md
@@ -152,5 +152,5 @@ Two details for whoever does this:
   signature change hits the same audience.
 
 After removal, a cookie-less datagram is classified `UDP_PACKET_CLASS_INVALID`
-and therefore covered by `--drop-invalid-packets`, which is the desired end
-state.
+and therefore dropped by the listener's early packet validation, which is the
+desired end state.

--- a/docs/stateless-nonce.md
+++ b/docs/stateless-nonce.md
@@ -15,7 +15,7 @@ stock implementation does that by *storing* a random nonce in per-client
 session state.
 
 That storage is the problem on UDP. Early packet validation
-(`--drop-invalid-packets`, PR #1768) discards malformed floods cheaply, but a
+(PR #1768) discards malformed floods cheaply, but a
 *structurally valid* STUN Allocate from a spoofed source still commits real
 resources before any authentication:
 

--- a/src/apps/relay/dtls_listener.c
+++ b/src/apps/relay/dtls_listener.c
@@ -1172,7 +1172,7 @@ static int process_udp_datagram(dtls_listener_relay_server_type *server, ioa_soc
   uint8_t *data = ioa_network_buffer_data(elem);
   const bool is_valid_packet = (packet_type != UDP_PACKET_CLASS_INVALID);
 
-  if (turn_params.drop_invalid_packets && !is_valid_packet) {
+  if (!is_valid_packet) {
     packetcounter++;
     if (turn_params.drop_invalid_packets_log && (packetcounter % 1000 == 0)) {
       uint8_t txt2pcap[1000]; // 1000 is enough to print ~300B packet (3 chars per byte) with extras

--- a/src/apps/relay/mainrelay.c
+++ b/src/apps/relay/mainrelay.c
@@ -245,7 +245,6 @@ turn_params_t turn_params = {
     false, /* rfc5766_channel_numbers */
     false, /* rfc3489_compatibility */
     false, /* respond_http_unsupported */
-    true,  /* drop_invalid_packets */
     false, /* drop_invalid_packets_log */
 #if defined(__linux__)
     true,  /* udp_recvmmsg (on by default; disable with --udp-recvmmsg=false) */
@@ -1430,7 +1429,6 @@ static char Usage[] =
     "connections made to ports not\n"
     "						supporting HTTP. The default behaviour is to immediately "
     "close the connection.\n"
-    " --drop-invalid-packets			   Drop invalid packets early. Enabled by default.\n"
     " --drop-invalid-packets-log			   Log invalid packets. The default behaviour is to not log "
     "invalid packets.\n"
 #if defined(__linux__)
@@ -1658,7 +1656,6 @@ enum EXTRA_OPTS {
   RFC3489_COMPATIBILITY_OPT,
   RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT,
   RESPOND_HTTP_UNSUPPORTED_OPT,
-  DROP_INVALID_PACKETS_OPT,
   DROP_INVALID_PACKETS_LOG_OPT,
 #if defined(__linux__)
   UDP_RECVMMSG_OPT,
@@ -1831,7 +1828,6 @@ static const struct myoption long_options[] = {
     {"rfc3489-compatibility", optional_argument, NULL, RFC3489_COMPATIBILITY_OPT},
     {"response-origin-only-with-rfc5780", optional_argument, NULL, RESPONSE_ORIGIN_ONLY_WITH_RFC5780_OPT},
     {"respond-http-unsupported", optional_argument, NULL, RESPOND_HTTP_UNSUPPORTED_OPT},
-    {"drop-invalid-packets", optional_argument, NULL, DROP_INVALID_PACKETS_OPT},
     {"drop-invalid-packets-log", optional_argument, NULL, DROP_INVALID_PACKETS_LOG_OPT},
 #if defined(__linux__)
     {"udp-recvmmsg", optional_argument, NULL, UDP_RECVMMSG_OPT},
@@ -2705,9 +2701,6 @@ static void set_option(int c, char *value) {
     break;
   case RESPOND_HTTP_UNSUPPORTED_OPT:
     turn_params.respond_http_unsupported = get_bool_value(value);
-    break;
-  case DROP_INVALID_PACKETS_OPT:
-    turn_params.drop_invalid_packets = get_bool_value(value);
     break;
   case DROP_INVALID_PACKETS_LOG_OPT:
     turn_params.drop_invalid_packets_log = get_bool_value(value);

--- a/src/apps/relay/mainrelay.h
+++ b/src/apps/relay/mainrelay.h
@@ -357,7 +357,6 @@ typedef struct _turn_params_ {
   bool rfc5766_channel_numbers;
   bool rfc3489_compatibility;
   bool respond_http_unsupported;
-  bool drop_invalid_packets;
   bool drop_invalid_packets_log;
 #if defined(__linux__)
   bool udp_recvmmsg;


### PR DESCRIPTION
This option has been on by default for multiple versions - removing the flag completely
Keeping logging option intentionally