### PR TITLE
stop convert_string_key_to_binary reading past a short key

### DIFF
--- a/src/apps/relay/dbdrivers/dbdriver.c
+++ b/src/apps/relay/dbdrivers/dbdriver.c
@@ -55,6 +55,13 @@ void convert_string_key_to_binary(const char *keysource, hmackey_t key, size_t s
   unsigned int v;
   is[2] = 0;
   for (i = 0; i < sz; i++) {
+    /* Each key byte is two hex chars: stop at the NUL rather than read past a
+       source string shorter than 2*sz. The short-circuit checks the first char
+       before touching the second, so the NUL terminator itself is never
+       overstepped. */
+    if (keysource[i * 2] == 0 || keysource[i * 2 + 1] == 0) {
+      break;
+    }
     is[0] = keysource[i * 2];
     is[1] = keysource[i * 2 + 1];
     sscanf(is, "%02x", &v);

--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -786,8 +786,13 @@ int add_static_user_account(char *user) {
     char *keysource = s + 2;
     const size_t sz = get_hmackey_size(SHATYPE_DEFAULT);
     if (strlen(keysource) < sz * 2) {
-      /* Do not log the key material itself; identify by username. */
+      /* A short key would make convert_string_key_to_binary read past its end;
+         reject the account instead of decoding it, as every DB driver does. Do
+         not log the key material itself; identify by username. */
       TURN_LOG_FUNC(TURN_LOG_LEVEL_ERROR, "Wrong key format for user: %s\n", usname);
+      free(usname);
+      free(key);
+      return -1;
     }
     convert_string_key_to_binary(keysource, *key, sz);
   } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,28 @@ coturn_add_test(test_log_min_level)
 coturn_add_test(test_ratelimit ../src/server/ns_turn_ratelimit.c)
 target_include_directories(test_ratelimit PRIVATE ../src/server ../src)
 
+# convert_string_key_to_binary() lives in dbdriver.c, which is not linkable on
+# its own (get_dbdriver() reaches turn_params and the driver getters), so the
+# real source is compiled in with a link-seam stub. TURN_NO_* keeps get_dbdriver
+# down to the always-present redis case, which the stub satisfies.
+add_executable(test_convert_key
+    test_convert_key.c
+    test_convert_key_stub.c
+    ../src/apps/relay/dbdrivers/dbdriver.c)
+target_include_directories(test_convert_key PRIVATE
+    ../src/apps/relay
+    ../src/server
+    ../src/apps/common
+    ../src
+    ../src/client)
+target_compile_definitions(test_convert_key PRIVATE
+    TURN_NO_MONGO TURN_NO_MYSQL TURN_NO_PQ TURN_NO_SQLITE TURN_NO_PROMETHEUS
+    TURN_NO_SCTP TURN_NO_SYSTEMD TURN_NO_THREAD_BARRIERS TURN_NO_HIREDIS
+    _FILE_OFFSET_BITS=64)
+target_link_libraries(test_convert_key PRIVATE turnclient unity)
+add_test(NAME test_convert_key COMMAND test_convert_key)
+list(APPEND COTURN_TEST_TARGETS test_convert_key)
+
 # Multiplex-peer demux table: per-session registration cap and per-session
 # deregistration. The module is self-contained, so it is compiled together
 # with the map implementation it uses.

--- a/tests/test_convert_key.c
+++ b/tests/test_convert_key.c
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * https://opensource.org/license/bsd-3-clause
+ *
+ * Regression test for convert_string_key_to_binary() in
+ * src/apps/relay/dbdrivers/dbdriver.c. The helper decodes 2*sz hex chars from
+ * its source string; a source shorter than that must not be read past its
+ * terminating NUL. The short-key inputs below are heap-allocated so a read
+ * past the string trips AddressSanitizer.
+ */
+
+#include "dbdrivers/dbdriver.h" /* convert_string_key_to_binary */
+#include "ns_turn_msg.h"        /* hmackey_t, get_hmackey_size, SHATYPE_DEFAULT */
+
+#include <unity.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* A full-length key still decodes exactly as before. */
+static void test_full_length_key_decodes(void) {
+  const size_t sz = get_hmackey_size(SHATYPE_DEFAULT); /* 16 */
+  char *src = strdup("0011223344556677889900aabbccddee");
+  hmackey_t key;
+  memset(key, 0xAA, sizeof(key));
+
+  convert_string_key_to_binary(src, key, sz);
+  free(src);
+
+  TEST_ASSERT_EQUAL_UINT8(0x00, key[0]);
+  TEST_ASSERT_EQUAL_UINT8(0x11, key[1]);
+  TEST_ASSERT_EQUAL_UINT8(0xee, key[15]);
+}
+
+/* An even-length key shorter than 2*sz must stop at the NUL, not read past the
+   heap allocation. */
+static void test_short_key_is_not_oob(void) {
+  const size_t sz = get_hmackey_size(SHATYPE_DEFAULT); /* 16 */
+  /* 4 hex chars decode to 2 key bytes, but sz asks for 32 chars. */
+  char *src = strdup("1234");
+  hmackey_t key;
+  memset(key, 0xAA, sizeof(key));
+
+  convert_string_key_to_binary(src, key, sz);
+  free(src);
+
+  TEST_ASSERT_EQUAL_UINT8(0x12, key[0]);
+  TEST_ASSERT_EQUAL_UINT8(0x34, key[1]);
+  /* Loop stopped at the NUL: the untouched byte keeps its sentinel. */
+  TEST_ASSERT_EQUAL_UINT8(0xAA, key[2]);
+}
+
+/* An odd-length key ends mid-byte; the second hex char of that byte is the NUL
+   terminator, so it must be read as the terminator and not overstepped. */
+static void test_odd_length_key_is_not_oob(void) {
+  const size_t sz = get_hmackey_size(SHATYPE_DEFAULT); /* 16 */
+  /* 3 chars: "12" then '3' followed by the NUL terminator. */
+  char *src = strdup("123");
+  hmackey_t key;
+  memset(key, 0xAA, sizeof(key));
+
+  convert_string_key_to_binary(src, key, sz);
+  free(src);
+
+  TEST_ASSERT_EQUAL_UINT8(0x12, key[0]);
+  TEST_ASSERT_EQUAL_UINT8(0xAA, key[1]);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_full_length_key_decodes);
+  RUN_TEST(test_short_key_is_not_oob);
+  RUN_TEST(test_odd_length_key_is_not_oob);
+  return UNITY_END();
+}

--- a/tests/test_convert_key_stub.c
+++ b/tests/test_convert_key_stub.c
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * https://opensource.org/license/bsd-3-clause
+ *
+ * Link seam for test_convert_key: dbdriver.c is compiled into the test to reach
+ * the real convert_string_key_to_binary(), which pulls in get_dbdriver() and
+ * its turn_params reference. The test never calls those, so provide the minimal
+ * definitions the linker needs and nothing more.
+ */
+
+#include "dbdrivers/dbdriver.h"
+#include "mainrelay.h"
+
+turn_params_t turn_params;
+
+const turn_dbdriver_t *get_redis_dbdriver(void) { return NULL; }


### PR DESCRIPTION
Repro: configure a static user with a short hex key, e.g. `turnserver --user=u:0x1234`; under an ASan build `convert_string_key_to_binary` reports a `heap-buffer-overflow READ`.

Cause: `convert_string_key_to_binary` (`src/apps/relay/dbdrivers/dbdriver.c`) decodes `2*sz` hex chars from `keysource` into an `hmackey_t` with no bound on the source length, trusting every caller to pass at least `2*sz` chars. `add_static_user_account` (`src/apps/relay/userdb.c`, the `--user` / config `user=` parser) breaks that contract: for a `0x` key shorter than `2*sz` it logs `Wrong key format` but then calls the helper anyway, so it reads past the end of the key string. The five DB-driver callers (`redis`/`sqlite`/`pgsql`/`mysql`/`mongo`) all skip the decode on a short key; this one only logged.

Fix: bound the helper to stop at the terminating NUL (the check short-circuits on the first hex char before touching the second, so the NUL itself is never overstepped, and a full-length `2*sz` key decodes exactly as before), and reject the short-key account in `add_static_user_account` like its siblings.

Verified: `tests/test_convert_key.c` (added) decodes a full key unchanged and asserts a short/odd key stops at the NUL; it trips ASan / fails on a short key before the fix and passes after. `ctest` and the `examples/` protocol tests stay green.