### PR TITLE
validate redis reply key prefix before offsetting past it

### DIFF
--- a/src/apps/relay/dbdrivers/dbd_redis.c
+++ b/src/apps/relay/dbdrivers/dbd_redis.c
@@ -933,9 +933,15 @@ static int redis_list_origins(uint8_t *realm, secrets_list_t *origins, secrets_l
           }
         } else {
           size_t i;
-          size_t offset = strlen("turn/origin/");
+          const char *prefix = "turn/origin/";
+          const size_t offset = strlen(prefix);
           for (i = 0; i < reply->elements; ++i) {
-            add_to_secrets_list(&keys, reply->element[i]->str + offset);
+            const char *okey = reply->element[i]->str;
+            /* The KEYS reply is not trusted to honour the glob: skip any key
+             * that does not carry the prefix before advancing past it. */
+            if (okey && strstr(okey, prefix) == okey) {
+              add_to_secrets_list(&keys, okey + offset);
+            }
           }
         }
         turnFreeRedisReply(reply);
@@ -1098,11 +1104,17 @@ static int redis_get_ip_list(const char *kind, ip_range_list_t *list) {
 
         redisReply *rget = (redisReply *)redisCommand(rc, "smembers %s", keys.secrets[isz]);
 
-        char *ptr = ((char *)keys.secrets[isz]) + header_len;
-        char *sep = strstr(ptr, "/");
-        if (sep) {
-          *sep = 0;
-          realm = ptr;
+        char *sep = NULL;
+        /* The KEYS reply is not trusted to honour the glob: only advance past
+         * the header when the key actually carries it, else ptr runs off the
+         * end of the string. */
+        if (strstr(keys.secrets[isz], header) == keys.secrets[isz]) {
+          char *ptr = ((char *)keys.secrets[isz]) + header_len;
+          sep = strstr(ptr, "/");
+          if (sep) {
+            *sep = 0;
+            realm = ptr;
+          }
         }
 
         if (rget) {
@@ -1165,9 +1177,15 @@ static void redis_reread_realms(secrets_list_t *realms_list) {
         }
       }
 
-      size_t offset = strlen("turn/origin/");
+      const char *prefix = "turn/origin/";
+      size_t offset = strlen(prefix);
 
       for (isz = 0; isz < keys.sz; ++isz) {
+        /* The KEYS reply is not trusted to honour the glob: skip any key that
+         * does not carry the prefix before advancing past it. */
+        if (strstr(keys.secrets[isz], prefix) != keys.secrets[isz]) {
+          continue;
+        }
         char *origin = keys.secrets[isz] + offset;
         redisReply *rget = (redisReply *)redisCommand(rc, "get %s", keys.secrets[isz]);
         if (rget) {


### PR DESCRIPTION
`redis_list_origins`, `redis_get_ip_list` and `redis_reread_realms` advance each key returned by `KEYS turn/origin/*` / `keys turn/realm/*...` past a fixed prefix without checking the key carries it. `redis_list_secrets` in the same file already guards this with `strstr(s, "turn/realm/") == s`; these three siblings do not.

Repro: point coturn at a redis backend whose `KEYS turn/origin/*` reply contains a key shorter than `turn/origin/` (e.g. `x`).
Cause: `str + strlen("turn/origin/")` (and `+ strlen("turn/realm/")`) runs the pointer past the key's `NUL`; the offset string is then `turn_strdup`'d / map-inserted (out-of-bounds heap read), and in `redis_get_ip_list` `strstr` walks off the end so `*sep = 0` writes out of bounds.
Fix: validate the prefix with `strstr(key, prefix) == key` (plus a `NULL` guard) before offsetting, matching `redis_list_secrets`.

`redis_reread_realms` and `redis_get_ip_list` run every 5s from the auth thread, so no admin action is needed to reach them. Confirmed under ASan: `heap-buffer-overflow` READ 10 bytes past a 2-byte key allocation on the unpatched code, clean after the guard.